### PR TITLE
Preventing losing keyboard focus by editor.

### DIFF
--- a/src/MainWindow.h
+++ b/src/MainWindow.h
@@ -181,7 +181,7 @@ public slots:
 	void viewCenter();
 	void viewPerspective();
 	void viewOrthogonal();
-        void viewResetView();
+	void viewResetView();
 	void hideConsole();
 	void animateUpdateDocChanged();
 	void animateUpdate();
@@ -198,14 +198,14 @@ public slots:
 
 private:
 	static void report_func(const class AbstractNode*, void *vp, int mark);
-	
+
 	char const * afterCompileSlot;
 	bool procevents;
 	class QTemporaryFile *tempFile;
-
 	class ProgressWidget *progresswidget;
 	class CGALWorker *cgalworker;
 	QMutex consolemutex;
+
 signals:
 	void highlightError(int);
 	void unhighlightLastError();

--- a/src/MainWindow.ui
+++ b/src/MainWindow.ui
@@ -126,6 +126,9 @@
             <pointsize>8</pointsize>
            </font>
           </property>
+          <property name="focusPolicy">
+           <enum>Qt::WheelFocus</enum>
+          </property>
          </widget>
         </item>
        </layout>
@@ -139,6 +142,9 @@
           </property>
           <widget class="QGLView" name="qglview" native="true"/>
           <widget class="QTextEdit" name="console">
+           <property name="focusPolicy">
+            <enum>Qt::ClickFocus</enum>
+           </property>
            <property name="readOnly">
             <bool>true</bool>
            </property>
@@ -327,6 +333,9 @@
     <addaction name="viewActionBack"/>
     <addaction name="viewActionDiagonal"/>
     <addaction name="viewActionCenter"/>
+    <addaction name="separator"/>
+    <addaction name="viewActionZoomIn"/>
+    <addaction name="viewActionZoomOut"/>
     <addaction name="separator"/>
     <addaction name="viewActionResetView"/>
     <addaction name="separator"/>
@@ -862,6 +871,22 @@
   <action name="viewActionResetView">
    <property name="text">
     <string>Reset View</string>
+   </property>
+  </action>
+  <action name="viewActionZoomIn">
+   <property name="text">
+    <string>Zoom In</string>
+   </property>
+   <property name="shortcut">
+    <string>Ctrl+]</string>
+   </property>
+  </action>
+  <action name="viewActionZoomOut">
+   <property name="text">
+    <string>Zoom Out</string>
+   </property>
+   <property name="shortcut">
+    <string>Ctrl+[</string>
    </property>
   </action>
  </widget>

--- a/src/QGLView.cc
+++ b/src/QGLView.cc
@@ -170,25 +170,6 @@ void QGLView::paintGL()
   if (running_under_wine) swapBuffers();
 }
 
-void QGLView::keyPressEvent(QKeyEvent *event)
-{
-  switch (event->key()) {
-  case Qt::Key_Plus:  // On many keyboards, this requires to press Shift-equals
-  case Qt::Key_Equal: // ...so simplify this a bit.
-    cam.viewer_distance *= 0.9;
-    updateGL();
-    break;
-  case Qt::Key_Minus:
-    cam.viewer_distance /= 0.9;
-    updateGL();
-    break;
-  case Qt::Key_C:     // 'center'
-    cam.object_trans << 0, 0, 0;
-    updateGL();
-    break;
-  }
-}
-
 void QGLView::wheelEvent(QWheelEvent *event)
 {
   cam.viewer_distance *= pow(0.9, event->delta() / 120.0);
@@ -197,7 +178,6 @@ void QGLView::wheelEvent(QWheelEvent *event)
 
 void QGLView::mousePressEvent(QMouseEvent *event)
 {
-  setFocus();
   mouse_drag_active = true;
   last_mouse = event->globalPos();
 }
@@ -298,3 +278,14 @@ bool QGLView::save(const char *filename)
   return img.save(filename, "PNG");
 }
 
+void QGLView::ZoomIn(void)
+{
+  cam.viewer_distance *= 0.9;
+  updateGL();
+}
+
+void QGLView::ZoomOut(void)
+{
+  cam.viewer_distance /= 0.9;
+  updateGL();
+}

--- a/src/QGLView.h
+++ b/src/QGLView.h
@@ -44,7 +44,11 @@ public:
 	float getDPI() { return this->devicePixelRatio(); }
 #endif
 	bool save(const char *filename);
-        void resetView();
+	void resetView();
+
+public slots:
+	void ZoomIn(void);
+	void ZoomOut(void);
 
 public:
 	QLabel *statusLabel;
@@ -55,7 +59,6 @@ private:
 	bool mouse_drag_active;
 	QPoint last_mouse;
 
-	void keyPressEvent(QKeyEvent *event);
 	void wheelEvent(QWheelEvent *event);
 	void mousePressEvent(QMouseEvent *event);
 	void mouseMoveEvent(QMouseEvent *event);


### PR DESCRIPTION
When you write your code in editor sometimes you want to rotate or move object
on 3D view, but due stealing focus by this widget it is quite tedious.
You need additional mouse click to return focus to editor and search line where
you last edited. This behavior is not neccessary as we can interpret keyboard
events globally (in MainWindow) and send commands to 3D view.

Console window need ClickFocus to show context menu.

Zoom In/Out 3D view is assigned to CTRL+[ and CTRL+]. Adding also additional
shortcut to zoom in editor font CTRL+= (with CTRL++ SHIFT is necessary).
