### PR TITLE
Keep cursor position on save

### DIFF
--- a/src/editor.cc
+++ b/src/editor.cc
@@ -108,3 +108,17 @@ void Editor::wheelEvent ( QWheelEvent * event )
 	}
 }
 
+void Editor::setPlainText(const QString &text)
+{
+	int y = verticalScrollBar()->sliderPosition();
+	// Save current cursor position
+	QTextCursor cursor = textCursor();
+	int n = cursor.position();
+	QTextEdit::setPlainText(text);
+	// Restore cursor position
+	if (n < text.length()) {
+		cursor.setPosition(n);
+		setTextCursor(cursor);
+		verticalScrollBar()->setSliderPosition(y);
+	}
+}

--- a/src/editor.h
+++ b/src/editor.h
@@ -2,6 +2,7 @@
 #include <QString>
 #include <QWidget>
 #include <QWheelEvent>
+#include <QScrollBar>
 
 #include <QTextEdit>
 class Editor : public QTextEdit
@@ -9,6 +10,7 @@ class Editor : public QTextEdit
 	Q_OBJECT
 public:
 	Editor(QWidget *parent) : QTextEdit(parent) { setAcceptRichText(false); }
+	void setPlainText(const QString &text);
 public slots:
 	void zoomIn();
 	void zoomOut();

--- a/src/mainwin.cc
+++ b/src/mainwin.cc
@@ -75,7 +75,6 @@
 #include <QSettings>
 #include <QProgressDialog>
 #include <QMutexLocker>
-#include <QScrollBar>
 
 #include <fstream>
 
@@ -505,6 +504,7 @@ MainWindow::openFile(const QString &new_filename)
 	}
 #endif
 	setFileName(actual_filename);
+	editor->setPlainText("");
 
 	fileChangedOnDisk(); // force cached autoReloadId to update
 	refreshDocument();
@@ -606,15 +606,7 @@ void MainWindow::refreshDocument()
 			reader.setCodec("UTF-8");
 			QString text = reader.readAll();
 			PRINTB("Loaded design '%s'.", this->fileName.toLocal8Bit().constData());
-			int y = editor->verticalScrollBar()->sliderPosition();
-			// Save current cursor position
-			QTextCursor cursor = editor->textCursor();
-			int n = cursor.position();
 			editor->setPlainText(text);
-			// Restore cursor position
-			cursor.setPosition(n);
-			editor->setTextCursor(cursor);
-			editor->verticalScrollBar()->setSliderPosition(y);
 		}
 	}
 	setCurrentOutput();


### PR DESCRIPTION
I've been using openscad a lot these days to start using my reprap 3D printer. Every time I hit "CTRL+S" for save my progress and see what changed, I was frustated by the fact that the cursos reset to the start of the file every time.

This patch aim to solve that problem. Before set the new file content via setPlainText I save the cursor position and the vertical scrollbar position and after the new text is set, I'm restoring that values to the original ones, so the cursor keeps in place and you can continue editing and the preview is updated at the same time.

When opening a new file, y set the content to an empty string, so the call on refreshDocument put the cursor at the start on the new file. Alto I'm doing boundary check to avoid putting the cursor past the last character.

I'm not used to user QT, so I hope the methos used to override the setPlainText is right, if not let me know.
