### PR TITLE
AST visitation

### DIFF
--- a/src/AST.cc
+++ b/src/AST.cc
@@ -39,3 +39,13 @@ std::string ASTNode::dump(const std::string &indent) const
 	print(stream, indent);
 	return stream.str();
 }
+
+void UseNode::print(std::ostream &stream, const std::string &indent) const
+{
+	stream << indent << "use <" << this->filename << ">\n";
+}
+
+void IncludeNode::print(std::ostream &stream, const std::string &indent) const
+{
+	stream << indent << "include <" << this->filename << ">\n";
+}

--- a/src/AST.h
+++ b/src/AST.h
@@ -55,3 +55,25 @@ protected:
 };
 
 std::ostream &operator<<(std::ostream &stream, const ASTNode &ast);
+
+class ExternalNode : public ASTNode
+{
+public:
+	ExternalNode(std::string filename, const Location &loc) : ASTNode(loc), filename(std::move(filename)) {}
+
+	std::string filename;
+};
+
+class UseNode : public ExternalNode
+{
+public:
+	UseNode(std::string filename, const Location &loc) : ExternalNode(filename, loc) {}
+	virtual void print(std::ostream &stream, const std::string &indent) const;
+};
+
+class IncludeNode : public ExternalNode
+{
+public:
+	IncludeNode(std::string filename, const Location &loc) : ExternalNode(filename, loc) {}
+	virtual void print(std::ostream &stream, const std::string &indent) const;
+};

--- a/src/FileModule.h
+++ b/src/FileModule.h
@@ -22,32 +22,33 @@ public:
 
 	void setModulePath(const std::string &path) { this->path = path; }
 	const std::string &modulePath() const { return this->path; }
-	void registerUse(const std::string path, const Location &loc);
-	void registerInclude(const std::string &localpath, const std::string &fullpath, const Location &loc);
-	std::time_t includesChanged() const;
+	void addExternalNode(const std::shared_ptr<ExternalNode> &node);
+	void resolveUseNodes();
+	void resolveIncludeNodes();
+	time_t includesChanged() const;
 	std::time_t handleDependencies(bool is_root = true);
-	bool hasIncludes() const { return !this->includes.empty(); }
-	bool usesLibraries() const { return !this->usedlibs.empty(); }
+	bool hasExternals() const { return !this->externalDict.empty(); }
 	bool isHandlingDependencies() const { return this->is_handling_dependencies; }
+	void resolveExternals();
+	std::vector<shared_ptr<UseNode>> getUseNodes() const;
+
 	void clearHandlingDependencies() { this->is_handling_dependencies = false; }
 	void setFilename(const std::string &filename) { this->filename = filename; }
 	const std::string &getFilename() const { return this->filename; }
 	const std::string getFullpath() const;
+
 	LocalScope scope;
-	typedef std::unordered_set<std::string> ModuleContainer;
-	ModuleContainer usedlibs;
+	std::unordered_map<std::string, shared_ptr<ExternalNode>> externalDict;
+	std::vector<shared_ptr<ExternalNode>> externalList;
 
 	std::vector<IndicatorData> indicatorData;
-
 private:
 	struct IncludeFile {
 		std::string filename;
 	};
 
-	std::time_t include_modified(const IncludeFile &inc) const;
+	std::time_t includeModified(const IncludeNode &node) const;
 
-	typedef std::unordered_map<std::string, struct IncludeFile> IncludeContainer;
-	IncludeContainer includes;
 	bool is_handling_dependencies;
 
 	std::string path;

