### PR TITLE
fix compilation and linking issues on mingw crossbuild

### DIFF
--- a/boost.pri
+++ b/boost.pri
@@ -13,7 +13,7 @@ boost {
     DEFINES += BOOST_STATIC
     DEFINES += BOOST_THREAD_USE_LIB
     DEFINES += Boost_USE_STATIC_LIBS
-    BOOST_LINK_FLAGS = -lboost_thread_win32-mt -lboost_program_options-mt -lboost_filesystem-mt -lboost_system-mt -lboost_regex-mt
+    BOOST_LINK_FLAGS = -lboost_thread_win32-mt -lboost_program_options-mt -lboost_filesystem-mt -lboost_system-mt -lboost_regex-mt -lboost_chrono-mt
   } 
 
   isEmpty(BOOST_LINK_FLAGS):win32 {
@@ -25,10 +25,10 @@ boost {
     OPENSCAD_LIBDIR = $$(OPENSCAD_LIBRARIES)
     !isEmpty(OPENSCAD_LIBDIR) {
       exists($$OPENSCAD_LIBDIR/lib/libboost*thread-mt*) {
-        BOOST_LINK_FLAGS = -lboost_thread-mt -lboost_program_options-mt -lboost_filesystem-mt -lboost_system-mt -lboost_regex-mt
+        BOOST_LINK_FLAGS = -lboost_thread-mt -lboost_program_options-mt -lboost_filesystem-mt -lboost_system-mt -lboost_regex-mt -lboost_chrono-mt
       } else {
         exists($$OPENSCAD_LIBDIR/lib/libboost*thread*) {
-          BOOST_LINK_FLAGS = -lboost_thread -lboost_program_options -lboost_filesystem -lboost_system -lboost_regex
+          BOOST_LINK_FLAGS = -lboost_thread -lboost_program_options -lboost_filesystem -lboost_system -lboost_regex -lboost_chrono
         }
       }
     }

--- a/src/import.cc
+++ b/src/import.cc
@@ -237,7 +237,7 @@ PolySet *ImportNode::evaluate_polyset(class PolySetEvaluator *) const
 std::string ImportNode::toString() const
 {
 	std::stringstream stream;
-	fs::path path(this->filename);
+	fs::path path((std::string)this->filename);
 
 	stream << this->name();
 	stream << "(file = " << this->filename << ", "

--- a/src/linearextrude.cc
+++ b/src/linearextrude.cc
@@ -146,7 +146,7 @@ std::string LinearExtrudeNode::toString() const
 
 	stream << this->name() << "(";
 	if (!this->filename.empty()) { // Ignore deprecated parameters if empty 
-		fs::path path(this->filename);
+		fs::path path( (std::string) this->filename );
 		stream <<
 			"file = " << this->filename << ", "
 			"layer = " << QuotedString(this->layername) << ", "

--- a/src/rotateextrude.cc
+++ b/src/rotateextrude.cc
@@ -115,7 +115,7 @@ std::string RotateExtrudeNode::toString() const
 
 	stream << this->name() << "(";
 	if (!this->filename.empty()) { // Ignore deprecated parameters if empty 
-		fs::path path(this->filename);
+		fs::path path((std::string)this->filename);
 		stream <<
 			"file = " << this->filename << ", "
 			"layer = " << QuotedString(this->layername) << ", "

--- a/src/surface.cc
+++ b/src/surface.cc
@@ -225,7 +225,7 @@ PolySet *SurfaceNode::evaluate_polyset(class PolySetEvaluator *) const
 std::string SurfaceNode::toString() const
 {
 	std::stringstream stream;
-	fs::path path(this->filename);
+	fs::path path((std::string)this->filename);
 
 	stream << this->name() << "(file = " << this->filename << ", "
 		"center = " << (this->center ? "true" : "false")


### PR DESCRIPTION
Brad's mxe crossbuild is now using boost 1.50 which needs boost_chrono linked for some reason. the compiler, gcc 4.7, was also complaining about converting Value/Filename into std::string.
