### PR TITLE
Change the order of the eigen discovery

### DIFF
--- a/scripts/check-dependencies.sh
+++ b/scripts/check-dependencies.sh
@@ -38,10 +38,10 @@ eigen_sysver()
 {
   debug eigen
   eigpath=
-  eig3path=$1/include/eigen3/Eigen/src/Core/util/Macros.h
   eig2path=$1/include/eigen2/Eigen/src/Core/util/Macros.h
-  if [ -e $eig3path ]; then eigpath=$eig3path; fi
+  eig3path=$1/include/eigen3/Eigen/src/Core/util/Macros.h
   if [ -e $eig2path ]; then eigpath=$eig2path; fi
+  if [ -e $eig3path ]; then eigpath=$eig3path; fi
   debug $eig2path
   if [ ! $eigpath ]; then return; fi
   eswrld=`grep "define  *EIGEN_WORLD_VERSION  *[0-9]*" $eigpath | awk '{print $3}'`


### PR DESCRIPTION
Change the order of the eigen libraries - if you have both eigen2 and eigen3 the eigen2 libraries were overwriting eigen3 path and the dependancy check was then failing.
I kept getting eigen3 notOK messages - it turn out that the eigen2 check was overwriting the eigen3 check.
Cheers
Fred
