### PR TITLE
Fix for issue 525

### DIFF
--- a/tests/test_pretty_print.py
+++ b/tests/test_pretty_print.py
@@ -426,6 +426,11 @@ def main():
     if not builddir:
         builddir = os.getcwd()
     debug('build dir set to ' +  builddir)
+
+    upload = False
+    if '--upload' in sys.argv:
+        upload = True
+        debug('will upload test report')
     
     # --- End Command Line Parsing ---
 
@@ -446,12 +451,13 @@ def main():
     debug('saving ' + html_filename + ' ' + str(len(html)) + ' bytes')
     trysave(html_filename, html)
 
-    page_url = create_page()
-    if upload_html(page_url, title='OpenSCAD test results', html=html):
-        share_url = page_url.partition('?')[0]
-        print 'html report uploaded at', share_url
-    else:
-        print 'could not upload html report'
+    if upload:
+        page_url = create_page()
+        if upload_html(page_url, title='OpenSCAD test results', html=html):
+            share_url = page_url.partition('?')[0]
+            print 'html report uploaded at', share_url
+        else:
+            print 'could not upload html report'
 
     debug('test_pretty_print complete')
 


### PR DESCRIPTION
This is a fix for https://github.com/openscad/openscad/issues/525. It removes all of the wiki code, instead uploading test results to a a site where single HTML pages can be shared. (Currently http://www.dinkypage.com/, but I'll change it if someone has a good suggestion.)
It prints the URL for this page near the end of its output, so the test results should be accessible from Travis CI.

Example page (with completely made-up results): http://www.dinkypage.com/446606/

I have not tested this with actual test results, but it closely follows the previous version, so it should work. I don't have a non-commandline Unix machine to test on, so someone else should probably test it.
