### PR TITLE
Savefonts

### DIFF
--- a/src/MainWindow.h
+++ b/src/MainWindow.h
@@ -67,11 +67,14 @@ private slots:
 	void updateTVal();
 	void setFileName(const QString &filename);
 	void setFont(const QString &family, uint size);
+	void zoomIn();
+	void zoomOut();
 #ifdef USE_PROGRESSWIDGET
 	void showProgress();
 #endif
 
 private:
+	void zoom(int n);
 	void openFile(const QString &filename);
 	void load();
 	AbstractNode *find_root_tag(AbstractNode *n);

--- a/src/linalg.cc
+++ b/src/linalg.cc
@@ -2,6 +2,7 @@
 
 BoundingBox operator*(const Transform3d &m, const BoundingBox &box)
 {
+  // FIXME - stopgap while waiting for real version
   BoundingBox bbox(box);
   bbox.extend(m * box.min());
   bbox.extend(m * box.max());

--- a/src/mainwin.cc
+++ b/src/mainwin.cc
@@ -177,7 +177,6 @@ MainWindow::MainWindow(const QString &filename)
 	editor->setTabStopWidth(30);
 #endif
 	editor->setLineWrapping(true); // Not designable
-	setFont("", 12); // Init default font
 
 	this->glview->statusLabel = new QLabel(this);
 	statusBar()->addWidget(this->glview->statusLabel);
@@ -251,8 +250,8 @@ MainWindow::MainWindow(const QString &filename)
 	connect(this->editActionUncomment, SIGNAL(triggered()), editor, SLOT(uncommentSelection()));
 	connect(this->editActionPasteVPT, SIGNAL(triggered()), this, SLOT(pasteViewportTranslation()));
 	connect(this->editActionPasteVPR, SIGNAL(triggered()), this, SLOT(pasteViewportRotation()));
-	connect(this->editActionZoomIn, SIGNAL(triggered()), editor, SLOT(zoomIn()));
-	connect(this->editActionZoomOut, SIGNAL(triggered()), editor, SLOT(zoomOut()));
+	connect(this->editActionZoomIn, SIGNAL(triggered()), this, SLOT(zoomIn()));
+	connect(this->editActionZoomOut, SIGNAL(triggered()), this, SLOT(zoomOut()));
 	connect(this->editActionHide, SIGNAL(triggered()), this, SLOT(hideEditor()));
 	connect(this->editActionPreferences, SIGNAL(triggered()), this, SLOT(preferences()));
 
@@ -347,6 +346,8 @@ MainWindow::MainWindow(const QString &filename)
 
 	// make sure it looks nice..
 	QSettings settings;
+	setFont(settings.value("editor/fontfamily","").toString(),
+		settings.value("editor/fontsize",12).toInt());
 	resize(settings.value("window/size", QSize(800, 600)).toSize());
 	move(settings.value("window/position", QPoint(0, 0)).toPoint());
 	QList<int> s1sizes = settings_valueList("window/splitter1sizes",QList<int>()<<400<<400);
@@ -1810,6 +1811,16 @@ MainWindow::preferences()
 	Preferences::inst()->activateWindow();
 	Preferences::inst()->raise();
 }
+
+void MainWindow::zoom(int n)
+{
+	QSettings settings;
+	editor->zoomIn(n);
+	QString pointsize = QString(editor->font().pointSize());
+	settings.setValue("editor/fontsize", pointsize );
+}
+void MainWindow::zoomIn() { zoom(1); }
+void MainWindow::zoomOut() { zoom(-1); }
 
 void MainWindow::setFont(const QString &family, uint size)
 {


### PR DESCRIPTION
this will save the fontsize setting as set by ctl- and ctl+ from the edit/zoomin edit/zoomout menu. it loads the saved setting on startup. 

it does not update the Preferences window simultaneously --- that required too much of a rewrite. 

it only has linalg.cc because the file is missing from current git. im guessing its not correct, but it seems to be mostly ok for a temporary solution until the real version can be put in git. 
