### PR TITLE
Remove automatic validity check at end of render

### DIFF
--- a/src/MainWindow.h
+++ b/src/MainWindow.h
@@ -137,6 +137,7 @@ private slots:
 	void actionRenderDone(shared_ptr<const class Geometry>);
 	void cgalRender();
 #endif
+	void actionCheckValidity();
 	void actionDisplayAST();
 	void actionDisplayCSGTree();
 	void actionDisplayCSGProducts();

--- a/src/MainWindow.ui
+++ b/src/MainWindow.ui
@@ -316,6 +316,7 @@
     <addaction name="designActionPreview"/>
     <addaction name="designActionRender"/>
     <addaction name="separator"/>
+	<addaction name="designCheckValidity"/>
     <addaction name="designActionDisplayAST"/>
     <addaction name="designActionDisplayCSGTree"/>
     <addaction name="designActionDisplayCSGProducts"/>
@@ -556,6 +557,11 @@
    <property name="shortcut">
     <string>F6</string>
    </property>
+  </action>
+  <action name="designCheckValidity">
+    <property name="text">
+      <string>Check Validity</string>
+    </property>
   </action>
   <action name="designActionDisplayAST">
    <property name="text">


### PR DESCRIPTION
In more complex cases, the final Nef_Polyhedron is_valid check() took up to 30 % of the total rendering time just to be able to say Valid: YES. In the case of cached geometry, the validity check was totally dominating the execution time when doing a render. This patch removes the automatic validity check, instead adding a menu command "Check Validity".

This is just a suggestion – please merge or discard. :-)
