### PR TITLE
Fix Qt 4.8.4 build when using Xcode 4.6's clang.

### DIFF
--- a/patches/qt-4.8.4.patch
+++ b/patches/qt-4.8.4.patch
@@ -1,0 +1,11 @@
+--- src/gui/kernel/qt_cocoa_helpers_mac_p.h	2013-03-23 11:38:03.000000000 -0700
++++ src/gui/kernel/qt_cocoa_helpers_mac_p.h	2013-03-23 11:38:06.000000000 -0700
+@@ -155,7 +155,7 @@
+ void qt_dispatchModifiersChanged(void * /*NSEvent * */flagsChangedEvent, QWidget *widgetToGetEvent);
+ bool qt_mac_handleTabletEvent(void * /*QCocoaView * */view, void * /*NSEvent * */event);
+ inline QApplication *qAppInstance() { return static_cast<QApplication *>(QCoreApplication::instance()); }
+-struct ::TabletProximityRec;
++struct TabletProximityRec;
+ void qt_dispatchTabletProximityEvent(const ::TabletProximityRec &proxRec);
+ Qt::KeyboardModifiers qt_cocoaModifiers2QtModifiers(ulong modifierFlags);
+ Qt::KeyboardModifiers qt_cocoaDragOperation2QtModifiers(uint dragOperations);

--- a/scripts/macosx-build-dependencies.sh
+++ b/scripts/macosx-build-dependencies.sh
@@ -53,6 +53,11 @@ build_qt()
   fi
   tar xzf qt-everywhere-opensource-src-$version.tar.gz
   cd qt-everywhere-opensource-src-$version
+
+  if [ -f $OPENSCADDIR/patches/qt-$version.patch ]; then
+    patch -p0 < $OPENSCADDIR/patches/qt-$version.patch
+  fi
+
   if $OPTION_32BIT; then
     QT_32BIT="-arch x86"
   fi


### PR DESCRIPTION
Backports https://bugreports.qt-project.org/browse/QTBUG-29373 .

`./scripts/macosx-build-dependencies.sh  -c` finishes successfully for me with this change. Building without `-c` fails somewhere in boost. You probably want to turn on `-c` by default on mac, or mention on the README that it's required at least with recent Xcode versions.
