### PR TITLE
Add optional target suffix for the binary / installation folder.

### DIFF
--- a/openscad.pro
+++ b/openscad.pro
@@ -12,6 +12,10 @@
 #
 #   PREFIX defines the base installation folder
 #
+#   SUFFIX defines an optional suffix for the binary and the
+#   resource folder. E.g. using SUFFIX=-nightly will name the
+#   resulting binary openscad-nightly.
+#
 # Please see the 'Building' sections of the OpenSCAD user manual 
 # for updated tips & workarounds.
 #
@@ -78,8 +82,10 @@ macx {
   TARGET = OpenSCAD
 }
 else {
-  TARGET = openscad
+  TARGET = openscad$${SUFFIX}
 }
+FULLNAME = openscad$${SUFFIX}
+!isEmpty(SUFFIX): DEFINES += INSTALL_SUFFIX="\"\\\"$${SUFFIX}\\\"\""
 
 macx {
   ICON = icons/OpenSCAD.icns
@@ -491,7 +497,7 @@ QMAKE_POST_LINK += $$PWD/scripts/translation-make.sh
 
 # Create install targets for the languages defined in LINGUAS
 LINGUAS = $$cat(locale/LINGUAS)
-LOCALE_PREFIX = $$PREFIX/share/openscad/locale
+LOCALE_PREFIX = "$$PREFIX/share/$${FULLNAME}/locale"
 for(language, LINGUAS) {
   catalog = locale/$$language/LC_MESSAGES/openscad.mo
   exists($$catalog) {
@@ -505,40 +511,40 @@ for(language, LINGUAS) {
   }
 }
 
-examples.path = $$PREFIX/share/openscad/examples/
+examples.path = "$$PREFIX/share/$${FULLNAME}/examples/"
 examples.files = examples/*
 INSTALLS += examples
 
-libraries.path = $$PREFIX/share/openscad/libraries/
+libraries.path = "$$PREFIX/share/$${FULLNAME}/libraries/"
 libraries.files = libraries/*
 INSTALLS += libraries
 
-fonts.path = $$PREFIX/share/openscad/fonts/
+fonts.path = "$$PREFIX/share/$${FULLNAME}/fonts/"
 fonts.files = fonts/*
 INSTALLS += fonts
 
-colorschemes.path = $$PREFIX/share/openscad/color-schemes/
+colorschemes.path = "$$PREFIX/share/$${FULLNAME}/color-schemes/"
 colorschemes.files = color-schemes/*
 INSTALLS += colorschemes
 
 applications.path = $$PREFIX/share/applications
-applications.files = icons/openscad.desktop
+applications.extra = cp -f icons/openscad.desktop \"$$applications.path/$${FULLNAME}.desktop\"
 INSTALLS += applications
 
 mimexml.path = $$PREFIX/share/mime/packages
-mimexml.files = icons/openscad.xml
+mimexml.extra = cp -f icons/openscad.xml \"$$mimexml.path/$${FULLNAME}.xml\"
 INSTALLS += mimexml
 
 appdata.path = $$PREFIX/share/appdata
-appdata.files = openscad.appdata.xml
+appdata.extra = cp -f openscad.appdata.xml \"$$appdata.path/$${FULLNAME}.appdata.xml\"
 INSTALLS += appdata
 
 icons.path = $$PREFIX/share/pixmaps
-icons.files = icons/openscad.png
+icons.extra = cp -f icons/openscad.png \"$$icons.path/$${FULLNAME}.png\"
 INSTALLS += icons
 
 man.path = $$PREFIX/share/man/man1
-man.files = doc/openscad.1
+man.extra = cp -f doc/openscad.1 \"$$man.path/$${FULLNAME}.1\"
 INSTALLS += man
 
 CONFIG(winconsole) {

--- a/src/PlatformUtils.cc
+++ b/src/PlatformUtils.cc
@@ -2,6 +2,12 @@
 
 #include "PlatformUtils.h"
 
+#ifdef INSTALL_SUFFIX
+#define RESOURCE_FOLDER(path) path INSTALL_SUFFIX
+#else
+#define RESOURCE_FOLDER(path) path
+#endif
+
 extern std::vector<std::string> librarypath;
 extern std::vector<std::string> fontpath;
 
@@ -28,8 +34,8 @@ static std::string lookupResourcesPath()
 	};
 #else
 	const char *searchpath[] = {
-	    "../share/openscad",
-	    "../../share/openscad",
+	    RESOURCE_FOLDER("../share/openscad"),
+	    RESOURCE_FOLDER("../../share/openscad"),
 	    ".",
 	    "..",
 	    "../..",


### PR DESCRIPTION
This is mainly intended to be used for building snapshot binaries that
are able to install in parallel to a release build. E.g. by using the
parameter "SUFFIX=-nightly" for qmake, the target binary will be called
openscad-nightly and the resource base folder /usr/share/openscad-nightly.
