### PR TITLE
Save to right path when multiple files are opened. Fix #1530.

### DIFF
--- a/src/mainwin.cc
+++ b/src/mainwin.cc
@@ -763,7 +763,7 @@ void MainWindow::setFileName(const QString &filename)
 		this->top_ctx.setDocumentPath(currentdir);
 	} else {
 		QFileInfo fileinfo(filename);
-		this->fileName = fileinfo.exists() ? fileinfo.absoluteFilePath() : fileinfo.fileName();
+		this->fileName = fileinfo.absoluteFilePath();
 		QString fn =fileinfo.absoluteFilePath();
 		setWindowFilePath(fn);
 


### PR DESCRIPTION
The file that didn't exist before is saved to current directory, not to directory we actually expect.