### PR TITLE
Fixed Free Software Foundation address

### DIFF
--- a/COPYING
+++ b/COPYING
@@ -10,7 +10,7 @@
 		       Version 2, June 1991
 
  Copyright (C) 1989, 1991 Free Software Foundation, Inc.
-     59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+     51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  Everyone is permitted to copy and distribute verbatim copies
  of this license document, but changing it is not allowed.
 


### PR DESCRIPTION
In COPYING is an old Free Software Foundation address, this pull corrects it.
