### PR TITLE
scripts/check-dependencies.sh can't determine version of opencsg

### DIFF
--- a/scripts/check-dependencies.sh
+++ b/scripts/check-dependencies.sh
@@ -50,7 +50,7 @@ opencsg_sysver()
 {
   debug opencsg_sysver
   if [ ! -e $1/include/opencsg.h ]; then return; fi
-  ocsgver=`grep "define  *OPENCSG_VERSION_STRING *[0-9x]*" $1/include/opencsg.h`
+  ocsgver=`grep -a "define  *OPENCSG_VERSION_STRING *[0-9x]*" $1/include/opencsg.h`
   ocsgver=`echo $ocsgver | awk '{print $4}' | sed s/'"'//g | sed s/[^1-9.]//g`
   opencsg_sysver_result=$ocsgver
 }


### PR DESCRIPTION
Grep doesn't return matching lines when it believes that the file is a binary.
The header for opencsg seems to trigger this behaviour. Added the -a switch to
the grep invocation to force interpretation as text file.

Maybe -a should be added to all grep invocations in the whole file/directory/repository.