### PR TITLE
prevent crash: make path absolute so that it has a parent to cwd to

### DIFF
--- a/src/openscad.cc
+++ b/src/openscad.cc
@@ -276,8 +276,11 @@ int main(int argc, char **argv)
 			root_module = parse(text.str().c_str(), fs::absolute(filename).generic_string().c_str(), false);
 			if (!root_module) exit(1);
 		}
+		
+		fs::path fpath = fs::absolute(fs::path(filename));
+		fs::path fparent = fpath.parent_path();
+		fs::current_path( fparent );
 
-		fs::current_path(fs::path(filename).parent_path());
 		AbstractNode::resetIndexCounter();
 		root_node = root_module->evaluate(&root_ctx, &root_inst);
 		tree.setRoot(root_node);


### PR DESCRIPTION
the code does a 'current_path(parent(filename))',  but if filename is something like this:

./openscad test.scad -o test.stl

then 'test.scad' has no parent directory, and boost throws an exception, stopping openscad like this:

terminate called after throwing an instance of 'boost::filesystem3::filesystem_error'
  what():  boost::filesystem::current_path: No such file or directory
Aborted

it is doing this because 'parent' of 'test' is null. 

by changing it to the absolute path, you have '/home/whatever/test' , and then you do have a non-null parent. 

then we are ok. 
