### PR TITLE
Win32 assertion error fix

### DIFF
--- a/src/dxfdata.h
+++ b/src/dxfdata.h
@@ -30,7 +30,7 @@ public:
 		}
 	};
 
-	std::vector<Vector2d, Eigen::aligned_allocator<Eigen::Vector2d> > points;
+	std::vector<Vector2d, Eigen::aligned_allocator<Vector2d> > points;
 	std::vector<Path> paths;
 	std::vector<Dim> dims;
 


### PR DESCRIPTION
This fixes the assertion error noticed on windows when compiling example 21.
The assertion caused a popup with this link:
http://eigen.tuxfamily.org/dox/UnalignedArrayAssert.html
which led to this page for the fix:
http://eigen.tuxfamily.org/dox/TopicStlContainers.html#allocator
