### PR TITLE
Orthogonal zoom fix

### DIFF
--- a/src/Camera.cc
+++ b/src/Camera.cc
@@ -101,25 +101,11 @@ void Camera::viewAll(const BoundingBox &bbox, float scalefactor)
 
 void Camera::zoom(int delta)
 {
-	if (this->projection == PERSPECTIVE) {
-		this->viewer_distance *= pow(0.9, delta / 120.0);
-	}
-	else {
-		this->height *= pow(0.9, delta / 120.0);
-	}
+	this->viewer_distance *= pow(0.9, delta / 120.0);
+	this->height = this->viewer_distance;
 }
 
 void Camera::setProjection(ProjectionType type)
 {
-	if (this->projection != type) {
-		switch (type) {
-		case PERSPECTIVE:
-			this->viewer_distance = this->height;
-			break;
-		case ORTHOGONAL:
-			this->height = this->viewer_distance;
-			break;
-		}
-		this->projection = type;
-	}
+	this->projection = type;
 }

--- a/src/Camera.cc
+++ b/src/Camera.cc
@@ -109,3 +109,12 @@ void Camera::setProjection(ProjectionType type)
 {
 	this->projection = type;
 }
+
+std::string Camera::statusText()
+{
+	boost::format fmt(_("Viewport: translate = [ %.2f %.2f %.2f ], rotate = [ %.2f %.2f %.2f ], distance = %.2f"));
+	fmt % object_trans.x() % object_trans.y() % object_trans.z()
+		% object_rot.x() % object_rot.y() % object_rot.z()
+		% (this->projection == PERSPECTIVE ? viewer_distance : height);
+	return fmt.str();
+}

--- a/src/Camera.h
+++ b/src/Camera.h
@@ -31,6 +31,7 @@ public:
 	void setProjection(ProjectionType type);
 	void zoom(int delta);
 	void viewAll(const BoundingBox &bbox, float scalefactor = 1.0f);
+        std::string statusText();
 
 	// Vectorcam
 	Eigen::Vector3d eye;

--- a/src/GLView.cc
+++ b/src/GLView.cc
@@ -91,21 +91,23 @@ void GLView::setupCamera()
   glLoadIdentity();
 
 	switch (this->cam.type) {
-	case Camera::GIMBAL:
+	case Camera::GIMBAL: {
+		double eyeY = 0.0;
 		switch (this->cam.projection) {
 		case Camera::PERSPECTIVE: {
-			double dist = cam.viewer_distance;
-			gluPerspective(cam.fov, aspectratio, 0.1*dist, 100*dist);
+			eyeY = cam.viewer_distance;
+			gluPerspective(cam.fov, aspectratio, 0.1 * eyeY, 100 * eyeY);
 			break;
 		}
 		case Camera::ORTHOGONAL: {
+			eyeY = cam.height;
 			glOrtho(-cam.height/2*aspectratio, cam.height*aspectratio/2,
 							-cam.height/2, cam.height/2,
 							-far_far_away, +far_far_away);
 			break;
 		}
 		}
-		gluLookAt(0.0, -cam.viewer_distance, 0.0,
+		gluLookAt(0.0, -eyeY, 0.0,
 							0.0, 0.0, 0.0,
 							0.0, 0.0, 1.0);
 		glMatrixMode(GL_MODELVIEW);
@@ -114,6 +116,7 @@ void GLView::setupCamera()
 		glRotated(cam.object_rot.y(), 0.0, 1.0, 0.0);
 		glRotated(cam.object_rot.z(), 0.0, 0.0, 1.0);
 		break;
+	}
 	case Camera::VECTOR: {
 		switch (this->cam.projection) {
 		case Camera::PERSPECTIVE: {

--- a/src/QGLView.cc
+++ b/src/QGLView.cc
@@ -164,16 +164,9 @@ void QGLView::paintGL()
   GLView::paintGL();
 
   if (statusLabel) {
-    QString msg;
-
     Camera nc(cam);
     nc.gimbalDefaultTranslate();
-    msg.sprintf(_("Viewport: translate = [ %.2f %.2f %.2f ], rotate = [ %.2f %.2f %.2f ], distance = %.2f"),
-      nc.object_trans.x(), nc.object_trans.y(), nc.object_trans.z(),
-      nc.object_rot.x(), nc.object_rot.y(), nc.object_rot.z(),
-      nc.viewer_distance );
-
-    statusLabel->setText(msg);
+    statusLabel->setText(QString::fromStdString(nc.statusText()));
   }
 
   if (running_under_wine) swapBuffers();


### PR DESCRIPTION
* Use correct eye position in orthogonal projection mode (fixes #1058).

* Use viewport height as "distance" for the status text in orthogonal mode. (While this is not strictly correct as the actual distance has no effect in orthogonal mode, it's giving the user an indication of the zoom factor.)