### PR TITLE
WIP: sweep()

### DIFF
--- a/openscad.pro
+++ b/openscad.pro
@@ -254,6 +254,8 @@ HEADERS += src/typedefs.h \
            src/offsetnode.h \
            src/linearextrudenode.h \
            src/rotateextrudenode.h \
+		   src/sweepnode.h \
+		   src/sweep.h \
            src/projectionnode.h \
            src/cgaladvnode.h \
            src/importnode.h \
@@ -345,6 +347,8 @@ SOURCES += src/version_check.cc \
            src/offset.cc \
            src/linearextrude.cc \
            src/rotateextrude.cc \
+		   src/sweepnode.cc \
+		   src/sweep.cc \
            src/printutils.cc \
            src/fileutils.cc \
            src/progress.cc \

--- a/src/GeometryEvaluator.h
+++ b/src/GeometryEvaluator.h
@@ -31,6 +31,7 @@ public:
 	virtual Response visit(State &state, const RenderNode &node);
 	virtual Response visit(State &state, const TextNode &node);
 	virtual Response visit(State &state, const OffsetNode &node);
+	virtual Response visit(State &state, const SweepNode &node);
 
 	const Tree &getTree() const { return this->tree; }
 

--- a/src/builtin.cc
+++ b/src/builtin.cc
@@ -46,6 +46,7 @@ extern void register_builtin_import();
 extern void register_builtin_projection();
 extern void register_builtin_cgaladv();
 extern void register_builtin_offset();
+extern void register_builtin_sweep();
 extern void register_builtin_dxf_linear_extrude();
 extern void register_builtin_dxf_rotate_extrude();
 extern void register_builtin_text();
@@ -73,6 +74,7 @@ void Builtins::initialize()
 	register_builtin_projection();
 	register_builtin_cgaladv();
 	register_builtin_offset();
+	register_builtin_sweep();
 	register_builtin_dxf_linear_extrude();
 	register_builtin_dxf_rotate_extrude();
 	register_builtin_text();

--- a/src/highlighter.cc
+++ b/src/highlighter.cc
@@ -226,7 +226,7 @@ Highlighter::Highlighter(QTextDocument *parent)
 	tokentypes["prim2d"] << "square" << "polygon" << "circle";
 	tokentypes["import"] << "include" << "use" << "import_stl" << "import" << "import_dxf" << "dxf_dim" << "dxf_cross" << "surface";
 	tokentypes["special"] << "$children" << "child" << "children" << "$fn" << "$fa" << "$fs" << "$t" << "$vpt" << "$vpr" << "$vpd";
-	tokentypes["extrude"] << "linear_extrude" << "rotate_extrude";
+	tokentypes["extrude"] << "linear_extrude" << "rotate_extrude" << "sweep";
 	tokentypes["bracket"] << "[" << "]" << "(" << ")";
 	tokentypes["curlies"] << "{" << "}";
 	tokentypes["bool"] << "true" << "false";

