### PR TITLE
Fix #536 - Failed to open file OPENSCAD_DIRECTORY:

### DIFF
--- a/src/openscad.cc
+++ b/src/openscad.cc
@@ -532,7 +532,16 @@ int gui(vector<string> &inputFiles, const fs::path &original_path, int argc, cha
 	}
 	app.connect(&app, SIGNAL(lastWindowClosed()), &app, SLOT(quit()));
 #else
-	MainWindow *m = new MainWindow(assemblePath(original_path, inputFiles[0]));
+	//If a file is provided (there is a push_back just above that
+	//creates an empty file if no param is provided)
+	//then we assemble a path.
+	//Else we send an empty file down (that is ignored in the code)
+	QString testedFileName = assemblePath(original_path, inputFiles[0]);
+	if( (inputFiles.size() == 1) && inputFiles[0].empty() )
+	{
+		testedFileName = "";
+	}
+	MainWindow *m = new MainWindow( testedFileName );
 	app.connect(m, SIGNAL(destroyed()), &app, SLOT(quit()));
 #endif
 	return app.exec();
@@ -561,7 +570,6 @@ int main(int argc, char **argv)
 
 	fs::path original_path = fs::current_path();
 
-	const char *filename = NULL;
 	const char *output_file = NULL;
 	const char *deps_output_file = NULL;
 


### PR DESCRIPTION
...file to open is a directory

The issue appears to be that an empty entry is put into inputFiles when
no others are provided.

```
if (!inputFiles.size()) inputFiles.push_back("");
```

and then that empty entry is used in an assembled path with a path

```
MainWindow *m = new MainWindow(assemblePath(original_path,
```

inputFiles[0]));

which makes it appears like a real file, which it is not.

This fix for #536 is:
Testing if the input file 0 is empty and if empty using the empty string
-- else if not empty assembling as before.

Also removed a dead variable called filename.
