### PR TITLE
Fix mingw build (fixes #581).

### DIFF
--- a/glib-2.0.pri
+++ b/glib-2.0.pri
@@ -30,6 +30,7 @@ isEmpty(GLIB2_LIBPATH) {
   GLIB2_LIBS = $$system("pkg-config --libs glib-2.0")
 } else {
   GLIB2_LIBS = -L$$GLIB2_LIBPATH -lglib-2.0
+  win*: GLIB2_LIBS += -lintl -liconv
 }
 
 QMAKE_CXXFLAGS += $$GLIB2_CFLAGS


### PR DESCRIPTION
Add libintl and libiconv to the library list for the MinGW / MXE build.
Build tested on 64-bit linux for mingw32, resulting Installer works on Win7.
