### PR TITLE
Improved DXF output compatibility

### DIFF
--- a/src/export.cc
+++ b/src/export.cc
@@ -468,10 +468,10 @@ void export_dxf(const Polygon2d &poly, std::ostream &output)
 						 << "0\n"
 						 << " 10\n"
 						 << x1 << "\n"
-						 << " 11\n"
-						 << x2 << "\n"
 						 << " 20\n"
 						 << y1 << "\n"
+						 << " 11\n"
+						 << x2 << "\n"
 						 << " 21\n"
 						 << y2 << "\n";
 		}


### PR DESCRIPTION
Changed coordinate order from `[X1 X2 Y1 Y2]` to `[X1 Y1 X2 Y2]`. Both orders are standard compliant but `[X1 Y1 X2 Y2]` is far more common and can be parsed linearly. Some libraries, like the python libraries dxfgrabber and ezdxf, cannot open `[X1 X2 Y1 Y2]` order.
