### PR TITLE
Enable packaging cross-compiled windows build

### DIFF
--- a/cgal.pri
+++ b/cgal.pri
@@ -1,6 +1,5 @@
 cgal {
   DEFINES += ENABLE_CGAL
-  CONFIG(mingw-cross-env):DEFINES += BOOST_STATIC BOOST_THREAD_USE_LIB Boost_USE_STATIC_LIBS
 
   isEmpty(DEPLOYDIR) {
     # Optionally specify location of CGAL using the 

--- a/src/CSGTermEvaluator.h
+++ b/src/CSGTermEvaluator.h
@@ -7,10 +7,6 @@
 #include <cstddef>
 #include "visitor.h"
 
-#if defined __WIN32__ && ! defined _MSC_VER
-#include <cstddef>
-#endif
-
 class CSGTermEvaluator : public Visitor
 {
 public:

--- a/src/dxfdata.h
+++ b/src/dxfdata.h
@@ -1,8 +1,5 @@
 #ifndef DXFDATA_H_
 #define DXFDATA_H_
-#ifndef EIGEN_DONT_ALIGN
-#define EIGEN_DONT_ALIGN
-#endif
 
 #include "linalg.h"
 #include <vector>

--- a/src/linalg.h
+++ b/src/linalg.h
@@ -1,8 +1,6 @@
 #ifndef LINALG_H_
 #define LINALG_H_
-#ifndef EIGEN_DONT_ALIGN
-#define EIGEN_DONT_ALIGN
-#endif
+
 #include <Eigen/Core>
 #include <Eigen/Geometry>
 #include <Eigen/Dense>


### PR DESCRIPTION
Some changes I made to the release scripts to ease the pain of packaging windows development builds.
