### PR TITLE
enable csg output when compiled without CGAL

### DIFF
--- a/src/openscad.cc
+++ b/src/openscad.cc
@@ -255,7 +255,6 @@ int main(int argc, char **argv)
 
 		if (!filename) help(argv[0]);
 
-#ifdef ENABLE_CGAL
 		Context root_ctx;
 		register_builtin(root_ctx);
 
@@ -299,6 +298,7 @@ int main(int argc, char **argv)
 			}
 		}
 		else {
+#ifdef ENABLE_CGAL
 			CGAL_Nef_polyhedron root_N = cgalevaluator.evaluateCGALMesh(*tree.root());
 			
 			fs::current_path(original_path);
@@ -373,12 +373,12 @@ int main(int argc, char **argv)
 					fstream.close();
 				}
 			}
+#else
+			fprintf(stderr, "OpenSCAD has been compiled without CGAL support!\n");
+			exit(1);
+#endif
 		}
 		delete root_node;
-#else
-		fprintf(stderr, "OpenSCAD has been compiled without CGAL support!\n");
-		exit(1);
-#endif
 	}
 	else if (useGUI)
 	{


### PR DESCRIPTION
openscad/openscad#264
