### PR TITLE
Mac: Give document windows proper proxy icons

### DIFF
--- a/src/MainWindow.ui
+++ b/src/MainWindow.ui
@@ -10,9 +10,6 @@
     <height>647</height>
    </rect>
   </property>
-  <property name="windowTitle">
-   <string>MainWindow</string>
-  </property>
   <widget class="QWidget" name="centralwidget">
    <layout class="QVBoxLayout" name="verticalLayout_2">
     <property name="margin">

--- a/src/mainwin.cc
+++ b/src/mainwin.cc
@@ -559,19 +559,31 @@ MainWindow::setFileName(const QString &filename)
 	if (filename.isEmpty()) {
 		this->fileName.clear();
 		this->top_ctx.setDocumentPath(currentdir);
+#if QT_VERSION >= QT_VERSION_CHECK(4, 4, 0)
+		setWindowTitle("");
+		setWindowFilePath("untitled.scad");
+#else
 		setWindowTitle("OpenSCAD - New Document[*]");
+#endif
 	}
 	else {
 		QFileInfo fileinfo(filename);
-		setWindowTitle("OpenSCAD - " + fileinfo.fileName() + "[*]");
 
 		// Check that the canonical file path exists - only update recent files
 		// if it does. Should prevent empty list items on initial open etc.
 		QString infoFileName = fileinfo.absoluteFilePath();
+
 		if (!infoFileName.isEmpty()) {
 			this->fileName = infoFileName;
+#if QT_VERSION >= QT_VERSION_CHECK(4, 4, 0)
+			setWindowTitle("");
+			this->setWindowFilePath(infoFileName);
+#else
+			setWindowTitle("OpenSCAD - " + fileinfo.fileName() + "[*]");
+#endif
 		} else {
 			this->fileName = fileinfo.fileName();
+			setWindowTitle("OpenSCAD - " + fileinfo.fileName() + "[*]");
 		}
 
 		this->top_ctx.setDocumentPath(fileinfo.dir().absolutePath().toLocal8Bit().constData());


### PR DESCRIPTION
Should also affect window titles slightly on Windows according to [the Qt documentation](http://doc.qt.digia.com/qt-maemo/qwidget.html#windowFilePath-prop).
