### PR TITLE
Improve command line help

### DIFF
--- a/cgal.pri
+++ b/cgal.pri
@@ -11,6 +11,8 @@ cgal {
     message("CGAL location: $$CGAL_DIR")
   }
 
+  QMAKE_CXXFLAGS += -std=c++11
+
   CONFIG(mingw-cross-env) {
     LIBS += -lgmp -lmpfr -lCGAL
     QMAKE_CXXFLAGS += -frounding-math 

--- a/src/openscad.cc
+++ b/src/openscad.cc
@@ -99,25 +99,14 @@ public:
 	}
 };
 
-static void help(const char *progname)
+static void help(const char *progname, vector<po::options_description> options)
 {
-  int tablen = strlen(progname)+8;
-  char tabstr[tablen+1];
-  for (int i=0;i<tablen;i++) tabstr[i] = ' ';
-  tabstr[tablen] = '\0';
-
-	PRINTB("Usage: %1% [ -o output_file [ -d deps_file ] ]\\\n"
-         "%2%[ -m make_command ] [ -D var=val [..] ] \\\n"
-         "%2%[ --version ] [ --info ] \\\n"
-         "%2%[ --camera=translatex,y,z,rotx,y,z,dist | \\\n"
-         "%2%  --camera=eyex,y,z,centerx,y,z ] \\\n"
-         "%2%[ --imgsize=width,height ] [ --projection=(o)rtho|(p)ersp] \\\n"
-         "%2%[ --render | --preview[=throwntogether] ] \\\n"
-         "%2%[ --csglimit=num ] \\\n"
-         "%2%[ --enable=<feature> ] \\\n"
-         "%2%filename\n",
- 				 progname % (const char *)tabstr);
-	exit(1);
+  std::ostringstream ss;
+  ss << "Usage: " << progname << " [options] [action]\n";
+  for (auto &opt : options)
+    ss << "\n" << opt ;
+  PRINT(ss.str());
+  exit(1);
 }
 
 #define STRINGIFY(x) #x
@@ -579,45 +568,57 @@ int main(int argc, char **argv)
 	const char *output_file = NULL;
 	const char *deps_output_file = NULL;
 
-	po::options_description desc("Allowed options");
-	desc.add_options()
-		("help,h", "help message")
-		("version,v", "print the version")
-		("info", "print information about the building process")
-		("render", "if exporting a png image, do a full CGAL render")
-		("preview", po::value<string>(), "if exporting a png image, do an OpenCSG(default) or ThrownTogether preview")
-		("csglimit", po::value<unsigned int>(), "if exporting a png image, stop rendering at the given number of CSG elements")
-		("camera", po::value<string>(), "parameters for camera when exporting png")
-	        ("imgsize", po::value<string>(), "=width,height for exporting png")
-		("projection", po::value<string>(), "(o)rtho or (p)erspective when exporting png")
-		("o,o", po::value<string>(), "out-file")
-		("s,s", po::value<string>(), "stl-file")
-		("x,x", po::value<string>(), "dxf-file")
-		("d,d", po::value<string>(), "deps-file")
-		("m,m", po::value<string>(), "makefile")
-		("D,D", po::value<vector<string> >(), "var=val")
-		("enable", po::value<vector<string> >(), "enable experimental features");
+	po::options_description opt_actions("Actions (pick one, or none to start the gui)");
+	opt_actions.add_options()
+	  ("o,o", po::value<string>(), "output file; file extensions determines action:\n"
+	                               "  .stl .off .dxf .csg - export geometry\n"
+	                               "  .png - render image\n"
+	                               "  .ast - export abstract syntax tree"
+	                               // TODO ".term"
+                                       // TODO ".echo"
+	   )
+	  ("help,h", "print this help message")
+	  ("info", "print information about the building process")
+	  ("version,v", "print the version");
 
