### PR TITLE
Highlight object with source under-cursor, pick object with ctrl-click select its source

### DIFF
--- a/src/CSGTreeEvaluator.cc
+++ b/src/CSGTreeEvaluator.cc
@@ -131,8 +131,17 @@ void CSGTreeEvaluator::applyToChildren(State &state, const AbstractNode &node, O
 		}
 	}
 	if (t1) {
+	  Location loc = node.modinst->getLocation();
+	  bool cursor_incl =
+	    (cursor_line > loc.first_line
+	      || (cursor_line == loc.first_line
+	        && cursor_column >= loc.first_column))
+	    &&
+	    (cursor_line < loc.last_line
+	      || (cursor_line == loc.last_line
+	        && cursor_column <= loc.last_column));
 		if (node.modinst->isBackground()) t1->setBackground(true);
-		if (node.modinst->isHighlight()) t1->setHighlight(true);
+		if (node.modinst->isHighlight() || cursor_incl) t1->setHighlight(true);
 	}
 	this->stored_term[node.index()] = t1;
 }
@@ -186,7 +195,17 @@ shared_ptr<CSGNode> CSGTreeEvaluator::evaluateCSGNodeFromGeometry(
 	}
 
 	shared_ptr<CSGNode> t(new CSGLeaf(g, state.matrix(), state.color(), stream.str()));
-	if (modinst->isHighlight()) t->setHighlight(true);
+	Location loc = modinst->getLocation();
+	bool cursor_incl =
+	  (cursor_line > loc.first_line
+	    || (cursor_line == loc.first_line
+	      && cursor_column >= loc.first_column))
+	  &&
+	  (cursor_line < loc.last_line
+	    || (cursor_line == loc.last_line
+	      && cursor_column <= loc.last_column));
+
+	if (modinst->isHighlight() || cursor_incl) t->setHighlight(true);
 	else if (modinst->isBackground()) t->setBackground(true);
 	return t;
 }

--- a/src/CSGTreeEvaluator.h
+++ b/src/CSGTreeEvaluator.h
@@ -11,8 +11,9 @@
 class CSGTreeEvaluator : public Visitor
 {
 public:
-	CSGTreeEvaluator(const class Tree &tree, class GeometryEvaluator *geomevaluator = NULL)
-		: tree(tree), geomevaluator(geomevaluator) {
+	CSGTreeEvaluator(const class Tree &tree, class GeometryEvaluator *geomevaluator = NULL,
+	                 int cursor_line = -1, int cursor_column=-1)
+		: tree(tree), geomevaluator(geomevaluator), cursor_line(cursor_line), cursor_column(cursor_column) {
 	}
   virtual ~CSGTreeEvaluator() {}
 
@@ -49,7 +50,8 @@ private:
   const AbstractNode *root;
   typedef std::list<const AbstractNode *> ChildList;
 	std::map<int, ChildList> visitedchildren;
-
+	int cursor_line;
+	int cursor_column;
 protected:
 	const Tree &tree;
 	class GeometryEvaluator *geomevaluator;

--- a/src/MainWindow.h
+++ b/src/MainWindow.h
@@ -246,7 +246,7 @@ public slots:
 	void waitAfterReload();
 	void autoReloadSet(bool);
 	void setContentsChanged();
-
+	void pickedObject(int);
 private:
 	static void report_func(const class AbstractNode*, void *vp, int mark);
 	static bool mdiMode;

--- a/src/MainWindow.h
+++ b/src/MainWindow.h
@@ -218,6 +218,7 @@ public slots:
 	void viewModeShowCrosshairs();
 	void viewModeShowScaleProportional();
 	void viewModeAnimate();
+	void viewModeHighlightUnderCursor();
 	void viewAngleTop();
 	void viewAngleBottom();
 	void viewAngleLeft();

--- a/src/MainWindow.ui
+++ b/src/MainWindow.ui
@@ -353,6 +353,7 @@
     <addaction name="viewActionShowScaleProportional"/>
     <addaction name="viewActionShowCrosshairs"/>
     <addaction name="viewActionAnimate"/>
+    <addaction name="viewActionHighlightUnderCursor"/>
     <addaction name="separator"/>
     <addaction name="viewActionTop"/>
     <addaction name="viewActionBottom"/>
@@ -926,6 +927,14 @@
    </property>
    <property name="text">
     <string>Animate</string>
+   </property>
+  </action>
+  <action name="viewActionHighlightUnderCursor">
+   <property name="checkable">
+    <bool>true</bool>
+   </property>
+   <property name="text">
+    <string>Highlight object under cursor</string>
    </property>
   </action>
   <action name="viewActionTop">

--- a/src/OpenCSGRenderer.h
+++ b/src/OpenCSGRenderer.h
@@ -16,6 +16,7 @@ public:
 									GLint *shaderinfo);
 	virtual void draw(bool showfaces, bool showedges) const;
 	virtual BoundingBox getBoundingBox() const;
+	void setPicking(bool p) { this->picking = p;}
 private:
 #ifdef ENABLE_OPENCSG
 	class OpenCSGPrim *createCSGPrimitive(const class CSGChainObject &csgobj, OpenCSG::Operation operation, bool highlight_mode, bool background_mode, OpenSCADOperator type) const;
@@ -27,4 +28,5 @@ private:
 	shared_ptr<CSGProducts> highlights_products;
 	shared_ptr<CSGProducts> background_products;
 	GLint *shaderinfo;
+	bool picking;
 };

