### PR TITLE
Bugfix: Cmd-S on an unmodified document inserted an 's'

### DIFF
--- a/src/mainwin.cc
+++ b/src/mainwin.cc
@@ -397,7 +397,6 @@ MainWindow::MainWindow(const QString &filename)
 
 	connect(editor->document(), SIGNAL(contentsChanged()), this, SLOT(animateUpdateDocChanged()));
 	connect(editor->document(), SIGNAL(modificationChanged(bool)), this, SLOT(setWindowModified(bool)));
-	connect(editor->document(), SIGNAL(modificationChanged(bool)), fileActionSave, SLOT(setEnabled(bool)));
 	connect(this->qglview, SIGNAL(doAnimateUpdate()), this, SLOT(animateUpdate()));
 
 	connect(Preferences::inst(), SIGNAL(requestRedraw()), this->qglview, SLOT(updateGL()));
@@ -1167,6 +1166,8 @@ void MainWindow::actionSave()
 		actionSaveAs();
 	}
 	else {
+		if (!editor->isContentModified())
+			return;
 		setCurrentOutput();
 		QFile file(this->fileName);
 		if (!file.open(QIODevice::WriteOnly | QIODevice::Truncate | QIODevice::Text)) {


### PR DESCRIPTION
I'm not sure if this is the best or correct way to fix it, but does the job and seems quite harmless.