--- a/src/sweep.cc
+++ b/src/sweep.cc
@@ -1,0 +1,104 @@
+//
+//  sweep.cpp
+//
+//
+//  Created by Oskar Linde on 2014-05-17.
+//
+//
+
+#include "sweep.h"
+
+#include "Polygon2d.h"
+#include "polyset.h"
+#include "clipper-utils.h"
+
+using namespace ClipperLib;
+using namespace ClipperUtils;
+
+namespace /* anonymous */ {
+
+ClipperLib::Path transform_path_2d(Eigen::Projective3d const& transform,
+								   ClipperLib::Path const& path) {
+
+	ClipperLib::Path ret(path.size());
+
+	for (int i = 0; i < path.size(); i++) {
+		Eigen::Vector3d p(path[i].X / double(CLIPPER_SCALE),
+						  path[i].Y / double(CLIPPER_SCALE),
+						  0);
+
+		Eigen::Vector4d r1 = transform * p.homogeneous();
+		Eigen::Vector3d r = r1.hnormalized();
+		ret[i].X = round(r[0] * double(CLIPPER_SCALE));
+		ret[i].Y = round(r[1] * double(CLIPPER_SCALE));
+	}
+
+	return ret;
+}
+
+void sweep_2d_2d(Path const& path1, Path const& path2, Paths & solution) {
+	assert(path1.size() == path2.size());
+	const int n = path1.size();
+
+	Paths triangles;
+	triangles.reserve(2*n);
+
+	for (size_t i = 0; i < n; i++) {
+		Path t1,t2;
+
+		t1.reserve(3);
+		t1.push_back(path1[i]);
+		t1.push_back(path2[i]);
+		t1.push_back(path2[(i+1)%n]);
+
+		t2.reserve(3);
+		t2.push_back(path1[i]);
+		t2.push_back(path2[(i+1)%n]);
+		t2.push_back(path1[(i+1)%n]);
+
+		if (!ClipperLib::Orientation(t1)) ReversePath(t1);
+		if (!ClipperLib::Orientation(t2)) ReversePath(t2);
+
+		triangles.push_back(t1);
+		triangles.push_back(t2);
+	}
+
+	Clipper c;
+	c.AddPaths(triangles, ptSubject, true);
+	c.Execute(ctUnion, solution, pftNonZero, pftNonZero);
+}
+
+}
+
+
+Polygon2d*
+sweep2d_2d(std::vector<Eigen::Projective3d> const& path, Polygon2d const& poly) {
+	ClipperLib::Paths paths = ClipperUtils::fromPolygon2d(poly);
+
+	Clipper c;
+
+	for (int i = 1; i < path.size(); i++) {
+		ClipperLib::Paths terms;
+		terms.reserve(paths.size() * 3);
+
+		for (int j = 0; j < paths.size(); j++) {
+			ClipperLib::Path path_0 = transform_path_2d(path[i-1], paths[j]);
+			ClipperLib::Path path_1 = transform_path_2d(path[i],   paths[j]);
+
+			ClipperLib::Paths result;
+			::sweep_2d_2d(path_0, path_1, result);
+
+			terms.insert(terms.end(),result.begin(),result.end());
+			terms.push_back(path_0);
+			terms.push_back(path_1);
+		}
+
+		c.AddPaths(terms, ClipperLib::ptSubject, true);
+	}
+
+	ClipperLib::PolyTree polytree;
+
+	c.Execute(ctUnion, polytree, pftNonZero, pftNonZero);
+
+	return toPolygon2d(polytree);
+}

--- a/src/sweep.h
+++ b/src/sweep.h
@@ -1,0 +1,19 @@
+//
+//  sweep.h
+//
+//
+//  Created by Oskar Linde on 2014-05-17.
+//
+//
+
+#pragma once
+
+#include <vector>
+#include <Eigen/Geometry>
+
+
+
+class Polygon2d * sweep2d_2d(std::vector<Eigen::Projective3d> const& path,
+							 Polygon2d const& poly);
+
+

