### PR TITLE
Minor fixes from Debian's checks

### DIFF
--- a/doc/openscad.1
+++ b/doc/openscad.1
@@ -82,8 +82,10 @@ If exporting an image, specify the pixel width and height
 If exporting an image, specify whether to use orthographic or perspective 
 projection
 .TP
-.B \-\-colorscheme=[Cornfield|Sunset|Metallic|Starnight|BeforeDawn|Nature|DeepOcean]
+.B \-\-colorscheme=\fIscheme
 If exporting an image, use the specified color scheme for the rendering.
+\fIscheme\fP can be any of \fBCornfield\fP, \fBSunset\fP, \fBMetallic\fP,
+\fBStarnight\fP, \fBBeforeDawn\fP, \fBNature\fP or \fBDeepOcean\fP.
 .TP
 .B \-v, \-\-version
 Show version of program.

--- a/icons/openscad.desktop
+++ b/icons/openscad.desktop
@@ -6,3 +6,4 @@ Icon=openscad
 Exec=openscad %f
 MimeType=application/x-openscad;
 Categories=Graphics;3DGraphics;Engineering;
+Keywords=3d;solid;geometry;csg;model;stl;

--- a/locale/cs.po
+++ b/locale/cs.po
@@ -936,7 +936,7 @@ msgid "PolySet Cache size"
 msgstr "Velikost PolySet cache"
 
 #: objects/ui_Preferences.h:1158
-msgid "Allow to open multiple documents"
+msgid "Allow opening multiple documents"
 msgstr "Povolit současné otevření více dokumentů"
 
 #: objects/ui_Preferences.h:1159

--- a/locale/de.po
+++ b/locale/de.po
@@ -956,7 +956,7 @@ msgid "PolySet Cache size"
 msgstr "PolySet Cache Größe"
 
 #: objects/ui_Preferences.h:1158
-msgid "Allow to open multiple documents"
+msgid "Allow opening multiple documents"
 msgstr "Öffnen von mehreren Dokumenten erlauben"
 
 #: objects/ui_Preferences.h:1159

--- a/locale/es.po
+++ b/locale/es.po
@@ -993,7 +993,7 @@ msgid "PolySet Cache size"
 msgstr "Tamaño de cache de PolySet"
 
 #: objects/ui_Preferences.h:1159
-msgid "Allow to open multiple documents"
+msgid "Allow opening multiple documents"
 msgstr "Permitir a abrir varios documentos"
 
 #: objects/ui_Preferences.h:1160

--- a/locale/fr.po
+++ b/locale/fr.po
@@ -956,7 +956,7 @@ msgid "PolySet Cache size"
 msgstr "Taille du Cache PolySet"
 
 #: objects/ui_Preferences.h:1158
-msgid "Allow to open multiple documents"
+msgid "Allow opening multiple documents"
 msgstr "Autoriser l'ouverture de plusieurs documents"
 
 #: objects/ui_Preferences.h:1159

--- a/locale/openscad.pot
+++ b/locale/openscad.pot
@@ -926,7 +926,7 @@ msgid "PolySet Cache size"
 msgstr ""
 
 #: objects/ui_Preferences.h:1158
-msgid "Allow to open multiple documents"
+msgid "Allow opening multiple documents"
 msgstr ""
 
 #: objects/ui_Preferences.h:1159

--- a/locale/ru.po
+++ b/locale/ru.po
@@ -954,7 +954,7 @@ msgid "PolySet Cache size"
 msgstr "Размер кэша PolySet"
 
 #: objects/ui_Preferences.h:1158
-msgid "Allow to open multiple documents"
+msgid "Allow opening multiple documents"
 msgstr "Разрешить открытие нескольких документов"
 
 #: objects/ui_Preferences.h:1159

--- a/src/Preferences.ui
+++ b/src/Preferences.ui
@@ -1333,7 +1333,7 @@
             <item>
              <widget class="QCheckBox" name="mdiCheckBox">
               <property name="text">
-               <string>Allow to open multiple documents</string>
+               <string>Allow opening multiple documents</string>
               </property>
              </widget>
             </item>

--- a/tests/test_cmdline_tool.py
+++ b/tests/test_cmdline_tool.py
@@ -1,3 +1,4 @@
+#!/usr/bin/python
 #
 # Regression test driver for cmd-line tools
 #


### PR DESCRIPTION
This is a bunch of probably non-controversial changes fixing the hashbang in an executable file (which is only used with explicit invocation anyway most of the time), desktop file extensions, man page line breaking errors and grammar.

The "Allow to open" issue might be better resolved by rephrasing it to not use "allow" at all (see [english localization notes](http://www.xibalba.demon.co.uk/jbr/linux/esl.html#b1)), but given it currently deviates from the other "enable" options in a seemingly purpuseful way, I didn't change it that way.