### PR TITLE
Make keyboard events working for GQLView

### DIFF
--- a/src/QGLView.cc
+++ b/src/QGLView.cc
@@ -167,15 +167,20 @@ void QGLView::paintGL()
 
 void QGLView::keyPressEvent(QKeyEvent *event)
 {
-  if (event->key() == Qt::Key_Plus) {
+  switch (event->key()) {
+  case Qt::Key_Plus:  // On many keyboards, this requires to press Shift-equals
+  case Qt::Key_Equal: // ...so simplify this a bit.
     cam.viewer_distance *= 0.9;
     updateGL();
-    return;
-  }
-  if (event->key() == Qt::Key_Minus) {
+    break;
+  case Qt::Key_Minus:
     cam.viewer_distance /= 0.9;
     updateGL();
-    return;
+    break;
+  case Qt::Key_C:     // 'center'
+    cam.object_trans << 0, 0, 0;
+    updateGL();
+    break;
   }
 }
 
@@ -187,6 +192,7 @@ void QGLView::wheelEvent(QWheelEvent *event)
 
 void QGLView::mousePressEvent(QMouseEvent *event)
 {
+  setFocus();
   mouse_drag_active = true;
   last_mouse = event->globalPos();
 }


### PR DESCRIPTION
Hi,
When working on my Notebook, I don't have a scroll-wheel mouse, so I was missing keyboard interactions to zoom.

Looking at the code I found, that + and - should actually work but didn't in practice, because the view never got the focus. So I changed that the focus is acquired when someone clicks into the view.

On my keyboard (as on a typical American keyboard), the - and + key are next to each other, but the '+' requires to press shift - the 'non-shifted' character is just an '=' sign. So to zoom in, this change allows to react on both, + and = sign for zooming (as is done in many other graphical applications).

Finally, while at it, I added a 'c(enter)' keypress; often it is simple to get lost in panning, so with 'c', things are nicely re-aligned in the middle.

Thoughts for follow-up keyboard addition: maybe have cursor-keys for simple yaw and pitch operation (essentially rotating through the horizontal or vertical axis as seen on the screen)

thanks for the awesome OpenScad ... I just got a 3D printer for testing, and for me as a programmer, I felt right at home in the language.

-h
