### PR TITLE
Handle RLIMIT_STACK set to infinity.

### DIFF
--- a/src/PlatformUtils-posix.cc
+++ b/src/PlatformUtils-posix.cc
@@ -58,9 +58,15 @@ unsigned long PlatformUtils::stackLimit()
 
     int ret = getrlimit(RLIMIT_STACK, &limit);
     if (ret == 0) {
+        if (limit.rlim_cur == RLIM_INFINITY) {
+	  return STACK_LIMIT_DEFAULT;
+        }
 	if (limit.rlim_cur > STACK_BUFFER_SIZE) {
 	    return limit.rlim_cur - STACK_BUFFER_SIZE;
 	}
+        if (limit.rlim_max == RLIM_INFINITY) {
+          return STACK_LIMIT_DEFAULT;
+        }
 	if (limit.rlim_max > STACK_BUFFER_SIZE) {
 	    return limit.rlim_max - STACK_BUFFER_SIZE;
 	}


### PR DESCRIPTION
GNU Make 3.81 on ubuntu 14.04 sets RLIMIT_STACK to infinity, which propagates to the commands being run. This breaks openscad as shown by the "recursion-test-function.scad" test, since (I'm guessing) it uses stack limits to detect infinit recursion.