--- a/src/PlatformUtils-posix.cc
+++ b/src/PlatformUtils-posix.cc
@@ -58,9 +58,15 @@ unsigned long PlatformUtils::stackLimit()
 
     int ret = getrlimit(RLIMIT_STACK, &limit);
     if (ret == 0) {
+        if (limit.rlim_cur == RLIM_INFINITY) {
+	  return STACK_LIMIT_DEFAULT;
+        }
 	if (limit.rlim_cur > STACK_BUFFER_SIZE) {
 	    return limit.rlim_cur - STACK_BUFFER_SIZE;
 	}
+        if (limit.rlim_max == RLIM_INFINITY) {
+          return STACK_LIMIT_DEFAULT;
+        }
 	if (limit.rlim_max > STACK_BUFFER_SIZE) {
 	    return limit.rlim_max - STACK_BUFFER_SIZE;
 	}

--- a/src/QGLView.h
+++ b/src/QGLView.h
@@ -98,4 +98,5 @@ private slots:
 
 signals:
 	void doAnimateUpdate();
+	void pickedObject(int);
 };

--- a/src/editor.h
+++ b/src/editor.h
@@ -23,6 +23,7 @@ public:
 	virtual void replaceSelectedText(const QString &newText) = 0;
 	virtual void replaceAll(const QString &findText, const QString &replaceText) = 0;
 	virtual QStringList colorSchemes() = 0;
+	virtual QPoint cursorPosition() = 0;
 
 signals:
   void contentsChanged();

--- a/src/editor.h
+++ b/src/editor.h
@@ -24,6 +24,7 @@ public:
 	virtual void replaceAll(const QString &findText, const QString &replaceText) = 0;
 	virtual QStringList colorSchemes() = 0;
 	virtual QPoint cursorPosition() = 0;
+	virtual void setSelection(QRect rect) {};
 
 signals:
   void contentsChanged();

--- a/src/legacyeditor.cc
+++ b/src/legacyeditor.cc
@@ -295,3 +295,8 @@ QStringList LegacyEditor::colorSchemes()
 	
 	return colorSchemes;
 }
+
+QPoint LegacyEditor::cursorPosition()
+{
+  return textedit->cursorRect().topLeft();
+}

--- a/src/legacyeditor.h
+++ b/src/legacyeditor.h
@@ -17,6 +17,7 @@ public:
 	void replaceAll(const QString &findText, const QString &replaceText);
 	bool findString(const QString & exp, bool findBackwards) const;
 	QStringList colorSchemes();
+	QPoint cursorPosition();
 
 public slots:
 	void zoomIn();

--- a/src/lexer.l
+++ b/src/lexer.l
@@ -88,6 +88,15 @@ std::vector<std::string> openfilenames;
 std::string filename;
 std::string filepath;
 
+
+extern YYLTYPE parserlloc;
+#define yylloc parserlloc
+
+int yycolumn = 1;
+#define YY_USER_ACTION yylloc.first_line = yylloc.last_line = yylineno; \
+    yylloc.first_column = yycolumn; yylloc.last_column = yycolumn+yyleng-1; \
+    yycolumn += yyleng;
+
 %}
 
 %option yylineno
@@ -199,7 +208,7 @@ use[ \t\r\n>]*"<"	{ BEGIN(cond_use); }
 			return TOK_STRING; }
 }
 
