### PR TITLE
Fixed Fedora Linux + DSO Fix

### DIFF
--- a/openscad.pro
+++ b/openscad.pro
@@ -82,8 +82,10 @@ CONFIG += qt
 QT += opengl
 
 # Fedora Linux + DSO fix
-linux*:exists(/usr/lib64/libGLU*)|linux*:exists(/usr/lib/libGLU*) {
-  LIBS += -lGLU
+linux* {
+  exists(/usr/lib64/libGLU*)|exists(/usr/lib/libGLU*) {
+    LIBS += -lGLU
+  }
 }
 
 netbsd* {


### PR DESCRIPTION
It seems that this chunk is not properly evaluated by qmake-qt4 on Fedora 16.

This patch makes the logic more verbose, but it evaluates properly now.
