### PR TITLE
Modernise help library info

### DIFF
--- a/openscad.pro
+++ b/openscad.pro
@@ -213,7 +213,8 @@ FORMS += src/MainWindow.ui \
            src/OpenCSGWarningDialog.ui \
            src/AboutDialog.ui \
            src/FontListDialog.ui \
-           src/ProgressWidget.ui
+           src/ProgressWidget.ui \
+    src/LibraryInfoDialog.ui
 
 HEADERS += src/typedefs.h \
            src/version_check.h \
@@ -306,7 +307,8 @@ src/FontCache.h \
            src/CsgInfo.h \
            \
            src/AutoUpdater.h \
-           src/legacyeditor.h
+           src/legacyeditor.h \
+    src/LibraryInfoDialog.h
 
 SOURCES += src/version_check.cc \
            src/ProgressWidget.cc \
@@ -393,7 +395,8 @@ src/FontCache.cc \
            src/openscad.cc \
            src/mainwin.cc \
            src/FontListDialog.cc \
-           src/legacyeditor.cc
+           src/legacyeditor.cc \
+    src/LibraryInfoDialog.cc
 
 # ClipperLib
 SOURCES += src/polyclipping/clipper.cpp

--- a/src/LibraryInfoDialog.cc
+++ b/src/LibraryInfoDialog.cc
@@ -1,0 +1,59 @@
+
+#include "LibraryInfoDialog.h"
+
+#include <QString>
+#include <QStringRef>
+#include <QTextEdit>
+#include "LibraryInfo.h"
+
+LibraryInfoDialog::LibraryInfoDialog(const QString& rendererInfo)
+{
+    setupUi(this);
+    connect(this->okButton, SIGNAL(clicked()), this, SLOT(accept()));
+    update_library_info(rendererInfo);
+}
+
+LibraryInfoDialog::~LibraryInfoDialog()
+{
+
+}
+
+void LibraryInfoDialog::update_library_info(const QString& rendererInfo)
+{
+    //Get library infos
+    QString info(LibraryInfo::info().c_str());
+    info += rendererInfo;
+
+    //Parse infos and make it html
+    info = info.replace("\n", "<br/>");
+
+    bool end = false;
+    int startIndex = 0;
+    while(!end)
+    {
+        int endIndex = info.indexOf(":", startIndex);
+        if(endIndex != -1)
+        {
+            //add bold to property name
+            info = info.insert(startIndex, "<b>");
+            endIndex += 3;
+            info = info.replace(endIndex, 1, ":</b>");
+            startIndex = info.indexOf("<br/>", endIndex);
+
+            //handle property with multiple lines
+            int endInd = info.indexOf(":", startIndex);
+            if(endInd != -1)
+            {
+                QStringRef lines(&info, startIndex, endInd - startIndex);
+                int lastIndex = lines.lastIndexOf("<br/>");
+                startIndex = lastIndex != -1 ? lastIndex+startIndex : startIndex;
+            }
+        }
+        else
+        {
+            end = true;
+        }
+    }
+
+    this->infoTextBox->setHtml(info);
+}

--- a/src/LibraryInfoDialog.h
+++ b/src/LibraryInfoDialog.h
@@ -1,0 +1,16 @@
+#pragma once
+
+#include <QDialog>
+#include <QString>
+#include "ui_LibraryInfoDialog.h"
+
+class LibraryInfoDialog : public QDialog, public Ui::LibraryInfoDialog
+{
+    Q_OBJECT;
+
+public:
+    LibraryInfoDialog(const QString& rendererInfo);
+    virtual ~LibraryInfoDialog();
+
+    void update_library_info(const QString& rendererInfo);
+};

