### PR TITLE
Fix "New" button in launching screen.

### DIFF
--- a/src/launchingscreen.cc
+++ b/src/launchingscreen.cc
@@ -14,6 +14,8 @@ LaunchingScreen *LaunchingScreen::getDialog() {
 	return LaunchingScreen::inst;
 }
 
+// Called (possibly multiple times) by EventFilter on MacOS, e.g.
+// when the user opens files from Finder.
 void LaunchingScreen::openFile(const QString &filename)
 {
 	QVariant v(filename);

--- a/src/openscad.cc
+++ b/src/openscad.cc
@@ -706,10 +706,14 @@ int gui(vector<string> &inputFiles, const fs::path &original_path, int argc, cha
 		LaunchingScreen *launcher = new LaunchingScreen();
 		int dialogResult = launcher->exec();
 		if (dialogResult == QDialog::Accepted) {
-			inputFiles.clear();
 			QStringList files = launcher->selectedFiles();
-			BOOST_FOREACH(const QString &f, files) {
-				inputFiles.push_back(f.toStdString());
+			// If nothing is selected in the launching screen, leave
+			// the "" dummy in inputFiles to open an empty MainWindow.
+			if (!files.empty()) {
+				inputFiles.clear();
+				BOOST_FOREACH(const QString &f, files) {
+					inputFiles.push_back(f.toStdString());
+				}
 			}
 			delete launcher;
 		} else {


### PR DESCRIPTION
The "New" button will cause the launching screen to return with an empty
selection of files. In this case, the dummy file name "" needs to remain
in the file list to allow the main window to open.