### PR TITLE
Create a new command called "convex"

### DIFF
--- a/src/cgalutils.cc
+++ b/src/cgalutils.cc
@@ -148,6 +148,11 @@ namespace CGALUtils {
 			}
 		}
 
+		return applyHull(points, result);
+	}
+
+	bool applyHull(const std::list<K::Point_3> &points, PolySet &result)
+	{
 		if (points.size() <= 3) return false;
 
 		// Apply hull

--- a/src/cgalutils.h
+++ b/src/cgalutils.h
@@ -13,6 +13,7 @@ typedef std::vector<PolygonK> PolyholeK;
 
 namespace CGALUtils {
 	bool applyHull(const Geometry::ChildList &children, PolySet &P);
+	bool applyHull(const std::list<K::Point_3>& points, PolySet &P);
 	CGAL_Nef_polyhedron *applyOperator(const Geometry::ChildList &children, OpenSCADOperator op);
 	//FIXME: Old, can be removed:
 	//void applyBinaryOperator(CGAL_Nef_polyhedron &target, const CGAL_Nef_polyhedron &src, OpenSCADOperator op);

--- a/src/highlighter.cc
+++ b/src/highlighter.cc
@@ -222,7 +222,7 @@ Highlighter::Highlighter(QTextDocument *parent)
 	tokentypes["keyword"] << "module" << "function" << "for" << "intersection_for" << "if" << "assign" << "echo"<< "search" << "str" << "let";
 	tokentypes["transform"] << "scale" << "translate" << "rotate" << "multmatrix" << "color" << "projection" << "hull" << "resize" << "mirror" << "minkowski";
 	tokentypes["csgop"]	<< "union" << "intersection" << "difference" << "render";
-	tokentypes["prim3d"] << "cube" << "cylinder" << "sphere" << "polyhedron";
+	tokentypes["prim3d"] << "cube" << "cylinder" << "sphere" << "polyhedron" << "convex";
 	tokentypes["prim2d"] << "square" << "polygon" << "circle";
 	tokentypes["import"] << "include" << "use" << "import_stl" << "import" << "import_dxf" << "dxf_dim" << "dxf_cross" << "surface";
 	tokentypes["special"] << "$children" << "child" << "children" << "$fn" << "$fa" << "$fs" << "$t" << "$vpt" << "$vpr" << "$vpd";


### PR DESCRIPTION
I always find myself constructing fairly simple polyhedra which are not quite cubes and not quite pyramids, but are always convex.  There's no obvious way to use hull() with a list of points, and it seems horrible to put epsilon sized cubes there.  Meanwhile, polyhedron() works, but it's kind of a pain to figure out the faces each time.  So, to simplify my life, I have created a command "convex", which takes an array of 3D-points and produces the convex hull of those points.