### PR TITLE
Switch menu order back to File, Edit, Design, View, Help (fixes #733).

### DIFF
--- a/src/MainWindow.ui
+++ b/src/MainWindow.ui
@@ -349,8 +349,8 @@
    </widget>
    <addaction name="menu_File"/>
    <addaction name="menu_Edit"/>
-   <addaction name="menu_View"/>
    <addaction name="menu_Design"/>
+   <addaction name="menu_View"/>
    <addaction name="menuHelp"/>
   </widget>
   <widget class="QStatusBar" name="statusbar"/>


### PR DESCRIPTION
Design and View were swapped somewhere in the past in the unstable branch.
