### PR TITLE
fix issue160 by adding updateGL() call after 'f5' (opencsg)

### DIFF
--- a/src/mainwin.cc
+++ b/src/mainwin.cc
@@ -1173,6 +1173,8 @@ void MainWindow::actionCompile()
 #endif
 	}
 
+	glview->updateGL(); // issue 160
+
 	if (viewActionAnimate->isChecked() && e_dump->isChecked()) {
 		QImage img = this->glview->grabFrameBuffer();
 		QString filename;


### PR DESCRIPTION
this solves issue #160 (f5 not updating the screen under Wine win32 build) by adding an updateGL call when the user presses the 'f5' key. 

i have tested on linux (32 bit build) and wine (mingw build) and have seen no problems. i also tested animation, and saw no problems. 
