### PR TITLE
Camera fix

### DIFF
--- a/src/Camera.cc
+++ b/src/Camera.cc
@@ -6,15 +6,17 @@ Camera::Camera(enum CameraType camtype) :
 	type(camtype), projection(Camera::PERSPECTIVE), fov(22.5), viewall(false)
 {
 	PRINTD("Camera()");
-	if (this->type == Camera::GIMBAL) {
-		object_trans << 0,0,0;
-		object_rot << 35,0,25;
-		viewer_distance = 500;
-	} else if (this->type == Camera::VECTOR) {
-		center << 0,0,0;
-		Eigen::Vector3d cameradir(1, 1, -0.5);
-		eye = center - 500 * cameradir;
-	}
+
+        // gimbal cam values
+        object_trans << 0,0,0;
+        object_rot << 35,0,25;
+        viewer_distance = 500;
+
+        // vector cam values
+        center << 0,0,0;
+        Eigen::Vector3d cameradir(1, 1, -0.5);
+        eye = center - 500 * cameradir;
+
 	pixel_width = RenderSettings::inst()->img_width;
 	pixel_height = RenderSettings::inst()->img_height;
 	autocenter = false;

--- a/src/GLView.cc
+++ b/src/GLView.cc
@@ -163,7 +163,7 @@ void GLView::paintGL()
   glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT | GL_STENCIL_BUFFER_BIT);
 
   setupCamera();
-  if (this->cam.type) {
+  if (this->cam.type == Camera::GIMBAL) {
     // Only for GIMBAL cam
     // The crosshair should be fixed at the center of the viewport...
     if (showcrosshairs) GLView::showCrosshairs();


### PR DESCRIPTION
This fixes the empty PNG export for me.

Update: found the root cause (2nd commit):

* PNG export initialized camera type NONE
* export calls ViewAll which sets the camera to VECTOR
* this means cam.object_trans is not initialized as this is for GIMBAL camera
* GLView uses the garbled object translation even with camera type VECTOR