-[\n\r\t ]
+[\r\t ]
 
 \/\/ BEGIN(cond_lcomment);
 <cond_lcomment>{
@@ -221,7 +230,7 @@ use[ \t\r\n>]*"<"	{ BEGIN(cond_use); }
 "!="	return NE;
 "&&"	return AND;
 "||"	return OR;
-
+\n { yycolumn = 1;}
 . { return yytext[0]; }
 
 %%

--- a/src/mainwin.cc
+++ b/src/mainwin.cc
@@ -391,6 +391,7 @@ MainWindow::MainWindow(const QString &filename)
 	connect(this->viewActionShowCrosshairs, SIGNAL(triggered()), this, SLOT(viewModeShowCrosshairs()));
 	connect(this->viewActionShowScaleProportional, SIGNAL(triggered()), this, SLOT(viewModeShowScaleProportional()));
 	connect(this->viewActionAnimate, SIGNAL(triggered()), this, SLOT(viewModeAnimate()));
+	connect(this->viewActionHighlightUnderCursor, SIGNAL(triggered()), this, SLOT(viewModeHighlightUnderCursor()));
 	connect(this->viewActionTop, SIGNAL(triggered()), this, SLOT(viewAngleTop()));
 	connect(this->viewActionBottom, SIGNAL(triggered()), this, SLOT(viewAngleBottom()));
 	connect(this->viewActionLeft, SIGNAL(triggered()), this, SLOT(viewAngleLeft()));
@@ -619,6 +620,9 @@ void MainWindow::loadViewSettings(){
 	if (settings.value("view/showScaleProportional", true).toBool()) {
         viewActionShowScaleProportional->setChecked(true);
         viewModeShowScaleProportional();
+    }
+  if (settings.value("view/highlightUnderCursor", true).toBool()) {
+        viewActionHighlightUnderCursor->setChecked(true);
     }
 	if (settings.value("view/orthogonalProjection").toBool()) {
 		viewOrthogonal();
@@ -1115,7 +1119,12 @@ void MainWindow::compileCSG(bool procevents)
 		// FIXME: Will we support this?
 #endif
 #ifdef ENABLE_OPENCSG
-		CSGTreeEvaluator csgrenderer(this->tree, &geomevaluator);
+    QPoint cursor;
+		if (this->viewActionHighlightUnderCursor->isChecked())
+		  cursor = this->editor->cursorPosition();
+		else
+		  cursor = QPoint(-1, -1);
+		CSGTreeEvaluator csgrenderer(this->tree, &geomevaluator, cursor.x()+1, cursor.y()+1);
 #endif
 
 	progress_report_prep(this->root_node, report_func, this);
@@ -2321,6 +2330,12 @@ void MainWindow::viewModeAnimate()
 bool MainWindow::isEmpty()
 {
 	return this->editor->toPlainText().isEmpty();
+}
+
+void MainWindow::viewModeHighlightUnderCursor()
+{
+  QSettings settings;
+  settings.setValue("view/highlightUnderCursor",viewActionHighlightUnderCursor->isChecked());
 }
 
 void MainWindow::animateUpdateDocChanged()

--- a/src/mainwin.cc
+++ b/src/mainwin.cc
@@ -561,7 +561,8 @@ MainWindow::MainWindow(const QString &filename)
 	
 	connect(this->editorDock, SIGNAL(topLevelChanged(bool)), this, SLOT(editorTopLevelChanged(bool)));
 	connect(this->consoleDock, SIGNAL(topLevelChanged(bool)), this, SLOT(consoleTopLevelChanged(bool)));
-	
+
+	connect(this->qglview, SIGNAL(pickedObject(int)), this, SLOT(pickedObject(int)));
 	// display this window and check for OpenGL 2.0 (OpenCSG) support
 	viewModeThrownTogether();
 	show();
@@ -2721,3 +2722,27 @@ void MainWindow::setContentsChanged()
 	this->contentschanged = true;
 }
 
+static AbstractNode* find_by_id(AbstractNode* n, int id)
+{
+	if (n->index() == id)
+		return n;
+	const std::vector<AbstractNode*> & children = n->getChildren();
+	for (std::vector<AbstractNode*>::const_iterator it = children.begin();
+			 it != children.end(); ++it)
+	{
+		AbstractNode* res = find_by_id(*it, id);
+		if (res)
+			return res;
+	}
+	return 0;
+}
+
+void MainWindow::pickedObject(int id)
+{
+	AbstractNode* node = find_by_id(absolute_root_node, id);
+	if (!node || !node->modinst)
+		return;
+	Location loc = node->modinst->getLocation();
+	editor->setSelection(QRect(QPoint(loc.first_column-1, loc.first_line-1),
+														 QPoint(loc.last_column-1, loc.last_line-1)));
+}

--- a/src/module.cc
+++ b/src/module.cc
@@ -374,3 +374,5 @@ void register_builtin_group()
 {
 	Builtins::init("group", new GroupModule());
 }
+
+const Location Location::none;

--- a/src/module.h
+++ b/src/module.h
@@ -14,6 +14,18 @@
 #include "localscope.h"
 #include "feature.h"
 
+struct Location
+{
+  Location() : first_line(-1), first_column(-1), last_line(-1), last_column(-1) {}
+  Location (int fl, int fc, int ll, int lc)
+   : first_line(fl), first_column(fc), last_line(ll), last_column(lc) {}
+  int first_line;
+  int first_column;
+  int last_line;
+  int last_column;
+  static const Location none;
+};
+
 class ModuleInstantiation
 {
 public:
@@ -29,6 +41,15 @@ public:
 	const std::string &path() const { return this->modpath; }
 	std::string getAbsolutePath(const std::string &filename) const;
 
+	void setLocation(int first_line, int first_column, int last_line, int last_column)
+	{
+	  this->location.first_line = first_line;
+	  this->location.first_column = first_column;
+	  this->location.last_line = last_line;
+	  this->location.last_column = last_column;
+	}
+	Location getLocation() const { return this->location;}
+
 	const std::string &name() const { return this->modname; }
 	bool isBackground() const { return this->tag_background; }
 	bool isHighlight() const { return this->tag_highlight; }
@@ -43,6 +64,7 @@ public:
 protected:
 	std::string modname;
 	std::string modpath;
+	Location location;
 
 	friend class Module;
 };

--- a/src/parser.y
+++ b/src/parser.y
@@ -25,6 +25,7 @@
  */
 
 %expect 2 /* Expect 2 shift/reduce conflict for ifelse_statement - "dangling else problem" */
+%locations
 
 %{
 
@@ -301,6 +302,8 @@ single_module_instantiation:
                 $$ = new ModuleInstantiation($1);
                 $$->arguments = *$3;
                 $$->setPath(boosty::stringy(parser_sourcefile.parent_path()));
+                $$->setLocation(@$.first_line, @$.first_column,
+                                @$.last_line, @$.last_column);
                 free($1);
                 delete $3;
             }

--- a/src/parser.y
+++ b/src/parser.y
@@ -69,7 +69,7 @@ extern FILE *lexerin;
 extern const char *parser_input_buffer;
 const char *parser_input_buffer;
 fs::path parser_sourcefile;
-
+extern std::vector<fs::path> filename_stack;
 %}
 
 %union {
@@ -302,8 +302,9 @@ single_module_instantiation:
                 $$ = new ModuleInstantiation($1);
                 $$->arguments = *$3;
                 $$->setPath(boosty::stringy(parser_sourcefile.parent_path()));
-                $$->setLocation(@$.first_line, @$.first_column,
-                                @$.last_line, @$.last_column);
+                if (filename_stack.empty())
+                  $$->setLocation(@$.first_line, @$.first_column,
+                                  @$.last_line, @$.last_column);
                 free($1);
                 delete $3;
             }

--- a/src/scintillaeditor.cpp
+++ b/src/scintillaeditor.cpp
@@ -768,3 +768,10 @@ bool ScintillaEditor::modifyNumber(int key)
 	emit previewRequest();
 	return true;
 }
