### PR TITLE
Fix path discovery for fonts

### DIFF
--- a/tests/test_cmdline_tool.py
+++ b/tests/test_cmdline_tool.py
@@ -231,7 +231,7 @@ def run_test(testname, cmd, args):
     try:
         cmdline = [cmd] + args + [outputname]
         print 'run_test() cmdline:',cmdline
-        fontdir =  os.path.join(os.path.dirname(cmd), "..", "testdata")
+        fontdir =  os.path.join(os.path.dirname(cmd), "testdata")
         fontenv = os.environ.copy()
         fontenv["OPENSCAD_FONT_PATH"] = fontdir
         print 'using font directory:', fontdir


### PR DESCRIPTION
When the path to the openscad binary changed in issue 1362, the relative path
was not changed and therefore led into the void, falling back to system
paths.