### PR TITLE
Add ray casting on model from command line

### DIFF
--- a/src/export.h
+++ b/src/export.h
@@ -15,6 +15,12 @@ enum FileFormat {
 	OPENSCAD_SVG
 };
 
+bool rayCastGeometry(
+    const double         *o,
+    const double         *v,
+    const class Geometry *rootGeom
+);
+
 // void exportFile(const class Geometry *root_geom, std::ostream &output, FileFormat format);
 void exportFileByName(const class Geometry *root_geom, FileFormat format,
 	const char *name2open, const char *name2display);


### PR DESCRIPTION

This adds a new command line option that casts one ray on the model and
outputs the result on stdout as:

<triangleId> <distance from ray origin> <intersection point> <normal at intersection point>

This is useful for doing after the fact measurements of the model.

It is also very useful to implement regression testing on complex parametric models.
