### PR TITLE
Render current selection or current line

### DIFF
--- a/src/MainWindow.ui
+++ b/src/MainWindow.ui
@@ -204,6 +204,7 @@
     <addaction name="designActionReloadAndPreview"/>
     <addaction name="designActionPreview"/>
     <addaction name="designActionRender"/>
+    <addaction name="designActionRenderSelection"/>
     <addaction name="separator"/>
     <addaction name="designCheckValidity"/>
     <addaction name="designActionDisplayAST"/>
@@ -599,6 +600,14 @@
    </property>
    <property name="shortcut">
     <string>F6</string>
+   </property>
+  </action>
+  <action name="designActionRenderSelection">
+   <property name="text">
+    <string>Render &amp;Selection</string>
+   </property>
+   <property name="shortcut">
+    <string>F7</string>
    </property>
   </action>
   <action name="designCheckValidity">


### PR DESCRIPTION
New menu action Design > Render &Selection (F7) so that you can more
easily see what your separate blocks do. Currently you need to comment
all and uncomment the lines you want. If nothing is selected, the current line is rendered - this can be also be proposed functionality for the comment / uncomment / indent actions.
