### PR TITLE
Introduce '_current_module' and '_parent_module' variables

### DIFF
--- a/src/cgaladv.cc
+++ b/src/cgaladv.cc
@@ -39,10 +39,10 @@ class CgaladvModule : public AbstractModule
 public:
 	cgaladv_type_e type;
 	CgaladvModule(cgaladv_type_e type) : type(type) { }
-	virtual AbstractNode *instantiate(const Context *ctx, const ModuleInstantiation *inst, const EvalContext *evalctx) const;
+	virtual AbstractNode *instantiate(const Context *ctx, const ModuleInstantiation *inst, const EvalContext *evalctx, const ModuleInstantiation *parent_inst = NULL) const;
 };
 
-AbstractNode *CgaladvModule::instantiate(const Context *ctx, const ModuleInstantiation *inst, const EvalContext *evalctx) const
+AbstractNode *CgaladvModule::instantiate(const Context *ctx, const ModuleInstantiation *inst, const EvalContext *evalctx, const ModuleInstantiation *parent_inst) const
 {
 	CgaladvNode *node = new CgaladvNode(inst, type);
 

--- a/src/color.cc
+++ b/src/color.cc
@@ -40,14 +40,14 @@ class ColorModule : public AbstractModule
 {
 public:
 	ColorModule() { }
-	virtual AbstractNode *instantiate(const Context *ctx, const ModuleInstantiation *inst, const EvalContext *evalctx) const;
+	virtual AbstractNode *instantiate(const Context *ctx, const ModuleInstantiation *inst, const EvalContext *evalctx, const ModuleInstantiation *parent_inst = NULL) const;
 
 private:
 	static boost::unordered_map<std::string, Color4f> colormap;
 };
 
 #include "colormap.h"
-AbstractNode *ColorModule::instantiate(const Context *ctx, const ModuleInstantiation *inst, const EvalContext *evalctx) const
+AbstractNode *ColorModule::instantiate(const Context *ctx, const ModuleInstantiation *inst, const EvalContext *evalctx, const ModuleInstantiation *parent_inst) const
 {
 	ColorNode *node = new ColorNode(inst);
 

--- a/src/context.cc
+++ b/src/context.cc
@@ -124,9 +124,9 @@ Value Context::evaluate_function(const std::string &name, const EvalContext *eva
 	return Value();
 }
 
-AbstractNode *Context::instantiate_module(const ModuleInstantiation &inst, const EvalContext *evalctx) const
+AbstractNode *Context::instantiate_module(const ModuleInstantiation &inst, const EvalContext *evalctx, const ModuleInstantiation *parent_inst) const
 {
-	if (this->parent) return this->parent->instantiate_module(inst, evalctx);
+	if (this->parent) return this->parent->instantiate_module(inst, evalctx, parent_inst);
 	PRINTB("WARNING: Ignoring unknown module '%s'.", inst.name());
 	return NULL;
 }

--- a/src/context.h
+++ b/src/context.h
@@ -14,7 +14,7 @@ public:
 	virtual ~Context();
 
 	virtual Value evaluate_function(const std::string &name, const class EvalContext *evalctx) const;
-	virtual class AbstractNode *instantiate_module(const class ModuleInstantiation &inst, const EvalContext *evalctx) const;
+	virtual class AbstractNode *instantiate_module(const class ModuleInstantiation &inst, const EvalContext *evalctx, const class ModuleInstantiation *parent_inst = NULL) const;
 
 	void setVariables(const AssignmentList &args,
 										const class EvalContext *evalctx = NULL);

--- a/src/control.cc
+++ b/src/control.cc
@@ -46,7 +46,7 @@ class ControlModule : public AbstractModule
 public:
 	control_type_e type;
 	ControlModule(control_type_e type) : type(type) { }
-	virtual AbstractNode *instantiate(const Context *ctx, const ModuleInstantiation *inst, const EvalContext *evalctx) const;
+	virtual AbstractNode *instantiate(const Context *ctx, const ModuleInstantiation *inst, const EvalContext *evalctx, const ModuleInstantiation *parent_inst = NULL) const;
 };
 
 void for_eval(AbstractNode &node, const ModuleInstantiation &inst, size_t l, 
@@ -86,7 +86,7 @@ void for_eval(AbstractNode &node, const ModuleInstantiation &inst, size_t l,
 	}
 }
 
-AbstractNode *ControlModule::instantiate(const Context *ctx, const ModuleInstantiation *inst, const EvalContext *evalctx) const
+AbstractNode *ControlModule::instantiate(const Context *ctx, const ModuleInstantiation *inst, const EvalContext *evalctx, const ModuleInstantiation *parent_inst) const
 {
 	AbstractNode *node = NULL;
 

--- a/src/csgops.cc
+++ b/src/csgops.cc
@@ -38,10 +38,10 @@ class CsgModule : public AbstractModule
 public:
 	csg_type_e type;
 	CsgModule(csg_type_e type) : type(type) { }
-	virtual AbstractNode *instantiate(const Context *ctx, const ModuleInstantiation *inst, const EvalContext *evalctx) const;
+	virtual AbstractNode *instantiate(const Context *ctx, const ModuleInstantiation *inst, const EvalContext *evalctx, const ModuleInstantiation *parent_inst = NULL) const;
 };
 
-AbstractNode *CsgModule::instantiate(const Context*, const ModuleInstantiation *inst, const EvalContext *evalctx) const
+AbstractNode *CsgModule::instantiate(const Context*, const ModuleInstantiation *inst, const EvalContext *evalctx, const ModuleInstantiation *parent_inst) const
 {
 	CsgNode *node = new CsgNode(inst, type);
 	std::vector<AbstractNode *> instantiatednodes = inst->instantiateChildren(evalctx);

--- a/src/import.cc
+++ b/src/import.cc
@@ -61,10 +61,10 @@ class ImportModule : public AbstractModule
 public:
 	import_type_e type;
 	ImportModule(import_type_e type = TYPE_UNKNOWN) : type(type) { }
-	virtual AbstractNode *instantiate(const Context *ctx, const ModuleInstantiation *inst, const EvalContext *evalctx) const;
+	virtual AbstractNode *instantiate(const Context *ctx, const ModuleInstantiation *inst, const EvalContext *evalctx, const ModuleInstantiation *parent_inst = NULL) const;
 };
 
-AbstractNode *ImportModule::instantiate(const Context *ctx, const ModuleInstantiation *inst, const EvalContext *evalctx) const
+AbstractNode *ImportModule::instantiate(const Context *ctx, const ModuleInstantiation *inst, const EvalContext *evalctx, const ModuleInstantiation *parent_inst) const
 {
 	AssignmentList args;
 	args += Assignment("file", NULL), Assignment("layer", NULL), Assignment("convexity", NULL), Assignment("origin", NULL), Assignment("scale", NULL);

--- a/src/linearextrude.cc
+++ b/src/linearextrude.cc
@@ -46,10 +46,10 @@ class LinearExtrudeModule : public AbstractModule
 {
 public:
 	LinearExtrudeModule() { }
-	virtual AbstractNode *instantiate(const Context *ctx, const ModuleInstantiation *inst, const EvalContext *evalctx) const;
+	virtual AbstractNode *instantiate(const Context *ctx, const ModuleInstantiation *inst, const EvalContext *evalctx, const ModuleInstantiation *parent_inst = NULL) const;
 };
 
-AbstractNode *LinearExtrudeModule::instantiate(const Context *ctx, const ModuleInstantiation *inst, const EvalContext *evalctx) const
+AbstractNode *LinearExtrudeModule::instantiate(const Context *ctx, const ModuleInstantiation *inst, const EvalContext *evalctx, const ModuleInstantiation *parent_inst) const
 {
 	LinearExtrudeNode *node = new LinearExtrudeNode(inst);
 

--- a/src/localscope.cc
+++ b/src/localscope.cc
@@ -44,7 +44,7 @@ std::string LocalScope::dump(const std::string &indent) const
 }
 
 // FIXME: Two parameters here is a hack. Rather have separate types of scopes, or check the type of the first parameter. Note const vs. non-const
-std::vector<AbstractNode*> LocalScope::instantiateChildren(const Context *evalctx, FileContext *filectx) const
+std::vector<AbstractNode*> LocalScope::instantiateChildren(const Context *evalctx, FileContext *filectx, const ModuleInstantiation *parent_inst) const
 {
 	Context *c = filectx;
 
@@ -64,7 +64,7 @@ std::vector<AbstractNode*> LocalScope::instantiateChildren(const Context *evalct
 
 	std::vector<AbstractNode*> childnodes;
 	BOOST_FOREACH (ModuleInstantiation *modinst, this->children) {
-		AbstractNode *node = modinst->evaluate(c);
+		AbstractNode *node = modinst->evaluate(c, parent_inst);
 		if (node) childnodes.push_back(node);
 	}
 

--- a/src/localscope.h
+++ b/src/localscope.h
@@ -12,7 +12,7 @@ public:
 
 	size_t numElements() const { return assignments.size() + children.size(); }
 	std::string dump(const std::string &indent) const;
-	std::vector<class AbstractNode*> instantiateChildren(const class Context *evalctx, class FileContext *filectx = NULL) const;
+	std::vector<class AbstractNode*> instantiateChildren(const class Context *evalctx, class FileContext *filectx = NULL, const class ModuleInstantiation *parent_inst = NULL) const;
 	void addChild(ModuleInstantiation *ch);
 
 	AssignmentList assignments;

--- a/src/modcontext.cc
+++ b/src/modcontext.cc
@@ -121,12 +121,12 @@ Value ModuleContext::evaluate_function(const std::string &name, const EvalContex
 	return Context::evaluate_function(name, evalctx);
 }
 
-AbstractNode *ModuleContext::instantiate_module(const ModuleInstantiation &inst, const EvalContext *evalctx) const
+AbstractNode *ModuleContext::instantiate_module(const ModuleInstantiation &inst, const EvalContext *evalctx, const ModuleInstantiation *parent_inst) const
 {
 	const AbstractModule *foundm = this->findLocalModule(inst.name());
-	if (foundm) return foundm->instantiate(this, &inst, evalctx);
+	if (foundm) return foundm->instantiate(this, &inst, evalctx, parent_inst);
 
-	return Context::instantiate_module(inst, evalctx);
+	return Context::instantiate_module(inst, evalctx, parent_inst);
 }
 
 #ifdef DEBUG
@@ -191,10 +191,10 @@ Value FileContext::evaluate_function(const std::string &name, const EvalContext 
 	return ModuleContext::evaluate_function(name, evalctx);
 }
 
-AbstractNode *FileContext::instantiate_module(const ModuleInstantiation &inst, const EvalContext *evalctx) const
+AbstractNode *FileContext::instantiate_module(const ModuleInstantiation &inst, const EvalContext *evalctx, const ModuleInstantiation *parent_inst) const
 {
 	const AbstractModule *foundm = this->findLocalModule(inst.name());
-	if (foundm) return foundm->instantiate(this, &inst, evalctx);
+	if (foundm) return foundm->instantiate(this, &inst, evalctx, parent_inst);
 
 	BOOST_FOREACH(const FileModule::ModuleContainer::value_type &m, this->usedlibs) {
 		FileModule *usedmod = ModuleCache::instance()->lookup(m);

--- a/src/modcontext.h
+++ b/src/modcontext.h
@@ -22,7 +22,8 @@ public:
 	virtual Value evaluate_function(const std::string &name, 
 																	const EvalContext *evalctx) const;
 	virtual AbstractNode *instantiate_module(const ModuleInstantiation &inst, 
-																					 const EvalContext *evalctx) const;
+																					 const EvalContext *evalctx,
+																					 const ModuleInstantiation *parent_inst = NULL) const;
 
 	const AbstractModule *findLocalModule(const std::string &name) const;
 	const AbstractFunction *findLocalFunction(const std::string &name) const;
@@ -48,7 +49,8 @@ public:
 	virtual ~FileContext() {}
 	virtual Value evaluate_function(const std::string &name, const EvalContext *evalctx) const;
 	virtual AbstractNode *instantiate_module(const ModuleInstantiation &inst, 
-																					 const EvalContext *evalctx) const;
+																					 const EvalContext *evalctx,
+																					 const ModuleInstantiation *parent_inst = NULL) const;
 
 private:
 	const FileModule::ModuleContainer &usedlibs;

--- a/src/module.h
+++ b/src/module.h
@@ -21,7 +21,7 @@ public:
 	virtual ~ModuleInstantiation();
 
 	virtual std::string dump(const std::string &indent) const;
-	class AbstractNode *evaluate(const class Context *ctx) const;
+	class AbstractNode *evaluate(const class Context *ctx, const class ModuleInstantiation* parent_inst = NULL) const;
 	std::vector<AbstractNode*> instantiateChildren(const Context *evalctx) const;
 
 	void setPath(const std::string &path) { this->modpath = path; }
@@ -61,7 +61,7 @@ class AbstractModule
 {
 public:
 	virtual ~AbstractModule();
-	virtual class AbstractNode *instantiate(const Context *ctx, const ModuleInstantiation *inst, const class EvalContext *evalctx = NULL) const;
+	virtual class AbstractNode *instantiate(const Context *ctx, const ModuleInstantiation *inst, const class EvalContext *evalctx = NULL, const class ModuleInstantiation *parent_inst = NULL) const;
 	virtual std::string dump(const std::string &indent, const std::string &name) const;
 };
 
@@ -71,7 +71,7 @@ public:
 	Module() { }
 	virtual ~Module();
 
-	virtual AbstractNode *instantiate(const Context *ctx, const ModuleInstantiation *inst, const EvalContext *evalctx = NULL) const;
+	virtual AbstractNode *instantiate(const Context *ctx, const ModuleInstantiation *inst, const EvalContext *evalctx = NULL, const class ModuleInstantiation* parent_inst = NULL) const;
 	virtual std::string dump(const std::string &indent, const std::string &name) const;
 
 	AssignmentList definition_arguments;
@@ -92,7 +92,7 @@ public:
 	void registerInclude(const std::string &localpath, const std::string &fullpath);
 	bool includesChanged() const;
 	bool handleDependencies();
-	virtual AbstractNode *instantiate(const Context *ctx, const ModuleInstantiation *inst, const EvalContext *evalctx = NULL) const;
+	virtual AbstractNode *instantiate(const Context *ctx, const ModuleInstantiation *inst, const EvalContext *evalctx = NULL, const ModuleInstantiation *parent_inst = NULL) const;
 	bool hasIncludes() const { return !this->includes.empty(); }
 	bool usesLibraries() const { return !this->usedlibs.empty(); }
 	bool isHandlingDependencies() const { return this->is_handling_dependencies; }

--- a/src/primitives.cc
+++ b/src/primitives.cc
@@ -56,7 +56,7 @@ class PrimitiveModule : public AbstractModule
 public:
 	primitive_type_e type;
 	PrimitiveModule(primitive_type_e type) : type(type) { }
-	virtual AbstractNode *instantiate(const Context *ctx, const ModuleInstantiation *inst, const EvalContext *evalctx) const;
+	virtual AbstractNode *instantiate(const Context *ctx, const ModuleInstantiation *inst, const EvalContext *evalctx, const ModuleInstantiation *parent_inst = NULL) const;
 };
 
 class PrimitiveNode : public AbstractPolyNode
@@ -105,7 +105,7 @@ public:
 	virtual PolySet *evaluate_polyset(class PolySetEvaluator *) const;
 };
 
-AbstractNode *PrimitiveModule::instantiate(const Context *ctx, const ModuleInstantiation *inst, const EvalContext *evalctx) const
+AbstractNode *PrimitiveModule::instantiate(const Context *ctx, const ModuleInstantiation *inst, const EvalContext *evalctx, const ModuleInstantiation *parent_inst) const
 {
 	PrimitiveNode *node = new PrimitiveNode(inst, this->type);
 

--- a/src/projection.cc
+++ b/src/projection.cc
@@ -41,10 +41,10 @@ class ProjectionModule : public AbstractModule
 {
 public:
 	ProjectionModule() { }
-	virtual AbstractNode *instantiate(const Context *ctx, const ModuleInstantiation *inst, const EvalContext *evalctx) const;
+	virtual AbstractNode *instantiate(const Context *ctx, const ModuleInstantiation *inst, const EvalContext *evalctx, const ModuleInstantiation *parent_inst = NULL) const;
 };
 
-AbstractNode *ProjectionModule::instantiate(const Context *ctx, const ModuleInstantiation *inst, const EvalContext *evalctx) const
+AbstractNode *ProjectionModule::instantiate(const Context *ctx, const ModuleInstantiation *inst, const EvalContext *evalctx, const ModuleInstantiation *parent_inst) const
 {
 	ProjectionNode *node = new ProjectionNode(inst);
 

--- a/src/render.cc
+++ b/src/render.cc
@@ -38,10 +38,10 @@ class RenderModule : public AbstractModule
 {
 public:
 	RenderModule() { }
-	virtual AbstractNode *instantiate(const Context *ctx, const ModuleInstantiation *inst, const EvalContext *evalctx) const;
+	virtual AbstractNode *instantiate(const Context *ctx, const ModuleInstantiation *inst, const EvalContext *evalctx, const ModuleInstantiation *parent_inst = NULL) const;
 };
 
-AbstractNode *RenderModule::instantiate(const Context *ctx, const ModuleInstantiation *inst, const EvalContext *evalctx) const
+AbstractNode *RenderModule::instantiate(const Context *ctx, const ModuleInstantiation *inst, const EvalContext *evalctx, const ModuleInstantiation *parent_inst) const
 {
 	RenderNode *node = new RenderNode(inst);
 

--- a/src/rotateextrude.cc
+++ b/src/rotateextrude.cc
@@ -45,10 +45,10 @@ class RotateExtrudeModule : public AbstractModule
 {
 public:
 	RotateExtrudeModule() { }
-	virtual AbstractNode *instantiate(const Context *ctx, const ModuleInstantiation *inst, const EvalContext *evalctx) const;
+	virtual AbstractNode *instantiate(const Context *ctx, const ModuleInstantiation *inst, const EvalContext *evalctx, const ModuleInstantiation *parent_inst = NULL) const;
 };
 
-AbstractNode *RotateExtrudeModule::instantiate(const Context *ctx, const ModuleInstantiation *inst, const EvalContext *evalctx) const
+AbstractNode *RotateExtrudeModule::instantiate(const Context *ctx, const ModuleInstantiation *inst, const EvalContext *evalctx, const ModuleInstantiation *parent_inst) const
 {
 	RotateExtrudeNode *node = new RotateExtrudeNode(inst);
 

--- a/src/surface.cc
+++ b/src/surface.cc
@@ -51,7 +51,7 @@ class SurfaceModule : public AbstractModule
 {
 public:
 	SurfaceModule() { }
-	virtual AbstractNode *instantiate(const Context *ctx, const ModuleInstantiation *inst, const EvalContext *evalctx) const;
+	virtual AbstractNode *instantiate(const Context *ctx, const ModuleInstantiation *inst, const EvalContext *evalctx, const ModuleInstantiation *parent_inst = NULL) const;
 };
 
 class SurfaceNode : public AbstractPolyNode
@@ -70,7 +70,7 @@ public:
 	virtual PolySet *evaluate_polyset(class PolySetEvaluator *) const;
 };
 
-AbstractNode *SurfaceModule::instantiate(const Context *ctx, const ModuleInstantiation *inst, const EvalContext *evalctx) const
+AbstractNode *SurfaceModule::instantiate(const Context *ctx, const ModuleInstantiation *inst, const EvalContext *evalctx, const ModuleInstantiation *parent_inst) const
 {
 	SurfaceNode *node = new SurfaceNode(inst);
 	node->center = false;

--- a/src/transform.cc
+++ b/src/transform.cc
@@ -50,10 +50,10 @@ class TransformModule : public AbstractModule
 public:
 	transform_type_e type;
 	TransformModule(transform_type_e type) : type(type) { }
-	virtual AbstractNode *instantiate(const Context *ctx, const ModuleInstantiation *inst, const EvalContext *evalctx) const;
+	virtual AbstractNode *instantiate(const Context *ctx, const ModuleInstantiation *inst, const EvalContext *evalctx, const ModuleInstantiation *parent_inst = NULL) const;
 };
 
-AbstractNode *TransformModule::instantiate(const Context *ctx, const ModuleInstantiation *inst, const EvalContext *evalctx) const
+AbstractNode *TransformModule::instantiate(const Context *ctx, const ModuleInstantiation *inst, const EvalContext *evalctx, const ModuleInstantiation *parent_inst) const
 {
 	TransformNode *node = new TransformNode(inst);
 


### PR DESCRIPTION
Add two built-in variables that provide access to the names
of the current and the previously instantiated modules.

Having these variables simplifies generation of BOMs and assembly
graphs (e.g. with GraphViz).

For example:

```
module foo() {
  echo(str("foo:", _parent_module, ":", _current_module));
  bar();
  echo(str("foo:", "still in", " ", _current_module));
  baz();
  echo(str("foo:", "finishing", " ", _current_module));
}

module bar() { echo(str("bar:", _parent_module, ":", _current_module));  baz(); }

module baz() { echo(str("baz:", _parent_module, ":", _current_module)); }

translate ([0,0,0]) foo();
```

gives

```
ECHO: "foo:undef:foo"
ECHO: "bar:foo:bar"
ECHO: "baz:bar:baz"
ECHO: "foo:still in foo"
ECHO: "baz:foo:baz"
ECHO: "foo:finishing foo"
```

With a single warning about undefined '_parent_module' variable in the top-level foo() module.
