### PR TITLE
Add option to disable window reordering by removing the dock window title bar

### DIFF
--- a/src/MainWindow.h
+++ b/src/MainWindow.h
@@ -67,6 +67,9 @@ public:
 	QAction *actionRecentFile[UIUtils::maxRecentFiles];
         QMap<QString, QString> knownFileExtensions;
 
+        QWidget *editorDockTitleWidget;
+        QWidget *consoleDockTitleWidget;
+        
 	QString editortype;	
 	bool useScintilla;
 
@@ -81,6 +84,7 @@ private slots:
 	void updateTVal();
         void updateMdiMode(bool mdi);
         void updateUndockMode(bool undockMode);
+        void updateReorderMode(bool reorderMode);
 	void setFileName(const QString &filename);
 	void setFont(const QString &family, uint size);
 	void setColorScheme(const QString &cs);
@@ -235,6 +239,7 @@ private:
 	static void report_func(const class AbstractNode*, void *vp, int mark);
 	static bool mdiMode;
 	static bool undockMode;
+	static bool reorderMode;
 	static QSet<MainWindow*> *windows;
 
 	char const * afterCompileSlot;

--- a/src/Preferences.cc
+++ b/src/Preferences.cc
@@ -103,6 +103,7 @@ Preferences::Preferences(QWidget *parent) : QMainWindow(parent)
 	this->defaultmap["advanced/forceGoldfeather"] = false;
 	this->defaultmap["advanced/mdi"] = true;
 	this->defaultmap["advanced/undockableWindows"] = false;
+	this->defaultmap["advanced/reorderWindows"] = true;
 	this->defaultmap["launcher/showOnStartup"] = true;
 
 	// Toolbar
@@ -322,6 +323,18 @@ Preferences::on_mdiCheckBox_toggled(bool state)
 }
 
 void
+Preferences::on_reorderCheckBox_toggled(bool state)
+{
+	if (!state) {
+		undockCheckBox->setChecked(false);
+	}
+	undockCheckBox->setEnabled(state);
+	QSettings settings;
+	settings.setValue("advanced/reorderWindows", state);
+	emit updateReorderMode(state);
+}
+
+void
 Preferences::on_undockCheckBox_toggled(bool state)
 {
 	QSettings settings;
@@ -467,7 +480,9 @@ void Preferences::updateGUI()
 	this->opencsgLimitEdit->setText(getValue("advanced/openCSGLimit").toString());
 	this->forceGoldfeatherBox->setChecked(getValue("advanced/forceGoldfeather").toBool());
 	this->mdiCheckBox->setChecked(getValue("advanced/mdi").toBool());
+	this->reorderCheckBox->setChecked(getValue("advanced/reorderWindows").toBool());
 	this->undockCheckBox->setChecked(getValue("advanced/undockableWindows").toBool());
+	this->undockCheckBox->setEnabled(this->reorderCheckBox->isChecked());
 	this->launcherBox->setChecked(getValue("launcher/showOnStartup").toBool());
 }
 

--- a/src/Preferences.h
+++ b/src/Preferences.h
@@ -33,6 +33,7 @@ public slots:
 	void on_updateCheckBox_toggled(bool);
 	void on_snapshotCheckBox_toggled(bool);
 	void on_mdiCheckBox_toggled(bool);
+	void on_reorderCheckBox_toggled(bool);
 	void on_undockCheckBox_toggled(bool);
 	void on_checkNowButton_clicked();
 	void on_launcherBox_toggled(bool);
@@ -41,7 +42,8 @@ public slots:
 signals:
 	void requestRedraw() const;
 	void updateMdiMode(bool mdi) const;
-	void updateUndockMode(bool mdi) const;
+	void updateUndockMode(bool undockMode) const;
+	void updateReorderMode(bool undockMode) const;
 	void fontChanged(const QString &family, uint size) const;
 	void colorSchemeChanged(const QString &scheme) const;
 	void openCSGSettingsChanged() const;

--- a/src/Preferences.ui
+++ b/src/Preferences.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>852</width>
-    <height>550</height>
+    <height>554</height>
    </rect>
   </property>
   <property name="sizePolicy">
@@ -27,7 +27,7 @@
     <item>
      <widget class="QStackedWidget" name="stackedWidget">
       <property name="currentIndex">
-       <number>3</number>
+       <number>4</number>
       </property>
       <widget class="QWidget" name="page3DView">
        <layout class="QVBoxLayout" name="verticalLayout_4">
