### PR TITLE
Mac build failing on line 908-909

### DIFF
--- a/locale/ru.po
+++ b/locale/ru.po
@@ -905,8 +905,8 @@ msgid "Fixed"
 msgstr "Фиксированный"
 
 #: objects/ui_Preferences.h:1122 src/settings.cc:128
-msgid "Same"
 #, fuzzy
+msgid "Same"
 msgstr "Так же"
 
 #: objects/ui_Preferences.h:1123 src/settings.cc:128


### PR DESCRIPTION
Looks like lines 908-909 need to be reversed for my Mac OS X build to work on my latest git pull.

Error message is:

--snip--

msgfmt -c -v -o ./locale/ru/LC_MESSAGES/openscad.mo ./locale/ru.po
./locale/ru.po:908: missing 'msgstr' section
./locale/ru.po:910:7: syntax error
msgfmt: found 2 fatal errors
error running msgfmt
make: *** [OpenSCAD.app/Contents/MacOS/OpenSCAD] Error 1

--end-snip--

Andrew.