### PR TITLE
Look for boost libraries installed on the Mac by port, brew, or fink.

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,8 +119,9 @@ Prerequisites:
 Then after you've cloned this git repository, run the script that sets up the
 environment variables.
 
-    source setenv_mjau.sh
+    source setenv_mac-gcc.sh
 
+(or setenv_mac-clang.sh if you want to use the clang compiler instead of gcc).
 Then run the script to compile all the prerequisite libraries above:
 
     ./scripts/macosx-build-dependencies.sh

--- a/setenv_mac-clang.sh
+++ b/setenv_mac-clang.sh
@@ -9,3 +9,17 @@ export PATH=$OPENSCAD_LIBRARIES/bin:$PATH
 # ccache:
 export PATH=/opt/local/libexec/ccache:$PATH
 export CCACHE_BASEDIR=$PWD/..
+
+# Find the BOOSTDIR if it was installed by port, fink or brew
+if [ -z $BOOSTDIR ]
+then
+    boostlib=`find {/opt/local,/sw,/usr/local}/lib -name libboost\* 2> /dev/null | head -1`
+    if [ -z $boostlib ]
+    then
+        echo 'WARNING: cannot find boost libraries in any of the normal places.'
+        echo '$BOOSTDIR may need to be set manually.'
+    else
+        boostlibdir=`dirname $boostlib`
+        export BOOSTDIR=`dirname $boostlibdir`
+    fi
+fi

--- a/setenv_mac-gcc.sh
+++ b/setenv_mac-gcc.sh
@@ -9,3 +9,18 @@ export PATH=$OPENSCAD_LIBRARIES/bin:$PATH
 # ccache:
 export PATH=/opt/local/libexec/ccache:$PATH
 export CCACHE_BASEDIR=$PWD/..
+
+
+# Find the BOOSTDIR if it was installed by port, fink or brew
+if [ -z $BOOSTDIR ]
+then
+    boostlib=`find {/opt/local,/sw,/usr/local}/lib -name libboost\* 2> /dev/null | head -1`
+    if [ -z $boostlib ]
+    then
+        echo 'WARNING: cannot find boost libraries in any of the normal places.'
+        echo '$BOOSTDIR may need to be set manually.'
+    else
+        boostlibdir=`dirname $boostlib`
+        export BOOSTDIR=`dirname $boostlibdir`
+    fi
+fi


### PR DESCRIPTION
As mentioned in #435, build fails on the Mac unless BOOSTDIR is set to the correct directory.

I have modified the setenv_mac*.sh scripts to set the environment variable based on what libraries it finds.  (i.e. Fix 2 of the problem report).  I have only tested it on my system which had Boost (multi-threaded) installed by macports.

tests/FindBoost.cmake might benefit form having /opt/local added to the list of of search paths.  however, that is not a complete solution because it doesn't allow boost.pri to make a distinction between single- and multi-threaded versions of the library.  I don't know enough about the various make systems in use to find a good solution.

I also modified the README.md to refer to the correct setenv*.sh names.
