### PR TITLE
Open non-ASCII filenames via the command line

### DIFF
--- a/src/openscad.cc
+++ b/src/openscad.cc
@@ -396,7 +396,7 @@ int main(int argc, char **argv)
 #endif
 
 		QString qfilename;
-		if (filename) qfilename = QString::fromStdString(boosty::stringy(boosty::absolute(filename)));
+		if (filename) qfilename = QString::fromUtf8(boosty::stringy(boosty::absolute(filename)).c_str());
 
 #if 0 /*** disabled by clifford wolf: adds rendering artefacts with OpenCSG ***/
 		// turn on anti-aliasing
@@ -411,7 +411,7 @@ int main(int argc, char **argv)
 		if (vm.count("input-file")) {
 			inputFiles = vm["input-file"].as<vector<string> >();
 			for (vector<string>::const_iterator infile = inputFiles.begin()+1; infile != inputFiles.end(); infile++) {
-				new MainWindow(QString::fromStdString(boosty::stringy((original_path / *infile))));
+				new MainWindow(QString::fromUtf8(boosty::stringy((original_path / *infile).c_str()));
 			}
 		}
 		app.connect(&app, SIGNAL(lastWindowClosed()), &app, SLOT(quit()));


### PR DESCRIPTION
I fixed so that files containing file non-ASCII characters can be opened
via the command line by converting the std::string to a QString by using
QString::fromUtf8(string.c_str()) instread of QString::fromStdString(string).

Non-ASCII characters are not a problem outside the command line, but
I do not known how it is on the command line options.

This is tested on GNU/Linux, I do not know have it will work on other
systems, but it should work since QString::fromStdString(string) did an
incorrect job of creating QString (because it is encoding unaware.)

Signed-off-by: Mattias Andrée maandree@operamail.com
