### PR TITLE
Fix compilation error on Ubuntu where uint32_t is not defined.

### DIFF
--- a/src/value.h
+++ b/src/value.h
@@ -11,6 +11,7 @@
 #include <boost/variant.hpp>
 #include <boost/lexical_cast.hpp>
 #endif
+#include <boost/cstdint.hpp>
 
 class QuotedString : public std::string
 {
@@ -84,7 +85,7 @@ public:
     iterator begin() { return iterator(*this, RANGE_TYPE_BEGIN); }
     iterator end() { return iterator(*this, RANGE_TYPE_END); }
 
-    /// return number of steps, max uint32_ value if step is 0
+    /// return number of steps, max uint32_t value if step is 0
     uint32_t nbsteps() const;
     
     friend class tostring_visitor;


### PR DESCRIPTION
Ubuntu does not seem to import uint32_t by default. This is using the boost header to fix that. Unfortunately #include <cstdint> is not yet available as this would require -std=c++11.