+
+QPoint ScintillaEditor::cursorPosition()
+{
+  int x, y;
+  qsci->getCursorPosition(&x, &y);
+  return QPoint(x, y);
+}

--- a/src/scintillaeditor.cpp
+++ b/src/scintillaeditor.cpp
@@ -775,3 +775,8 @@ QPoint ScintillaEditor::cursorPosition()
   qsci->getCursorPosition(&x, &y);
   return QPoint(x, y);
 }
+
+void ScintillaEditor::setSelection(QRect r)
+{
+  qsci->setSelection(r.top(), r.left(), r.bottom(), r.right());
+}

--- a/src/scintillaeditor.h
+++ b/src/scintillaeditor.h
@@ -55,7 +55,7 @@ public:
 	void replaceAll(const QString &findText, const QString &replaceText);
 	QStringList colorSchemes();
 	QPoint cursorPosition();
-        
+	void setSelection(QRect selection);
 private:
         void getRange(int *lineFrom, int *lineTo);
         void setColormap(const EditorColorScheme *colorScheme);

--- a/src/scintillaeditor.h
+++ b/src/scintillaeditor.h
@@ -54,6 +54,7 @@ public:
 	void replaceSelectedText(const QString&);
 	void replaceAll(const QString &findText, const QString &replaceText);
 	QStringList colorSchemes();
+	QPoint cursorPosition();
         
 private:
         void getRange(int *lineFrom, int *lineTo);


### PR DESCRIPTION
This branch adds two feature that help matching the source code and the opencsg rendering:
- If enabled as a show option, the nodes whose source is under the cursor in editor are highlighted
- When ctrl-clicking on the rendering, the source code of the node being clicked is selected
