### PR TITLE
Added missing include stdint.h to work with gcc 4.8.1

### DIFF
--- a/src/dxfdim.cc
+++ b/src/dxfdim.cc
@@ -36,6 +36,8 @@
 #include "mathc99.h"
 #include <sstream>
 
+#include <stdint.h>
+
 #include <boost/filesystem.hpp>
 boost::unordered_map<std::string,Value> dxf_dim_cache;
 boost::unordered_map<std::string,Value> dxf_cross_cache;


### PR DESCRIPTION
Without this include, this was not possible to build with gcc 4.8.1:

Build log (without this commit): http://kojipkgs.fedoraproject.org//work/tasks/1370/5521370/build.log
