### PR TITLE
Fix travis status link

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-![Travis CI](https://api.travis-ci.org/openscad/openscad.png)
+[![Travis CI](https://api.travis-ci.org/openscad/openscad.png)](https://travis-ci.org/openscad/openscad)
 
 # What is OpenSCAD?
 [![Flattr this git repo](http://api.flattr.com/button/flattr-badge-large.png)](https://flattr.com/submit/auto?user_id=openscad&url=http://openscad.org&title=OpenSCAD&language=&tags=github&category=software)


### PR DESCRIPTION
Clicking the travis-ci badge should go to the openscad build page instead of opening up the status png.
