### PR TITLE
Update macosx-build-dependencies.sh

### DIFF
--- a/scripts/macosx-build-dependencies.sh
+++ b/scripts/macosx-build-dependencies.sh
@@ -236,7 +236,8 @@ build_qt5()
 		-skip enginio -skip graphicaleffects -skip location -skip multimedia \
 		-skip quick1 -skip quickcontrols -skip script -skip sensors -skip serialport \
 		-skip svg -skip webkit -skip webkit-examples -skip websockets -skip xmlpatterns -skip qtwebchannel
-  make -j"$NUMCPU" install
+  make -j"$NUMCPU" 
+  make install
 }
 
 check_qscintilla()


### PR DESCRIPTION
Split the single 'make -j"$NUMCPU" install' into two-stage.  This patch solves the first "-lqtpcre link failure" part in issue #1490.

My previous patch to configure '-skip qtwebchannel' solved the second QJSValue not found problem, uncovered after splitting make;make install.