### PR TITLE
allow dxf deps writing

### DIFF
--- a/src/openscad.cc
+++ b/src/openscad.cc
@@ -304,8 +304,19 @@ int main(int argc, char **argv)
 			fs::current_path(original_path);
 			
 			if (deps_output_file) {
-				if (!write_deps(deps_output_file, 
-												stl_output_file ? stl_output_file : off_output_file)) {
+				std::string deps_out( deps_output_file );
+				std::string geom_out;
+				if ( stl_output_file ) geom_out = std::string(stl_output_file);
+				else if ( off_output_file ) geom_out = std::string(off_output_file);
+				else if ( dxf_output_file ) geom_out = std::string(dxf_output_file);
+				else {
+					PRINTB("Output file:%s\n",output_file);
+					PRINT("Sorry, don't know how to write deps for that file type. Exiting\n");
+					exit(1);
+				}
+				int result = write_deps( deps_out, geom_out );
+				if ( !result ) {
+					PRINT("error writing deps");
 					exit(1);
 				}
 			}


### PR DESCRIPTION
From the mailing list 1/16/2013:
post by W. Craig Trader

quote
"
The source file is here:  

```
https://github.com/wcraigtrader/game-parts/blob/master/population_storage_tray.scad
```

. . . 
    $ make
    openscad -m make -o population_storage_tray.dxf -d population_storage_tray.dxf.deps population_storage_tray.scad
"

it resulted in a crash at the write_deps() call. 

This patch fixes by properly detecting dxf_output file and feeding as appropriate. 

I tested it and the dxf appears to be properly generated but the patch could definitely use some outside verification
