### PR TITLE
Difference test for subtracting something from nothing

### DIFF
--- a/testdata/scad/features/difference-tests.scad
+++ b/testdata/scad/features/difference-tests.scad
@@ -28,3 +28,8 @@ translate([24,0,0]) difference() {
   cube([10,10,10], center=true);
   translate([0,0,6.99]) cylinder(r=4, h=4, center=true);
 }
+
+translate([24,12,0]) difference() {
+  cube([0,10,10], center=true);
+  # cylinder(r=4, h=20, center=true);
+}


### PR DESCRIPTION
The difference tests all subtract objects from an existing object but if
there is no existing object as the first argument the results are
inconsistent across Mac and Linux platforms.  Added a test to highlight
this condition.

This is in response to https://github.com/openscad/openscad/issues/221
