### PR TITLE
remove deprecated option from the manpage

### DIFF
--- a/doc/openscad.1
+++ b/doc/openscad.1
@@ -108,7 +108,7 @@ distance 500, with orthographic projection:
 Set the 'mode' variable in example017 so that it will render only the 
 parts of the shape. Export to a .dxf file.
 .PP
-.B openscad -x example017.dxf -D'mode="parts"' examples/example017.scad
+.B openscad -o example017.dxf -D'mode="parts"' examples/example017.scad
 
 .SH AUTHOR
 OpenSCAD was written by Clifford Wolf, Marius Kintel, and others.


### PR DESCRIPTION
the option -x seems to be deprecated but was still in the examples of the manpage