### PR TITLE
Add support for interactive axis-aligned clipping planes in OpenGL window

### DIFF
--- a/src/GLView.cc
+++ b/src/GLView.cc
@@ -163,6 +163,7 @@ void GLView::paintGL()
   glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT | GL_STENCIL_BUFFER_BIT);
 
   setupCamera();
+
   if (this->cam.type) {
     // Only for GIMBAL cam
     // The crosshair should be fixed at the center of the viewport...
@@ -181,12 +182,50 @@ void GLView::paintGL()
   glLineWidth(2);
   glColor3d(1.0, 0.0, 0.0);
 
+  if(kClipN!=clipMode) {
+    double eqn[4];
+    glEnable(GL_CLIP_PLANE0);
+    switch(clipMode) {
+      case kClipX:
+        eqn[0] = -1.0;
+        eqn[1] =  0.0;
+        eqn[2] =  0.0;
+        break;
+      case kClipY:
+        eqn[0] =  0.0;
+        eqn[1] = -1.0;
+        eqn[2] =  0.0;
+        break;
+      case kClipZ:
+        eqn[0] =  0.0;
+        eqn[1] =  0.0;
+        eqn[2] = -1.0;
+        break;
+      case kClipV:  // TODO
+        eqn[0] = -1.0;
+        eqn[1] = -1.0;
+        eqn[2] = -1.0;
+        break;
+      case kClipN:
+        break;
+    }
+
+    double lo = -10.0;
+    double hi =  10.0;
+    eqn[3] = lo + clipPosition*(hi-lo);
+    glClipPlane(GL_CLIP_PLANE0, eqn);
+  }
+
   if (this->renderer) {
 #if defined(ENABLE_OPENCSG)
     // FIXME: This belongs in the OpenCSG renderer, but it doesn't know about this ID yet
     OpenCSG::setContext(this->opencsg_id);
 #endif
     this->renderer->draw(showfaces, showedges);
+  }
+
+  if(kClipN!=clipMode) {
+    glDisable(GL_CLIP_PLANE0);
   }
 
   // Only for GIMBAL

--- a/src/GLView.cc
+++ b/src/GLView.cc
@@ -182,50 +182,63 @@ void GLView::paintGL()
   glLineWidth(2);
   glColor3d(1.0, 0.0, 0.0);
 
-  if(kClipN!=clipMode) {
-    double eqn[4];
-    glEnable(GL_CLIP_PLANE0);
-    switch(clipMode) {
-      case kClipX:
-        eqn[0] = -1.0;
-        eqn[1] =  0.0;
-        eqn[2] =  0.0;
-        break;
-      case kClipY:
-        eqn[0] =  0.0;
-        eqn[1] = -1.0;
-        eqn[2] =  0.0;
-        break;
-      case kClipZ:
-        eqn[0] =  0.0;
-        eqn[1] =  0.0;
-        eqn[2] = -1.0;
-        break;
-      case kClipV:  // TODO
-        eqn[0] = -1.0;
-        eqn[1] = -1.0;
-        eqn[2] = -1.0;
-        break;
-      case kClipN:
-        break;
+  if (this->renderer) {
+
+    if(kClipN!=clipMode) {
+
+        glEnable(GL_CLIP_PLANE0);
+
+        double eqn[4];
+        BoundingBox box = this->renderer->getBoundingBox();
+
+        double lo = -1000.0;
+        double hi =  1000.0;
+        switch(clipMode) {
+            case kClipX:
+                eqn[0] = -1.0;
+                eqn[1] =  0.0;
+                eqn[2] =  0.0;
+                lo = box.min()[0];
+                hi = box.max()[0];
+                break;
+            case kClipY:
+                eqn[0] =  0.0;
+                eqn[1] = -1.0;
+                eqn[2] =  0.0;
+                lo = box.min()[1];
+                hi = box.max()[1];
+                break;
+            case kClipZ:
+                eqn[0] =  0.0;
+                eqn[1] =  0.0;
+                eqn[2] = -1.0;
+                lo = box.min()[2];
+                hi = box.max()[2];
+                break;
+            case kClipV:  // TODO
+                eqn[0] = -1.0;
+                eqn[1] = -1.0;
+                eqn[2] = -1.0;
+                break;
+            case kClipN:
+                break;
+        }
+
+        lo -= 0.01*(hi-lo);
+        hi += 0.01*(hi-lo);
+        eqn[3] = lo + clipPosition*(hi-lo);
+        glClipPlane(GL_CLIP_PLANE0, eqn);
     }
 
-    double lo = -10.0;
-    double hi =  10.0;
-    eqn[3] = lo + clipPosition*(hi-lo);
-    glClipPlane(GL_CLIP_PLANE0, eqn);
-  }
-
-  if (this->renderer) {
 #if defined(ENABLE_OPENCSG)
     // FIXME: This belongs in the OpenCSG renderer, but it doesn't know about this ID yet
     OpenCSG::setContext(this->opencsg_id);
 #endif
     this->renderer->draw(showfaces, showedges);
-  }
 
-  if(kClipN!=clipMode) {
-    glDisable(GL_CLIP_PLANE0);
+    if(kClipN!=clipMode) {
+        glDisable(GL_CLIP_PLANE0);
+    }
   }
 
   // Only for GIMBAL

--- a/src/GLView.h
+++ b/src/GLView.h
@@ -64,6 +64,15 @@ public:
 	bool showcrosshairs;
 	bool showscale;
 
+        enum ClipMode {
+            kClipN,
+            kClipX,
+            kClipY,
+            kClipZ,
+            kClipV,
+        } clipMode;
+        double clipPosition;
+
 #ifdef ENABLE_OPENCSG
 	GLint shaderinfo[11];
 	bool is_opencsg_capable;

--- a/src/MainWindow.h
+++ b/src/MainWindow.h
@@ -152,6 +152,7 @@ private slots:
 private slots:
 	void pasteViewportTranslation();
 	void pasteViewportRotation();
+        void clippingPlaneChanged();
 	void preferences();
 	void hideToolbars();
 	void hideEditor();

--- a/src/MainWindow.ui
+++ b/src/MainWindow.ui
@@ -206,6 +206,59 @@
         </widget>
        </item>
        <item>
+        <widget class="QWidget" name="clippingPlaneBar" native="true">
+         <layout class="QHBoxLayout" name="horizontalLayout">
+          <item>
+           <widget class="QRadioButton" name="clipRadioButtonX">
+            <property name="text">
+             <string>X</string>
+            </property>
+            <property name="checked">
+             <bool>true</bool>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <widget class="QRadioButton" name="clipRadioButtonY">
+            <property name="text">
+             <string>Y</string>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <widget class="QRadioButton" name="clipRadioButtonZ">
+            <property name="text">
+             <string>Z</string>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <widget class="QRadioButton" name="clipRadioButtonV">
+            <property name="text">
+             <string>V</string>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <widget class="QSlider" name="clipSlider">
+            <property name="maximum">
+             <number>10000</number>
+            </property>
+            <property name="singleStep">
+             <number>1</number>
+            </property>
+            <property name="pageStep">
+             <number>10</number>
+            </property>
+            <property name="orientation">
+             <enum>Qt::Horizontal</enum>
+            </property>
+           </widget>
+          </item>
+         </layout>
+        </widget>
+       </item>
+       <item>
         <widget class="QToolBar" name="viewerToolBar">
          <addaction name="designActionPreview"/>
          <addaction name="designActionRender"/>
@@ -235,6 +288,7 @@
       <zorder>qglview</zorder>
       <zorder>viewerToolBar</zorder>
       <zorder>frameCompileResult</zorder>
+      <zorder>clippingPlaneBar</zorder>
      </widget>
     </item>
    </layout>
@@ -245,7 +299,7 @@
      <x>0</x>
      <y>0</y>
      <width>1118</width>
-     <height>22</height>
+     <height>25</height>
     </rect>
    </property>
    <widget class="QMenu" name="menu_File">

--- a/src/MainWindow.ui
+++ b/src/MainWindow.ui
@@ -209,6 +209,13 @@
         <widget class="QWidget" name="clippingPlaneBar" native="true">
          <layout class="QHBoxLayout" name="horizontalLayout">
           <item>
+           <widget class="QLabel" name="label_4">
+            <property name="text">
+             <string>Clip</string>
+            </property>
+           </widget>
+          </item>
+          <item>
            <widget class="QRadioButton" name="clipRadioButtonX">
             <property name="text">
              <string>X</string>

--- a/src/MainWindow.ui
+++ b/src/MainWindow.ui
@@ -257,6 +257,9 @@
             <property name="pageStep">
              <number>10</number>
             </property>
+            <property name="value">
+             <number>10000</number>
+            </property>
             <property name="orientation">
              <enum>Qt::Horizontal</enum>
             </property>

--- a/src/mainwin.cc
+++ b/src/mainwin.cc
@@ -2488,7 +2488,7 @@ void MainWindow::clippingPlaneChanged()
     int mu = clipSlider->value();
     int lo = clipSlider->minimum();
     int hi = clipSlider->maximum();
-    double param = (mu-lo)/(double)(hi-lo);
+    double clipValue = (mu-lo)/(double)(hi-lo);
 
     GLView::ClipMode clipMode =
         0==mu                         ? GLView::kClipN :
@@ -2498,7 +2498,10 @@ void MainWindow::clippingPlaneChanged()
         clipRadioButtonV->isChecked() ? GLView::kClipV :
                                         GLView::kClipN
         ;
-    printf("%.20f %d\n", param, (int)clipMode);
+
+    qglview->clipMode = clipMode;
+    qglview->clipPosition = clipValue;
+    qglview->updateGL();
 }
 
 void MainWindow::dragEnterEvent(QDragEnterEvent *event)

--- a/src/mainwin.cc
+++ b/src/mainwin.cc
@@ -405,6 +405,13 @@ MainWindow::MainWindow(const QString &filename)
 	connect(this->viewActionHideEditor, SIGNAL(triggered()), this, SLOT(hideEditor()));
 	connect(this->viewActionHideConsole, SIGNAL(triggered()), this, SLOT(hideConsole()));
 
+        // Clipping plane bar
+	connect(this->clipRadioButtonX, SIGNAL(clicked()), this, SLOT(clippingPlaneChanged()));
+	connect(this->clipRadioButtonY, SIGNAL(clicked()), this, SLOT(clippingPlaneChanged()));
+	connect(this->clipRadioButtonZ, SIGNAL(clicked()), this, SLOT(clippingPlaneChanged()));
+	connect(this->clipRadioButtonV, SIGNAL(clicked()), this, SLOT(clippingPlaneChanged()));
+	connect(this->clipSlider, SIGNAL(valueChanged(int)), this, SLOT(clippingPlaneChanged()));
+
 	// Help menu
 	connect(this->helpActionAbout, SIGNAL(triggered()), this, SLOT(helpAbout()));
 	connect(this->helpActionHomepage, SIGNAL(triggered()), this, SLOT(helpHomepage()));
@@ -2474,6 +2481,24 @@ void MainWindow::hideConsole()
 	} else {
 		consoleDock->show();
 	}
+}
+
+void MainWindow::clippingPlaneChanged()
+{
+    int mu = clipSlider->value();
+    int lo = clipSlider->minimum();
+    int hi = clipSlider->maximum();
+    double param = (mu-lo)/(double)(hi-lo);
+
+    GLView::ClipMode clipMode =
+        0==mu                         ? GLView::kClipN :
+        clipRadioButtonX->isChecked() ? GLView::kClipX :
+        clipRadioButtonY->isChecked() ? GLView::kClipY :
+        clipRadioButtonZ->isChecked() ? GLView::kClipZ :
+        clipRadioButtonV->isChecked() ? GLView::kClipV :
+                                        GLView::kClipN
+        ;
+    printf("%.20f %d\n", param, (int)clipMode);
 }
 
 void MainWindow::dragEnterEvent(QDragEnterEvent *event)

