### PR TITLE
Make OpenSCAD look better on retina displays.

### DIFF
--- a/Info.plist
+++ b/Info.plist
@@ -35,15 +35,17 @@
 			<string>Editor</string>
 			<key>CFBundleTypeIconFile</key>
 			<string>SCAD.icns</string>
-		        <key>LSIsAppleDefaultForType</key>
+			<key>LSIsAppleDefaultForType</key>
 			<true/>
 		</dict>
 	</array>
 	<key>NSAppleScriptEnabled</key>
-        <true/>
+	<true/>
+	<key>NSPrincipalClass</key>
+	<string>NSApplication</string>
 	<key>OSAScriptingDefinition</key>
 	<string>OpenSCAD.sdef</string>
-        <key>SUPublicDSAKeyFile</key>
-        <string>dsa_pub.pem</string>
+	<key>SUPublicDSAKeyFile</key>
+	<string>dsa_pub.pem</string>
 </dict>
 </plist>


### PR DESCRIPTION
Apps need an NSPrincipalClass entry in Info.plist to look good on retina
displays, see "Framework-Scaled Mode Provides Automatic Scaling" in
http://developer.apple.com/library/mac/#documentation/GraphicsAnimation/Conceptual/HighResolutionOSX/Explained/Explained.html

It's also what we did in Chromium ( https://codereview.chromium.org/10069029 )
and what was suggested in openscad issue #279.

This only makes the window decoration and all text pretty. The 3d view
is still pixel-doubled: OpenGL is a pixel-based API and needs an
explicit opt-in. This can be addressed in a future patch.

While here, also consistently use tabs instead of spaces.
