### PR TITLE
Add a axes-color option for color schemes

### DIFF
--- a/color-schemes/render/beforedawn.json
+++ b/color-schemes/render/beforedawn.json
@@ -5,6 +5,7 @@
 
     "colors" : {
         "background" :         "#333333",
+        "axes-color" :         "#c1c1c1",
         "opencsg-face-front" : "#cccccc",
         "opencsg-face-back" :  "#5563dd",
         "cgal-face-front" :    "#cccccc",

--- a/color-schemes/render/deepocean.json
+++ b/color-schemes/render/deepocean.json
@@ -5,6 +5,7 @@
 
     "colors" : {
         "background" :         "#333333",
+        "axes-color" :         "#c1c1c1",
         "opencsg-face-front" : "#eeeeee",
         "opencsg-face-back" :  "#0babc8",
         "cgal-face-front" :    "#eeeeee",

--- a/color-schemes/render/metallic.json
+++ b/color-schemes/render/metallic.json
@@ -5,6 +5,7 @@
 
     "colors" : {
         "background" :         "#aaaaff",
+        "axes-color" :         "#222233",
         "opencsg-face-front" : "#ddddff",
         "opencsg-face-back" :  "#dd22dd",
         "cgal-face-front" :    "#ddddff",

--- a/color-schemes/render/monotone.json
+++ b/color-schemes/render/monotone.json
@@ -6,6 +6,7 @@
 
     "colors" : {
         "background" :         "#ffffe5",
+        "axes-color" :         "#191916",
         "opencsg-face-front" : "#f9d72c",
         "opencsg-face-back" :  "#f9d72c",
         "cgal-face-front" :    "#f9d72c",

--- a/color-schemes/render/nature.json
+++ b/color-schemes/render/nature.json
@@ -5,6 +5,7 @@
 
     "colors" : {
         "background" :         "#fafafa",
+        "axes-color" :         "#323232",
         "opencsg-face-front" : "#16a085",
         "opencsg-face-back" :  "#dbf4da",
         "cgal-face-front" :    "#16a085",

--- a/color-schemes/render/solarized.json
+++ b/color-schemes/render/solarized.json
@@ -5,6 +5,7 @@
 
     "colors" : {
         "background" :         "#fdf6e3",
+        "axes-color" :         "#191816",
         "opencsg-face-front" : "#b58800",
         "opencsg-face-back" :  "#882233",
         "cgal-face-front" :    "#b58800",

--- a/color-schemes/render/starnight.json
+++ b/color-schemes/render/starnight.json
@@ -5,6 +5,7 @@
 
     "colors" : {
         "background" :         "#000000",
+        "axes-color" :         "#e5e5e5",
         "opencsg-face-front" : "#ffffe0",
         "opencsg-face-back" :  "#00ffff",
         "cgal-face-front" :    "#ffffe0",

--- a/color-schemes/render/sunset.json
+++ b/color-schemes/render/sunset.json
@@ -5,6 +5,7 @@
 
     "colors" : {
         "background" :         "#aa4444",
+        "axes-color" :         "#220d0d",
         "opencsg-face-front" : "#ffaaaa",
         "opencsg-face-back" :  "#882233",
         "cgal-face-front" :    "#ffaaaa",

--- a/color-schemes/render/tomorrow-night.json
+++ b/color-schemes/render/tomorrow-night.json
@@ -5,6 +5,7 @@
 
     "colors" : {
         "background" :         "#1d1f21",
+        "axes-color" :         "#e8e8e8",
         "opencsg-face-front" : "#81a2be",
         "opencsg-face-back" :  "#de935f",
         "cgal-face-front" :    "#8abeb7",

--- a/color-schemes/render/tomorrow.json
+++ b/color-schemes/render/tomorrow.json
@@ -5,6 +5,7 @@
 
     "colors" : {
         "background" :         "#f8f8f8",
+        "axes-color" :         "#181818",
         "opencsg-face-front" : "#4271ae",
         "opencsg-face-back" :  "#f5871f",
         "cgal-face-front" :    "#3e999f",

--- a/src/GLView.cc
+++ b/src/GLView.cc
@@ -158,7 +158,7 @@ void GLView::paintGL()
   glDisable(GL_LIGHTING);
 
   Color4f bgcol = ColorMap::getColor(*this->colorscheme, BACKGROUND_COLOR);
-  Color4f bgcontrast = ColorMap::getContrastColor(bgcol);
+  Color4f axescolor = ColorMap::getColor(*this->colorscheme, AXES_COLOR);
   glClearColor(bgcol[0], bgcol[1], bgcol[2], 1.0);
   glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT | GL_STENCIL_BUFFER_BIT);
 
@@ -169,9 +169,9 @@ void GLView::paintGL()
     if (showcrosshairs) GLView::showCrosshairs();
     glTranslated(cam.object_trans.x(), cam.object_trans.y(), cam.object_trans.z());
     // ...the axis lines need to follow the object translation.
-    if (showaxes) GLView::showAxes(bgcontrast);
+    if (showaxes) GLView::showAxes(axescolor);
     // mark the scale along the axis lines
-    if (showaxes && showscale) GLView::showScalemarkers(bgcontrast);
+    if (showaxes && showscale) GLView::showScalemarkers(axescolor);
   }
 
   glEnable(GL_LIGHTING);
@@ -191,7 +191,7 @@ void GLView::paintGL()
 
   // Only for GIMBAL
   glDisable(GL_LIGHTING);
-  if (showaxes) GLView::showSmallaxes(bgcontrast);
+  if (showaxes) GLView::showSmallaxes(axescolor);
 }
 
 #ifdef ENABLE_OPENCSG

--- a/src/colormap.cc
+++ b/src/colormap.cc
@@ -37,7 +37,7 @@ RenderColorScheme::RenderColorScheme() : _path("")
 	_show_in_gui = true;
 
 	_color_scheme.insert(ColorScheme::value_type(BACKGROUND_COLOR, Color4f(0xff, 0xff, 0xe5)));
-	_color_scheme.insert(ColorScheme::value_type(AXES_COLOR, Color4f(0x00, 0x00, 0xff)));
+	_color_scheme.insert(ColorScheme::value_type(AXES_COLOR, Color4f(0x00, 0x00, 0x7f)));
 	_color_scheme.insert(ColorScheme::value_type(OPENCSG_FACE_FRONT_COLOR, Color4f(0xf9, 0xd7, 0x2c)));
 	_color_scheme.insert(ColorScheme::value_type(OPENCSG_FACE_BACK_COLOR, Color4f(0x9d, 0xcb, 0x51)));
 	_color_scheme.insert(ColorScheme::value_type(CGAL_FACE_FRONT_COLOR, Color4f(0xf9, 0xd7, 0x2c)));

--- a/src/colormap.cc
+++ b/src/colormap.cc
@@ -37,7 +37,7 @@ RenderColorScheme::RenderColorScheme() : _path("")
 	_show_in_gui = true;
 
 	_color_scheme.insert(ColorScheme::value_type(BACKGROUND_COLOR, Color4f(0xff, 0xff, 0xe5)));
-	_color_scheme.insert(ColorScheme::value_type(AXES_COLOR, Color4f(0x00, 0x00, 0x7f)));
+	_color_scheme.insert(ColorScheme::value_type(AXES_COLOR, Color4f(0x00, 0x00, 0x00)));
 	_color_scheme.insert(ColorScheme::value_type(OPENCSG_FACE_FRONT_COLOR, Color4f(0xf9, 0xd7, 0x2c)));
 	_color_scheme.insert(ColorScheme::value_type(OPENCSG_FACE_BACK_COLOR, Color4f(0x9d, 0xcb, 0x51)));
 	_color_scheme.insert(ColorScheme::value_type(CGAL_FACE_FRONT_COLOR, Color4f(0xf9, 0xd7, 0x2c)));

--- a/src/colormap.cc
+++ b/src/colormap.cc
@@ -37,6 +37,7 @@ RenderColorScheme::RenderColorScheme() : _path("")
 	_show_in_gui = true;
 
 	_color_scheme.insert(ColorScheme::value_type(BACKGROUND_COLOR, Color4f(0xff, 0xff, 0xe5)));
+	_color_scheme.insert(ColorScheme::value_type(AXES_COLOR, Color4f(0x00, 0x00, 0xff)));
 	_color_scheme.insert(ColorScheme::value_type(OPENCSG_FACE_FRONT_COLOR, Color4f(0xf9, 0xd7, 0x2c)));
 	_color_scheme.insert(ColorScheme::value_type(OPENCSG_FACE_BACK_COLOR, Color4f(0x9d, 0xcb, 0x51)));
 	_color_scheme.insert(ColorScheme::value_type(CGAL_FACE_FRONT_COLOR, Color4f(0xf9, 0xd7, 0x2c)));

--- a/src/colormap.cc
+++ b/src/colormap.cc
@@ -58,6 +58,7 @@ RenderColorScheme::RenderColorScheme(fs::path path) : _path(path)
 	_show_in_gui = pt.get<bool>("show-in-gui");
 	
 	addColor(BACKGROUND_COLOR, "background");
+	addColor(AXES_COLOR, "axes-color");
 	addColor(OPENCSG_FACE_FRONT_COLOR, "opencsg-face-front");
 	addColor(OPENCSG_FACE_BACK_COLOR, "opencsg-face-back");
 	addColor(CGAL_FACE_FRONT_COLOR, "cgal-face-front");

--- a/src/colormap.h
+++ b/src/colormap.h
@@ -13,6 +13,7 @@ namespace fs = boost::filesystem;
 
 enum RenderColor {
 	BACKGROUND_COLOR,
+	AXES_COLOR,
 	OPENCSG_FACE_FRONT_COLOR,
 	OPENCSG_FACE_BACK_COLOR,
 	CGAL_FACE_FRONT_COLOR,


### PR DESCRIPTION
This implements the feature request in #1328.
I've added an `AXES_COLOR` key to **`ColorMap`**, and hooked it up to `axes-color` in the colorscheme JSON.
I've also updated all the colorschemes with very contrasty axis colors :smiley: