### PR TITLE
Probe

### DIFF
--- a/src/GeometryEvaluator.cc
+++ b/src/GeometryEvaluator.cc
@@ -43,6 +43,7 @@ GeometryEvaluator::GeometryEvaluator(const class Tree &tree):
 shared_ptr<const Geometry> GeometryEvaluator::evaluateGeometry(const AbstractNode &node, 
 																															 bool allownef)
 {
+	std::cout << "geom eval allownef = "<<allownef<<std::endl;
 	if (!GeometryCache::instance()->contains(this->tree.getIdString(node))) {
 		shared_ptr<const CGAL_Nef_polyhedron> N;
 		if (CGALCache::instance()->contains(this->tree.getIdString(node))) {

--- a/src/GeometryEvaluator.cc
+++ b/src/GeometryEvaluator.cc
@@ -43,7 +43,6 @@ GeometryEvaluator::GeometryEvaluator(const class Tree &tree):
 shared_ptr<const Geometry> GeometryEvaluator::evaluateGeometry(const AbstractNode &node, 
 																															 bool allownef)
 {
-	std::cout << "geom eval allownef = "<<allownef<<std::endl;
 	if (!GeometryCache::instance()->contains(this->tree.getIdString(node))) {
 		shared_ptr<const CGAL_Nef_polyhedron> N;
 		if (CGALCache::instance()->contains(this->tree.getIdString(node))) {

--- a/src/cgalutils-applyops.cc
+++ b/src/cgalutils-applyops.cc
@@ -208,6 +208,7 @@ namespace CGALUtils {
 	*/
 	Geometry const * applyMinkowski(const Geometry::ChildList &children)
 	{
+		std::cout << "Minkowski!!!\n";
 		CGAL::Timer t,t_tot;
 		assert(children.size() >= 2);
 		Geometry::ChildList::const_iterator it = children.begin();
@@ -223,30 +224,33 @@ namespace CGALUtils {
 				std::list<CGAL::Polyhedron_3<Hull_kernel> > result_parts;
 
 				for (size_t i = 0; i < 2; i++) {
+					std::cout << "yo!!!"<<i<<"\n";
 					CGAL_Polyhedron poly;
 
 					const PolySet * ps = dynamic_cast<const PolySet *>(operands[i]);
 
 					const CGAL_Nef_polyhedron * nef = dynamic_cast<const CGAL_Nef_polyhedron *>(operands[i]);
 
+					std::cout << "ps "<<(ps==NULL?"NULL":"ok")<<" nef "<<(nef==NULL?"NULL":"ok")<<((nef&&nef->p3->is_simple())?" simple":" not simple")<<"?\n";
+
 					if (ps) CGALUtils::createPolyhedronFromPolySet(*ps, poly);
 					else if (nef && nef->p3->is_simple()) nefworkaround::convert_to_Polyhedron<CGAL_Kernel3>(*nef->p3, poly);
-					else throw 0;
+					else { std::cout<<"throw\n"; throw 0; }
 
 					if ((ps && ps->is_convex()) ||
 							(!ps && is_weakly_convex(poly))) {
-						PRINTDB("Minkowski: child %d is convex and %s",i % (ps?"PolySet":"Nef"));
+						PRINTB("Minkowski: child %d is convex and %s",i % (ps?"PolySet":"Nef"));
 						P[i].push_back(poly);
 					} else {
 						CGAL_Nef_polyhedron3 decomposed_nef;
 
 						if (ps) {
-							PRINTDB("Minkowski: child %d is nonconvex PolySet, transforming to Nef and decomposing...", i);
+							PRINTB("Minkowski: child %d is nonconvex PolySet, transforming to Nef and decomposing...", i);
 							CGAL_Nef_polyhedron *p = createNefPolyhedronFromGeometry(*ps);
 							if (!p->isEmpty()) decomposed_nef = *p->p3;
 							delete p;
 						} else {
-							PRINTDB("Minkowski: child %d is nonconvex Nef, decomposing...",i);
+							PRINTB("Minkowski: child %d is nonconvex Nef, decomposing...",i);
 							decomposed_nef = *nef->p3;
 						}
 
@@ -264,9 +268,9 @@ namespace CGALUtils {
 						}
 
 
-						PRINTDB("Minkowski: decomposed into %d convex parts", P[i].size());
+						PRINTB("Minkowski: decomposed into %d convex parts", P[i].size());
 						t.stop();
-						PRINTDB("Minkowski: decomposition took %f s", t.time());
+						PRINTB("Minkowski: decomposition took %f s", t.time());
 					}
 				}
 
@@ -402,7 +406,7 @@ namespace CGALUtils {
 		}
 		catch (...) {
 			// If anything throws we simply fall back to Nef Minkowski
-			PRINTD("Minkowski: Falling back to Nef Minkowski");
+			PRINTB("Minkowski: Falling back to Nef Minkowski %d",0);
 
 			CGAL_Nef_polyhedron *N = applyOperator(children, OPENSCAD_MINKOWSKI);
 			return N;

--- a/src/cgalutils.cc
+++ b/src/cgalutils.cc
@@ -16,6 +16,8 @@
 #include <CGAL/normal_vector_newell_3.h>
 #include <CGAL/Handle_hash_function.h>
 
+#include <CGAL/Triangulation_3.h>
+
 #include <CGAL/config.h> 
 #include <CGAL/version.h> 
 
@@ -113,7 +115,157 @@ static CGAL_Nef_polyhedron *createNefPolyhedronFromPolygon2d(const Polygon2d &po
 	return createNefPolyhedronFromPolySet(*ps);
 }
 
+
+static void updateCenterOfMass( CGAL_Polyhedron::Point_3 const& p1,
+				CGAL_Polyhedron::Point_3 const& p2,
+				CGAL_Polyhedron::Point_3 const& p3,
+				CGAL_Polyhedron::Point_3 const& ps,
+				NT3 &volumeTotal,
+				NT3 centerOfMass[3]) {
+	//std::cout << "p1 ("<<p1.x()<<","<<p1.y()<<","<<p1.z()<<")\n";
+	//std::cout << "p2 ("<<p2.x()<<","<<p2.y()<<","<<p2.z()<<")\n";
+	//std::cout << "p3 ("<<p3.x()<<","<<p3.y()<<","<<p3.z()<<")\n";
+	//std::cout << "ps ("<<ps.x()<<","<<ps.y()<<","<<ps.z()<<")\n";
+	NT3 vol=abs(CGAL::volume(ps,p1,p2,p3));
+	NT3 centroid[3];
+	centroid[0]=(p1[0]+p2[0]+p3[0]+ps[0])/4;
+	centroid[1]=(p1[1]+p2[1]+p3[1]+ps[1])/4;
+	centroid[2]=(p1[2]+p2[2]+p3[2]+ps[2])/4;
+	volumeTotal+=vol;
+	centerOfMass[0]+=centroid[0]*vol;
+	centerOfMass[1]+=centroid[1]*vol;
+	centerOfMass[2]+=centroid[2]*vol;
+	//std::cout << "volume="<<to_double(vol)<<" centroid="<<to_double(centroid[0])<<","<<to_double(centroid[1])<<","<<to_double(centroid[2])<<"\n";
+	//std::cout<<"center of mass is ("<<to_double(centerOfMass[0])<<","<<to_double(centerOfMass[1])<<","<<to_double(centerOfMass[2])<<")\n";
+}
+
 namespace CGALUtils {
+
+	void computeVolume(const PolySet &ps,NT3 &volumeTotal,NT3 centerOfMass[3])
+	{
+		std::cout << "volume of polyset!"<<std::endl;
+		CGAL_Polyhedron poly;
+		CGALUtils::createPolyhedronFromPolySet(ps, poly);
+		CGAL_Nef_polyhedron *p = createNefPolyhedronFromGeometry(ps);
+		if (!p->isEmpty()) computeVolume(*p->p3,volumeTotal,centerOfMass);
+	}
+	void computeVolume(const CGAL_Nef_polyhedron3 &N,NT3 &volumeTotal,NT3 centerOfMass[3])
+	{
+		// attention, il faut etre sur que N->p3()->is_simple(), sinon ca fonctionne pas fort
+		std::cout << "volumen of nef!"<<std::endl;
+		CGAL::Timer t;
+		std::vector<CGAL_Polyhedron> parts;
+		t.start();
+		CGAL_Nef_polyhedron3 decomp=N;
+		CGAL::convex_decomposition_3(decomp);
+		std::cout <<"nb volumes = "<<decomp.number_of_volumes()<<"\n";
+		// the first volume is the outer volume, which ignored in the decomposition
+		CGAL_Nef_polyhedron3::Volume_const_iterator ci = decomp.volumes_begin();
+		for(; ci != decomp.volumes_end(); ++ci) {
+			std::cout <<"one part...\n";
+			/*CGAL_Nef_polyhedron3::Shell_entry_const_iterator si=ci->shells_begin();
+			for(; si != ci->shells_end(); ++si) {
+				std::cout <<"shell\n";
+				std::cout<<" converting to poly.\n";
+				CGAL_Polyhedron poly;
+				decomp.convert_inner_shell_to_polyhedron(si, poly);
+				parts.push_back(poly);
+			}
+			*/
+
+			if(ci->mark()) {
+				std::cout<<" converting to poly.\n";
+				CGAL_Polyhedron poly;
+				decomp.convert_inner_shell_to_polyhedron(ci->shells_begin(), poly);
+				parts.push_back(poly);
+			}
+
+		}
+		t.stop();
+		PRINTB("Center of mass: decomposed into %d convex parts", parts.size());
+		PRINTB("Center of mass: decomposition took %f s", t.time());
+
+		volumeTotal=0;
+		centerOfMass[0]=0;
+		centerOfMass[1]=0;
+		centerOfMass[2]=0;
+
+		// on affiche chaque partie...
+		for(int i=0;i<(int)parts.size();i++) {
+			std::cout<<"part "<<i<<" : facets = "<<parts[i].size_of_facets()<<", vertex="<<parts[i].size_of_vertices()<<"\n";
+			//
+			// on trouve le centre des points (xs,ys,zs)
+			//
+			CGAL_Polyhedron::Vertex_const_iterator vi = parts[i].vertices_begin();
+			NT3 xs=0,ys=0,zs=0;
+			int nb=0;
+			for(;vi!=parts[i].vertices_end();vi++) {
+				CGAL_Polyhedron::Point_3 const& p = vi->point();
+				xs+=p[0];
+				ys+=p[1];
+				zs+=p[2];
+				nb++;
+				//std::cout << "vertice ("<<x<<","<<y<<","<<z<<")\n";
+			}
+			CGAL_Polyhedron::Point_3 ps(xs/nb,ys/nb,zs/nb);
+			//std::cout << "center is ("<<ps[0]<<","<<ps[1]<<","<<ps[2]<<")\n";
+			//
+			// on visite chaque facette...
+			// on la triangule
+			//
+			CGAL_Polyhedron::Facet_const_iterator fi = parts[i].facets_begin();
+			for(;fi!=parts[i].facets_end();fi++) {
+				//std::cout << "facet "<<fi->is_triangle()<<" , nbedge="<<fi->facet_degree()<<"\n";
+				if( fi->is_triangle() ) {
+					// tetrahedre avec le centre... et voila!
+					CGAL_Polyhedron::Facet::Halfedge_around_facet_const_circulator he,end;
+					end = he = fi->facet_begin();
+					//CGAL_Polyhedron P;
+
+					CGAL_Polyhedron::Point_3 const& p1 = he->vertex()->point();he++;
+					CGAL_Polyhedron::Point_3 const& p2 = he->vertex()->point();he++;
+					CGAL_Polyhedron::Point_3 const& p3 = he->vertex()->point();
+					updateCenterOfMass(p1,p2,p3,ps,volumeTotal,centerOfMass);
+
+				}else{
+					// on decoupe!
+					// trouve le centre de la facette
+					CGAL_Polyhedron::Facet::Halfedge_around_facet_const_circulator he,end;
+					NT3 xc=0,yc=0,zc=0;
+					end = he = fi->facet_begin();
+                        		CGAL_For_all(he,end) {
+						CGAL_Polyhedron::Point_3 const& p = he->vertex()->point();
+						xc+=p[0];yc+=p[1];zc+=p[2];
+						//std::cout << "facet halfedge ("<<to_double(p[0])<<","<<to_double(p[1])<<","<<to_double(p[2])<<")\n";
+					}
+					xc/=(int)fi->facet_degree();
+					yc/=(int)fi->facet_degree();
+					zc/=(int)fi->facet_degree();
+					CGAL_Polyhedron::Point_3 pc(xc,yc,zc);
+					//std::cout << "facet center ("<<to_double(xc)<<","<<to_double(yc)<<","<<to_double(zc)<<")\n";
+					// on fait le tour de la facette, en ajoutant les tetra (p1,p2,ps,pc)
+					end = he = fi->facet_begin();
+                        		CGAL_For_all(he,end) {
+						CGAL_Polyhedron::Point_3 const& p1 = he->vertex()->point();
+						CGAL_Polyhedron::Point_3 const& p2 = he->next()->vertex()->point();
+						//std::cout << "facet halfedge p1 ("<<to_double(p1[0])<<","<<to_double(p1[1])<<","<<to_double(p1[2])<<")\n";
+						//std::cout << "facet halfedge p2 ("<<to_double(p2[0])<<","<<to_double(p2[1])<<","<<to_double(p2[2])<<")\n";
+						updateCenterOfMass(p1,p2,pc,ps,volumeTotal,centerOfMass);
+					}
+				}
+			}
+		}
+		// finalise le centre de masse
+		if( volumeTotal>0 ) {
+			centerOfMass[0]/=volumeTotal;
+			centerOfMass[1]/=volumeTotal;
+			centerOfMass[2]/=volumeTotal;
+		}
+		std::cout<<"Volume Total = "<<to_double(volumeTotal)<<"\n";
+		std::cout<<"center of mass is ("<<to_double(centerOfMass[0])<<","<<to_double(centerOfMass[1])<<","<<to_double(centerOfMass[2])<<")\n";
+	//	std::cout<<"center of mass is ("<<centerOfMass[0]<<","<<centerOfMass[1]<<","<<centerOfMass[2]<<")\n";
+		
+	}
 
 	CGAL_Iso_cuboid_3 boundingBox(const CGAL_Nef_polyhedron3 &N)
 	{

--- a/src/cgalutils.h
+++ b/src/cgalutils.h
@@ -19,6 +19,9 @@ namespace /* anonymous */ {
 }
 
 namespace CGALUtils {
+	void computeVolume(const CGAL_Nef_polyhedron3 &N,NT3 &volumeTotal,NT3 centerOfMass[3]);
+	void computeVolume(const PolySet &ps,NT3 &volumeTotal,NT3 centerOfMass[3]);
+
 	bool applyHull(const Geometry::ChildList &children, PolySet &P);
 	CGAL_Nef_polyhedron *applyOperator(const Geometry::ChildList &children, OpenSCADOperator op);
 	//FIXME: Old, can be removed:

--- a/src/control.cc
+++ b/src/control.cc
@@ -333,39 +333,46 @@ AbstractNode *ControlModule::instantiate(const Context* /*ctx*/, const ModuleIns
 	}
 		break;
 	case PROBE: {
-		std::cout << "probe!" << std::endl;
-
+		//
+		// render first children, then compute the bounding box.
+		// set the following 4 vector variables and 1 bool variable:
+		//    bbempty = true/false, state if there was any usable geometry.
+		//              when bbempty is false, the next variables are undef
+		//    bbmin = [xmin,ymin,zmin], the minimum of the bounding box
+		//    bbmax = [xmax,ymax,zmax], the maximum of the bounding box
+		//    bbsize = [xmax-xmin,...], the size of the bounding box
+		//    bbcenter = [(xmax+xmin)/2, ...], the center of the bounding box
+		//
+		// the only parameter that probe takes is $exact=true/false
+		// it is generaly set to true, but with false the rendering will not be Nef (so its faster).
+		// any other parameter will be treated just like assign() (i.e. passed inside)
+		//
 		node = new AbstractNode(inst);
 		Context c(evalctx);
 
 		// les parametres.. au cas ou on fera $exact=1
 		for (size_t i = 0; i < evalctx->numArgs(); i++) {
 			if (!evalctx->getArgName(i).empty()) {
-				std::cout << "param "<<evalctx->getArgName(i) <<std::endl;
 				c.set_variable(evalctx->getArgName(i), evalctx->getArgValue(i));
 			}
 		}
 
+		// not sure how to set the default value to true... for now its false.
         	bool exact = c.lookup_variable("$exact")->toBool();
-		std::cout << "probe: exact="<<exact<<std::endl;
 
 		// Let any local variables override the parameters
 		inst->scope.apply(c);
 
 		// instantiate children one by one...
                 std::vector<AbstractNode*> childnodes;
-                std::cout << "probe nbchildren=" << node->children.size()<<std::endl;
-                std::cout << "probe nb=" << evalctx->numChildren()<<std::endl;
                 AbstractNode *nc;
 
+		double xmin,ymin,zmin,xmax,ymax,zmax;
 
                 for(unsigned int k=0;k<evalctx->numChildren();k++) {
-                        std::cout << "eval child "<<k<<std::endl;
                         nc = evalctx->getChild(k)->evaluate(&c);
-                        // check render bbox
+                        // first child? then we render and set the bbox variables
                         if( k==0 && nc!=NULL ) {
-				std::cout << "process child 0" << std::endl;
-
                                 Tree tree;
                                 tree.setRoot(nc);
                                 GeometryEvaluator geomEvaluator(tree);
@@ -374,152 +381,74 @@ AbstractNode *ControlModule::instantiate(const Context* /*ctx*/, const ModuleIns
 				shared_ptr<const CGAL_Nef_polyhedron> N;
 				shared_ptr<const Geometry> geom;
 
-				//shared_ptr<const Geometry> geom; 
+				bool empty=true;
+
 				geom=geomEvaluator.evaluateGeometry(*nc,exact); // false-> no NEF, true= ok NEF
 				G = dynamic_pointer_cast<const PolySet>(geom);
-				if( G==NULL ) {
-					std::cout << "G is NULL!"<<std::endl;
+				// we assueme that we will get either CSG or CGAL, but not both
+				if( G!=NULL ) {
+					// we obtained a fast CSG geometry instead of a Nef polyhedron.
+					empty=G->isEmpty();
+					if( !empty ) {
+						BoundingBox bb = G->getBoundingBox();
+						xmin=bb.min().x();
+						ymin=bb.min().y();
+						zmin=bb.min().z();
+						xmax=bb.max().x();
+						ymax=bb.max().y();
+						zmax=bb.max().z();
+					}
 				}else{
-				    c.set_variable("empty",Value(G->isEmpty()));
-				    if( !G->isEmpty() ) {
-					std::cout << "G empty = "<<G->isEmpty() <<std::endl;
-					BoundingBox bb = G->getBoundingBox();
-					double xmin=bb.min().x();
-					double ymin=bb.min().y();
-					double zmin=bb.min().z();
-					double xmax=bb.max().x();
-					double ymax=bb.max().y();
-					double zmax=bb.max().z();
-
-					std::cout << "X " << xmin << "..." << xmax << std::endl;
-					std::cout << "Y " << ymin << "..." << ymax << std::endl;
-					std::cout << "Z " << zmin << "..." << zmax << std::endl;
-
-                                        c.set_variable("xmin",Value(xmin));
-                                        c.set_variable("ymin",Value(ymin));
-                                        c.set_variable("zmin",Value(zmin));
-                                        c.set_variable("xmax",Value(xmax));
-                                        c.set_variable("ymax",Value(ymax));
-                                        c.set_variable("zmax",Value(zmax));
-
-                                        Value::VectorType center;
-                                        center.push_back((xmin+xmax)/2.0);
-                                        center.push_back((ymin+ymax)/2.0);
-                                        center.push_back((zmin+zmax)/2.0);
-                                        c.set_variable("center",Value(center));
-
-                                        Value::VectorType boxsize;
-                                        boxsize.push_back(xmax-xmin);
-                                        boxsize.push_back(ymax-ymin);
-                                        boxsize.push_back(zmax-zmin);
-                                        c.set_variable("boxsize",Value(boxsize));
-				    }
-				}
-
 #ifdef ENABLE_CGAL
-				N = dynamic_pointer_cast<const CGAL_Nef_polyhedron>(geom);
-				if( N==NULL ) {
-					std::cout << "N is NULL!"<<std::endl;
-				}else{
-				    c.set_variable("empty",Value(N->isEmpty()));
-				    std::cout << "N empty = "<<N->isEmpty() <<std::endl;
-				    if( !N->isEmpty() ) {
-                                        CGAL_Iso_cuboid_3 bb;
-                                        bb = CGALUtils::boundingBox( *(N->p3) );
-                                        double xmin=CGAL::to_double(bb.xmin());
-                                        double ymin=CGAL::to_double(bb.ymin());
-                                        double zmin=CGAL::to_double(bb.zmin());
-                                        double xmax=CGAL::to_double(bb.xmax());
-                                        double ymax=CGAL::to_double(bb.ymax());
-                                        double zmax=CGAL::to_double(bb.zmax());
-
-					std::cout << "X " << xmin << "..." << xmax << std::endl;
-					std::cout << "Y " << ymin << "..." << ymax << std::endl;
-					std::cout << "Z " << zmin << "..." << zmax << std::endl;
-
-                                        c.set_variable("xmin",Value(xmin));
-                                        c.set_variable("ymin",Value(ymin));
-                                        c.set_variable("zmin",Value(zmin));
-                                        c.set_variable("xmax",Value(xmax));
-                                        c.set_variable("ymax",Value(ymax));
-                                        c.set_variable("zmax",Value(zmax));
-
-                                        Value::VectorType center;
-                                        center.push_back((xmin+xmax)/2.0);
-                                        center.push_back((ymin+ymax)/2.0);
-                                        center.push_back((zmin+zmax)/2.0);
-                                        c.set_variable("center",Value(center));
-
-                                        Value::VectorType boxsize;
-                                        boxsize.push_back(xmax-xmin);
-                                        boxsize.push_back(ymax-ymin);
-                                        boxsize.push_back(zmax-zmin);
-                                        c.set_variable("boxsize",Value(boxsize));
-				    }
-				}
-/*
-				if( true ) {
-                                        CGAL_Iso_cuboid_3 bb;
-                                        bb = CGALUtils::boundingBox( *(N->p3) );
-                                        std::cout << "**** bounding xmin=" << bb.xmin() << std::endl;
-                                        std::cout << "**** bounding xmax=" << bb.xmax() << std::endl;
-                                        std::cout << "**** bounding ymin=" << bb.ymin() << std::endl;
-                                        std::cout << "**** bounding ymax=" << bb.ymax() << std::endl;
-                                        std::cout << "**** bounding zmin=" << bb.zmin() << std::endl;
-                                        std::cout << "**** bounding zmax=" << bb.zmax() << std::endl;
-				}else{
-					std::cout << "empty!" << std::endl;
-				}
-*/
-
-/*
-                                Tree tree;
-                                tree.setRoot(nc);
-                                CGALEvaluator cgalevaluator(tree);
-
-                                CGAL_Nef_polyhedron N=cgalevaluator.evaluateCGALMesh(*nc);
-                                if( !N.isNull() && ! N.isEmpty() ) {
-                                        CGAL_Iso_cuboid_3 bb;
-                                        bb = bounding_box( *N.p3 );
-                                        std::cout << "**** bounding xmin=" << bb.xmin() << std::endl;
-                                        std::cout << "**** bounding xmax=" << bb.xmax() << std::endl;
-                                        std::cout << "**** bounding ymin=" << bb.ymin() << std::endl;
-                                        std::cout << "**** bounding ymax=" << bb.ymax() << std::endl;
-                                        std::cout << "**** bounding zmin=" << bb.zmin() << std::endl;
-                                        std::cout << "**** bounding zmax=" << bb.zmax() << std::endl;
-                                        double xmin=CGAL::to_double(bb.xmin());
-                                        double ymin=CGAL::to_double(bb.ymin());
-                                        double zmin=CGAL::to_double(bb.zmin());
-                                        double xmax=CGAL::to_double(bb.xmax());
-                                        double ymax=CGAL::to_double(bb.ymax());
-                                        double zmax=CGAL::to_double(bb.zmax());
-
-                                        c.set_variable("xmin",xmin);
-                                        c.set_variable("xmax",xmax);
-                                        c.set_variable("ymin",ymin);
-                                        c.set_variable("ymax",ymax);
-                                        c.set_variable("zmin",zmin);
-                                        c.set_variable("zmax",zmax);
-
-                                        Value::VectorType center;
-                                        center.push_back((xmin+xmax)/2.0);
-                                        center.push_back((ymin+ymax)/2.0);
-                                        center.push_back((zmin+zmax)/2.0);
-                                        c.set_variable("center",center);
-
-                                        Value::VectorType boxsize;
-                                        boxsize.push_back(xmax-xmin);
-                                        boxsize.push_back(ymax-ymin);
-                                        boxsize.push_back(zmax-zmin);
-                                        c.set_variable("boxsize",boxsize);
-                                }
-*/
+					N = dynamic_pointer_cast<const CGAL_Nef_polyhedron>(geom);
+					if( N!=NULL ) {
+					    empty=N->isEmpty();
+					    if( !empty ) {
+						CGAL_Iso_cuboid_3 bb;
+						bb = CGALUtils::boundingBox( *(N->p3) );
+						xmin=CGAL::to_double(bb.xmin());
+						ymin=CGAL::to_double(bb.ymin());
+						zmin=CGAL::to_double(bb.zmin());
+						xmax=CGAL::to_double(bb.xmax());
+						ymax=CGAL::to_double(bb.ymax());
+						zmax=CGAL::to_double(bb.zmax());
+					    }
+					}
 #endif
+				}
+			        c.set_variable("bbempty",Value(empty));
+				if( !empty ) {
+					// define the variables
+                                        Value::VectorType bbmin;
+					bbmin.push_back(xmin);
+					bbmin.push_back(ymin);
+					bbmin.push_back(zmin);
+                                        c.set_variable("bbmin",Value(bbmin));
 
+                                        Value::VectorType bbmax;
+					bbmax.push_back(xmax);
+					bbmax.push_back(ymax);
+					bbmax.push_back(zmax);
+                                        c.set_variable("bbmax",Value(bbmax));
+
+                                        Value::VectorType bbcenter;
+                                        bbcenter.push_back((xmin+xmax)/2.0);
+                                        bbcenter.push_back((ymin+ymax)/2.0);
+                                        bbcenter.push_back((zmin+zmax)/2.0);
+                                        c.set_variable("bbcenter",Value(bbcenter));
+
+                                        Value::VectorType bbsize;
+                                        bbsize.push_back(xmax-xmin);
+                                        bbsize.push_back(ymax-ymin);
+                                        bbsize.push_back(zmax-zmin);
+                                        c.set_variable("bbsize",Value(bbsize));
+				}
+				// this node is not added to the final rendering.
 				delete nc;
-				continue;
+			}else{
+				// add the node to the final rendering
+				if( nc!=NULL ) node->children.push_back(nc);
 			}
-			if( nc!=NULL ) node->children.push_back(nc);
 		}
 
 		//std::vector<AbstractNode *> instantiatednodes = inst->instantiateChildren(&c);

--- a/src/control.cc
+++ b/src/control.cc
@@ -35,6 +35,8 @@
 #include <sstream>
 #include "mathc99.h"
 
+// pour le probe()
+
 
 #define foreach BOOST_FOREACH
 

--- a/src/control.cc
+++ b/src/control.cc
@@ -358,6 +358,7 @@ AbstractNode *ControlModule::instantiate(const Context* /*ctx*/, const ModuleIns
                 std::cout << "probe nb=" << evalctx->numChildren()<<std::endl;
                 AbstractNode *nc;
 
+
                 for(unsigned int k=0;k<evalctx->numChildren();k++) {
                         std::cout << "eval child "<<k<<std::endl;
                         nc = evalctx->getChild(k)->evaluate(&c);

--- a/src/func.cc
+++ b/src/func.cc
@@ -283,11 +283,11 @@ ValuePtr builtin_min(const Context *, const EvalContext *evalctx)
 	size_t n = evalctx->numArgs();
 	if (n >= 1) {
 		ValuePtr v0 = evalctx->getArgValue(0);
-
 		if (n == 1 && v0->type() == Value::VECTOR && !v0->toVector().empty()) {
-			Value min = v0->toVector()[0];
-			for (size_t i = 1; i < v0->toVector().size(); i++) {
-				if (v0->toVector()[i] < min) min = v0->toVector()[i];
+			Value min = Value::undefined;//v0->toVector()[0];
+			for (size_t i = 0; i < v0->toVector().size(); i++) {
+		                if (v0->toVector()[i].type()!=Value::NUMBER ) continue;
+				if (!min.isDefined() || v0->toVector()[i] < min) min = v0->toVector()[i];
 			}
 			return ValuePtr(min);
 		}
@@ -317,9 +317,10 @@ ValuePtr builtin_max(const Context *, const EvalContext *evalctx)
 		ValuePtr v0 = evalctx->getArgValue(0);
 
 		if (n == 1 && v0->type() == Value::VECTOR && !v0->toVector().empty()) {
-			Value max = v0->toVector()[0];
+			Value max = Value::undefined; // v0->toVector()[0];
 			for (size_t i = 1; i < v0->toVector().size(); i++) {
-				if (v0->toVector()[i] > max) max = v0->toVector()[i];
+		                if (v0->toVector()[i].type()!=Value::NUMBER ) continue;
+				if (!max.isDefined() || v0->toVector()[i] > max) max = v0->toVector()[i];
 			}
 			return ValuePtr(max);
 		}

--- a/src/highlighter.cc
+++ b/src/highlighter.cc
@@ -149,7 +149,7 @@ void format_colors_for_light_background(QMap<QString,QTextCharFormat> &formats)
 	formats["keyword"].setForeground(QColor("Green"));
 	formats["keyword"].setToolTip("Keyword");
 	formats["transform"].setForeground(QColor("Indigo"));
-	formats["csgop"].setForeground(QColor("DarkGreen"));
+	formats["csgop"].setForeground(QColor("Red"/*"DarkGreen"*/));
 	formats["prim3d"].setForeground(QColor("DarkBlue"));
 	formats["prim2d"].setForeground(QColor("MidnightBlue"));
 	formats["import"].setForeground(Qt::darkYellow);
@@ -172,7 +172,7 @@ void format_colors_for_dark_background(QMap<QString,QTextCharFormat> &formats)
 	formats["keyword"].setForeground(QColor("LightGreen"));
 	formats["keyword"].setToolTip("Keyword");
 	formats["transform"].setForeground(QColor("Thistle"));
-	formats["csgop"].setForeground(QColor("LightGreen"));
+	formats["csgop"].setForeground(QColor("Red"/*"LightGreen"*/));
 	formats["prim3d"].setForeground(QColor("LightBlue"));
 	formats["prim2d"].setForeground(QColor("LightBlue"));
 	formats["import"].setForeground(QColor("LightYellow"));
@@ -221,7 +221,7 @@ Highlighter::Highlighter(QTextDocument *parent)
 	tokentypes["math"] << "abs" << "sign" << "acos" << "asin" << "atan" << "atan2" << "sin" << "cos" << "floor" << "round" << "ceil" << "ln" << "log" << "lookup" << "min" << "max" << "pow" << "sqrt" << "exp" << "rands";
 	tokentypes["keyword"] << "module" << "function" << "for" << "intersection_for" << "if" << "assign" << "echo"<< "search" << "str" << "let";
 	tokentypes["transform"] << "scale" << "translate" << "rotate" << "multmatrix" << "color" << "projection" << "hull" << "resize" << "mirror" << "minkowski";
-	tokentypes["csgop"]	<< "union" << "intersection" << "difference" << "render";
+	tokentypes["csgop"]	<< "union" << "intersection" << "difference" << "render" << "probe";
 	tokentypes["prim3d"] << "cube" << "cylinder" << "sphere" << "polyhedron";
 	tokentypes["prim2d"] << "square" << "polygon" << "circle";
 	tokentypes["import"] << "include" << "use" << "import_stl" << "import" << "import_dxf" << "dxf_dim" << "dxf_cross" << "surface";

--- a/src/module.cc
+++ b/src/module.cc
@@ -149,6 +149,9 @@ AbstractNode *ModuleInstantiation::evaluate(const Context *ctx) const
 {
 	EvalContext c(ctx, this->arguments, &this->scope);
 
+	// seb
+	//std::cout << "evaluate module  " << modname << std::endl;
+
 #if 0 && DEBUG
 	PRINT("New eval ctx:");
 	c.dump(NULL, this);
@@ -180,6 +183,9 @@ AbstractNode *Module::instantiate(const Context *ctx, const ModuleInstantiation 
 		throw RecursionException::create("module", inst->name());
 		return NULL;
 	}
+
+	// seb
+	//std::cout << "instantiate module  " << inst->modname << std::endl;
 
 	// At this point we know that nobody will modify the dependencies of the local scope
 	// passed to this instance, so we can populate the context

--- a/src/module.h
+++ b/src/module.h
@@ -18,7 +18,7 @@ class ModuleInstantiation
 {
 public:
 	ModuleInstantiation(const std::string &name = "")
-		: tag_root(false), tag_highlight(false), tag_background(false), modname(name) { }
+		: tag_root(false), tag_highlight(false), tag_background(false), modname(name) { std::cout<<"modinst "<<name<<std::endl;}
 	virtual ~ModuleInstantiation();
 
 	virtual std::string dump(const std::string &indent) const;


### PR DESCRIPTION
A while ago I posted about adding a feature to measure geometry dimensions (see issue #301).
Time has passed, openscad improved, and I still need this feature. So I re-implemented it for the current openscad version.

It adds a new function, probe(), which will analyse the geometry of its first children, set some variables about its bounding box, and then evaluate the remaining children with those variables available. The variables are:
bbempty : true if the geometry is empty
bbmin and bbmax : the minimum and maximum coordinates of the bounding box
bbsize and bbcenter : the size and center of the bounding box

For example, you can do this:
probe() {
    sphere(r=10);
    echo(bbsize);
}
and you shoud see the size (near 10x10x10) displayed. To get the geometry, you have to repeat it:
probe() {
   sphere();
   sphere();
}
So to center only in X the object, simply do this:
probe() {
   object();
   translate([-bbcenter[0],0,0]) object();
}
You can impose fast computation using $exact=false, which will turn off CGAL. In all cases, it must be understood that this function has a computational cost. This is why I call it probe(), to suggest it will do some work, rather than bounds(), for example.

To display the bounding of an object, you can do this:
module see_bbox() {
    probe()  {
        children();
        if( !bbempty ) {
            %translate(bbcenter) cube(bbsize,center=true);
            children(); // display the geometry itself
        }
    }
}

If used sparingly, this function can help do things that are impossible right now because they require to estimate dimensions on complex geometry, which can be mathematically intractable.

Here are a few example of what you can do easily using probe(). It can align objects bounding boxes in many different ways. It makes attaching objects together very easy also.
![probe_bbox](https://cloud.githubusercontent.com/assets/3324317/8664865/41e29468-29ab-11e5-87a6-54a24a1620cc.png)

It makes "probing" objects possibile: you can intersect with a "probe" and obtain specific measures that can be used to place other objects. For example:

![piston](https://cloud.githubusercontent.com/assets/3324317/8664929/feb82a4e-29ab-11e5-84bc-5590e0e18519.gif)

Also, you can do more complex things, like search for complex intersections that are very hard to compute in any other way. For example:
![touch](https://cloud.githubusercontent.com/assets/3324317/8664938/1c947af4-29ac-11e5-8a31-47c0659edf0d.gif)

Technically, the probe() function is located in control.cc. It evaluates the geometry just like render, and can process polyset as well as nef_polyhedron representations.

This is the first pull request I make... I have no idea if its going to work or if this is the proper procedure to submit for openscad. In any case, I truly enjoy openscad and I think it really needs that feature. I hope it can be useful.

I will post documentation, examples and tests on request.

