### PR TITLE
Enable compilation without OpenCSG.

### DIFF
--- a/opencsg.pri
+++ b/opencsg.pri
@@ -1,6 +1,5 @@
 opencsg {
   DEFINES += ENABLE_OPENCSG
-  CONFIG += glew
 
   # Optionally specify location of OpenCSG using the 
   # OPENCSGDIR env. variable

--- a/openscad.pro
+++ b/openscad.pro
@@ -179,6 +179,7 @@ macx:CONFIG += mdi
 #CONFIG += c++11
 CONFIG += cgal
 CONFIG += opencsg
+CONFIG += glew
 CONFIG += boost
 CONFIG += eigen
 CONFIG += glib-2.0

--- a/src/OpenCSGRenderer.cc
+++ b/src/OpenCSGRenderer.cc
@@ -31,7 +31,6 @@
 #include "stl-utils.h"
 #ifdef ENABLE_OPENCSG
 #  include <opencsg.h>
-#endif
 
 class OpenCSGPrim : public OpenCSG::Primitive
 {
@@ -48,6 +47,8 @@ public:
 		glPopMatrix();
 	}
 };
+
+#endif
 
 OpenCSGRenderer::OpenCSGRenderer(CSGChain *root_chain, CSGChain *highlights_chain,
 																 CSGChain *background_chain, GLint *shaderinfo)
@@ -74,6 +75,7 @@ void OpenCSGRenderer::draw(bool /*showfaces*/, bool showedges) const
 void OpenCSGRenderer::renderCSGChain(CSGChain *chain, GLint *shaderinfo, 
 																		 bool highlight, bool background) const
 {
+#ifdef ENABLE_OPENCSG
 	std::vector<OpenCSG::Primitive*> primitives;
 	size_t j = 0;
 	for (size_t i = 0;; i++) {
@@ -151,6 +153,7 @@ void OpenCSGRenderer::renderCSGChain(CSGChain *chain, GLint *shaderinfo,
 		}
 	}
 	std::for_each(primitives.begin(), primitives.end(), del_fun<OpenCSG::Primitive>());
+#endif
 }
 
 BoundingBox OpenCSGRenderer::getBoundingBox() const

--- a/src/mainwin.cc
+++ b/src/mainwin.cc
@@ -1073,8 +1073,10 @@ void MainWindow::instantiateRoot()
 
   // Invalidate renderers before we kill the CSG tree
 	this->qglview->setRenderer(NULL);
+#ifdef ENABLE_OPENCSG
 	delete this->opencsgRenderer;
 	this->opencsgRenderer = NULL;
+#endif
 	delete this->thrownTogetherRenderer;
 	this->thrownTogetherRenderer = NULL;
 
@@ -1156,9 +1158,11 @@ void MainWindow::compileCSG(bool procevents)
 #else
 		// FIXME: Will we support this?
 #endif
+#ifdef ENABLE_OPENCSG
 		CSGTermEvaluator csgrenderer(this->tree, &geomevaluator);
 		if (procevents) QApplication::processEvents();
 		this->root_raw_term = csgrenderer.evaluateCSGTerm(*root_node, highlight_terms, background_terms);
+#endif
 		GeometryCache::instance()->print();
 #ifdef ENABLE_CGAL
 		CGALCache::instance()->print();
@@ -1218,6 +1222,7 @@ void MainWindow::compileCSG(bool procevents)
 		PRINTB("WARNING: Normalized tree has %d elements!", this->root_chain->objects.size());
 		PRINT("WARNING: OpenCSG rendering has been disabled.");
 	}
+#ifdef ENABLE_OPENCSG
 	else {
 		PRINTB("Normalized CSG tree has %d elements",
 					 (this->root_chain ? this->root_chain->objects.size() : 0));
@@ -1226,6 +1231,7 @@ void MainWindow::compileCSG(bool procevents)
 																								this->background_chain,
 																								this->qglview->shaderinfo);
 	}
+#endif
 	this->thrownTogetherRenderer = new ThrownTogetherRenderer(this->root_chain,
 																														this->highlights_chain,
 																														this->background_chain);


### PR DESCRIPTION
This is just a patch so that the ENABLE_OPENCSG compiler define works again, should someone want to compile without OpenCSG for whatever reason.