### PR TITLE
Fix Z-fighting in Ortho view, Issue #1483

### DIFF
--- a/src/GLView.cc
+++ b/src/GLView.cc
@@ -105,7 +105,7 @@ void GLView::setupCamera()
 			double height = dist * tan(cam.fov/2*M_PI/180);
 			glOrtho(-height*aspectratio, height*aspectratio,
 							-height, height,
-							-far_far_away, +far_far_away);
+							-100*dist, +100*dist);
 			break;
 		}
 		}
@@ -130,7 +130,7 @@ void GLView::setupCamera()
 			double height = dist * tan(cam.fov/2*M_PI/180);
 			glOrtho(-height*aspectratio, height*aspectratio,
 							-height, height,
-							-far_far_away, +far_far_away);
+							-100*dist, +100*dist);
 			break;
 		}
 		}


### PR DESCRIPTION
This change scales the zNear and zFar orthographic projection parameters based on the camera zoom level.

With this change, a cube renders normally with no z-fighting on edges from sizes of 1e-20 to 1e18, in orthographic view.