### PR TITLE
In this commit i'll change just the Qt project, c and header files to ge...

### DIFF
--- a/bison.pri
+++ b/bison.pri
@@ -3,7 +3,7 @@
   bison.input = BISONSOURCES
   bison.output = ${QMAKE_FILE_PATH}/${QMAKE_FILE_BASE}_yacc.cpp
   bison.commands = bison -d -p ${QMAKE_FILE_BASE} -o ${QMAKE_FILE_PATH}/${QMAKE_FILE_BASE}_yacc.cpp ${QMAKE_FILE_IN}
-  bison.commands += && if [ -e ${QMAKE_FILE_PATH}/${QMAKE_FILE_BASE}_yacc.hpp ]; then mv ${QMAKE_FILE_PATH}/${QMAKE_FILE_BASE}_yacc.hpp ${QMAKE_FILE_PATH}/${QMAKE_FILE_BASE}_yacc.h ; fi
+#  bison.commands += && if [[ -e ${QMAKE_FILE_PATH}/${QMAKE_FILE_BASE}_yacc.hpp ]] ; then mv ${QMAKE_FILE_PATH}/${QMAKE_FILE_BASE}_yacc.hpp ${QMAKE_FILE_PATH}/${QMAKE_FILE_BASE}_yacc.h ; fi
   bison.CONFIG += target_predeps
   bison.variable_out = GENERATED_SOURCES
   silent:bison.commands = @echo Bison ${QMAKE_FILE_IN} && $$bison.commands
@@ -11,7 +11,7 @@
   bison_header.input = BISONSOURCES
   bison_header.output = ${QMAKE_FILE_PATH}/${QMAKE_FILE_BASE}_yacc.h
   bison_header.commands = bison -d -p ${QMAKE_FILE_BASE} -o ${QMAKE_FILE_PATH}/${QMAKE_FILE_BASE}_yacc.cpp ${QMAKE_FILE_IN}
-  bison_header.commands += && if [ -e ${QMAKE_FILE_PATH}/${QMAKE_FILE_BASE}_yacc.hpp ]; then mv ${QMAKE_FILE_PATH}/${QMAKE_FILE_BASE}_yacc.hpp ${QMAKE_FILE_PATH}/${QMAKE_FILE_BASE}_yacc.h ; fi
+#  bison_header.commands += && if [ -e ${QMAKE_FILE_PATH}/${QMAKE_FILE_BASE}_yacc.hpp ]; then mv ${QMAKE_FILE_PATH}/${QMAKE_FILE_BASE}_yacc.hpp ${QMAKE_FILE_PATH}/${QMAKE_FILE_BASE}_yacc.h ; fi
   bison_header.CONFIG += target_predeps no_link
   silent:bison_header.commands = @echo Bison ${QMAKE_FILE_IN} && $$bison.commands
   QMAKE_EXTRA_COMPILERS += bison_header
@@ -39,4 +39,7 @@ netbsd* {
   } else { # look in $PATH
     QMAKE_YACC = bison
   }
+}
+
+win32*msvc* {
 }

