### PR TITLE
updates submodules if building from git

### DIFF
--- a/scripts/release-common.sh
+++ b/scripts/release-common.sh
@@ -110,7 +110,7 @@ case $OS in
     ;;
 esac
 
-if [ -n .git ]; then
+if [ -d .git ]; then
   git submodule update
 fi
 


### PR DESCRIPTION
This is just a small change to the release script to updated submodules (MCAD) before packaging, if building from git. I forgot to update and had to rebuild because of it, so I added this.