--- a/src/LibraryInfoDialog.ui
+++ b/src/LibraryInfoDialog.ui
@@ -1,0 +1,72 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>LibraryInfoDialog</class>
+ <widget class="QDialog" name="LibraryInfoDialog">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>587</width>
+    <height>466</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>Lib &amp; Build Info</string>
+  </property>
+  <layout class="QGridLayout" name="gridLayout">
+   <property name="sizeConstraint">
+    <enum>QLayout::SetDefaultConstraint</enum>
+   </property>
+   <property name="verticalSpacing">
+    <number>6</number>
+   </property>
+   <item row="0" column="0">
+    <widget class="QLabel" name="label">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+     <property name="minimumSize">
+      <size>
+       <width>0</width>
+       <height>20</height>
+      </size>
+     </property>
+     <property name="text">
+      <string>OpenSCAD Detailed Library and Build Information</string>
+     </property>
+    </widget>
+   </item>
+   <item row="1" column="0">
+    <widget class="QTextEdit" name="infoTextBox">
+     <property name="minimumSize">
+      <size>
+       <width>0</width>
+       <height>0</height>
+      </size>
+     </property>
+     <property name="readOnly">
+      <bool>true</bool>
+     </property>
+    </widget>
+   </item>
+   <item row="2" column="0" alignment="Qt::AlignRight">
+    <widget class="QPushButton" name="okButton">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+     <property name="text">
+      <string>&amp;OK</string>
+     </property>
+    </widget>
+   </item>
+  </layout>
+ </widget>
+ <resources/>
+ <connections/>
+</ui>

--- a/src/MainWindow.h
+++ b/src/MainWindow.h
@@ -111,7 +111,7 @@ private:
 
 	EditorInterface *editor;
 
-  class QMessageBox *openglbox;
+  class LibraryInfoDialog* library_info_dialog;
   class FontListDialog *font_list_dialog;
 
 private slots:

--- a/src/mainwin.cc
+++ b/src/mainwin.cc
@@ -45,6 +45,7 @@
 #endif
 #include "AboutDialog.h"
 #include "FontListDialog.h"
+#include "LibraryInfoDialog.h"
 #ifdef ENABLE_OPENCSG
 #include "CSGTermEvaluator.h"
 #include "OpenCSGRenderer.h"
@@ -59,7 +60,6 @@
 #include "CocoaUtils.h"
 #endif
 #include "PlatformUtils.h"
-#include "LibraryInfo.h"
 
 #include <QMenu>
 #include <QTime>
@@ -166,7 +166,7 @@ bool MainWindow::mdiMode = false;
 bool MainWindow::undockMode = false;
 
 MainWindow::MainWindow(const QString &filename)
-	: root_inst("group"), font_list_dialog(NULL), tempFile(NULL), progresswidget(NULL)
+    : root_inst("group"), library_info_dialog(NULL), font_list_dialog(NULL), tempFile(NULL), progresswidget(NULL)
 {
 	setupUi(this);
 
@@ -201,7 +201,6 @@ MainWindow::MainWindow(const QString &filename)
 
 	top_ctx.registerBuiltin();
 
-	this->openglbox = NULL;
 	root_module = NULL;
 	absolute_root_node = NULL;
 	this->root_chain = NULL;
@@ -2273,15 +2272,12 @@ MainWindow::helpManual()
 
 void MainWindow::helpLibrary()
 {
-	QString info(LibraryInfo::info().c_str());
-	info += QString(qglview->getRendererInfo().c_str());
-	if (!this->openglbox) {
-		this->openglbox = new QMessageBox(QMessageBox::Information,
-                                      "OpenGL Info", "OpenSCAD Detailed Library and Build Information",
-                                      QMessageBox::Ok, this);
-	}
-	this->openglbox->setDetailedText(info);
-	this->openglbox->show();
+    if (!this->library_info_dialog) {
+        QString rendererInfo(qglview->getRendererInfo().c_str());
+        LibraryInfoDialog *dialog = new LibraryInfoDialog(rendererInfo);
+        this->library_info_dialog = dialog;
+    }
+    this->library_info_dialog->show();
 }
 
 void MainWindow::helpFontInfo()


### PR DESCRIPTION
Hello, this is my first pull request ever so be cool..
I made the UI revamp of the old library info dialog, which should fix the issue: https://github.com/openscad/openscad/issues/919
- [x] show all the info direcly
- [x] window is larger
- [x] window is sizable
- [x] changed the title of the window to something more appropriate
- [x] improved lisibility with bold font

Before:
![libinfo_before](https://cloud.githubusercontent.com/assets/3892244/4266450/4144076e-3c7e-11e4-8f31-63a5fee5e67f.PNG)

After:
![libinfo_after](https://cloud.githubusercontent.com/assets/3892244/4266454/46a0713e-3c7e-11e4-8e90-8ef3bb3142e9.PNG)

I hope this is usefull :)
