### PR TITLE
Do not clear handler after save

### DIFF
--- a/src/mainwin.cc
+++ b/src/mainwin.cc
@@ -1390,7 +1390,6 @@ void MainWindow::actionSave()
 			saveError(file, _("Error saving design"));
 		}
 	}
-	clearCurrentOutput();
 	updateRecentFiles();
 }
 


### PR DESCRIPTION
Fixes issue #1488. Now saving action doesn't break log output in window.