### PR TITLE
Disable Eigen alignment

### DIFF
--- a/src/dxfdata.h
+++ b/src/dxfdata.h
@@ -1,5 +1,8 @@
 #ifndef DXFDATA_H_
 #define DXFDATA_H_
+#ifndef EIGEN_DONT_ALIGN
+#define EIGEN_DONT_ALIGN
+#endif
 
 #include <vector>
 #include <Eigen/Dense>
@@ -30,7 +33,7 @@ public:
 		}
 	};
 
-	std::vector<Vector2d, Eigen::aligned_allocator<Vector2d> > points;
+	std::vector<Vector2d> points;
 	std::vector<Path> paths;
 	std::vector<Dim> dims;
 

--- a/src/linalg.h
+++ b/src/linalg.h
@@ -1,6 +1,8 @@
 #ifndef LINALG_H_
 #define LINALG_H_
-
+#ifndef EIGEN_DONT_ALIGN
+#define EIGEN_DONT_ALIGN
+#endif
 #include <Eigen/Core>
 #include <Eigen/Geometry>
 


### PR DESCRIPTION
After this commit:
https://github.com/openscad/openscad/commit/f5e0f3a531b0c8806e4ebc62cd91ca31275ae481

the changes in this pull request were the only way I was able to get the windows build to work. Otherwise, it would throw assertion errors any time I tried to compile anything.
