### PR TITLE
Use FileContext when evaluating $vp{rtd} variables (fixes #949).

### DIFF
--- a/src/mainwin.cc
+++ b/src/mainwin.cc
@@ -938,6 +938,7 @@ void MainWindow::compileDone(bool didchange)
 	const char *callslot;
 	if (didchange) {
 		instantiateRoot();
+		updateCamera();
 		callslot = afterCompileSlot;
 	}
 	else {
@@ -1525,34 +1526,27 @@ void MainWindow::updateCamera()
 	double rz = cam.object_rot.z();
 	double d = cam.viewer_distance;
 
-	ModuleContext mc(&top_ctx, NULL);
-	mc.initializeModule(*root_module);
+	double x, y, z;
+	const Value vpr = root_module->lookup_variable("$vpr");
+	if (vpr.getVec3(x, y, z)) {
+		rx = x;
+		ry = y;
+		rz = z;
+		camera_set = true;
+	}
 
-	BOOST_FOREACH(const Assignment &a, root_module->scope.assignments) {
-		double x, y, z;
-		if ("$vpr" == a.first) {
-			const Value vpr = a.second.get()->evaluate(&mc);
-			if (vpr.getVec3(x, y, z)) {
-				rx = x;
-				ry = y;
-				rz = z;
-				camera_set = true;
-			}
-		} else if ("$vpt" == a.first) {
-			const Value vpt = a.second.get()->evaluate(&mc);
-			if (vpt.getVec3(x, y, z)) {
-				tx = x;
-				ty = y;
-				tz = z;
-				camera_set = true;
-			}
-		} else if ("$vpd" == a.first) {
-			const Value vpd = a.second.get()->evaluate(&mc);
-			if (vpd.type() == Value::NUMBER) {
-				d = vpd.toDouble();
-				camera_set = true;
-			}
-		}
+	const Value vpt = root_module->lookup_variable("$vpt");
+	if (vpt.getVec3(x, y, z)) {
+		tx = x;
+		ty = y;
+		tz = z;
+		camera_set = true;
+	}
+
+	const Value vpd = root_module->lookup_variable("$vpd");
+	if (vpd.type() == Value::NUMBER) {
+		d = vpd.toDouble();
+		camera_set = true;
 	}
 
 	if (camera_set) {
@@ -1613,8 +1607,6 @@ void MainWindow::compileTopLevelDocument()
 	this->root_module = parse(fulltext.c_str(),
 	this->fileName.isEmpty() ? "" :
 	QFileInfo(this->fileName).absolutePath().toLocal8Bit(), false);
-
-	updateCamera();
 }
 
 void MainWindow::checkAutoReload()

--- a/src/module.cc
+++ b/src/module.cc
@@ -238,6 +238,11 @@ std::string Module::dump(const std::string &indent, const std::string &name) con
 	return dump.str();
 }
 
+FileModule::~FileModule()
+{
+	delete context;
+}
+
 void FileModule::registerUse(const std::string path) {
 	std::string extraw = boosty::extension_str(fs::path(path));
 	std::string ext = boost::algorithm::to_lower_copy(extraw);
@@ -346,19 +351,31 @@ bool FileModule::handleDependencies()
 	return somethingchanged;
 }
 
-AbstractNode *FileModule::instantiate(const Context *ctx, const ModuleInstantiation *inst, EvalContext *evalctx) const
+AbstractNode *FileModule::instantiate(const Context *ctx, const ModuleInstantiation *inst, EvalContext *evalctx)
 {
 	assert(evalctx == NULL);
-	FileContext c(*this, ctx);
-	c.initializeModule(*this);
+	
+	delete context;
+	context = new FileContext(*this, ctx);
+	context->initializeModule(*this);
+
 	// FIXME: Set document path to the path of the module
 #if 0 && DEBUG
 	c.dump(this, inst);
 #endif
 
 	AbstractNode *node = new AbstractNode(inst);
-	std::vector<AbstractNode *> instantiatednodes = this->scope.instantiateChildren(&c);
+	std::vector<AbstractNode *> instantiatednodes = this->scope.instantiateChildren(context);
 	node->children.insert(node->children.end(), instantiatednodes.begin(), instantiatednodes.end());
 
 	return node;
+}
+
+Value FileModule::lookup_variable(const std::string &name) const
+{
+	if (!context) {
+		return Value::undefined;
+	}
+	
+	return context->lookup_variable(name, true);
 }

--- a/src/module.h
+++ b/src/module.h
@@ -99,8 +99,8 @@ private:
 class FileModule : public Module
 {
 public:
-	FileModule() : is_handling_dependencies(false) {}
-	virtual ~FileModule() {}
+	FileModule() : context(NULL), is_handling_dependencies(false) {}
+	virtual ~FileModule();
 
 	void setModulePath(const std::string &path) { this->path = path; }
 	const std::string &modulePath() const { return this->path; }
@@ -108,14 +108,17 @@ public:
 	void registerInclude(const std::string &localpath, const std::string &fullpath);
 	bool includesChanged() const;
 	bool handleDependencies();
-	virtual AbstractNode *instantiate(const Context *ctx, const ModuleInstantiation *inst, EvalContext *evalctx = NULL) const;
+	virtual AbstractNode *instantiate(const Context *ctx, const ModuleInstantiation *inst, EvalContext *evalctx = NULL);
 	bool hasIncludes() const { return !this->includes.empty(); }
 	bool usesLibraries() const { return !this->usedlibs.empty(); }
 	bool isHandlingDependencies() const { return this->is_handling_dependencies; }
+        Value lookup_variable(const std::string &name) const;
 
 	typedef boost::unordered_set<std::string> ModuleContainer;
 	ModuleContainer usedlibs;
 private:
+        /** Reference to retain the context that was used in the last evaluation */
+        class FileContext *context;
 	struct IncludeFile {
 		std::string filename;
 		bool valid;


### PR DESCRIPTION
Just using a ModuleContext causes any used libraries to be unavailable.
