### PR TITLE
Linear extrude argument

### DIFF
--- a/src/linearextrude.cc
+++ b/src/linearextrude.cc
@@ -77,11 +77,12 @@ AbstractNode *LinearExtrudeModule::evaluate(const Context *ctx, const ModuleInst
 
 	// if height not given, and first argument is a number,
 	// then assume it should be the height.
-	if ( c.lookup_variable("height").type == Value::UNDEFINED )
-		if ( inst->argnames.size()>0 )
-			if ( inst->argnames[0] == "" )
-				if ( inst->argvalues[0].type == Value::NUMBER )
-					height = Value(inst->argvalues[0]);
+	if (c.lookup_variable("height").type == Value::UNDEFINED &&
+			inst->argnames.size() > 0 && 
+			inst->argnames[0] == "" &&
+			inst->argvalues[0].type == Value::NUMBER) {
+		height = Value(inst->argvalues[0]);
+	}
 
 	node->layername = layer.text;
 	node->height = height.num;


### PR DESCRIPTION
per discussion on mailing list that I cannot seem to locate. 

if there is no height specified for linear_extrude, and the first argument is a number by itself (not labeled), then use that number as the height. 