--- a/src/sweepnode.cc
+++ b/src/sweepnode.cc
@@ -1,0 +1,201 @@
+//
+//  sweepnode.cpp
+//
+//
+//  Created by Oskar Linde on 2014-05-17.
+//
+//
+
+#include "sweepnode.h"
+#include "module.h"
+#include "evalcontext.h"
+#include "printutils.h"
+#include "fileutils.h"
+#include "builtin.h"
+#include "polyset.h"
+#include "visitor.h"
+
+#include <sstream>
+#include <boost/assign/std/vector.hpp>
+using namespace boost::assign; // bring 'operator+=()' into scope
+
+#include <boost/filesystem.hpp>
+namespace fs = boost::filesystem;
+
+class SweepModule : public AbstractModule
+{
+public:
+	SweepModule() { }
+	virtual AbstractNode *instantiate(const Context *ctx, const ModuleInstantiation *inst, const EvalContext *evalctx) const;
+};
+
+double deg_to_rad(double deg) {
+	return deg / 180 * M_PI;
+}
+
+/* The interpretation of the transforms are:
+ *
+ * - a single number is interpreted as a angle for a rotation around the z-axis
+ * - a vector of two numbers is interpreted as a 2-d translation
+ * - a vector of three numbers is interpreted as a 3-d translation
+ * - a vector of vectors is interpreted as a transformation matrix. Valid sizes are:
+ *    2x3 Interpreted as a 2-d Affine transformation
+ *    3x3 Interpreted as a 2-d Projective transformation
+ *    3x4 Interpreted as a 3-d Affine transformation
+ *    4x4 Interpreted as a 3-d Projective transformation
+ */
+
+Eigen::Projective3d make_transform(Value const& v) {
+	Eigen::Projective3d ret = Eigen::Projective3d::Identity();
+
+	if (v.type() == Value::NUMBER) {
+		ret.matrix().topLeftCorner<2,2>() = Eigen::Rotation2D<double>(deg_to_rad(v.toDouble())).toRotationMatrix();
+		return ret;
+	}
+
+	if (v.type() != Value::VECTOR || v.toVector().empty()) {
+		PRINT("Invalid transformation value to sweep()");
+		return ret;
+	}
+
+	std::vector<Value> const& vec = v.toVector();
+
+	if (vec[0].type() == Value::NUMBER) {
+
+		if (vec.size() == 2) {
+			ret.matrix()(0,2) = vec[0].toDouble();
+			ret.matrix()(1,2) = vec[1].toDouble();
+		} else if (vec.size() == 3) {
+			ret.matrix()(0,2) = vec[0].toDouble();
+			ret.matrix()(1,2) = vec[1].toDouble();
+			ret.matrix()(2,2) = vec[2].toDouble();
+		} else {
+			PRINT("Invalid transformation vector to sweep()");
+			return ret;
+		}
+
+		return ret;
+	}
+
+	if (vec[0].type() == Value::VECTOR) {
+		int M = vec.size();
+		int N = vec[0].toVector().size();
+
+		if (!(M == 2 && N == 3 ||
+			  M == 3 && N == 3 ||
+			  M == 3 && N == 4 ||
+			  M == 4 && N == 4)) {
+			PRINT("Invalid transformation matrix size to sweep()");
+			return ret;
+		}
+
+		// Make sure we have a proper matrix
+		for (int i = 1; i < M; i++) {
+			if (vec[i].toVector().size() != N) {
+				PRINT("Not a valid matrix as argument to sweep()");
+				return ret;
+			}
+		}
+
+		if (N == 3) {
+			for (int i = 0; i < M; i++) {
+				int r = i == 2 ? 3 : i;
+				ret.matrix()(r,0) = vec[i].toVector()[0].toDouble();
+				ret.matrix()(r,1) = vec[i].toVector()[1].toDouble();
+				ret.matrix()(r,3) = vec[i].toVector()[2].toDouble();
+			}
+		} else if (N == 4) {
+			for (int i = 0; i < M; i++) {
+				for (int j = 0; j < N; j++) {
+					ret.matrix()(i,j) = vec[i].toVector()[j].toDouble();
+				}
+			}
+		} else assert(0);
+
+		return ret;
+	}
+
+	PRINT("Invalid argument to sweep()");
+	return ret;
+}
+
+
+AbstractNode *SweepModule::instantiate(const Context *ctx, const ModuleInstantiation *inst, const EvalContext *evalctx) const
+{
+	SweepNode *node = new SweepNode(inst);
+
+	AssignmentList args;
+	args += Assignment("path");
+
+	Context c(ctx);
+	c.setVariables(args, evalctx);
+
+	Value path_value = c.lookup_variable("path");
+
+	if (path_value.type() != Value::VECTOR || path_value.toVector().empty() ) {
+		PRINT("Error: sweep(): invalid path");
+	}
+
+	std::vector<Value> const& path = path_value.toVector();
+	node->sweep_path.resize(path.size());
+
+	int dimensionality = 2;
+
+	for (int p = 0; p < path.size(); p++) {
+		node->sweep_path[p] = make_transform(path[p]);
+
+		if (dimensionality == 2) {
+			int i = 2;
+			for (int j = 0; j < 4; j++) {
+				if (node->sweep_path[p](i,j) != (i==j?1:0)) {
+					dimensionality = 3;
+				}
+			}
+		}
+	}
+
+	node->dimensions = dimensionality;
+
+	node->convexity = c.lookup_variable("convexity", true).toDouble();
+
+	if (node->convexity <= 0)
+		node->convexity = 1;
+
+	std::vector<AbstractNode *> instantiatednodes = inst->instantiateChildren(evalctx);
+	node->children.insert(node->children.end(), instantiatednodes.begin(), instantiatednodes.end());
+
+	return node;
+}
+
+
+std::string SweepNode::toString() const
+{
+	std::stringstream stream;
+
+	stream << this->name() << "(";
+	stream <<
+	"convexity = " << this->convexity << ", "
+	"path = [";
+
+	for (int k = 0; k < this->sweep_path.size(); k++) {
+		stream << "[";
+		for (int i = 0; i < 4; i++) {
+			stream << "[";
+			for (int j = 0; j < 4; j++) {
+				stream << this->sweep_path[k].matrix()(i,j) << ",";
+			}
+			stream << "],";
+		}
+		stream << "],";
+	}
+
+	stream << "])";
+
+	return stream.str();
+}
+
+
+void register_builtin_sweep()
+{
+	Builtins::init("sweep", new SweepModule());
+}

