### PR TITLE
cgal 4.0.2 has a bugfix re clang and gcc 4.7 ( issue #117 )

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ are build scripts that download and compile the libraries from source.
 Follow the instructions for the platform you're compiling on below.
 
 * [Qt4 (4.4 - 4.7)](http://www.qt.nokia.com/)
-* [CGAL (3.6 - 3.9)](http://www.cgal.org/)
+* [CGAL (3.6 - 4.0.2)](http://www.cgal.org/)
  * [GMP (5.0.x)](http://www.gmplib.org/)
  * [cmake (2.6 - 2.8, required by CGAL and the test framework)](http://www.cmake.org/)
  * [MPFR (3.x)](http://www.mpfr.org/)

--- a/scripts/linux-build-dependencies.sh
+++ b/scripts/linux-build-dependencies.sh
@@ -129,13 +129,14 @@ build_cgal()
   cd $BASEDIR/src
   rm -rf CGAL-$version
   if [ ! -f CGAL-$version.tar.gz ]; then
-    #4.0
-    curl -O https://gforge.inria.fr/frs/download.php/30387/CGAL-$version.tar.gz
+    #4.0.2
+    curl -O https://gforge.inria.fr/frs/download.php/31174/CGAL-$version.tar.bz2
+    # 4.0 curl -O https://gforge.inria.fr/frs/download.php/30387/CGAL-$version.tar.gz
     # 3.9 curl -O https://gforge.inria.fr/frs/download.php/29125/CGAL-$version.tar.gz
     # 3.8 curl -O https://gforge.inria.fr/frs/download.php/28500/CGAL-$version.tar.gz
     # 3.7 curl -O https://gforge.inria.fr/frs/download.php/27641/CGAL-$version.tar.gz
   fi
-  tar xzf CGAL-$version.tar.gz
+  tar jxf CGAL-$version.tar.bz2
   cd CGAL-$version
   if [ $2 = use-sys-libs ]; then 
     cmake -DCMAKE_INSTALL_PREFIX=$DEPLOYDIR -DWITH_CGAL_Qt3=OFF -DWITH_CGAL_Qt4=OFF -DWITH_CGAL_ImageIO=OFF -DCMAKE_BUILD_TYPE=Debug

--- a/scripts/setenv-linbuild.sh
+++ b/scripts/setenv-linbuild.sh
@@ -3,9 +3,9 @@
 
 # run this file with 'source setenv-linbuild.sh' every time you re-login
 # and want to build or run openscad against custom libraries installed
-# into BASEDIR.  
+# into BASEDIR.
 
-# copy this file to your .bashrc if desired. 
+# copy this file to your .bashrc if desired.
 
 if [ ! $BASEDIR ]; then
   BASEDIR=$HOME/openscad_deps

--- a/src/version_check.h
+++ b/src/version_check.h
@@ -53,7 +53,7 @@ a time, to avoid confusion.
 #error CGAL library missing or version too old. See README.md. To force compile, run qmake CONFIG=skip-version-check
 #else
 
-#if CGAL_VERSION_NR < 1040001000
+#if CGAL_VERSION_NR < 1040021000
 #warning "======================="
 #warning "."
 #warning "."


### PR DESCRIPTION
this will cause the linux-build script to download and build cgal 4.0.2 instead of 4.0. 

cgal 4.0.2 has a bugfix re clang and gcc 4.7 ( issue #117 )

it will also cause version.h to throw a large warning message on older versions of CGAL than 4.0.2 
