### PR TITLE
Issue159

### DIFF
--- a/src/dxftess-cgal.cc
+++ b/src/dxftess-cgal.cc
@@ -167,7 +167,7 @@ void dxf_tesselate(PolySet *ps, DxfData &dxf, double rot, bool up, bool /* do_tr
 	}
 
 	if ( duplicate_vertices > 0 )
-		PRINT( "WARNING: duplicate vertices and/or intersecting lines found during DXF Tessellation. Render may be incorrect." );
+		PRINT( "WARNING: Duplicate vertices and/or intersecting lines found during DXF Tessellation. Render may be incorrect." );
 
 	}
 	catch (CGAL::Assertion_exception e) {


### PR DESCRIPTION
see issue #159

this alters the CGAL dxf tessellation to allow intersections. 

this allows bad DXF to be imported, but the user can view the import and see where the problem is and perhaps fix it, instead of being given an CGAL assertion error. 
