### PR TITLE
Introduce '_current_module' and '_parent_module' variables

### DIFF
--- a/src/module.cc
+++ b/src/module.cc
@@ -153,6 +153,8 @@ std::vector<AbstractNode*> IfElseModuleInstantiation::instantiateElseChildren(co
 	return this->else_scope.instantiateChildren(evalctx);
 }
 
+std::string Module::parent_module;
+
 Module::~Module()
 {
 }
@@ -181,15 +183,21 @@ AbstractNode *Module::instantiate(const Context *ctx, const ModuleInstantiation 
 
 	ModuleContext c(ctx, evalctx);
 	c.initializeModule(*this);
+	c.set_variable("_current_module", inst->name());
+	if (!parent_module.empty())
+		c.set_variable("_parent_module", parent_module);
 	c.set_variable("$children", Value(double(inst->scope.children.size())));
 	// FIXME: Set document path to the path of the module
 #if 0 && DEBUG
 	c.dump(this, inst);
 #endif
 
+	std::string pm = parent_module;
+	parent_module = inst->name();
 	AbstractNode *node = new AbstractNode(inst);
 	std::vector<AbstractNode *> instantiatednodes = this->scope.instantiateChildren(&c);
 	node->children.insert(node->children.end(), instantiatednodes.begin(), instantiatednodes.end());
+	parent_module = pm;
 
 	return node;
 }

--- a/src/module.h
+++ b/src/module.h
@@ -77,6 +77,8 @@ public:
 	AssignmentList definition_arguments;
 
 	LocalScope scope;
+private:
+	static std::string parent_module;
 };
 
 // FIXME: A FileModule doesn't have definition arguments, so we shouldn't really


### PR DESCRIPTION
Add two built-in variables that provide access to the names
of the current and the previously instantiated modules.

Having these variables simplifies generation of BOMs and assembly
graphs (e.g. with GraphViz).

[staic member + CPU stack]

Alternate approach to #457
