### PR TITLE
Fix linux releases

### DIFF
--- a/scripts/chrpath_linux.c
+++ b/scripts/chrpath_linux.c
@@ -107,9 +107,6 @@
 /* Define to the version of this package. */
 #define PACKAGE_VERSION ""0.13""
 
-/* The size of a `void *', as computed by sizeof. */
-#define SIZEOF_VOID_P 4
-
 /* Define to 1 if you have the ANSI C header files. */
 #define STDC_HEADERS 1
 

--- a/scripts/openscad-linux
+++ b/scripts/openscad-linux
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+cd "$( dirname "$( type -p $0 )" )"
+libdir=$PWD/../lib/openscad/
+cd "$OLDPWD"
+
+export LD_LIBRARY_PATH="$libdir${LD_LIBRARY_PATH:+:}$LD_LIBRARY_PATH"
+exec $libdir/openscad "$@"


### PR DESCRIPTION
This commit is to fix the Linix release script. There were a few dependencies that weren't being packaged up so I added them and moves the script into release-common.sh. I was able to build 32-bit and 64-bit releases. I had a few problems\* executing that script with sh, so I changed it to bash. Does this still work on Mac OS X?

*the if [[ ... ]] statements throw errors for me, and the $OSTYPE variable is empty, despite the fact that "echo $OSTYPE" in the shell produces "linux-gnu"
