### PR TITLE
Needed changes to have NULLGL compiling.

### DIFF
--- a/src/NULLGL.cc
+++ b/src/NULLGL.cc
@@ -4,17 +4,19 @@ GLView::GLView() {}
 void GLView::setRenderer(Renderer* r) {}
 void GLView::initializeGL() {}
 void GLView::resizeGL(int w, int h) {}
-void GLView::setupGimbalCamPerspective() {}
-void GLView::setupGimbalCamOrtho(double distance, bool offset) {}
-void GLView::setupVectorCamPerspective() {}
-void GLView::setupVectorCamOrtho(bool offset) {}
-void GLView::setCamera( Camera &cam ) {}
+//void GLView::setupGimbalCamPerspective() {}
+//void GLView::setupGimbalCamOrtho(double distance, bool offset) {}
+//void GLView::setupVectorCamPerspective() {}
+//void GLView::setupVectorCamOrtho(bool offset) {}
+void GLView::setCamera(const Camera &cam ) {}
 void GLView::paintGL() {}
-void GLView::vectorCamPaintGL() {}
-void GLView::gimbalCamPaintGL() {}
+//void GLView::vectorCamPaintGL() {}
+//void GLView::gimbalCamPaintGL() {}
 void GLView::showSmallaxes() {}
 void GLView::showAxes() {}
 void GLView::showCrosshairs() {}
+void GLView::setColorScheme(const ColorScheme &cs){assert(false && "not implemented");}
+void GLView::setColorScheme(const std::string &cs) {assert(false && "not implemented");}
 
 #include "ThrownTogetherRenderer.h"
 
@@ -23,12 +25,16 @@ ThrownTogetherRenderer::ThrownTogetherRenderer(CSGChain *root_chain,
 void ThrownTogetherRenderer::draw(bool /*showfaces*/, bool showedges) const {}
 void ThrownTogetherRenderer::renderCSGChain(CSGChain *chain, bool
   highlight, bool background, bool showedges, bool fberror) const {}
+BoundingBox ThrownTogetherRenderer::getBoundingBox() const {assert(false && "not implemented");}
 
 #include "CGALRenderer.h"
 
 CGALRenderer::CGALRenderer(shared_ptr<const class Geometry> geom) {}
 CGALRenderer::~CGALRenderer() {}
 void CGALRenderer::draw(bool showfaces, bool showedges) const {}
+BoundingBox CGALRenderer::getBoundingBox() const {assert(false && "not implemented");}
+void CGALRenderer::setColorScheme(const ColorScheme &cs){assert(false && "not implemented");}
+
 
 #include "system-gl.h"
 


### PR DESCRIPTION
-DNULLGL compiling is not working in current master.
This patch fixes this. As I lack deep understanding of the OpenStack stack, this patch need review. For example, unclear why so many methods must be removed.
Also, is the approach of using {assert(false && "not implemented");} as method body good, or should we stick to just {} ...
