### PR TITLE
Enable GL_LINE_STIPPLE only for the block where a stipple pattern is used

### DIFF
--- a/src/GLView.cc
+++ b/src/GLView.cc
@@ -354,7 +354,6 @@ void GLView::initializeGL()
   glEnable(GL_LIGHT1);
   glEnable(GL_LIGHTING);
   glEnable(GL_NORMALIZE);
-  glEnable(GL_LINE_STIPPLE);
 
   glColorMaterial(GL_FRONT_AND_BACK, GL_AMBIENT_AND_DIFFUSE);
   // The following line is reported to fix issue #71
@@ -468,6 +467,7 @@ void GLView::showAxes(const Color4f &col)
   glEnd();
 
   glPushAttrib(GL_LINE_BIT);
+  glEnable(GL_LINE_STIPPLE);
   glLineStipple(3, 0xAAAA);
   glBegin(GL_LINES);
   glVertex3d(0, 0, 0);


### PR DESCRIPTION
Fixes stipple handling for "GL Renderer: Intel(R) HD Graphics / OpenGL Version: 4.0.0 - Build 10.18.10.3496" (#1111).
