### PR TITLE
Avoid leaving the first empty document window open when opening a file in MDI mode

### DIFF
--- a/src/mainwin.cc
+++ b/src/mainwin.cc
@@ -518,6 +518,18 @@ void MainWindow::report_func(const class AbstractNode*, void *vp, int mark)
 #ifdef ENABLE_MDI
 void MainWindow::requestOpenFile(const QString &filename)
 {
+	// if we have an empty open window, use that one
+	QSetIterator<MainWindow *> i(*MainWindow::windows);
+	while (i.hasNext()) {
+		MainWindow *w = i.next();
+
+		if (w->editor->toPlainText().isEmpty()) {
+			w->openFile(filename);
+			return;
+		}
+	}
+
+	// otherwise, create a new one
 	new MainWindow(filename);
 }
 #else
@@ -962,7 +974,7 @@ void MainWindow::actionOpen()
 	}
 #ifdef ENABLE_MDI
 	if (!new_filename.isEmpty()) {
-		new MainWindow(new_filename);
+		openFile(new_filename);
 	}
 #else
 	if (!new_filename.isEmpty()) {
@@ -981,7 +993,7 @@ void MainWindow::actionOpenRecent()
 	QAction *action = qobject_cast<QAction *>(sender());
 
 #ifdef ENABLE_MDI
-	new MainWindow(action->data().toString());
+	openFile(action->data().toString());
 #else
 	if (!maybeSave())
 		return;


### PR DESCRIPTION
More in line with the customary behavior on Mac (the only platform that defaults to MDI mode).