--- a/src/ModuleCache.cc
+++ b/src/ModuleCache.cc
@@ -104,6 +104,7 @@ std::time_t ModuleCache::evaluate(const std::string &mainFile,const std::string 
 		
 		delete cacheEntry.parsed_module;
 		lib_mod = parse(cacheEntry.parsed_module, text, filename, mainFile, false) ? cacheEntry.parsed_module : nullptr;
+		lib_mod->resolveExternals();
 		PRINTDB("compiled module: %s", filename);
 		cacheEntry.module = lib_mod;
 		cacheEntry.cache_id = cache_id;

--- a/src/lexer.l
+++ b/src/lexer.l
@@ -103,7 +103,6 @@ extern YYLTYPE parserlloc;
 
 extern void parsererror(char const *s);
 void to_utf8(const char *, char *);
-void includefile(const Location& loc);
 std::shared_ptr<fs::path> sourcefile();
 std::shared_ptr<fs::path> parser_sourcefile;
 std::vector<std::shared_ptr<fs::path>> filename_stack;
@@ -142,7 +141,13 @@ include[ \t\r\n]*"<"	{ BEGIN(cond_include); filepath = filename = ""; }
 <cond_include>{
 [^\t\r\n>]*"/"			{ filepath = yytext; }
 [^\t\r\n>/]+			{ filename = yytext; }
-">"						{ BEGIN(INITIAL); includefile(LOCATION(parserlloc));  }
+">"		{
+	BEGIN(INITIAL);
+	auto localpath = (fs::path{filepath} / filename).generic_string();
+	parserlval.text = strdup(localpath.c_str());
+	// FIXME: How to handle LOCATION(parserlloc) ?
+	return TOK_INCLUDE;
+    }
 <<EOF>>					{ parsererror("Unterminated include statement"); return TOK_ERROR; }
 }
 
@@ -150,16 +155,9 @@ include[ \t\r\n]*"<"	{ BEGIN(cond_include); filepath = filename = ""; }
 use[ \t\r\n]*"<"		{ BEGIN(cond_use); }
 <cond_use>{
 [^\t\r\n>]+				{ filename = yytext; }
- ">"					{
-							BEGIN(INITIAL);
-							fs::path fullpath = find_valid_path(sourcefile()->parent_path(), fs::path(filename), &openfilenames);
-							if (fullpath.empty()) {
-								PRINTB("WARNING: Can't open library '%s'.", filename);
-								parserlval.text = strdup(filename.c_str());
-							} else {
-								handle_dep(fullpath.generic_string());
-								parserlval.text = strdup(fullpath.string().c_str());
-							}
+">"		{
+	BEGIN(INITIAL);
+        parserlval.text = strdup(filename.c_str());
 							return TOK_USE;
 						}
 <<EOF>>					{ parsererror("Unterminated use statement"); return TOK_ERROR; }
@@ -292,49 +290,6 @@ std::shared_ptr<fs::path>  sourcefile()
   if (!filename_stack.empty()) return filename_stack.back();
 
   return parser_sourcefile;
-}
-
-/*
-  Rules for include <path/file>
-  1) include <sourcepath/path/file>
-  2) include <librarydir/path/file>
-
-  Globals used: filepath, sourcefile, filename
- */
-void includefile(const Location& loc)
-{
-  fs::path localpath = fs::path(filepath) / filename;
-  fs::path fullpath = find_valid_path(sourcefile()->parent_path(), localpath, &openfilenames);
-  if (!fullpath.empty()) {
-    rootmodule->registerInclude(localpath.generic_string(), fullpath.generic_string(), loc_stack.empty() ? loc : Location::NONE);
-  }
-  else {
-    rootmodule->registerInclude(localpath.generic_string(), localpath.generic_string(), Location::NONE);
-    PRINTB("WARNING: Can't open include file '%s'.", localpath.generic_string());
-    return;
-  };
-
-  std::string fullname = fullpath.generic_string();
-
-  filepath.clear();
-  filename_stack.push_back(std::make_shared<fs::path>(fullpath));
-
-  handle_dep(fullname);
-
-  yyin = fopen(fullname.c_str(), "r");
-  if (!yyin) {
-    PRINTB("WARNING: Can't open include file '%s'.", localpath.generic_string());
-    filename_stack.pop_back();
-    return;
-  }
-
-  loc_stack.push_back(parserlloc);
-  LOCATION_INIT(parserlloc);  
-  openfiles.push_back(yyin);
-  openfilenames.push_back(fullname);
-  filename.clear();
-
-  yypush_buffer_state(yy_create_buffer(yyin, YY_BUF_SIZE));
 }
 
 /*!

--- a/src/mainwin.cc
+++ b/src/mainwin.cc
@@ -27,6 +27,8 @@
 #include "comment.h"
 #include "openscad.h"
 #include "GeometryCache.h"
+#include "FileModule.h"
+#include "modcontext.h"
 #include "ModuleCache.h"
 #include "MainWindow.h"
 #include "OpenSCADApp.h"
@@ -976,7 +978,7 @@ void MainWindow::compile(bool reload, bool forcedone, bool rebuildParameterWidge
 		// If we're auto-reloading, listen for a cascade of changes by starting a timer
 		// if something changed _and_ there are any external dependencies
 		if (reload && didcompile && this->root_module) {
-			if (this->root_module->hasIncludes() ||	this->root_module->usesLibraries()) {
+			if (this->root_module->hasExternals()) {
 				this->waitAfterReloadTimer->start();
 				this->procevents = false;
 				return;
@@ -1713,6 +1715,7 @@ void MainWindow::parseTopLevelDocument(bool rebuildParameterWidget)
 	const char* fname = activeEditor->filepath.isEmpty() ? "" : fnameba;
 	delete this->parsed_module;
 	this->root_module = parse(this->parsed_module, fulltext, fname, fname, false) ? this->parsed_module : nullptr;
+	this->root_module->resolveExternals();
 
 	if (this->root_module!=nullptr) {
 		//add parameters as annotation in AST

--- a/src/modcontext.h
+++ b/src/modcontext.h
@@ -51,10 +51,10 @@ public:
 	AbstractNode *instantiate_module(const ModuleInstantiation &inst, const std::shared_ptr<EvalContext>& evalctx) const override;
 
 protected:
-	FileContext(const std::shared_ptr<Context> parent) : ModuleContext(parent), usedlibs_p(nullptr) {}
+	FileContext(const std::shared_ptr<Context> parent) : ModuleContext(parent) {}
 
 private:
-	const FileModule::ModuleContainer *usedlibs_p;
+	std::vector<shared_ptr<UseNode>> usedlibs;
 
 	// This sub_* method is needed to minimize stack usage only.
 	ValuePtr sub_evaluate_function(const std::string &name, const std::shared_ptr<EvalContext>& evalctx, FileModule *usedmod) const;

--- a/src/openscad.cc
+++ b/src/openscad.cc
@@ -342,6 +342,8 @@ int cmdline(const char *deps_output_file, const std::string &filename, const cha
 		PRINTB("Can't parse file '%s'!\n", filename.c_str());
 		return 1;
 	}
+	// FIXME: If we want to export as AST, we should export _before_ resolving includes
+	root_module->resolveExternals();
 
 	// add parameter to AST
 	CommentParser::collectParameters(text.c_str(), root_module);

--- a/src/parser.y
+++ b/src/parser.y
@@ -123,6 +123,7 @@ bool fileEnded=false;
 %token <text> TOK_ID
 %token <text> TOK_STRING
 %token <text> TOK_USE
+%token <text> TOK_INCLUDE
 %token <number> TOK_NUMBER
 
 %token TOK_TRUE
@@ -173,7 +174,13 @@ input
         | input
           TOK_USE
             {
-              rootmodule->registerUse(std::string($2), LOC(@2));
+              rootmodule->addExternalNode(make_shared<UseNode>($2, LOC(@2)));
+              free($2);
+            }
+        | input
+	  TOK_INCLUDE
+            {
+              rootmodule->addExternalNode(make_shared<IncludeNode>($2, LOC(@2)));
               free($2);
             }
         | input statement


### PR DESCRIPTION
This PR aims to extend the AST refactoring to allow visitation of the AST and generally move towards being able to build the AST separately from OpenSCAD

TODO:
- [x] Move more classes into the ASTNode hierarchy: UseNode, FileModule
- [x] Refactor dump(), prepare for it to become a visitor? (AST serialization)
- [ ] Preserve `use` statements in AST dumps (without resolving filenames)
- [ ] Preserve `include` statements in AST dumps (without resolving filenames?)
- [ ] LocalScope -> ASTNode?
- [ ] Resolve include & use using a visitor
- [ ] General traversal API
- [ ] Build as separate library

NB! While the list above is exhaustive, we should merge to master whenever we have a stable checkpoint.
