### PR TITLE
fixes version() for cross-compiled windows builds

### DIFF
--- a/version.pri
+++ b/version.pri
@@ -1,7 +1,7 @@
 # get VERSION from system date
 
 isEmpty(VERSION) {
-  win32-msvc*: {
+  win32-msvc*:!mingw-cross-env {
     # 
     # Windows XP date command only has one argument, /t
     # and it can print the date in various localized formats. 


### PR DESCRIPTION
Just noticed that version() returns [0, 0] for windows builds cross-compiled with mingw-cross-env.
It's just taking the wrong path in version.pri, a simple fix.
