### PR TITLE
Fix issue 214. When a syntax error is reported, we report the source …

### DIFF
--- a/src/ModuleCache.cc
+++ b/src/ModuleCache.cc
@@ -105,8 +105,8 @@ bool ModuleCache::evaluate(const std::string &filename, FileModule *&module)
 		
 		FileModule *oldmodule = lib_mod;
 		
-		std::string pathname = boosty::stringy(fs::path(filename).parent_path());
-		lib_mod = dynamic_cast<FileModule*>(parse(textbuf.str().c_str(), pathname.c_str(), false));
+        fs::path pathname = fs::path(filename);
+		lib_mod = dynamic_cast<FileModule*>(parse(textbuf.str().c_str(), pathname, false));
 		PRINTDB("  compiled module: %p", lib_mod);
 		
 		// We defer deletion so we can ensure that the new module won't

--- a/src/lexer.l
+++ b/src/lexer.l
@@ -54,7 +54,7 @@ int lexerget_lineno(void);
 static void yyunput(int, char*) __attribute__((unused));
 #endif
 extern const char *parser_input_buffer;
-extern std::string parser_source_path;
+extern fs::path parser_sourcefile;
 extern FileModule *rootmodule;
 
 #define YY_INPUT(buf,result,max_size) {   \
@@ -79,8 +79,9 @@ extern FileModule *rootmodule;
 
 void to_utf8(const char *, char *);
 void includefile();
-fs::path sourcepath();
-std::vector<fs::path> path_stack;
+fs::path sourcefile();
+std::vector<fs::path> filename_stack;
+std::vector<int> lineno_stack;
 std::vector<FILE*> openfiles;
 std::vector<std::string> openfilenames;
 
@@ -121,7 +122,7 @@ use[ \t\r\n>]*"<"	{ BEGIN(cond_use); }
 [^\t\r\n>]+	{ filename = yytext; }
  ">"		{
 	BEGIN(INITIAL);
-        fs::path fullpath = find_valid_path(sourcepath(), fs::path(filename), &openfilenames);
+        fs::path fullpath = find_valid_path(sourcefile().parent_path(), fs::path(filename), &openfilenames);
 	if (fullpath.empty()) {
           PRINTB("WARNING: Can't open library '%s'.", filename);
           parserlval.text = strdup(filename.c_str());
@@ -134,7 +135,11 @@ use[ \t\r\n>]*"<"	{ BEGIN(cond_use); }
 }
 
 <<EOF>> {
-	if(!path_stack.empty()) path_stack.pop_back();
+	if (!filename_stack.empty()) filename_stack.pop_back();
+	if (!lineno_stack.empty()) {
+		yylineno = lineno_stack.back();
+		lineno_stack.pop_back();
+	}
 	if (yyin && yyin != stdin) {
 		assert(!openfiles.empty());
 		fclose(openfiles.back());
@@ -237,11 +242,12 @@ void to_utf8(const char *str, char *out)
     }
 }
 
-fs::path sourcepath()
+// Filename of the source file currently being lexed.
+fs::path sourcefile()
 {
-  if (!path_stack.empty()) return path_stack.back();
+  if (!filename_stack.empty()) return filename_stack.back();
 
-  return fs::path(parser_source_path);
+  return parser_sourcefile;
 }
 
 /*
@@ -249,12 +255,12 @@ fs::path sourcepath()
   1) include <sourcepath/path/file>
   2) include <librarydir/path/file>
 
-  Globals used: filepath, sourcepath, filename
+  Globals used: filepath, sourcefile, filename
  */
 void includefile()
 {
   fs::path localpath = fs::path(filepath) / filename;
-  fs::path fullpath = find_valid_path(sourcepath(), localpath, &openfilenames);
+  fs::path fullpath = find_valid_path(sourcefile().parent_path(), localpath, &openfilenames);
   if (!fullpath.empty()) {
     rootmodule->registerInclude(boosty::stringy(localpath), boosty::stringy(fullpath));
   }
@@ -267,17 +273,19 @@ void includefile()
   std::string fullname = boosty::stringy(fullpath);
 
   filepath.clear();
-  path_stack.push_back(fullpath.parent_path());
+  filename_stack.push_back(fullpath);
 
   handle_dep(fullname);
 
   yyin = fopen(fullname.c_str(), "r");
   if (!yyin) {
     PRINTB("WARNING: Can't open include file '%s'.", boosty::stringy(localpath));
-    path_stack.pop_back();
+    filename_stack.pop_back();
     return;
   }
 
+  lineno_stack.push_back(yylineno);
+  yylineno = 1;
   openfiles.push_back(yyin);
   openfilenames.push_back(fullname);
   filename.clear();
@@ -294,5 +302,6 @@ void lexerdestroy()
 	for (auto f : openfiles) fclose(f);
 	openfiles.clear();
 	openfilenames.clear();
-	path_stack.clear();
+	filename_stack.clear();
+	lineno_stack.clear();
 }

--- a/src/mainwin.cc
+++ b/src/mainwin.cc
@@ -1695,10 +1695,10 @@ void MainWindow::compileTopLevelDocument()
 	delete this->root_module;
 	this->root_module = NULL;
 
-    fs::path fname = fs::path(
+    const char* fname =
         this->fileName.isEmpty() ? "" :
-        QFileInfo(this->fileName).absolutePath().toLocal8Bit());
-	this->root_module = parse(fulltext.c_str(), fname, false);
+        QFileInfo(this->fileName).absolutePath().toLocal8Bit();
+	this->root_module = parse(fulltext.c_str(), fs::path(fname), false);
 }
 
 void MainWindow::checkAutoReload()

