### PR TITLE
Dependency searching and results display should be more robust

### DIFF
--- a/scripts/check-dependencies.sh
+++ b/scripts/check-dependencies.sh
@@ -548,7 +548,7 @@ main()
     dep_minver=$find_min_version_result
     compare_version $dep_minver $dep_sysver
     dep_compare=$compare_version_result
-    pretty_print $depname $dep_minver $dep_sysver $dep_compare
+    pretty_print $depname "$dep_minver" "$dep_sysver" $dep_compare
   done
   check_old_local
   check_misc


### PR DESCRIPTION
I happened to have a "README.md" in ../README.md when I run "scripts/check_dependency.sh", and the script only searched the first file found. Refactored to continue searching until a result is found.

Pretty_print's arguments weren't protected with double quotes, so an empty variable was NOT passed as an empty string, as it should've been.
