### PR TITLE
Issue 1647: remove workarounds for older versions of boost

### DIFF
--- a/src/boosty.h
+++ b/src/boosty.h
@@ -31,7 +31,7 @@ namespace fs = boost::filesystem;
 
 namespace boosty {
 
-#if BOOST_VERSION >= 104400 && BOOST_FILESYSTEM_VERSION >= 3
+#if BOOST_VERSION >= 104800 && BOOST_FILESYSTEM_VERSION >= 3
 
 inline bool is_absolute( fs::path p )
 {
@@ -53,36 +53,6 @@ inline std::string extension_str( fs::path p)
 	return p.extension().generic_string();
 }
 
-#else
-
-inline bool is_absolute( fs::path p )
-{
-	return p.is_complete();
-}
-
-inline fs::path absolute( fs::path p )
-{
-	return fs::complete(p, fs::current_path());
-}
-
-inline std::string stringy( fs::path p )
-{
-	return p.string();
-}
-
-inline std::string extension_str( fs::path p)
-{
-	return p.extension();
-}
-
-#endif
-
-
-
-
-
-#if BOOST_VERSION >= 104800
-
 inline fs::path canonical( fs::path p, fs::path p2 )
 {
 	return fs::canonical( p, p2 );
@@ -94,48 +64,7 @@ inline fs::path canonical( fs::path p )
 }
 
 #else
-
-inline fs::path canonical( fs::path p, fs::path p2 )
-{
-#if defined (__WIN32__) || defined(__APPLE__)
-#error you should be using a newer version of boost on win/mac
+#error you should be using a newer version of boost on win/mac/linux
 #endif
-	// based on the code in boost
-	fs::path result;
-	if (p=="") p=p2;
-	std::string result_s;
-	std::vector<std::string> resultv, pieces;
-	std::vector<std::string>::iterator pi;
-	std::string tmps = boosty::stringy( p );
-	boost::split( pieces, tmps, boost::is_any_of("/") );
-	for ( pi = pieces.begin(); pi != pieces.end(); ++pi )
-	{
-		if (*pi == "..")
-			resultv.erase( resultv.end() );
-		else
-			resultv.push_back( *pi );
-	}
-	for ( pi = resultv.begin(); pi != resultv.end(); ++pi )
-	{
-		if ((*pi).length()>0) result_s = result_s + "/" + *pi;
-	}
-	result = fs::path( result_s );
-	if (fs::is_symlink(result))
-	{
-		PRINT("WARNING: canonical() wrapper can't do symlinks. rebuild openscad with boost >=1.48");
-		PRINT("WARNING: or don't use symbolic links");
-	}
-	return result;
-}
-
-inline fs::path canonical( fs::path p )
-{
-	return canonical( p, fs::current_path() );
-}
-
-#endif
-
-
-
 
 } // namespace


### PR DESCRIPTION
I have removed the workarounds for older versions of boost from boosty.h file.