--- a/src/mainwin.cc
+++ b/src/mainwin.cc
@@ -1695,9 +1695,10 @@ void MainWindow::compileTopLevelDocument()
 	delete this->root_module;
 	this->root_module = NULL;
 
-	this->root_module = parse(fulltext.c_str(),
-	this->fileName.isEmpty() ? "" :
-	QFileInfo(this->fileName).absolutePath().toLocal8Bit(), false);
+    fs::path fname = fs::path(
+        this->fileName.isEmpty() ? "" :
+        QFileInfo(this->fileName).absolutePath().toLocal8Bit());
+	this->root_module = parse(fulltext.c_str(), fname, false);
 }
 
 void MainWindow::checkAutoReload()

--- a/src/mainwin.cc
+++ b/src/mainwin.cc
@@ -1696,8 +1696,7 @@ void MainWindow::compileTopLevelDocument()
 	this->root_module = NULL;
 
     const char* fname =
-        this->fileName.isEmpty() ? "" :
-        QFileInfo(this->fileName).absolutePath().toLocal8Bit();
+        this->fileName.isEmpty() ? "" : this->fileName.toLocal8Bit();
 	this->root_module = parse(fulltext.c_str(), fs::path(fname), false);
 }
 

--- a/src/openscad.cc
+++ b/src/openscad.cc
@@ -394,8 +394,7 @@ int cmdline(const char *deps_output_file, const std::string &filename, Camera &c
 	std::string text((std::istreambuf_iterator<char>(ifs)), std::istreambuf_iterator<char>());
 	text += "\n" + commandline_commands;
 	fs::path abspath = boosty::absolute(filename);
-	std::string parentpath = boosty::stringy(abspath.parent_path());
-	root_module = parse(text.c_str(), parentpath.c_str(), false);
+	root_module = parse(text.c_str(), abspath, false);
 	if (!root_module) {
 		PRINTB("Can't parse file '%s'!\n", filename.c_str());
 		return 1;

--- a/src/openscad.h
+++ b/src/openscad.h
@@ -26,8 +26,7 @@
 
 #pragma once
 
-// forward declaration
-namespace boost { namespace filesystem { class path; }};
+#include <boost/filesystem.hpp>
 
 extern class FileModule *parse(const char *text, const boost::filesystem::path &filename, int debug);
 

--- a/src/openscad.h
+++ b/src/openscad.h
@@ -26,7 +26,10 @@
 
 #pragma once
 
-extern class FileModule *parse(const char *text, const char *path, int debug);
+// forward declaration
+namespace boost { namespace filesystem { class path; }};
+
+extern class FileModule *parse(const char *text, const boost::filesystem::path &filename, int debug);
 
 #include <string>
 extern std::string commandline_commands;

--- a/src/parser.y
+++ b/src/parser.y
@@ -56,6 +56,7 @@ int parserlex(void);
 void yyerror(char const *s);
 
 int lexerget_lineno(void);
+fs::path sourcefile(void);
 int lexerlex_destroy(void);
 int lexerlex(void);
 
@@ -66,7 +67,7 @@ extern void lexerdestroy();
 extern FILE *lexerin;
 extern const char *parser_input_buffer;
 const char *parser_input_buffer;
-std::string parser_source_path;
+fs::path parser_sourcefile;
 
 %}
 
@@ -261,7 +262,7 @@ if_statement:
             {
                 $<ifelse>$ = new IfElseModuleInstantiation();
                 $<ifelse>$->arguments.push_back(Assignment("", shared_ptr<Expression>($3)));
-                $<ifelse>$->setPath(parser_source_path);
+                $<ifelse>$->setPath(boosty::stringy(parser_sourcefile.parent_path()));
                 scope_stack.push(&$<ifelse>$->scope);
             }
           child_statement
@@ -299,7 +300,7 @@ single_module_instantiation:
             {
                 $$ = new ModuleInstantiation($1);
                 $$->arguments = *$3;
-                $$->setPath(parser_source_path);
+                $$->setPath(boosty::stringy(parser_sourcefile.parent_path()));
                 free($1);
                 delete $3;
             }
@@ -590,19 +591,20 @@ int parserlex(void)
 
 void yyerror (char const *s)
 {
-  // FIXME: We leak memory on parser errors...
-  PRINTB("ERROR: Parser error in line %d: %s\n", lexerget_lineno() % s);
+    // FIXME: We leak memory on parser errors...
+    PRINTB("ERROR: Parser error in file %s, line %d: %s\n",
+        sourcefile() % lexerget_lineno() % s);
 }
 
-FileModule *parse(const char *text, const char *path, int debug)
+FileModule *parse(const char *text, const fs::path &filename, int debug)
 {
   lexerin = NULL;
   parser_error_pos = -1;
   parser_input_buffer = text;
-  parser_source_path = boosty::absolute(std::string(path)).string();
+  parser_sourcefile = boosty::absolute(filename);
 
   rootmodule = new FileModule();
-  rootmodule->setModulePath(path);
+  rootmodule->setModulePath(boosty::stringy(filename.parent_path()));
   scope_stack.push(&rootmodule->scope);
   //        PRINTB_NOCACHE("New module: %s %p", "root" % rootmodule);
 

--- a/testdata/manual/issue214/README.md
+++ b/testdata/manual/issue214/README.md
@@ -1,0 +1,82 @@
+Manual tests for pull request #1637, which fixes issue #214.
+
+There are 4 'good' tests, which should render with no errors,
+and 4 'bad' tests, which should fail with an error message.
+The tests should be run both using the CLI, and using the GUI.
+
+TODO: These tests should be automated.
+
+1. Relative pathnames
+
+The code that handles relative pathnames in import() statements has
+been refactored, so test it. (Imported files are found relative to the directory
+containing the script that performs the import, which may be different from
+the directory containing the "root" script file, as in the case where A.scad
+uses B.scad, which in turn imports an STL file.
+
+Part of the pathname resolution code is different between the command line
+case and the interactive GUI case, and both versions of this code were changed,
+so it's necessary to test both cases.
+
+2. Syntax errors in the presence of `include`
+
+The actual bug fix is that, when a syntax error is encountered, we report
+the file name and the correct line number. Previously,
+* No file name was reported, which creates a problem if the syntax error was
+  actually in an included file.
+* The reported line number could be incorrect if the script uses `include`.
+
+3. Run the tests
+
+To run the tests using the CLI,
+use this shell script:
+```
+scad=<pathname of project root>/openscad
+for f in [gb]*.scad; do echo $f; $scad -o ,.stl $f; done
+```
+
+And here's the output:
+```
+bad-include-synerr.scad
+ERROR: Parser error in file "/res/doug/src/openscad/testdata/manual/issue214/syntax-error-in-line-2.scad", line 2: syntax error
+
+Can't parse file 'bad-include-synerr.scad'!
+
+bad-includeX.scad
+WARNING: Can't open import file '"cube.stl"'.
+Current top level object is empty.
+bad-synerr.scad
+ERROR: Parser error in file "/res/doug/src/openscad/testdata/manual/issue214/bad-synerr.scad", line 3: syntax error
+
+Can't parse file 'bad-synerr.scad'!
+
+bad-useX2.scad
+DEPRECATED: Imported file (cube2.stl) found in document root instead of relative to the importing module. This behavior is deprecated
+good-include2.scad
+good-includeX2.scad
+good-use2.scad
+good-useX.scad
+```
+
+I'm testing a bunch of combinations of `include` and `use` to make sure that
+pathname interpretation still works as before. Note that `include` and `use`
+use different algorithms for looking up relative pathnames in an `import`
+statement, as reflected in these tests. The behaviour of `include` looks like
+a bug. But, the behaviour is unchanged from before this pull request.
+
+I have two test cases for syntax errors:
+* `bad-include-synerr.scad` tests a syntax error in an included file:
+  the reported filename is the name of the included file,
+  and the line number is correct.
+* `bad-synerr.scad` tests a syntax error in the root script, after including
+  a file that doesn't have a syntax error. The improvement is that the reported
+  line number is correct.
+
+These tests should also be run in the GUI, since different code is involved.
+Use a similar shell script:
+```
+scad=<pathname of project root>/openscad
+for f in [gb]*.scad; do echo $f; $scad $f; done
+```
+This script will open each window one at a time; verify the results then close
+the window, and the next window will pop up.

--- a/testdata/manual/issue214/X/cube.stl
+++ b/testdata/manual/issue214/X/cube.stl
@@ -1,0 +1,86 @@
+solid OpenSCAD_Model
+  facet normal -0 0 1
+    outer loop
+      vertex -5 5 5
+      vertex 5 -5 5
+      vertex 5 5 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 5 -5 5
+      vertex -5 5 5
+      vertex -5 -5 5
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -5 -5 -5
+      vertex 5 5 -5
+      vertex 5 -5 -5
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 5 5 -5
+      vertex -5 -5 -5
+      vertex -5 5 -5
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex -5 -5 -5
+      vertex 5 -5 5
+      vertex -5 -5 5
+    endloop
+  endfacet
+  facet normal 0 -1 -0
+    outer loop
+      vertex 5 -5 5
+      vertex -5 -5 -5
+      vertex 5 -5 -5
+    endloop
+  endfacet
+  facet normal 1 -0 0
+    outer loop
+      vertex 5 -5 5
+      vertex 5 5 -5
+      vertex 5 5 5
+    endloop
+  endfacet
+  facet normal 1 0 0
+    outer loop
+      vertex 5 5 -5
+      vertex 5 -5 5
+      vertex 5 -5 -5
+    endloop
+  endfacet
+  facet normal 0 1 -0
+    outer loop
+      vertex 5 5 -5
+      vertex -5 5 5
+      vertex 5 5 5
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex -5 5 5
+      vertex 5 5 -5
+      vertex -5 5 -5
+    endloop
+  endfacet
+  facet normal -1 0 0
+    outer loop
+      vertex -5 -5 -5
+      vertex -5 5 5
+      vertex -5 5 -5
+    endloop
+  endfacet
+  facet normal -1 -0 0
+    outer loop
+      vertex -5 5 5
+      vertex -5 -5 -5
+      vertex -5 -5 5
+    endloop
+  endfacet
+endsolid OpenSCAD_Model

--- a/testdata/manual/issue214/X/import.scad
+++ b/testdata/manual/issue214/X/import.scad
@@ -1,0 +1,1 @@
+module m() import("cube.stl");

--- a/testdata/manual/issue214/X/import2.scad
+++ b/testdata/manual/issue214/X/import2.scad
@@ -1,0 +1,1 @@
+module m() import("cube2.stl");

--- a/testdata/manual/issue214/bad-include-synerr.scad
+++ b/testdata/manual/issue214/bad-include-synerr.scad
@@ -1,0 +1,4 @@
+// https://github.com/openscad/openscad/issues/214
+// Line numbers in error messages are incorrect after an include.
+
+include <syntax-error-in-line-2.scad>

--- a/testdata/manual/issue214/bad-includeX.scad
+++ b/testdata/manual/issue214/bad-includeX.scad
@@ -1,0 +1,2 @@
+include <X/import.scad>
+m();

--- a/testdata/manual/issue214/bad-synerr.scad
+++ b/testdata/manual/issue214/bad-synerr.scad
@@ -1,0 +1,3 @@
+include <import2.scad>
+m();
+:-(

--- a/testdata/manual/issue214/bad-useX2.scad
+++ b/testdata/manual/issue214/bad-useX2.scad
@@ -1,0 +1,2 @@
+use <X/import2.scad>
+m();

--- a/testdata/manual/issue214/cube2.stl
+++ b/testdata/manual/issue214/cube2.stl
@@ -1,0 +1,86 @@
+solid OpenSCAD_Model
+  facet normal -0 0 1
+    outer loop
+      vertex -5 5 5
+      vertex 5 -5 5
+      vertex 5 5 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 5 -5 5
+      vertex -5 5 5
+      vertex -5 -5 5
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -5 -5 -5
+      vertex 5 5 -5
+      vertex 5 -5 -5
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 5 5 -5
+      vertex -5 -5 -5
+      vertex -5 5 -5
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex -5 -5 -5
+      vertex 5 -5 5
+      vertex -5 -5 5
+    endloop
+  endfacet
+  facet normal 0 -1 -0
+    outer loop
+      vertex 5 -5 5
+      vertex -5 -5 -5
+      vertex 5 -5 -5
+    endloop
+  endfacet
+  facet normal 1 -0 0
+    outer loop
+      vertex 5 -5 5
+      vertex 5 5 -5
+      vertex 5 5 5
+    endloop
+  endfacet
+  facet normal 1 0 0
+    outer loop
+      vertex 5 5 -5
+      vertex 5 -5 5
+      vertex 5 -5 -5
+    endloop
+  endfacet
+  facet normal 0 1 -0
+    outer loop
+      vertex 5 5 -5
+      vertex -5 5 5
+      vertex 5 5 5
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex -5 5 5
+      vertex 5 5 -5
+      vertex -5 5 -5
+    endloop
+  endfacet
+  facet normal -1 0 0
+    outer loop
+      vertex -5 -5 -5
+      vertex -5 5 5
+      vertex -5 5 -5
+    endloop
+  endfacet
+  facet normal -1 -0 0
+    outer loop
+      vertex -5 5 5
+      vertex -5 -5 -5
+      vertex -5 -5 5
+    endloop
+  endfacet
+endsolid OpenSCAD_Model

--- a/testdata/manual/issue214/good-include2.scad
+++ b/testdata/manual/issue214/good-include2.scad
@@ -1,0 +1,2 @@
+include <import2.scad>
+m();

--- a/testdata/manual/issue214/good-includeX2.scad
+++ b/testdata/manual/issue214/good-includeX2.scad
@@ -1,0 +1,2 @@
+include <X/import2.scad>
+m();

--- a/testdata/manual/issue214/good-use2.scad
+++ b/testdata/manual/issue214/good-use2.scad
@@ -1,0 +1,2 @@
+use <import2.scad>
+m();

--- a/testdata/manual/issue214/good-useX.scad
+++ b/testdata/manual/issue214/good-useX.scad
@@ -1,0 +1,2 @@
+use <X/import.scad>
+m();

--- a/testdata/manual/issue214/import2.scad
+++ b/testdata/manual/issue214/import2.scad
@@ -1,0 +1,1 @@
+module m() import("cube2.stl");

--- a/testdata/manual/issue214/syntax-error-in-line-2.scad
+++ b/testdata/manual/issue214/syntax-error-in-line-2.scad
@@ -1,0 +1,2 @@
+// syntax error in line 2
+:-(


### PR DESCRIPTION
…file name

and the line number within the source file where the error occurred.
This works even if the syntax error is within an included file.

The parse() function, and the places where it is called, have been changed
as necessary to enforce the convention that the second argument is the source
filename, and not the name of the parent directory containing the source file.
Previously, different calls to parse() made different assumptions about
the meaning of the second argument, which probably means include and import
were broken in some cases.