### PR TITLE
Create multilingual appdata file using itstool

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,6 +37,7 @@ testdata/scad/misc/use-tests.scad
 /lexer_lex.cpp
 /parser_yacc.cpp
 /OpenSCAD.app
+/openscad.appdata.xml
 /openscad.pro.user
 /openscad
 /locale/*/*/*.mo

--- a/contrib/appdata.its
+++ b/contrib/appdata.its
@@ -1,0 +1,9 @@
+<!-- Copyright 2013 Richard Hughes <richard@hughsie.com> -->
+<its:rules
+  xmlns:its="http://www.w3.org/2005/11/its"
+  version="1.0">
+  <its:translateRule translate="no" selector="/component"/>
+  <its:translateRule translate="yes"
+    selector="/component/summary |
+              /component/description"/>
+</its:rules>

--- a/openscad.appdata.xml.in
+++ b/openscad.appdata.xml.in
@@ -1,7 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<application>
- <id type="desktop">openscad.desktop</id>
- <licence>CC0</licence>
+<component type="desktop">
+ <id>openscad.desktop</id>
+ <metadata_license>CC0-1.0</metadata_license>
+ <project_license>GPL-2.0+ and CC0-1.0</project_license>
+ <name>OpenSCAD</name>
  <summary>The Programmers Solid 3D CAD Modeller</summary>
  <description>
   <p>OpenSCAD is a software for creating solid 3D CAD models. Unlike most free software for creating 3D models (such as Blender) it does not focus on the artistic aspects of 3D modelling but instead on the CAD aspects. Thus it might be the application you are looking for when you are planning to create 3D models of machine parts but pretty sure is not what you are looking for when you are more interested in creating computer-animated movies.</p>
@@ -9,8 +11,12 @@
   <p>OpenSCAD provides two main modelling techniques: First there is constructive solid geometry (aka CSG) and second there is extrusion of 2D outlines. As data exchange format format for this 2D outlines Autocad DXF files are used. In addition to 2D paths for extrusion it is also possible to read design parameters from DXF files. Besides DXF files OpenSCAD can read and create 3D models in the STL and OFF file formats.</p>
  </description>
  <screenshots>
-  <screenshot type="default" width="800" height="437">http://www.openscad.org/images/appdata-screenshot-1.png</screenshot>
-  <screenshot width="800" height="465">http://www.openscad.org/images/appdata-screenshot-2.png</screenshot>
+  <screenshot type="default">
+   <image>http://www.openscad.org/images/appdata-screenshot-1.png</image>
+  </screenshot>
+  <screenshot>
+   <image>http://www.openscad.org/images/appdata-screenshot-2.png</image>
+  </screenshot>
  </screenshots>
  <url type="homepage">http://www.openscad.org/</url>
-</application>
+</component>

--- a/scripts/translation-update.sh
+++ b/scripts/translation-update.sh
@@ -25,6 +25,9 @@ updatepot()
 	| awk '{ printf "#: examples/examples.json:%d\nmsgid %s\nmsgstr \"\"\n\n", $1, $2 }' \
 	> ./locale/json-strings.pot
 
+ # extract strings from appdata file
+ itstool -o ./locale/appdata-strings.pot ./openscad.appdata.xml.in --its=./contrib/appdata.its
+
  VER=`date +"%Y.%m.%d"`
  OPTS=
  OPTS=$OPTS' --package-name=OpenSCAD'
@@ -41,7 +44,7 @@ updatepot()
   exit 1
  fi
 
- cmd="${GETTEXT_PATH}msgcat -o ./locale/openscad.pot ./locale/openscad-tmp.pot ./locale/json-strings.pot"
+ cmd="${GETTEXT_PATH}msgcat -o ./locale/openscad.pot ./locale/openscad-tmp.pot ./locale/json-strings.pot ./locale/appdata-strings.pot"
  echo $cmd
  $cmd
  if [ ! $? = 0 ]; then
@@ -50,7 +53,7 @@ updatepot()
  fi
 
  sed -e s/"CHARSET"/"UTF-8"/g ./locale/openscad.pot > ./locale/openscad.pot.new && mv ./locale/openscad.pot.new ./locale/openscad.pot
- rm -f ./locale/json-strings.pot ./locale/openscad-tmp.pot
+ rm -f ./locale/json-strings.pot ./locale/openscad-tmp.pot ./locale/appdata-strings.pot
 }
 
 updatepo()
@@ -80,6 +83,26 @@ updatemo()
    exit 1
   fi
  done
+
+ if which itstool > /dev/null 2>&1; then
+  # ugly workaround for bug https://bugs.freedesktop.org/show_bug.cgi?id=90937
+  for LANGCODE in `cat locale/LINGUAS | grep -v "#"`; do
+   ln -s openscad.mo ./locale/$LANGCODE/LC_MESSAGES/$LANGCODE.mo
+  done
+
+  # generate translated appdata file
+  itstool -j ./openscad.appdata.xml.in -o ./openscad.appdata.xml ./locale/*/LC_MESSAGES/[a-z][a-z].mo
+
+  # clean the mess
+  for LANGCODE in `cat locale/LINGUAS | grep -v "#"`; do
+   unlink ./locale/$LANGCODE/LC_MESSAGES/$LANGCODE.mo
+  done
+ else
+  if [ x"$(uname -s)" == x"Linux" ]; then
+   echo "itstool missing, won't apply translations to openscad.appdata.xml"
+  fi
+  cp -f ./openscad.appdata.xml.in ./openscad.appdata.xml
+ fi
 }
 
 GETTEXT_PATH=""


### PR DESCRIPTION
 - updated appdata file to a newer syntax
 - created an english appdata template
 - the strings are extracted during updatepot function in translation-update.sh
 - the multilingual file is created at the end of updatemo in the same script
 - itstool needed when running make (added this information to README)

Note: I did not update the scripts for dependencies obtaining, don't know what's the proper way of dealing with them.

Please sanity check this and let me know what you think.