@@ -547,8 +547,8 @@
               <rect>
                <x>0</x>
                <y>0</y>
-               <width>832</width>
-               <height>420</height>
+               <width>100</width>
+               <height>30</height>
               </rect>
              </property>
              <layout class="QVBoxLayout" name="verticalLayout_10">
@@ -686,9 +686,16 @@
          </widget>
         </item>
         <item>
+         <widget class="QCheckBox" name="reorderCheckBox">
+          <property name="text">
+           <string>Enable docking of Editor and Console in different places</string>
+          </property>
+         </widget>
+        </item>
+        <item>
          <widget class="QCheckBox" name="undockCheckBox">
           <property name="text">
-           <string>Enable undocking of Editor and Console</string>
+           <string>Enable undocking of Editor and Console to separate windows</string>
           </property>
          </widget>
         </item>

--- a/src/mainwin.cc
+++ b/src/mainwin.cc
@@ -172,11 +172,15 @@ settings_valueList(const QString &key, const QList<int> &defaultList = QList<int
 
 bool MainWindow::mdiMode = false;
 bool MainWindow::undockMode = false;
+bool MainWindow::reorderMode = false;
 
 MainWindow::MainWindow(const QString &filename)
     : root_inst("group"), library_info_dialog(NULL), font_list_dialog(NULL), tempFile(NULL), progresswidget(NULL)
 {
 	setupUi(this);
+
+	editorDockTitleWidget = new QWidget();
+        consoleDockTitleWidget = new QWidget();
 
 	this->editorDock->setConfigKey("view/hideEditor");
 	this->editorDock->setAction(this->viewActionHideEditor);
@@ -422,6 +426,7 @@ MainWindow::MainWindow(const QString &filename)
 
 	connect(Preferences::inst(), SIGNAL(requestRedraw()), this->qglview, SLOT(updateGL()));
 	connect(Preferences::inst(), SIGNAL(updateMdiMode(bool)), this, SLOT(updateMdiMode(bool)));
+	connect(Preferences::inst(), SIGNAL(updateReorderMode(bool)), this, SLOT(updateReorderMode(bool)));
 	connect(Preferences::inst(), SIGNAL(updateUndockMode(bool)), this, SLOT(updateUndockMode(bool)));
 	connect(Preferences::inst(), SIGNAL(fontChanged(const QString&,uint)), 
 					editor, SLOT(initFont(const QString&,uint)));
@@ -619,6 +624,7 @@ void MainWindow::loadViewSettings(){
 	hideToolbars();
 	updateMdiMode(settings.value("advanced/mdi").toBool());
 	updateUndockMode(settings.value("advanced/undockableWindows").toBool());
+	updateReorderMode(settings.value("advanced/reorderWindows").toBool());
 }
 
 void MainWindow::loadDesignSettings()
@@ -647,9 +653,22 @@ void MainWindow::updateUndockMode(bool undockMode)
 		editorDock->setFeatures(editorDock->features() | QDockWidget::DockWidgetFloatable);
 		consoleDock->setFeatures(consoleDock->features() | QDockWidget::DockWidgetFloatable);
 	} else {
+		if (editorDock->isFloating()) {
+			editorDock->setFloating(false);
+		}
 		editorDock->setFeatures(editorDock->features() & ~QDockWidget::DockWidgetFloatable);
+		if (consoleDock->isFloating()) {
+			consoleDock->setFloating(false);
+		}
 		consoleDock->setFeatures(consoleDock->features() & ~QDockWidget::DockWidgetFloatable);
 	}
+}
+
+void MainWindow::updateReorderMode(bool reorderMode)
+{
+	MainWindow::reorderMode = reorderMode;
+	editorDock->setTitleBarWidget(reorderMode ? 0 : editorDockTitleWidget);
+	consoleDock->setTitleBarWidget(reorderMode ? 0 : consoleDockTitleWidget);
 }
 
 MainWindow::~MainWindow()


### PR DESCRIPTION
Add option to remove the dock widget title bar. The main benefit is to get back some screen area that is used by the title bar.

The change is based on discussion in http://forum.openscad.org/Performance-regression-2014-10-02-td9989.html.

With the undock option this effectively enables 3 cases:
- No reorder possible due to missing title bar (reorder = false, undock = false)
- Reorder but no undocking, title bar is visible (reorder = true, undock = false)
- Reorder and undocking of windows is possible (reorder = true, undock = true)
