### PR TITLE
Missing quotes in cmake

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -71,8 +71,7 @@ endif()
 
 # MCAD
 if(NOT EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/../libraries/MCAD/__init__.py)
-  #message(FATAL_ERROR "MCAD not found. You can install from the OpenSCAD root as follows: \n  git submodule update --init")
-  message(STATUS "MCAD not found, no tests of MCAD possible. You can install from the OpenSCAD root as follows: \n  git submodule update --init")
+  message(FATAL_ERROR "MCAD not found. You can install from the OpenSCAD root as follows: \n  git submodule update --init")
 endif()
 
 # NULLGL - Allow us to build without OpenGL(TM). run 'cmake .. -DNULLGL=1'


### PR DESCRIPTION
Flags in CmakeLists.txt should be quoted for those cases they consist of more than one string
