### PR TITLE
Fix keyboard shortcuts in automatically generated actions (fixes #408).

### DIFF
--- a/src/MainWindow.ui
+++ b/src/MainWindow.ui
@@ -419,6 +419,9 @@
    <property name="shortcut">
     <string>Ctrl+Z</string>
    </property>
+   <property name="shortcutContext">
+    <enum>Qt::WidgetWithChildrenShortcut</enum>
+   </property>
   </action>
   <action name="editActionRedo">
    <property name="text">
@@ -426,6 +429,9 @@
    </property>
    <property name="shortcut">
     <string>Ctrl+Shift+Z</string>
+   </property>
+   <property name="shortcutContext">
+    <enum>Qt::WidgetWithChildrenShortcut</enum>
    </property>
   </action>
   <action name="editActionCut">
@@ -435,6 +441,9 @@
    <property name="shortcut">
     <string>Ctrl+X</string>
    </property>
+   <property name="shortcutContext">
+    <enum>Qt::WidgetWithChildrenShortcut</enum>
+   </property>
   </action>
   <action name="editActionCopy">
    <property name="text">
@@ -443,6 +452,9 @@
    <property name="shortcut">
     <string>Ctrl+C</string>
    </property>
+   <property name="shortcutContext">
+    <enum>Qt::WidgetWithChildrenShortcut</enum>
+   </property>
   </action>
   <action name="editActionPaste">
    <property name="text">
@@ -450,6 +462,9 @@
    </property>
    <property name="shortcut">
     <string>Ctrl+V</string>
+   </property>
+   <property name="shortcutContext">
+    <enum>Qt::WidgetWithChildrenShortcut</enum>
    </property>
   </action>
   <action name="editActionIndent">


### PR DESCRIPTION
Having our own "copy" menu did cause the automatically generated action
of the QTextEditor used as console to drop the CTRL+C link. Using the
WidgetWithChildrenShortcut settings seems to fix that for Qt4 and Qt5.
