### PR TITLE
Fail if any polygon points for rotate_extrude are less than 0

### DIFF
--- a/src/PolySetCGALEvaluator.cc
+++ b/src/PolySetCGALEvaluator.cc
@@ -457,7 +457,13 @@ PolySet *PolySetCGALEvaluator::rotateDxfData(const RotateExtrudeNode &node, DxfD
 	{
 		double max_x = 0;
 		for (size_t j = 0; j < dxf.paths[i].indices.size(); j++) {
-			max_x = fmax(max_x, dxf.points[dxf.paths[i].indices[j]][0]);
+			double point_x = dxf.points[dxf.paths[i].indices[j]][0];
+			if(point_x < 0){
+				PRINT("ERROR: all points for rotate_extrude() must have non-negative X coordinates");
+				PRINT((boost::format("[Point %d on path %d has X coordinate %f]") % j % i % point_x).str());
+				return NULL;
+			}
+			max_x = fmax(max_x, point_x);
 		}
 
 		int fragments = get_fragments_from_r(max_x, node.fn, node.fs, node.fa);


### PR DESCRIPTION
A 360 degree rotate extrude with any negative points will most likely cause overlaps (except for an oddly-formed polygon), and not having negative points seems to be implied by line 458 (set max_x to be initially 0, rather than the x location of the first point). This modification makes this explicit, causing a failure if negative points are detected.

It would also be possible to include a min_x variable, and check if it equals 0 -- the documentation suggests this should always be the case [http://en.wikibooks.org/wiki/OpenSCAD_User_Manual/2D_to_3D_Extrusion#Rotate_Extrude].