--- a/src/mainwin.cc
+++ b/src/mainwin.cc
@@ -238,6 +238,8 @@ MainWindow::MainWindow(const QString &filename)
 	this->opencsgRenderer = NULL;
 #endif
 	this->thrownTogetherRenderer = NULL;
+	this->clipSlider->setValue(10000);
+        this->qglview->clipMode = GLView::kClipN;
 
 	highlights_chain = NULL;
 	background_chain = NULL;
@@ -2491,13 +2493,15 @@ void MainWindow::clippingPlaneChanged()
     double clipValue = (mu-lo)/(double)(hi-lo);
 
     GLView::ClipMode clipMode =
-        0==mu                         ? GLView::kClipN :
+        hi==mu                        ? GLView::kClipN :
         clipRadioButtonX->isChecked() ? GLView::kClipX :
         clipRadioButtonY->isChecked() ? GLView::kClipY :
         clipRadioButtonZ->isChecked() ? GLView::kClipZ :
         clipRadioButtonV->isChecked() ? GLView::kClipV :
                                         GLView::kClipN
         ;
+
+printf("MODE:%d\n",(int)clipMode);
 
     qglview->clipMode = clipMode;
     qglview->clipPosition = clipValue;


### PR DESCRIPTION
This adds a slider and 4 radio buttons below the OpenGL view of the scene.

The radio buttons let the user pick an axis-aligned clipping plane:

X, Y, Z, or V (V is the vector [1,1,1] for now, but will be the view vector soon)

The slider moves the clipping plane along the axis and spans the length of
the bounding box of the scene.

When the slider is all the way to the right, clipping plane is disabled and
full scene is visible.

Very useful to check tolerances and fits in a complex CAD object.

Implemented using glClipPlane, not the most modern way (should use vertex shader
clipping), but ... good enough for now.