-	po::options_description hidden("Hidden options");
-	hidden.add_options()
-		("input-file", po::value< vector<string> >(), "input file");
+	po::options_description opt_options("Options");
+	opt_options.add_options()
+	  ("render", "if exporting a png image, do a full CGAL render")
+	  ("preview", po::value<string>(), "if exporting a png image, do an OpenCSG(default) or ThrownTogether preview")
+	  ("csglimit", po::value<unsigned int>(), "if exporting a png image, stop rendering at the given number of CSG elements")
+	  ("camera", po::value<string>(), "parameters for camera when exporting png; one of:\ntranslatex,y,z,rotx,y,z,dist\neyex,y,z,centerx,y,z")
+	  ("imgsize", po::value<string>(), "width,height for exporting png")
+	  ("projection", po::value<string>(), "(o)rtho or (p)erspective when exporting png")
+	  ("m,m", po::value<string>(), "make command")
+	  ("d,d", po::value<string>(), "filename to write the dependencies to (in conjunction with -m)")
+	  ("D,D", po::value<vector<string> >(), "var=val to override variables")
+	  ("enable", po::value<vector<string> >(), "enable experimental features; can be used several times to enable more than one feature");
 
-	po::positional_options_description p;
-	p.add("input-file", -1);
+	po::options_description opt_hidden("Hidden options");
+	opt_hidden.add_options()
+	  ("input-file", po::value< vector<string> >(), "input file")
+	  ("s,s", po::value<string>(), "stl-file")
+	  ("x,x", po::value<string>(), "dxf-file");
+
+	po::positional_options_description opt_positional;
+	opt_positional.add("input-file", -1);
 
 	po::options_description all_options;
-	all_options.add(desc).add(hidden);
+	for (auto &opt : {opt_actions, opt_options, opt_hidden})
+	  all_options.add(opt);
+
+	auto help = [&]{ ::help(argv[0], {opt_actions, opt_options}); };
 
 	po::variables_map vm;
 	try {
-		po::store(po::command_line_parser(argc, argv).options(all_options).allow_unregistered().positional(p).run(), vm);
+		po::store(po::command_line_parser(argc, argv).options(all_options).allow_unregistered().positional(opt_positional).run(), vm);
 	}
 	catch(const std::exception &e) { // Catches e.g. unknown options
 		PRINTB("%s\n", e.what());
-		help(argv[0]);
+		help();
 	}
 
-	if (vm.count("help")) help(argv[0]);
+	if (vm.count("help")) help();
 	if (vm.count("version")) version();
 	if (vm.count("info")) info();
 
@@ -634,27 +635,27 @@ int main(int argc, char **argv)
 
 	if (vm.count("o")) {
 		// FIXME: Allow for multiple output files?
-		if (output_file) help(argv[0]);
+		if (output_file) help();
 		output_file = vm["o"].as<string>().c_str();
 	}
 	if (vm.count("s")) {
 		PRINT("DEPRECATED: The -s option is deprecated. Use -o instead.\n");
-		if (output_file) help(argv[0]);
+		if (output_file) help();
 		output_file = vm["s"].as<string>().c_str();
 	}
 	if (vm.count("x")) { 
 		PRINT("DEPRECATED: The -x option is deprecated. Use -o instead.\n");
-		if (output_file) help(argv[0]);
+		if (output_file) help();
 		output_file = vm["x"].as<string>().c_str();
 	}
 	if (vm.count("d")) {
 		if (deps_output_file)
-			help(argv[0]);
+			help();
 		deps_output_file = vm["d"].as<string>().c_str();
 	}
 	if (vm.count("m")) {
 		if (make_command)
-			help(argv[0]);
+			help();
 		make_command = vm["m"].as<string>().c_str();
 	}
 
@@ -675,7 +676,7 @@ int main(int argc, char **argv)
 	}
 #ifndef ENABLE_MDI
 	if (inputFiles.size() > 1) {
-		help(argv[0]);
+		help();
 	}
 #endif
 
@@ -690,7 +691,7 @@ int main(int argc, char **argv)
 	bool cmdlinemode = false;
 	if (output_file) { // cmd-line mode
 		cmdlinemode = true;
-		if (!inputFiles.size()) help(argv[0]);
+		if (!inputFiles.size()) help();
 	}
 
 	if (cmdlinemode) {
@@ -701,7 +702,7 @@ int main(int argc, char **argv)
 	}
 	else {
 		PRINT("Requested GUI mode but can't open display!\n");
-		help(argv[0]);
+		help();
 	}
 
 	Builtins::instance(true);


### PR DESCRIPTION
Generate the cmdline() help text programmatically using boost::program_options. This way the help text is never out of sync with the command line options.

Requires C++ (pull request #657)
