### PR TITLE
Adding marker() nodes

### DIFF
--- a/openscad.pro
+++ b/openscad.pro
@@ -260,6 +260,7 @@ HEADERS += src/typedefs.h \
            src/transformnode.h \
            src/colornode.h \
            src/rendernode.h \
+           src/markernode.h \
            src/textnode.h \
            src/openscad.h \
            src/handle_dep.h \
@@ -340,6 +341,7 @@ SOURCES += src/version_check.cc \
            src/surface.cc \
            src/control.cc \
            src/render.cc \
+           src/marker.cc \
            src/text.cc \
            src/dxfdata.cc \
            src/dxfdim.cc \

--- a/src/control.cc
+++ b/src/control.cc
@@ -31,6 +31,7 @@
 #include "modcontext.h"
 #include "builtin.h"
 #include "printutils.h"
+#include "markernode.h"
 #include <sstream>
 #include "mathc99.h"
 
@@ -45,6 +46,7 @@ public: // types
 		CHILD,
 		CHILDREN,
 		ECHO,
+        MARKER,
 		ASSIGN,
 		FOR,
 		INT_FOR,
@@ -257,10 +259,12 @@ AbstractNode *ControlModule::instantiate(const Context* /*ctx*/, const ModuleIns
 	else
 		node = new AbstractNode(inst);
 
-	if (type == ECHO)
+	if (type == ECHO || type == MARKER)
 	{
 		std::stringstream msg;
-		msg << "ECHO: ";
+        if (type == ECHO) {
+    		msg << "ECHO: ";
+        }
 		for (size_t i = 0; i < inst->arguments.size(); i++) {
 			if (i > 0) msg << ", ";
 			if (!evalctx->getArgName(i).empty()) msg << evalctx->getArgName(i) << " = ";
@@ -271,7 +275,13 @@ AbstractNode *ControlModule::instantiate(const Context* /*ctx*/, const ModuleIns
 				msg << val.toString();
 			}
 		}
-		PRINTB("%s", msg.str());
+        if (type == ECHO) {
+    		PRINTB("%s", msg.str());
+        } else {
+            MarkerNode *markernode = new MarkerNode(inst);
+            markernode->value = msg.str();
+            node = markernode;
+        }
 	}
 
 	if (type == ASSIGN)
@@ -311,6 +321,7 @@ void register_builtin_control()
 	Builtins::init("child", new ControlModule(ControlModule::CHILD));
 	Builtins::init("children", new ControlModule(ControlModule::CHILDREN));
 	Builtins::init("echo", new ControlModule(ControlModule::ECHO));
+	Builtins::init("marker", new ControlModule(ControlModule::MARKER));
 	Builtins::init("assign", new ControlModule(ControlModule::ASSIGN));
 	Builtins::init("for", new ControlModule(ControlModule::FOR));
 	Builtins::init("intersection_for", new ControlModule(ControlModule::INT_FOR));

--- a/src/marker.cc
+++ b/src/marker.cc
@@ -1,0 +1,38 @@
+/*
+ *  OpenSCAD (www.openscad.org)
+ *  Copyright (C) 2009-2011 Clifford Wolf <clifford@clifford.at> and
+ *                          Marius Kintel <marius@kintel.net>
+ *
+ *  This program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  As a special exception, you have permission to link this program
+ *  with the CGAL library and distribute executables, as long as you
+ *  follow the requirements of the GNU GPL in regard to all of the
+ *  software in the executable aside from CGAL.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program; if not, write to the Free Software
+ *  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ *
+ */
+
+#include "markernode.h"
+
+#include <sstream>
+
+std::string MarkerNode::toString() const
+{
+	std::stringstream stream;
+
+	stream << this->name() << "(" << value << ")";
+
+	return stream.str();
+}

--- a/src/markernode.h
+++ b/src/markernode.h
@@ -1,0 +1,18 @@
+#pragma once
+
+#include "node.h"
+#include "visitor.h"
+#include <string>
+
+class MarkerNode : public AbstractNode
+{
+    public:
+        MarkerNode(const ModuleInstantiation *mi) : AbstractNode(mi) { }
+        virtual Response accept(class State &state, Visitor &visitor) const {
+            return visitor.visit(state, *this);
+        }
+        virtual std::string name() const { return "marker"; }
+	    virtual std::string toString() const;
+
+        std::string value;
+};


### PR DESCRIPTION
This introduces `marker()` nodes.

Markers are preserved during the CSG rendering, the contents is evaluated just like echo so you can pass it variables etc.

The advantage is that you can "mark" some parts of your code, and then access your markers in the CSG, simple to parse, to get for instance the locate coordinate system at a certain point from the origin of the part

See #937
