### PR TITLE
Restores the call to combineCallback with NULL args.

### DIFF
--- a/patches/CGAL-OGL_helper-tesscombine.patch
+++ b/patches/CGAL-OGL_helper-tesscombine.patch
@@ -32,3 +32,11 @@
        gluTessCallback(tess_, GLenum(GLU_TESS_BEGIN),
  		      (GLvoid (CGAL_GLU_TESS_CALLBACK *)(CGAL_GLU_TESS_DOTS)) &beginCallback);
        gluTessCallback(tess_, GLenum(GLU_TESS_END),
+@@ -410,6 +429,7 @@
+       gluTessEndPolygon(tess_);
+       //      CGAL_NEF_TRACEN("End Polygon");
+       gluDeleteTess(tess_);
++      combineCallback(NULL, NULL, NULL, NULL);
+     }
+ 
+     void construct_axes() const

--- a/src/OGL_helper.h
+++ b/src/OGL_helper.h
@@ -486,6 +486,7 @@ namespace OGL {
       gluTessEndPolygon(tess_);
       //      CGAL_NEF_TRACEN("End Polygon");
       gluDeleteTess(tess_);
+      combineCallback(NULL, NULL, NULL, NULL);
     }
 
     void construct_axes() const


### PR DESCRIPTION
This was required to ensure pcache is cleared. Without it there
was a minor memory leak.

This got accidentally removed as can be seen in the following history:
https://github.com/openscad/openscad/commits/1b31c32638faa0429ffb6af0751a2199b33c52a0/src/OGL_helper.h