### PR TITLE
Introduce '_current_module' and '_parent_module' variables

### DIFF
--- a/src/func.cc
+++ b/src/func.cc
@@ -528,6 +528,29 @@ Value builtin_version_num(const Context *ctx, const EvalContext *evalctx)
 	return Value(y * 10000 + m * 100 + d);
 }
 
+Value builtin_parent_module(const Context *, const EvalContext *evalctx)
+{
+	int n;
+	double d;
+	int s = Module::stack_size();
+	if (evalctx->numArgs() == 0)
+		d=1; // parent module
+	else if (evalctx->numArgs() == 1 && evalctx->getArgValue(0).type() == Value::NUMBER)
+		evalctx->getArgValue(0).getDouble(d);
+	else
+			return Value();
+	n=trunc(d);
+	if (n < 0) {
+		PRINTB("WARNING: Negative parent module index (%d) not allowed", n);
+		return Value();
+	}
+	if (n >= s) {
+		PRINTB("WARNING: Parent module index (%d) greater than the number of modules on the stack", n);
+		return Value();
+	}
+	return Value(Module::stack_element(s - 1 - n));
+}
+
 void register_builtin_functions()
 {
 	Builtins::init("abs", new BuiltinFunction(&builtin_abs));
@@ -556,4 +579,5 @@ void register_builtin_functions()
 	Builtins::init("search", new BuiltinFunction(&builtin_search));
 	Builtins::init("version", new BuiltinFunction(&builtin_version));
 	Builtins::init("version_num", new BuiltinFunction(&builtin_version_num));
+	Builtins::init("parent_module", new BuiltinFunction(&builtin_parent_module));
 }

--- a/src/module.h
+++ b/src/module.h
@@ -4,7 +4,7 @@
 #include <string>
 #include <vector>
 #include <list>
-#include <stack>
+#include <deque>
 #include <boost/unordered_map.hpp>
 #include <boost/unordered_set.hpp>
 #include <time.h>
@@ -74,12 +74,15 @@ public:
 
 	virtual AbstractNode *instantiate(const Context *ctx, const ModuleInstantiation *inst, const EvalContext *evalctx = NULL) const;
 	virtual std::string dump(const std::string &indent, const std::string &name) const;
+	static const std::string& stack_element(int n) { return module_stack[n]; };
+	static int stack_size() { return module_stack.size(); };
 
 	AssignmentList definition_arguments;
 
 	LocalScope scope;
+
 private:
-	static std::stack<std::string> stack;
+	static std::deque<std::string> module_stack;
 };
 
 // FIXME: A FileModule doesn't have definition arguments, so we shouldn't really


### PR DESCRIPTION
Add two built-in variables that provide access to the names
of the current and the previously instantiated modules.

Having these variables simplifies generation of BOMs and assembly
graphs (e.g. with GraphViz).

[std::stack]

Alternate approach to #457. More (maybe?) by the book than #459 as it allocates separate structure for the stack instead of (ab)using the CPU stack. This might be beneficial if there is to be a need to inspect the module stack.
