### PR TITLE
".nefdbg" extension to dump debug info on CGALNefPolyhedron3+SphereMaps

### DIFF
--- a/cgal/decompose.pro
+++ b/cgal/decompose.pro
@@ -54,10 +54,12 @@ macx {
   }
 }
 
-# See Dec 2011 OpenSCAD mailing list, re: CGAL/GCC bugs.
 *g++* {
+  # See Dec 2011 OpenSCAD mailing list, re: CGAL/GCC bugs.
   QMAKE_CXXFLAGS *= -fno-strict-aliasing
   QMAKE_CXXFLAGS_WARN_ON += -Wno-unused-local-typedefs # ignored before 4.8
+  # use of 'auto'
+  QMAKE_CXXFLAGS += -std=c++11
 }
 
 *clang* {
@@ -80,7 +82,10 @@ CONFIG += gettext
 
 mac: {
    LIBS += -framework OpenGL
+} else {
+   LIBS += -lGL
 }
+
 
 include(../common.pri)
 

--- a/src/export.cc
+++ b/src/export.cc
@@ -64,6 +64,9 @@ void exportFile(const class Geometry *root_geom, std::ostream &output, FileForma
 		case OPENSCAD_DXF:
 			assert(false && "Export Nef polyhedron as DXF not supported");
 			break;
+		case OPENSCAD_NEFDBG:
+			output << N->dump();
+			break;
 		default:
 			assert(false && "Unknown file format");
 		}
@@ -79,6 +82,9 @@ void exportFile(const class Geometry *root_geom, std::ostream &output, FileForma
 				break;
 			case OPENSCAD_AMF:
 				export_amf(*ps, output);
+				break;
+			case OPENSCAD_NEFDBG:
+				PRINT("Not a CGALNefPoly. Add some CSG ops.");
 				break;
 			default:
 				assert(false && "Unsupported file format");

--- a/src/export.cc
+++ b/src/export.cc
@@ -40,6 +40,7 @@
 #include "CGAL_Nef_polyhedron.h"
 #include "cgal.h"
 #include "cgalutils.h"
+#include <CGAL/IO/Nef_polyhedron_iostream_3.h> // for dumping .nef3
 
 struct triangle {
     std::string vs1;
@@ -67,6 +68,9 @@ void exportFile(const class Geometry *root_geom, std::ostream &output, FileForma
 		case OPENSCAD_NEFDBG:
 			output << N->dump();
 			break;
+		case OPENSCAD_NEF3:
+			output << *(N->p3);
+			break;
 		default:
 			assert(false && "Unknown file format");
 		}
@@ -84,7 +88,10 @@ void exportFile(const class Geometry *root_geom, std::ostream &output, FileForma
 				export_amf(*ps, output);
 				break;
 			case OPENSCAD_NEFDBG:
-				PRINT("Not a CGALNefPoly. Add some CSG ops.");
+				PRINT("Not a CGALNefPoly. Add some CSG ops?");
+				break;
+			case OPENSCAD_NEF3:
+				PRINT("Not a CGALNefPoly. Add some CSG ops?");
 				break;
 			default:
 				assert(false && "Unsupported file format");

--- a/src/export.h
+++ b/src/export.h
@@ -13,7 +13,8 @@ enum FileFormat {
 	OPENSCAD_AMF,
 	OPENSCAD_DXF,
 	OPENSCAD_SVG,
-	OPENSCAD_NEFDBG
+	OPENSCAD_NEFDBG,
+	OPENSCAD_NEF3
 };
 
 // void exportFile(const class Geometry *root_geom, std::ostream &output, FileFormat format);

--- a/src/export.h
+++ b/src/export.h
@@ -12,7 +12,8 @@ enum FileFormat {
 	OPENSCAD_OFF,
 	OPENSCAD_AMF,
 	OPENSCAD_DXF,
-	OPENSCAD_SVG
+	OPENSCAD_SVG,
+	OPENSCAD_NEFDBG
 };
 
 // void exportFile(const class Geometry *root_geom, std::ostream &output, FileFormat format);

--- a/src/openscad.cc
+++ b/src/openscad.cc
@@ -344,6 +344,7 @@ int cmdline(const char *deps_output_file, const std::string &filename, Camera &c
 	const char *ast_output_file = NULL;
 	const char *term_output_file = NULL;
 	const char *echo_output_file = NULL;
+	const char *nefdbg_output_file = NULL;
 
 	std::string suffix = boosty::extension_str( output_file );
 	boost::algorithm::to_lower( suffix );
@@ -358,6 +359,7 @@ int cmdline(const char *deps_output_file, const std::string &filename, Camera &c
 	else if (suffix == ".ast") ast_output_file = output_file;
 	else if (suffix == ".term") term_output_file = output_file;
 	else if (suffix == ".echo") echo_output_file = output_file;
+	else if (suffix == ".nefdbg") nefdbg_output_file = output_file;
 	else {
 		PRINTB("Unknown suffix for output file %s\n", output_file);
 		return 1;
@@ -539,6 +541,11 @@ int cmdline(const char *deps_output_file, const std::string &filename, Camera &c
 				}
 				fstream.close();
 			}
+		}
+
+		if (nefdbg_output_file) {
+			if (!checkAndExport(root_geom, 3, OPENSCAD_NEFDBG, nefdbg_output_file))
+				return 1;
 		}
 #else
 		PRINT("OpenSCAD has been compiled without CGAL support!\n");

--- a/src/openscad.cc
+++ b/src/openscad.cc
@@ -345,6 +345,7 @@ int cmdline(const char *deps_output_file, const std::string &filename, Camera &c
 	const char *term_output_file = NULL;
 	const char *echo_output_file = NULL;
 	const char *nefdbg_output_file = NULL;
+	const char *nef3_output_file = NULL;
 
 	std::string suffix = boosty::extension_str( output_file );
 	boost::algorithm::to_lower( suffix );
@@ -360,6 +361,7 @@ int cmdline(const char *deps_output_file, const std::string &filename, Camera &c
 	else if (suffix == ".term") term_output_file = output_file;
 	else if (suffix == ".echo") echo_output_file = output_file;
 	else if (suffix == ".nefdbg") nefdbg_output_file = output_file;
+	else if (suffix == ".nef3") nef3_output_file = output_file;
 	else {
 		PRINTB("Unknown suffix for output file %s\n", output_file);
 		return 1;
@@ -545,6 +547,11 @@ int cmdline(const char *deps_output_file, const std::string &filename, Camera &c
 
 		if (nefdbg_output_file) {
 			if (!checkAndExport(root_geom, 3, OPENSCAD_NEFDBG, nefdbg_output_file))
+				return 1;
+		}
+
+		if (nef3_output_file) {
+			if (!checkAndExport(root_geom, 3, OPENSCAD_NEF3, nef3_output_file))
 				return 1;
 		}
 #else


### PR DESCRIPTION
This is a small patch to allow an easier dump of already existing debug code for CGAL Nef Polyhedrons. It also adds some code to dump Sphere Map information as well.

It allows the ".nefdbg" file extension that will trigger a dump of an SVG file containing detailed information about the Nef Polyhedron and it's associated Vertex Sphere Maps. This will make it a bit easier to debug Nef Polyhedron issues in the future. The feature is left as an "undocumented" feature so that users will not rely on the format and it can change as needed.

The SVG file has dual use - it contains very detail information as 'comments' within the text file, while the file itself can be opened in a web browser to view a graphic picture of the Nef Polyhedron faces.

Here is an example of the svg text for a vertex sphere map

```
<!-- vertex sphere map begin. vertex counter is 1
     vertex coordinates: -32.5,16.9177,-23.3125-->
  vertex sphere map info
  number of svertices: 3
  number of shalfedges: 6
  number of shalfloops: 0
  number of sfaces: 2
  number of sface cycles: 2
  connected_components: 1
  integrity check...(asserts if not OK)
 the sface cycles of sface 0 start with an
  shalfedge from 0,0,47.744 to 0,-37.652,0
 the sface cycles of sface 1 start with an
  shalfedge from 0,-37.652,0 to 0,0,47.744

  vertex sphere map end -->
```

Here is a snippet showing a HalfFacet visit (part of a Volume visit)

```
<!-- Halffacet visit. Mark: 1 -->
   <!-- Halffacet cycle begin: -->
    <!-- Body contour:--> 
     <!-- -32.5,16.9177,-23.3125 -->
     <line x1="130.71" y1="307.358" x2="43.8203" y2="394.248"  stroke="gold" />
     <!-- -30,16.9177,-23.3125 -->
     <line x1="142.12" y1="307.358" x2="130.71" y2="307.358"  stroke="gold" />
     <!-- -30,-20.7343,-23.3125 -->
     <line x1="55.2304" y1="394.248" x2="142.12" y2="307.358"  stroke="gold" />
     <!-- -32.5,-20.7343,-23.3125 -->
     <line x1="43.8203" y1="394.248" x2="55.2304" y2="394.248"  stroke="gold" />
   <!-- Halffacet cycle end -->
  <!-- Halffacet visit end -->
```

The SVG file can also be loaded in a web browser, where it currently looks like this:

![d](https://cloud.githubusercontent.com/assets/896858/10746588/7d3dcd7c-7c1a-11e5-8025-2ee351e78f0d.png)
