### PR TITLE
Filemodule cleanup

### DIFF
--- a/src/FileModule.cc
+++ b/src/FileModule.cc
@@ -40,7 +40,6 @@ namespace fs = boost::filesystem;
 
 FileModule::~FileModule()
 {
-	delete context;
 }
 
 std::string FileModule::dump(const std::string &indent, const std::string &name) const
@@ -160,14 +159,20 @@ AbstractNode *FileModule::instantiate(const Context *ctx, const ModuleInstantiat
 {
 	assert(evalctx == NULL);
 	
-	delete this->context;
-	this->context = new FileContext(ctx);
-	context->initializeModule(*this);
+	FileContext context(ctx);
+	return this->instantiateWithFileContext(&context, inst, evalctx);
+}
+
+AbstractNode *FileModule::instantiateWithFileContext(FileContext *ctx, const ModuleInstantiation *inst, EvalContext *evalctx) const
+{
+	assert(evalctx == NULL);
+	
+	ctx->initializeModule(*this);
 
 	AbstractNode *node = new RootNode(inst);
 	try {
 		// FIXME: Set document path to the path of the module
-		std::vector<AbstractNode *> instantiatednodes = this->scope.instantiateChildren(context);
+		std::vector<AbstractNode *> instantiatednodes = this->scope.instantiateChildren(ctx);
 		node->children.insert(node->children.end(), instantiatednodes.begin(), instantiatednodes.end());
 	}
 	catch (EvaluationException &e) {
@@ -175,10 +180,4 @@ AbstractNode *FileModule::instantiate(const Context *ctx, const ModuleInstantiat
 	}
 
 	return node;
-}
-
-ValuePtr FileModule::lookup_variable(const std::string &name) const
-{
-	if (!this->context) return ValuePtr::undefined;
-	return this->context->lookup_variable(name, true);
 }

--- a/src/FileModule.cc
+++ b/src/FileModule.cc
@@ -167,10 +167,9 @@ AbstractNode *FileModule::instantiateWithFileContext(FileContext *ctx, const Mod
 {
 	assert(evalctx == NULL);
 	
-	ctx->initializeModule(*this);
-
 	AbstractNode *node = new RootNode(inst);
 	try {
+		ctx->initializeModule(*this); // May throw an ExperimentalFeatureException
 		// FIXME: Set document path to the path of the module
 		std::vector<AbstractNode *> instantiatednodes = this->scope.instantiateChildren(ctx);
 		node->children.insert(node->children.end(), instantiatednodes.begin(), instantiatednodes.end());

--- a/src/FileModule.cc
+++ b/src/FileModule.cc
@@ -161,13 +161,12 @@ AbstractNode *FileModule::instantiate(const Context *ctx, const ModuleInstantiat
 	assert(evalctx == NULL);
 	
 	delete this->context;
-	this->context = new FileContext(*this, ctx);
+	this->context = new FileContext(ctx);
+	context->initializeModule(*this);
+
 	AbstractNode *node = new RootNode(inst);
-
 	try {
-		context->initializeModule(*this);
-
-	// FIXME: Set document path to the path of the module
+		// FIXME: Set document path to the path of the module
 		std::vector<AbstractNode *> instantiatednodes = this->scope.instantiateChildren(context);
 		node->children.insert(node->children.end(), instantiatednodes.begin(), instantiatednodes.end());
 	}

--- a/src/FileModule.h
+++ b/src/FileModule.h
@@ -12,12 +12,14 @@
 class FileModule : public AbstractModule
 {
 public:
-	FileModule() : context(nullptr), is_handling_dependencies(false) {}
+	FileModule() : is_handling_dependencies(false) {}
 	virtual ~FileModule();
 
 	virtual AbstractNode *instantiate(const Context *ctx, const ModuleInstantiation *inst, EvalContext *evalctx = NULL) const;
 	virtual std::string dump(const std::string &indent, const std::string &name) const;
-	void setModulePath(const std::string &path) { this->path = path; }
+	AbstractNode *instantiateWithFileContext(class FileContext *ctx, const ModuleInstantiation *inst, EvalContext *evalctx) const;
+
+void setModulePath(const std::string &path) { this->path = path; }
 	const std::string &modulePath() const { return this->path; }
         void registerUse(const std::string path);
 	void registerInclude(const std::string &localpath, const std::string &fullpath);
@@ -26,14 +28,11 @@ public:
 	bool hasIncludes() const { return !this->includes.empty(); }
 	bool usesLibraries() const { return !this->usedlibs.empty(); }
 	bool isHandlingDependencies() const { return this->is_handling_dependencies; }
-	ValuePtr lookup_variable(const std::string &name) const;
 
 	LocalScope scope;
 	typedef std::unordered_set<std::string> ModuleContainer;
 	ModuleContainer usedlibs;
 private:
-	// Reference to retain the context that was used in the last evaluation
-	mutable class FileContext *context;
 	struct IncludeFile {
 		std::string filename;
 		bool valid;

--- a/src/MainWindow.h
+++ b/src/MainWindow.h
@@ -97,7 +97,7 @@ private:
         void initActionIcon(QAction *action, const char *darkResource, const char *lightResource);
         void handleFileDrop(const QString &filename);
 	void refreshDocument();
-        void updateCamera();
+	void updateCamera(const class FileContext &ctx);
 	void updateTemporalVariables();
 	bool fileChangedOnDisk();
 	void compileTopLevelDocument();

--- a/src/ModuleCache.cc
+++ b/src/ModuleCache.cc
@@ -106,7 +106,7 @@ bool ModuleCache::evaluate(const std::string &filename, FileModule *&module)
 		FileModule *oldmodule = lib_mod;
 		
         fs::path pathname = fs::path(filename);
-		lib_mod = dynamic_cast<FileModule*>(parse(textbuf.str().c_str(), pathname, false));
+		lib_mod = parse(textbuf.str().c_str(), pathname, false);
 		PRINTDB("  compiled module: %p", lib_mod);
 		
 		// We defer deletion so we can ensure that the new module won't

--- a/src/mainwin.cc
+++ b/src/mainwin.cc
@@ -1016,7 +1016,6 @@ void MainWindow::compileDone(bool didchange)
 	if (didchange) {
 		updateTemporalVariables();
 		instantiateRoot();
-		updateCamera();
 		updateCompileResult();
 		callslot = afterCompileSlot;
 	}
@@ -1070,8 +1069,10 @@ void MainWindow::instantiateRoot()
 		ModuleInstantiation mi = ModuleInstantiation( "group" );
 		this->root_inst = mi;
 
-		this->absolute_root_node = this->root_module->instantiate(&top_ctx, &this->root_inst, NULL);
-
+		FileContext filectx(&top_ctx);
+		this->absolute_root_node = this->root_module->instantiateWithFileContext(&filectx, &this->root_inst, NULL);
+		this->updateCamera(filectx);
+		
 		if (this->absolute_root_node) {
 			// Do we have an explicit root node (! modifier)?
 			if (!(this->root_node = find_root_tag(this->absolute_root_node))) {
@@ -1604,11 +1605,8 @@ void MainWindow::updateTemporalVariables()
  * are assigned on top-level, the values are used to change the camera
  * rotation, translation and distance. 
  */
-void MainWindow::updateCamera()
+void MainWindow::updateCamera(const FileContext &ctx)
 {
-	if (!root_module)
-		return;
-	
 	bool camera_set = false;
 
 	Camera cam(qglview->cam);
@@ -1622,7 +1620,7 @@ void MainWindow::updateCamera()
 	double d = cam.zoomValue();
 
 	double x, y, z;
-	const ValuePtr vpr = root_module->lookup_variable("$vpr");
+	const ValuePtr vpr = ctx.lookup_variable("$vpr");
 	if (vpr->getVec3(x, y, z)) {
 		rx = x;
 		ry = y;
@@ -1630,7 +1628,7 @@ void MainWindow::updateCamera()
 		camera_set = true;
 	}
 
-	const ValuePtr vpt = root_module->lookup_variable("$vpt");
+	const ValuePtr vpt = ctx.lookup_variable("$vpt");
 	if (vpt->getVec3(x, y, z)) {
 		tx = x;
 		ty = y;
@@ -1638,7 +1636,7 @@ void MainWindow::updateCamera()
 		camera_set = true;
 	}
 
-	const ValuePtr vpd = root_module->lookup_variable("$vpd");
+	const ValuePtr vpd = ctx.lookup_variable("$vpd");
 	if (vpd->type() == Value::NUMBER) {
 		d = vpd->toDouble();
 		camera_set = true;

--- a/src/modcontext.cc
+++ b/src/modcontext.cc
@@ -176,17 +176,15 @@ std::string ModuleContext::dump(const AbstractModule *mod, const ModuleInstantia
 }
 #endif
 
-FileContext::FileContext(const class FileModule &module, const Context *parent)
-	: ModuleContext(parent), usedlibs(module.usedlibs)
+FileContext::FileContext(const Context *parent) : ModuleContext(parent)
 {
-	if (!module.modulePath().empty()) this->document_path = module.modulePath();
 }
 
 ValuePtr FileContext::sub_evaluate_function(const std::string &name, 
-																													 const EvalContext *evalctx,
-																													 FileModule *usedmod) const
+																						const EvalContext *evalctx,
+																						FileModule *usedmod) const
 {
-	FileContext ctx(*usedmod, this->parent);
+	FileContext ctx(this->parent);
 	ctx.initializeModule(*usedmod);
 	// FIXME: Set document path
 #ifdef DEBUG
@@ -202,7 +200,7 @@ ValuePtr FileContext::evaluate_function(const std::string &name,
 	const AbstractFunction *foundf = findLocalFunction(name);
 	if (foundf) return foundf->evaluate(this, evalctx);
 
-	for(const auto &m : this->usedlibs) {
+	for(const auto &m : *this->usedlibs_p) {
 		// usedmod is NULL if the library wasn't be compiled (error or file-not-found)
 		FileModule *usedmod = ModuleCache::instance()->lookup(m);
 		if (usedmod && usedmod->scope.functions.find(name) != usedmod->scope.functions.end())
@@ -217,12 +215,12 @@ AbstractNode *FileContext::instantiate_module(const ModuleInstantiation &inst, E
 	const AbstractModule *foundm = this->findLocalModule(inst.name());
 	if (foundm) return foundm->instantiate(this, &inst, evalctx);
 
-	for(const auto &m : this->usedlibs) {
+	for(const auto &m : *this->usedlibs_p) {
 		FileModule *usedmod = ModuleCache::instance()->lookup(m);
 		// usedmod is NULL if the library wasn't be compiled (error or file-not-found)
 		if (usedmod &&
 				usedmod->scope.modules.find(inst.name()) != usedmod->scope.modules.end()) {
-			FileContext ctx(*usedmod, this->parent);
+			FileContext ctx(this->parent);
 			ctx.initializeModule(*usedmod);
 			// FIXME: Set document path
 #ifdef DEBUG
@@ -238,10 +236,12 @@ AbstractNode *FileContext::instantiate_module(const ModuleInstantiation &inst, E
 
 void FileContext::initializeModule(const class FileModule &module)
 {
+	if (!module.modulePath().empty()) this->document_path = module.modulePath();
 	// FIXME: Don't access module members directly
 	this->functions_p = &module.scope.functions;
 	this->modules_p = &module.scope.modules;
 	for(const auto &ass : module.scope.assignments) {
 		this->set_variable(ass.name, ass.expr->evaluate(this));
 	}
+	this->usedlibs_p = &module.usedlibs;
 }

--- a/src/modcontext.cc
+++ b/src/modcontext.cc
@@ -176,7 +176,7 @@ std::string ModuleContext::dump(const AbstractModule *mod, const ModuleInstantia
 }
 #endif
 
-FileContext::FileContext(const Context *parent) : ModuleContext(parent)
+FileContext::FileContext(const Context *parent) : ModuleContext(parent), usedlibs_p(nullptr)
 {
 }
 
@@ -238,10 +238,10 @@ void FileContext::initializeModule(const class FileModule &module)
 {
 	if (!module.modulePath().empty()) this->document_path = module.modulePath();
 	// FIXME: Don't access module members directly
+	this->usedlibs_p = &module.usedlibs;
 	this->functions_p = &module.scope.functions;
 	this->modules_p = &module.scope.modules;
 	for(const auto &ass : module.scope.assignments) {
 		this->set_variable(ass.name, ass.expr->evaluate(this));
 	}
-	this->usedlibs_p = &module.usedlibs;
 }

--- a/src/modcontext.h
+++ b/src/modcontext.h
@@ -42,7 +42,7 @@ private:
 class FileContext : public ModuleContext
 {
 public:
-	FileContext(const FileModule &module, const Context *parent);
+	FileContext(const Context *parent);
 	virtual ~FileContext() {}
 	void initializeModule(const FileModule &module);
 	virtual ValuePtr evaluate_function(const std::string &name, 
@@ -51,7 +51,7 @@ public:
 																					 EvalContext *evalctx) const;
 
 private:
-	const FileModule::ModuleContainer &usedlibs;
+	const FileModule::ModuleContainer *usedlibs_p;
 
 	// This sub_* method is needed to minimize stack usage only.
 	ValuePtr sub_evaluate_function(const std::string &name, 


### PR DESCRIPTION
This cleans up FileModule a bit to avoid having to leak its internal FileContext to allow side-effects like updating the camera from an openscad script.

This becomes important later when we want to make FileModule inherit from ASTNode.

