### PR TITLE
add cylinder() optional args ir= ir1= ir2= which specify an inner-radius

### DIFF
--- a/src/primitives.cc
+++ b/src/primitives.cc
@@ -190,9 +190,9 @@ AbstractNode *PrimitiveModule::evaluate(const Context *ctx, const ModuleInstanti
 		Value center = c.lookup_variable("center");
 
 		// Maybe use interior radius values
-		Value ir = c.lookup_variable("ir");
-		Value ir1 = c.lookup_variable("ir1");
-		Value ir2 = c.lookup_variable("ir2");
+		Value ir = c.lookup_variable("ir", true);
+		Value ir1 = c.lookup_variable("ir1", true);
+		Value ir2 = c.lookup_variable("ir2", true);
 		if (ir.type == Value::NUMBER) {
 			double vertex_radius = node->vertex_radius_from_inner_radius(ir.num);
 			node->r1 = vertex_radius;


### PR DESCRIPTION
add cylinder() optional args ir= ir1= ir2= which specify an inner-radius
which the facets of the cylinder will be tangent to (alternative to the
usual vertex-radius which causes a polygon inscribed within some radius).
