### PR TITLE
Probe

### DIFF
--- a/color-schemes/editor/visualstudio.json
+++ b/color-schemes/editor/visualstudio.json
@@ -36,6 +36,6 @@
     "keywords" : {
         "keyword-set1" : "if else let for module function true false undef include use",
         "keyword-set2" : "abs sign rands min max sin cos asin acos tan atan atan2 round ceil floor pow sqrt exp len log ln str chr concat lookup search version version_num norm cross parent_module dxf_dim dxf_cross",
-        "keyword-set3" : "cube sphere cylinder polyhedron square circle polygon text minkowski hull resize child echo union difference intersection linear_extrude rotate_extrude import group projection render surface scale rotate mirror translate multmatrix color offset"
+        "keyword-set3" : "cube sphere cylinder polyhedron square circle polygon text minkowski hull resize child echo union difference intersection linear_extrude rotate_extrude import group projection render probe surface scale rotate mirror translate multmatrix color offset"
     }
 }

--- a/src/cgalutils.cc
+++ b/src/cgalutils.cc
@@ -142,7 +142,7 @@ namespace CGALUtils {
 
 	void computeVolume(const PolySet &ps,NT3 &volumeTotal,NT3 centerOfMass[3])
         {
-                std::cout << "volume of polyset!"<<std::endl;
+                //std::cout << "volume of polyset!"<<std::endl;
                 CGAL_Polyhedron poly;
                 CGALUtils::createPolyhedronFromPolySet(ps, poly);
                 CGAL_Nef_polyhedron *p = createNefPolyhedronFromGeometry(ps);
@@ -152,29 +152,19 @@ namespace CGALUtils {
         void computeVolume(const CGAL_Nef_polyhedron3 &N,NT3 &volumeTotal,NT3 centerOfMass[3])
         {
                 // attention, il faut etre sur que N->p3()->is_simple(), sinon ca fonctionne pas fort
-                std::cout << "volumen of nef!"<<std::endl;
+                //std::cout << "volumen of nef!"<<std::endl;
                 CGAL::Timer t;
                 std::vector<CGAL_Polyhedron> parts;
                 t.start();
                 CGAL_Nef_polyhedron3 decomp=N;
                 CGAL::convex_decomposition_3(decomp);
-                std::cout <<"nb volumes = "<<decomp.number_of_volumes()<<"\n";
+                //std::cout <<"nb volumes = "<<decomp.number_of_volumes()<<"\n";
                 // the first volume is the outer volume, which ignored in the decomposition
                 CGAL_Nef_polyhedron3::Volume_const_iterator ci = decomp.volumes_begin();
                 for(; ci != decomp.volumes_end(); ++ci) {
-                        std::cout <<"one part...\n";
-                        /*CGAL_Nef_polyhedron3::Shell_entry_const_iterator si=ci->shells_begin();
-                        for(; si != ci->shells_end(); ++si) {
-                                std::cout <<"shell\n";
-                                std::cout<<" converting to poly.\n";
-                                CGAL_Polyhedron poly;
-                                decomp.convert_inner_shell_to_polyhedron(si, poly);
-                                parts.push_back(poly);
-                        }
-                        */
-
+                        //std::cout <<"one part...\n";
                         if(ci->mark()) {
-                                std::cout<<" converting to poly.\n";
+                                //std::cout<<" converting to poly.\n";
                                 CGAL_Polyhedron poly;
                                 decomp.convert_inner_shell_to_polyhedron(ci->shells_begin(), poly);
                                 parts.push_back(poly);
@@ -191,7 +181,7 @@ namespace CGALUtils {
                 centerOfMass[2]=0;
                 // on affiche chaque partie...
                 for(int i=0;i<(int)parts.size();i++) {
-                        std::cout<<"part "<<i<<" : facets = "<<parts[i].size_of_facets()<<", vertex="<<parts[i].size_of_vertices()<<"\n";
+                        //std::cout<<"part "<<i<<" : facets = "<<parts[i].size_of_facets()<<", vertex="<<parts[i].size_of_vertices()<<"\n";
                         //
                         // on trouve le centre des points (xs,ys,zs)
                         //
@@ -260,10 +250,8 @@ namespace CGALUtils {
                         centerOfMass[1]/=volumeTotal;
                         centerOfMass[2]/=volumeTotal;
                 }
-                std::cout<<"Volume Total = "<<to_double(volumeTotal)<<"\n";
-                std::cout<<"center of mass is ("<<to_double(centerOfMass[0])<<","<<to_double(centerOfMass[1])<<","<<to_double(centerOfMass[2])<<")\n";
-        //      std::cout<<"center of mass is ("<<centerOfMass[0]<<","<<centerOfMass[1]<<","<<centerOfMass[2]<<")\n";
-
+                //std::cout<<"Volume Total = "<<to_double(volumeTotal)<<"\n";
+                //std::cout<<"center of mass is ("<<to_double(centerOfMass[0])<<","<<to_double(centerOfMass[1])<<","<<to_double(centerOfMass[2])<<")\n";
         }
 
 

--- a/src/cgalutils.cc
+++ b/src/cgalutils.cc
@@ -112,7 +112,161 @@ static CGAL_Nef_polyhedron *createNefPolyhedronFromPolygon2d(const Polygon2d &po
 	return createNefPolyhedronFromPolySet(*ps);
 }
 
+
+static void updateCenterOfMass( CGAL_Polyhedron::Point_3 const& p1,
+                                CGAL_Polyhedron::Point_3 const& p2,
+                                CGAL_Polyhedron::Point_3 const& p3,
+                                CGAL_Polyhedron::Point_3 const& ps,
+                                NT3 &volumeTotal,
+                                NT3 centerOfMass[3]) {
+        //std::cout << "p1 ("<<p1.x()<<","<<p1.y()<<","<<p1.z()<<")\n";
+        //std::cout << "p2 ("<<p2.x()<<","<<p2.y()<<","<<p2.z()<<")\n";
+        //std::cout << "p3 ("<<p3.x()<<","<<p3.y()<<","<<p3.z()<<")\n";
+        //std::cout << "ps ("<<ps.x()<<","<<ps.y()<<","<<ps.z()<<")\n";
+        NT3 vol=abs(CGAL::volume(ps,p1,p2,p3));
+        NT3 centroid[3];
+        centroid[0]=(p1[0]+p2[0]+p3[0]+ps[0])/4;
+        centroid[1]=(p1[1]+p2[1]+p3[1]+ps[1])/4;
+        centroid[2]=(p1[2]+p2[2]+p3[2]+ps[2])/4;
+        volumeTotal+=vol;
+        centerOfMass[0]+=centroid[0]*vol;
+        centerOfMass[1]+=centroid[1]*vol;
+        centerOfMass[2]+=centroid[2]*vol;
+        //std::cout << "volume="<<to_double(vol)<<" centroid="<<to_double(centroid[0])<<","<<to_double(centroid[1])<<","<<to_double(centroid[2])<<"\n";
+        //std::cout<<"center of mass is ("<<to_double(centerOfMass[0])<<","<<to_double(centerOfMass[1])<<","<<to_double(centerOfMass[2])<<")\n";
+}
+
+
+
 namespace CGALUtils {
+
+	void computeVolume(const PolySet &ps,NT3 &volumeTotal,NT3 centerOfMass[3])
+        {
+                std::cout << "volume of polyset!"<<std::endl;
+                CGAL_Polyhedron poly;
+                CGALUtils::createPolyhedronFromPolySet(ps, poly);
+                CGAL_Nef_polyhedron *p = createNefPolyhedronFromGeometry(ps);
+                if (!p->isEmpty()) computeVolume(*p->p3,volumeTotal,centerOfMass);
+        }
+
+        void computeVolume(const CGAL_Nef_polyhedron3 &N,NT3 &volumeTotal,NT3 centerOfMass[3])
+        {
+                // attention, il faut etre sur que N->p3()->is_simple(), sinon ca fonctionne pas fort
+                std::cout << "volumen of nef!"<<std::endl;
+                CGAL::Timer t;
+                std::vector<CGAL_Polyhedron> parts;
+                t.start();
+                CGAL_Nef_polyhedron3 decomp=N;
+                CGAL::convex_decomposition_3(decomp);
+                std::cout <<"nb volumes = "<<decomp.number_of_volumes()<<"\n";
+                // the first volume is the outer volume, which ignored in the decomposition
+                CGAL_Nef_polyhedron3::Volume_const_iterator ci = decomp.volumes_begin();
+                for(; ci != decomp.volumes_end(); ++ci) {
+                        std::cout <<"one part...\n";
+                        /*CGAL_Nef_polyhedron3::Shell_entry_const_iterator si=ci->shells_begin();
+                        for(; si != ci->shells_end(); ++si) {
+                                std::cout <<"shell\n";
+                                std::cout<<" converting to poly.\n";
+                                CGAL_Polyhedron poly;
+                                decomp.convert_inner_shell_to_polyhedron(si, poly);
+                                parts.push_back(poly);
+                        }
+                        */
+
+                        if(ci->mark()) {
+                                std::cout<<" converting to poly.\n";
+                                CGAL_Polyhedron poly;
+                                decomp.convert_inner_shell_to_polyhedron(ci->shells_begin(), poly);
+                                parts.push_back(poly);
+                        }
+
+                }
+                t.stop();
+                PRINTB("Center of mass: decomposed into %d convex parts", parts.size());
+                PRINTB("Center of mass: decomposition took %f s", t.time());
+
+                volumeTotal=0;
+                centerOfMass[0]=0;
+                centerOfMass[1]=0;
+                centerOfMass[2]=0;
+                // on affiche chaque partie...
+                for(int i=0;i<(int)parts.size();i++) {
+                        std::cout<<"part "<<i<<" : facets = "<<parts[i].size_of_facets()<<", vertex="<<parts[i].size_of_vertices()<<"\n";
+                        //
+                        // on trouve le centre des points (xs,ys,zs)
+                        //
+                        CGAL_Polyhedron::Vertex_const_iterator vi = parts[i].vertices_begin();
+                        NT3 xs=0,ys=0,zs=0;
+                        int nb=0;
+                        for(;vi!=parts[i].vertices_end();vi++) {
+                                CGAL_Polyhedron::Point_3 const& p = vi->point();
+                                xs+=p[0];
+                                ys+=p[1];
+                                zs+=p[2];
+                                nb++;
+                                //std::cout << "vertice ("<<x<<","<<y<<","<<z<<")\n";
+                        }
+                        CGAL_Polyhedron::Point_3 ps(xs/nb,ys/nb,zs/nb);
+                        //std::cout << "center is ("<<ps[0]<<","<<ps[1]<<","<<ps[2]<<")\n";
+                        //
+                        // on visite chaque facette...
+                        // on la triangule
+                        //
+                        CGAL_Polyhedron::Facet_const_iterator fi = parts[i].facets_begin();
+                        for(;fi!=parts[i].facets_end();fi++) {
+                                //std::cout << "facet "<<fi->is_triangle()<<" , nbedge="<<fi->facet_degree()<<"\n";
+                                if( fi->is_triangle() ) {
+                                        // tetrahedre avec le centre... et voila!
+                                        CGAL_Polyhedron::Facet::Halfedge_around_facet_const_circulator he,end;
+                                        end = he = fi->facet_begin();
+                                        //CGAL_Polyhedron P;
+
+                                        CGAL_Polyhedron::Point_3 const& p1 = he->vertex()->point();he++;
+                                        CGAL_Polyhedron::Point_3 const& p2 = he->vertex()->point();he++;
+                                        CGAL_Polyhedron::Point_3 const& p3 = he->vertex()->point();
+                                        updateCenterOfMass(p1,p2,p3,ps,volumeTotal,centerOfMass);
+
+                                }else{
+                                        // on decoupe!
+                                        // trouve le centre de la facette
+                                        CGAL_Polyhedron::Facet::Halfedge_around_facet_const_circulator he,end;
+                                        NT3 xc=0,yc=0,zc=0;
+                                        end = he = fi->facet_begin();
+                                        CGAL_For_all(he,end) {
+                                                CGAL_Polyhedron::Point_3 const& p = he->vertex()->point();
+                                                xc+=p[0];yc+=p[1];zc+=p[2];
+                                                //std::cout << "facet halfedge ("<<to_double(p[0])<<","<<to_double(p[1])<<","<<to_double(p[2])<<")\n";
+                                        }
+                                        xc/=(int)fi->facet_degree();
+                                        yc/=(int)fi->facet_degree();
+                                        zc/=(int)fi->facet_degree();
+                                        CGAL_Polyhedron::Point_3 pc(xc,yc,zc);
+                                        //std::cout << "facet center ("<<to_double(xc)<<","<<to_double(yc)<<","<<to_double(zc)<<")\n";
+                                        // on fait le tour de la facette, en ajoutant les tetra (p1,p2,ps,pc)
+                                        end = he = fi->facet_begin();
+                                        CGAL_For_all(he,end) {
+                                                CGAL_Polyhedron::Point_3 const& p1 = he->vertex()->point();
+                                                CGAL_Polyhedron::Point_3 const& p2 = he->next()->vertex()->point();
+                                                //std::cout << "facet halfedge p1 ("<<to_double(p1[0])<<","<<to_double(p1[1])<<","<<to_double(p1[2])<<")\n";
+                                                //std::cout << "facet halfedge p2 ("<<to_double(p2[0])<<","<<to_double(p2[1])<<","<<to_double(p2[2])<<")\n";
+                                                updateCenterOfMass(p1,p2,pc,ps,volumeTotal,centerOfMass);
+                                        }
+                                }
+                        }
+                }
+                // finalise le centre de masse
+                if( volumeTotal>0 ) {
+                        centerOfMass[0]/=volumeTotal;
+                        centerOfMass[1]/=volumeTotal;
+                        centerOfMass[2]/=volumeTotal;
+                }
+                std::cout<<"Volume Total = "<<to_double(volumeTotal)<<"\n";
+                std::cout<<"center of mass is ("<<to_double(centerOfMass[0])<<","<<to_double(centerOfMass[1])<<","<<to_double(centerOfMass[2])<<")\n";
+        //      std::cout<<"center of mass is ("<<centerOfMass[0]<<","<<centerOfMass[1]<<","<<centerOfMass[2]<<")\n";
+
+        }
+
+
 
 	CGAL_Iso_cuboid_3 boundingBox(const CGAL_Nef_polyhedron3 &N)
 	{

--- a/src/cgalutils.h
+++ b/src/cgalutils.h
@@ -19,6 +19,9 @@ namespace /* anonymous */ {
 }
 
 namespace CGALUtils {
+        void computeVolume(const CGAL_Nef_polyhedron3 &N,NT3 &volumeTotal,NT3 centerOfMass[3]);
+        void computeVolume(const PolySet &ps,NT3 &volumeTotal,NT3 centerOfMass[3]);
+
 	bool applyHull(const Geometry::Geometries &children, PolySet &P);
 	CGAL_Nef_polyhedron *applyOperator(const Geometry::Geometries &children, OpenSCADOperator op);
 	//FIXME: Old, can be removed:

--- a/src/control.cc
+++ b/src/control.cc
@@ -337,22 +337,25 @@ AbstractNode *ControlModule::instantiate(const Context* /*ctx*/, const ModuleIns
 			std::vector<AbstractNode *> instantiatednodes = ifelse->instantiateElseChildren(evalctx);
 			node->children.insert(node->children.end(), instantiatednodes.begin(), instantiatednodes.end());
 		}
+		break;
 	}
 
- case PROBE: {
+ 	case PROBE: {
                 //
                 // render first children, then compute the bounding box.
                 // set the following 4 vector variables and 1 bool variable:
                 //    empty = true/false, state if there was any usable geometry.
-                //              when bbempty is false, the next variables are undef
+                //              when empty is false, the next variables are undef
                 //    bbmin = [xmin,ymin,zmin], the minimum of the bounding box
                 //    bbmax = [xmax,ymax,zmax], the maximum of the bounding box
                 //    bbsize = [xmax-xmin,...], the size of the bounding box
                 //    bbcenter = [(xmax+xmin)/2, ...], the center of the bounding box
+		//
+		// if called with (volume=true), then these variables are also defined
                 //    volume = volume of object
                 //    centroid = center of mass of object
                 //
-                // the only parameter that probe takes is $exact=true/false
+                // A parameter that probe takes is $exact=true/false
                 // it is generaly set to true, but with false the rendering will not be Nef (so its faster).
                 // any other parameter will be treated just like assign() (i.e. passed inside)
                 //
@@ -415,17 +418,17 @@ AbstractNode *ControlModule::instantiate(const Context* /*ctx*/, const ModuleIns
                                                 xmax=bb.max().x();
                                                 ymax=bb.max().y();
                                                 zmax=bb.max().z();
-                                                std::cout << "CSG!" << std::endl;
+                                                //std::cout << "CSG!" << std::endl;
                                                 //G->dump();
                                                 //full=isBBoxFull(G);
                                                 //std::cout << "full:" <<full<<std::endl;
                                                 if( volume ) {
                                                         NT3 volumeTotal;
                                                         NT3 centerOfMass[3];
-                                                        std::cout << "PolySet volume!" << std::endl;
+                                                        //std::cout << "PolySet volume!" << std::endl;
                                                         CGALUtils::computeVolume( *G,volumeTotal,centerOfMass );
-                                                        std::cout<<"Volume Total = "<<to_double(volumeTotal)<<"\n";
-                                                        std::cout<<"center of mass is ("<<to_double(centerOfMass[0])<<","<<to_double(centerOfMass[1])<<","<<to_double(centerOfMass[2])<<")\n";
+                                                        //std::cout<<"Volume Total = "<<to_double(volumeTotal)<<"\n";
+                                                        //std::cout<<"center of mass is ("<<to_double(centerOfMass[0])<<","<<to_double(centerOfMass[1])<<","<<to_double(centerOfMass[2])<<")\n";
                                                         c.set_variable("volume",Value(to_double(volumeTotal)));
                                                         Value::VectorType bbcentroid;
                                                         bbcentroid.push_back(to_double(centerOfMass[0]));
@@ -452,10 +455,10 @@ AbstractNode *ControlModule::instantiate(const Context* /*ctx*/, const ModuleIns
                                                         NT3 volumeTotal;
                                                         NT3 centerOfMass[3];
                                                         // check the volume
-                                                        std::cout << "NEF volume!" << std::endl;
+                                                        //std::cout << "NEF volume!" << std::endl;
                                                         CGALUtils::computeVolume( *(N->p3), volumeTotal,centerOfMass );
-                                                        std::cout<<"Volume Total = "<<to_double(volumeTotal)<<"\n";
-                                                        std::cout<<"center of mass is ("<<to_double(centerOfMass[0])<<","<<to_double(centerOfMass[1])<<","<<to_double(centerOfMass[2])<<")\n";
+                                                        //std::cout<<"Volume Total = "<<to_double(volumeTotal)<<"\n";
+                                                        //std::cout<<"center of mass is ("<<to_double(centerOfMass[0])<<","<<to_double(centerOfMass[1])<<","<<to_double(centerOfMass[2])<<")\n";
                                                         c.set_variable("volume",Value(to_double(volumeTotal)));
                                                         Value::VectorType bbcentroid;
                                                         bbcentroid.push_back(to_double(centerOfMass[0]));
@@ -467,7 +470,7 @@ AbstractNode *ControlModule::instantiate(const Context* /*ctx*/, const ModuleIns
                                         }
 #endif
                                 }
-                                c.set_variable("bbempty",Value(empty));
+                                c.set_variable("empty",Value(empty));
                                 //c.set_variable("bbfull",Value(full));
                                 if( !empty ) {
                                         // define the variables
@@ -503,11 +506,9 @@ AbstractNode *ControlModule::instantiate(const Context* /*ctx*/, const ModuleIns
                         }
 
 		}
-
-
 		break;
 	}
-	}
+	} // switch
 	return node;
 }
 

--- a/src/control.cc
+++ b/src/control.cc
@@ -377,7 +377,11 @@ AbstractNode *ControlModule::instantiate(const Context* /*ctx*/, const ModuleIns
                 bool exact = c.lookup_variable("$exact")->toBool();
                 bool volume = c.lookup_variable("volume")->toBool();
 
-                PRINTB("probe volume=%d", volume);
+		if( exact ) {
+			PRINTB("probe volume=%d (exact)", volume);
+		}else{
+			PRINTB("probe volume=%d (not exact)", volume);
+		}
 
                 // Let any local variables override the parameters
                 inst->scope.apply(c);

--- a/src/control.cc
+++ b/src/control.cc
@@ -37,7 +37,7 @@
 
 
 // pour le probe()
-#include "CGAL_Nef_polyhedron.h"
+//#include "CGAL_Nef_polyhedron.h"
 #include "GeometryEvaluator.h"
 #include "Tree.h"
 #include "cgalutils.h"

--- a/src/highlighter.cc
+++ b/src/highlighter.cc
@@ -221,7 +221,7 @@ Highlighter::Highlighter(QTextDocument *parent)
 	tokentypes["math"] << "abs" << "sign" << "acos" << "asin" << "atan" << "atan2" << "sin" << "cos" << "floor" << "round" << "ceil" << "ln" << "log" << "lookup" << "min" << "max" << "pow" << "sqrt" << "exp" << "rands";
 	tokentypes["keyword"] << "module" << "function" << "for" << "intersection_for" << "if" << "assign" << "echo"<< "search" << "str" << "let" << "each";
 	tokentypes["transform"] << "scale" << "translate" << "rotate" << "multmatrix" << "color" << "projection" << "hull" << "resize" << "mirror" << "minkowski";
-	tokentypes["csgop"]	<< "union" << "intersection" << "difference" << "render";
+	tokentypes["csgop"]	<< "union" << "intersection" << "difference" << "render" << "probe";
 	tokentypes["prim3d"] << "cube" << "cylinder" << "sphere" << "polyhedron";
 	tokentypes["prim2d"] << "square" << "polygon" << "circle";
 	tokentypes["import"] << "include" << "use" << "import_stl" << "import" << "import_dxf" << "dxf_dim" << "dxf_cross" << "surface";


### PR DESCRIPTION
probe() feature which computes useful information about a geometry : bounding box, volume, and centroid (center of mass).

Example usage:

probe() {
        // the first children of probe is going to be "probed" for bounding box and volume
        someGeometry();
        // variable containing the information are set and usable for the evalution of all following children (empty, bbsize,bbmin,bbmax,bbcenter, volume, centroid)
        echo("bounding box center is ",bbcenter);
        // the resulting geometry will be centered
        translate-(bbcenter) someGeometry();
}

By default, the volume and centroid are not computed. Use volume=true to get them:

probe(volume=true) {
    someGeometry();
    echo("volume=",volume);
    echo("centroid=",centroid);
    someGeometry();
}

The volume computation proceed by using a decomposition into convex parts, then sum the volumes of each parts. The center of mass is computed at the same time.

This is a test pull request. I did not add the examples yet. I just want to see if it works. I'll add examples in a subsequent pull request.