### PR TITLE
Fix fontconfig logic

### DIFF
--- a/src/FontCache.cc
+++ b/src/FontCache.cc
@@ -110,14 +110,6 @@ FontCache::FontCache()
 
 	const char *home = getenv("HOME");
 
-#ifdef WIN32
-	// Add Window font folders.
-	const char *windir = getenv("WinDir");
-	if (windir) {
-		add_font_dir(std::string(windir) + "\\Fonts");
-	}
-#endif
-
 	// Add Linux font folders, the system folders are expected to be
 	// configured by the system configuration for fontconfig.
 	if (home) {


### PR DESCRIPTION
- Use FcMatchPattern to make alias replacement work.
- Remove code to add Windows font folder - handled by `fonts.conf`.
