### PR TITLE
Fix invalid use after free in compileTopLevelDocument.

### DIFF
--- a/src/mainwin.cc
+++ b/src/mainwin.cc
@@ -1697,8 +1697,9 @@ void MainWindow::compileTopLevelDocument()
 	delete this->root_module;
 	this->root_module = NULL;
 
+	auto fnameba = this->fileName.toLocal8Bit();
     const char* fname =
-        this->fileName.isEmpty() ? "" : this->fileName.toLocal8Bit();
+        this->fileName.isEmpty() ? "" : fnameba;
 	this->root_module = parse(fulltext.c_str(), fs::path(fname), false);
 }
 


### PR DESCRIPTION
toLocal8Bit() returns a QByteArray which casts into a const char\*, so the QByteArray must be held for the const char\* to remain valid.