### PR TITLE
Change invalid Programming category to Development

### DIFF
--- a/icons/openscad.desktop
+++ b/icons/openscad.desktop
@@ -4,4 +4,4 @@ Version=1.0
 Name=OpenSCAD
 Icon=openscad
 Exec=openscad %f
-Categories=Graphics;3DGraphics;Engineering;Programming;
+Categories=Graphics;3DGraphics;Engineering;Development;


### PR DESCRIPTION
Programming is not a valid category of .desktop file, it is not listed in either [Main Categories](http://standards.freedesktop.org/menu-spec/latest/apa.html) or [Additional Categories](http://standards.freedesktop.org/menu-spec/latest/apas02.html).

desktop-file-validate returns error:

```
openscad.desktop: error: value "Graphics;3DGraphics;Engineering;Programming;" for key "Categories" in group "Desktop Entry" contains an unregistered value "Programming"; values extending the format should start with "X-"
```

This changes it to Development, witch is a valid category listed in Additional Categories. Now desktop-file-validate only gives us a hint:

```
openscad.desktop: hint: value "Graphics;3DGraphics;Engineering;Development;" for key "Categories" in group "Desktop Entry" contains more than one main category; application might appear more than once in the application menu.
```

That is fine, as we want it both in Graphics and Development.

This is a valid response to #533
