### PR TITLE
Mac Build update build to 2013-09 versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,8 +119,9 @@ Prerequisites:
 Then after you've cloned this git repository, run the script that sets up the
 environment variables.
 
-    source setenv_mjau.sh
+    source setenv_mac-gcc.sh
 
+(or setenv_mac-clang.sh if you want to use the clang compiler instead of gcc).
 Then run the script to compile all the prerequisite libraries above:
 
     ./scripts/macosx-build-dependencies.sh

--- a/scripts/macosx-build-dependencies.sh
+++ b/scripts/macosx-build-dependencies.sh
@@ -51,7 +51,7 @@ build_qt()
   cd $BASEDIR/src
   rm -rf qt-everywhere-opensource-src-$version
   if [ ! -f qt-everywhere-opensource-src-$version.tar.gz ]; then
-    curl -O http://releases.qt-project.org/qt4/source/qt-everywhere-opensource-src-$version.tar.gz
+     curl -O -L http://download.qt-project.org/official_releases/qt/4.8/4.8.5/qt-everywhere-opensource-src-4.8.5.tar.gz
   fi
   tar xzf qt-everywhere-opensource-src-$version.tar.gz
   cd qt-everywhere-opensource-src-$version
@@ -435,7 +435,7 @@ fi
 
 echo "Using basedir:" $BASEDIR
 mkdir -p $SRCDIR $DEPLOYDIR
-build_qt 4.8.4
+build_qt 4.8.5
 # NB! For eigen, also update the path in the function
 build_eigen 3.1.3
 build_gmp 5.1.2

--- a/tests/FindBoost.cmake
+++ b/tests/FindBoost.cmake
@@ -887,6 +887,8 @@ else(_boost_IN_CACHE)
     "$ENV{ProgramFiles}/boost/lib"
     "$ENV{ProgramFiles}/boost"
     /sw/local/lib
+    /opt/local/lib
+    /usr/local/lib
   )
   set(_boost_LIBRARY_SEARCH_DIRS ${_boost_LIBRARY_SEARCH_DIRS_ALWAYS})
   if( Boost_NO_SYSTEM_PATHS )


### PR DESCRIPTION
Openscad did not build cleanly on the Mac (issue #435) because of link rot in the script to build dependencies.  When dependencies were installed with MacPorts, it failed when the Boost libraries were installed with the multi-thread variant.

This pull request fixes the first problem so that the build can generate the libraries it needs without using the Ports/Fink/Brew versions.  It also cleans up an error in documentation.  

Although it is not tested, it lets FindBoost.cmake search for MacPorts and Brew installs (it already searched for the Fink install.)

Commit message:
Bring macosx-build-dependencies.sh up to date, following the qt4 version bump from 4.8.4 to 4.8.5 and change in host for download.

Replacement for pull request #465

README.md
   reflect change in setenv_mac*.sh files
macosx-build-dependencies.sh
    qt4 version updated to 4.8.5 and is now at a different host which uses 302 redirection
FindBoost.cmake
    Added paths for MacPorts (/opt/local) and Brew (/usr/local) to previous Fink (/sw/local)
