### PR TITLE
Add a let() expression

### DIFF
--- a/src/expr.cc
+++ b/src/expr.cc
@@ -170,6 +170,16 @@ Value Expression::evaluate(const Context *context) const
 		EvalContext c(context, this->call_arguments);
 		return context->evaluate_function(this->call_funcname, &c);
 	}
+	if (this->type == "l") { // let expression
+		EvalContext let_context(context, this->call_arguments);
+
+		Context c(context);
+		for (int i = 0; i < let_context.numArgs(); i++) {
+			// NOTE: iteratively evaluated list of arguments
+			c.set_variable(let_context.getArgName(i), let_context.getArgValue(i, &c));
+		}
+		return this->children[0]->evaluate(&c);
+	}
 	abort();
 }
 
@@ -228,6 +238,17 @@ std::string Expression::toString() const
 			stream << *arg.second;
 		}
 		stream << ")";
+	}
+	else if (this->type == "l") {
+		stream << "let(";
+		for (size_t i=0; i < this->call_arguments.size(); i++) {
+			const Assignment &arg = this->call_arguments[i];
+			if (i > 0) stream << ", ";
+			if (!arg.first.empty()) stream << arg.first  << " = ";
+			stream << *arg.second;
+		}
+		stream << ") ";
+		stream << *this->children[0];
 	}
 	else {
 		assert(false && "Illegal expression type");

--- a/src/highlighter.cc
+++ b/src/highlighter.cc
@@ -219,7 +219,7 @@ Highlighter::Highlighter(QTextDocument *parent)
 {
 	tokentypes["operator"] << "=" << "!" << "&&" << "||" << "+" << "-" << "*" << "/" << "%" << "!" << "#" << ";";
 	tokentypes["math"] << "abs" << "sign" << "acos" << "asin" << "atan" << "atan2" << "sin" << "cos" << "floor" << "round" << "ceil" << "ln" << "log" << "lookup" << "min" << "max" << "pow" << "sqrt" << "exp" << "rands";
-	tokentypes["keyword"] << "module" << "function" << "for" << "intersection_for" << "if" << "assign" << "echo"<< "search" << "str";
+	tokentypes["keyword"] << "module" << "function" << "for" << "intersection_for" << "if" << "assign" << "echo"<< "search" << "str" << "let";
 	tokentypes["transform"] << "scale" << "translate" << "rotate" << "multmatrix" << "color" << "projection" << "hull" << "resize" << "mirror" << "minkowski";
 	tokentypes["csgop"]	<< "union" << "intersection" << "difference" << "render";
 	tokentypes["prim3d"] << "cube" << "cylinder" << "sphere" << "polyhedron";

--- a/src/lexer.l
+++ b/src/lexer.l
@@ -142,6 +142,7 @@ use[ \t\r\n>]*"<"	{ BEGIN(cond_use); }
 "function"	return TOK_FUNCTION;
 "if"		return TOK_IF;
 "else"		return TOK_ELSE;
+"let"		return TOK_LET;
 
 "true"		return TOK_TRUE;
 "false"		return TOK_FALSE;

--- a/src/parser.y
+++ b/src/parser.y
@@ -84,6 +84,7 @@ std::string parser_source_path;
 %token TOK_FUNCTION
 %token TOK_IF
 %token TOK_ELSE
+%token TOK_LET
 
 %token <text> TOK_ID
 %token <text> TOK_STRING
@@ -95,6 +96,8 @@ std::string parser_source_path;
 %token TOK_UNDEF
 
 %token LE GE EQ NE AND OR
+
+%right LET
 
 %right '?' ':'
 
@@ -323,6 +326,14 @@ expr:
         | TOK_NUMBER
             {
                 $$ = new Expression(Value($1));
+            }
+        | TOK_LET '(' arguments_call ')' expr %prec LET
+            {
+                $$ = new Expression();
+                $$->type = "l";
+                $$->call_arguments = *$3;
+                delete $3;
+                $$->children.push_back($5);
             }
         | '[' expr ':' expr ']'
             {


### PR DESCRIPTION
This pull request adds a let()-expression according to [a recent](http://forum.openscad.org/Variable-assignment-expression-tt7670.html) mailing-list thread.

The proposed syntax is: `let (assignments,...) expression`. A summary of design choices (open for discussion):
- The assignments are evaluated sequentially rather than in parallel as for normal function argument evaluation. For this reason, the name `let()` is chosen instead of `assign()`.
- Variables can be reassigned (same name assigned values multiple times). This is consistent with the equivalence:
  
  ```
  let(variable1 = value1, 
      variable2 = value2,
      variable3 = value3,
      ...
  ) expr;
  ```
  
  being equivalent to
  
  ```
  let(variable1 = value1)
      let(variable2 = value2)
          let(variable3 = value3)
              let(...)
                  expr;
  ```
- The syntax was chosen in preference of other alternatives such as c-style comma expression: `var1=val1, var2=val2, ..., expr`, for being clearer, and e.g. curly-braces imperative style syntax `{var1=val1; var2=val2; ...; return expr; }` for being more in line with the everything-is-an-expression context which functions represent in OpenSCAD.
- The syntax is also consistent with the list comprehension syntax proposed in issue #775.