--- a/src/sweepnode.h
+++ b/src/sweepnode.h
@@ -1,0 +1,32 @@
+//
+//  sweepnode.h
+//
+//
+//  Created by Oskar Linde on 2014-05-17.
+//
+//
+
+#pragma once
+
+#include "node.h"
+#include "visitor.h"
+#include "value.h"
+#include <Eigen/Geometry>
+
+class SweepNode : public AbstractPolyNode
+{
+public:
+	SweepNode(const ModuleInstantiation *mi) : AbstractPolyNode(mi) {
+		convexity = 0;
+		dimensions = 0;
+	}
+	virtual Response accept(class State &state, Visitor &visitor) const {
+		return visitor.visit(state, *this);
+	}
+	virtual std::string toString() const;
+	virtual std::string name() const { return "sweep"; }
+
+	int convexity;
+	int dimensions;
+	std::vector<Eigen::Projective3d> sweep_path;
+};

--- a/src/visitor.h
+++ b/src/visitor.h
@@ -57,5 +57,8 @@ public:
   virtual Response visit(class State &state, const class OffsetNode &node) {
 		return visit(state, (const class AbstractPolyNode &)node);
 	}
+  virtual Response visit(class State &state, const class SweepNode &node) {
+		return visit(state, (const class AbstractPolyNode &)node);
+    }
 	// Add visit() methods for new visitable subtypes of AbstractNode here
 };


### PR DESCRIPTION
This pull request serves to document the work in progress on sweep(). The current status is a 2d->2d sweep that seems to work well. 2d->3d sweeping that handles self-intersecting sweep volumes turned out to be a bit tricky so is still being worked on.

The 2d->2d sweep is quite useful by itself. Here is a few examples:

A properly undercut involute pion gear constructed by sweeping a rack profile:

![rack_gear](https://cloud.githubusercontent.com/assets/3725313/4020621/4d86c34e-2ac3-11e4-8ed1-b017943ea801.gif)

Here's what the scad code for the sweep operation looks like:

```
path = [
    for (t = [0:0.01:1.01]) 
        rotation(-t*360) * translation([-m*gear_teeth/2,0,0]) * translation([0,-t*m*PI*gear_teeth,0])
];

sweep(path) rack(number_of_teeth = gear_teeth+1, addendum_coefficient=1.25, dedendum_coefficient=1.0);
```

And the sweep operation isolated:

![sweep_gear](https://cloud.githubusercontent.com/assets/3725313/4020624/8d55c042-2ac3-11e4-82d6-48f3c5a8b15b.gif)
