### PR TITLE
Pre-fill full file base name on export. Fix #1552.

### DIFF
--- a/src/mainwin.cc
+++ b/src/mainwin.cc
@@ -2097,7 +2097,7 @@ void MainWindow::actionExport(export_type_e, QString, QString)
 
 	QString title = QString(_("Export %1 File")).arg(type_name);
 	QString filter = QString(_("%1 Files (*%2)")).arg(type_name, suffix);
-	QString filename = this->fileName.isEmpty() ? QString(_("Untitled")) + suffix : QFileInfo(this->fileName).baseName() + suffix;
+	QString filename = this->fileName.isEmpty() ? QString(_("Untitled")) + suffix : QFileInfo(this->fileName).completeBaseName() + suffix;
 	QString export_filename = QFileDialog::getSaveFileName(this, title, filename, filter);
 	if (export_filename.isEmpty()) {
 		clearCurrentOutput();


### PR DESCRIPTION
See Qt docs
http://doc.qt.io/qt-5/qfileinfo.html#baseName
http://doc.qt.io/qt-5/qfileinfo.html#completeBaseName