--- a/cgal.pri
+++ b/cgal.pri
@@ -19,7 +19,7 @@ cgal {
       *-g++* { 
         QMAKE_CXXFLAGS += -frounding-math 
       }
-      LIBS += $$CGAL_DIR/auxiliary/gmp/lib/libmpfr-4.lib -lCGAL-vc90-mt-s
+      LIBS += $$CGAL_DIR/auxiliary/gmp/lib/libmpfr-4.lib -lCGAL-vc110-mt-gd
     } else {
       LIBS += -lgmp -lmpfr -lCGAL
       QMAKE_CXXFLAGS += -frounding-math 

--- a/src/GLView.cc
+++ b/src/GLView.cc
@@ -2,6 +2,7 @@
 
 #include "stdio.h"
 #include "rendersettings.h"
+#include "mathc99.h"
 
 #ifdef _WIN32
 #include <GL/wglew.h>

--- a/src/OpenCSGRenderer.cc
+++ b/src/OpenCSGRenderer.cc
@@ -77,8 +77,8 @@ void OpenCSGRenderer::renderCSGChain(CSGChain *chain, GLint *shaderinfo,
 	std::vector<OpenCSG::Primitive*> primitives;
 	size_t j = 0;
 	for (size_t i = 0;; i++) {
-		const CSGChainObject &i_obj = chain->objects[i];
 		bool last = i == chain->objects.size();
+		const CSGChainObject &i_obj = last ? chain->objects[i-1] : chain->objects[i];
 		if (last || i_obj.type == CSGTerm::TYPE_UNION) {
 			if (j+1 != i) {
 				 OpenCSG::render(primitives);

--- a/src/control.cc
+++ b/src/control.cc
@@ -31,6 +31,7 @@
 #include "builtin.h"
 #include "printutils.h"
 #include <sstream>
+#include "mathc99.h"
 
 enum control_type_e {
 	CHILD,

--- a/src/import.cc
+++ b/src/import.cc
@@ -212,7 +212,9 @@ PolySet *ImportNode::evaluate_polyset(class PolySetEvaluator *) const
 #ifdef BOOST_BIG_ENDIAN
 			uint32_byte_swap( facenum );
 #endif
-			if (file_size == 80 + 4 + 50*facenum) binary = true;
+			if (file_size ==  static_cast<std::streamoff>(80 + 4 + 50*facenum)) {
+				binary = true;
+			}
 		}
 		f.seekg(0);
 

--- a/src/lexer.l
+++ b/src/lexer.l
@@ -30,7 +30,7 @@
 #include "handle_dep.h"
 #include "printutils.h"
 #include "parsersettings.h"
-#include "parser_yacc.h"
+#include "parser_yacc.hpp"
 #include "module.h"
 #include <assert.h>
 #include <boost/foreach.hpp>

--- a/src/mathc99.cc
+++ b/src/mathc99.cc
@@ -3,8 +3,12 @@
 #ifdef WIN32
 #include <algorithm>
 
+double trunc(double a) {
+	return (a >= 0) ? floor(a) : ceil(a);
+}
+
 double round(double a) {
-	return a > 0 ? floor(a+0.5) : ceil(a-0.5);
+	return a < 0 ? ceil(a - 0.5f) : floor(a + 0.5f);
 }
 
 float fmin(float a, float b) {

--- a/src/mathc99.h
+++ b/src/mathc99.h
@@ -5,6 +5,7 @@
 
 #include <cmath>
 //for native win32 builds we need to provide C99 math functions by ourselves
+double trunc(double a);
 double round(double a);
 float fmin(float a, float b);
 float fmax(float a, float b);

--- a/win.pri
+++ b/win.pri
@@ -5,7 +5,8 @@ win32*msvc* {
   INCLUDEPATH += $$(MPIRDIR)
   INCLUDEPATH += $$(MPFRDIR)
 
-  DEFINES += _USE_MATH_DEFINES NOMINMAX _CRT_SECURE_NO_WARNINGS YY_NO_UNISTD_H
+  # don't know where the __WIN32__ is usually set
+  DEFINES += _USE_MATH_DEFINES NOMINMAX _CRT_SECURE_NO_WARNINGS YY_NO_UNISTD_H __WIN32__
 
   # disable MSVC warnings that are of very low importance
   # disable warning about too long decorated names
@@ -16,5 +17,9 @@ win32*msvc* {
   QMAKE_CXXFLAGS += -wd4100
   # lexer uses strdup() & other POSIX stuff
   QMAKE_CXXFLAGS += -D_CRT_NONSTDC_NO_DEPRECATE
+  # Treat WChar_t as a builtin type, allows Qt to call boost funcions
+  QMAKE_CXXFLAGS += /Zc:wchar_t
+  # increases the number of sections in .obj file
+  QMAKE_CXXFLAGS += /bigobj
 
 }


### PR DESCRIPTION
...t OpenSCAD

building and working on Windows 7 compiled with Visual Studio Express 2012.

A couple of things needed changing :
- MSVC 2012 has no trunc or round, i have added those to mathc99 and included mathc99 to the files needed.
  The implementations were taken from boost.
- MSVC 2012 stl does now allow accessing out of bounds elements in std:vector as an array, so "chain->objects[i]" will
  fail in "OpenCSGRenderer::renderCSGChain". Whatever the platform, it will be a good idea to change this
  code to something that does not trigger undefined behavior.
- MSVC 2012 cannot figure out the types involved in "if (file_size ==  80 + 4 + 50_facenum) {", i have added
  a cast to force it to "if (file_size ==  static_caststd::streamoff(80 + 4 + 50_facenum)) {".

The next round would be regression testing and debugging and possibly more changes to the OpenSCAD main code.

The round after that would be changing the .pro and .pri files to create correct visual studio solutions.
