### PR TITLE
Ensure to always return a value to fix OBS builds.

### DIFF
--- a/src/expr.cc
+++ b/src/expr.cc
@@ -88,7 +88,7 @@ ValuePtr UnaryOp::evaluate(const Context *context) const
 	case (Op::Negate):
 		return -this->expr->evaluate(context);
 	default:
-		break;
+		return ValuePtr::undefined;
 		// FIXME: error:
 	}
 }
@@ -103,7 +103,7 @@ const char *UnaryOp::opString() const
 		return "-";
 		break;
 	default:
-		break;
+		return "";
 		// FIXME: Error: unknown op
 	}
 }
@@ -161,7 +161,7 @@ ValuePtr BinaryOp::evaluate(const Context *context) const
 		return this->left->evaluate(context) != this->right->evaluate(context);
 		break;
 	default:
-		break;
+		return ValuePtr::undefined;
 		// FIXME: Error: unknown op
 	}
 }
@@ -209,7 +209,7 @@ const char *BinaryOp::opString() const
 		return "!=";
 		break;
 	default:
-		break;
+		return "";
 		// FIXME: Error: unknown op
 	}
 }


### PR DESCRIPTION
OBS checks that functions always return a value when building RPM based packages:
```
[  743s] I: Program returns random data in a function
[  743s] E: openscad-nightly no-return-in-nonvoid-function src/expr.cc:94, 109, 167, 215
[  743s] 
[  743s] I: Program returns random data in a function
[  743s] E: openscad-nightly no-return-in-nonvoid-function src/expr.cc:94, 109, 167, 215
[  743s] 
[  743s] build80 failed "build openscad-nightly.spec" at Sun Jun 26 02:44:21 UTC 2016.
```