### PR TITLE
Compile as C++11

### DIFF
--- a/openscad.pro
+++ b/openscad.pro
@@ -67,7 +67,7 @@ deploy {
   }
 }
 
-MAKE_CXXFLAGS += -std=c++0x
+QMAKE_CXXFLAGS += -std=c++0x
 
 macx {
   TARGET = OpenSCAD


### PR DESCRIPTION
C++11 enables features that significantly simplify C++ development. Allow OpenSCAD code to use these features.
