### PR TITLE
Redesign find and replace panel

### DIFF
--- a/src/MainWindow.ui
+++ b/src/MainWindow.ui
@@ -15,7 +15,16 @@
     <property name="spacing">
      <number>0</number>
     </property>
-    <property name="margin">
+    <property name="leftMargin">
+     <number>0</number>
+    </property>
+    <property name="topMargin">
+     <number>0</number>
+    </property>
+    <property name="rightMargin">
+     <number>0</number>
+    </property>
+    <property name="bottomMargin">
      <number>0</number>
     </property>
     <item>
@@ -30,7 +39,16 @@
        <property name="spacing">
         <number>0</number>
        </property>
-       <property name="margin">
+       <property name="leftMargin">
+        <number>0</number>
+       </property>
+       <property name="topMargin">
+        <number>0</number>
+       </property>
+       <property name="rightMargin">
+        <number>0</number>
+       </property>
+       <property name="bottomMargin">
         <number>0</number>
        </property>
        <item>
@@ -162,7 +180,16 @@
           <number>0</number>
          </property>
          <layout class="QHBoxLayout" name="horizontalLayoutAnimate">
-          <property name="margin">
+          <property name="leftMargin">
+           <number>0</number>
+          </property>
+          <property name="topMargin">
+           <number>0</number>
+          </property>
+          <property name="rightMargin">
+           <number>0</number>
+          </property>
+          <property name="bottomMargin">
            <number>0</number>
           </property>
           <item>
@@ -245,7 +272,7 @@
      <x>0</x>
      <y>0</y>
      <width>1118</width>
-     <height>22</height>
+     <height>19</height>
     </rect>
    </property>
    <widget class="QMenu" name="menu_File">
@@ -402,7 +429,16 @@
      <property name="spacing">
       <number>0</number>
      </property>
-     <property name="margin">
+     <property name="leftMargin">
+      <number>0</number>
+     </property>
+     <property name="topMargin">
+      <number>0</number>
+     </property>
+     <property name="rightMargin">
+      <number>0</number>
+     </property>
+     <property name="bottomMargin">
       <number>0</number>
      </property>
      <item>
@@ -452,66 +488,72 @@
         <property name="verticalSpacing">
          <number>0</number>
         </property>
-        <item row="0" column="0">
-         <widget class="QComboBox" name="findTypeComboBox">
-          <item>
-           <property name="text">
-            <string>Find</string>
-           </property>
-          </item>
-          <item>
-           <property name="text">
-            <string>Replace</string>
-           </property>
-          </item>
-         </widget>
-        </item>
         <item row="0" column="1">
          <widget class="QLineEdit" name="findInputField">
           <property name="placeholderText">
-           <string>Search string</string>
+           <string/>
+          </property>
+          <property name="clearButtonEnabled">
+           <bool>true</bool>
           </property>
          </widget>
         </item>
         <item row="0" column="2">
-         <widget class="QPushButton" name="prevButton">
+         <widget class="QPushButton" name="findPrevButton">
           <property name="text">
-           <string>&lt;</string>
+           <string>Find Previous</string>
           </property>
          </widget>
         </item>
         <item row="0" column="3">
-         <widget class="QPushButton" name="nextButton">
+         <widget class="QPushButton" name="findNextButton">
           <property name="text">
-           <string>&gt;</string>
+           <string>Find Next</string>
           </property>
          </widget>
         </item>
         <item row="0" column="4">
-         <widget class="QPushButton" name="hideFindButton">
+         <widget class="QPushButton" name="cancelButton">
           <property name="text">
-           <string>Done</string>
+           <string>Cancel</string>
           </property>
          </widget>
         </item>
         <item row="1" column="1">
          <widget class="QLineEdit" name="replaceInputField">
           <property name="placeholderText">
-           <string>Replacement string</string>
+           <string/>
+          </property>
+          <property name="clearButtonEnabled">
+           <bool>true</bool>
           </property>
          </widget>
         </item>
-        <item row="1" column="2" colspan="2">
+        <item row="0" column="0">
+         <widget class="QLabel" name="findLabel">
+          <property name="text">
+           <string>Find:</string>
+          </property>
+         </widget>
+        </item>
+        <item row="1" column="2">
          <widget class="QPushButton" name="replaceButton">
           <property name="text">
            <string>Replace</string>
           </property>
          </widget>
         </item>
-        <item row="1" column="4">
+        <item row="1" column="3">
          <widget class="QPushButton" name="replaceAllButton">
           <property name="text">
-           <string>All</string>
+           <string>Replace All</string>
+          </property>
+         </widget>
+        </item>
+        <item row="1" column="0">
+         <widget class="QLabel" name="replaceLabel">
+          <property name="text">
+           <string>Replace with:</string>
           </property>
          </widget>
         </item>
@@ -528,7 +570,16 @@
    </attribute>
    <widget class="QWidget" name="consoleDockContents">
     <layout class="QVBoxLayout" name="verticalLayout_5">
-     <property name="margin">
+     <property name="leftMargin">
+      <number>0</number>
+     </property>
+     <property name="topMargin">
+      <number>0</number>
+     </property>
+     <property name="rightMargin">
+      <number>0</number>
+     </property>
+     <property name="bottomMargin">
       <number>0</number>
      </property>
      <item>

--- a/src/mainwin.cc
+++ b/src/mainwin.cc
@@ -459,7 +459,7 @@ MainWindow::MainWindow(const QString &filename)
 
 	//find and replace panel
 	connect(this->findInputField, SIGNAL(textChanged(QString)), this, SLOT(findString(QString)));
-    connect(this->findInputField, SIGNAL(returnPressed()), this->findNextButton, SLOT(animateClick()));
+        connect(this->findInputField, SIGNAL(returnPressed()), this->findNextButton, SLOT(animateClick()));
 	find_panel->installEventFilter(this);
 	if (QApplication::clipboard()->supportsFindBuffer()) {
 		connect(this->findInputField, SIGNAL(textChanged(QString)), this, SLOT(updateFindBuffer(QString)));
@@ -469,9 +469,9 @@ MainWindow::MainWindow(const QString &filename)
 		this->findInputField->setText(QApplication::clipboard()->text(QClipboard::FindBuffer));
 	}
 
-    connect(this->findPrevButton, SIGNAL(clicked()), this, SLOT(findPrev()));
-    connect(this->findNextButton, SIGNAL(clicked()), this, SLOT(findNext()));
-    connect(this->cancelButton, SIGNAL(clicked()), find_panel, SLOT(hide()));
+        connect(this->findPrevButton, SIGNAL(clicked()), this, SLOT(findPrev()));
+        connect(this->findNextButton, SIGNAL(clicked()), this, SLOT(findNext()));
+        connect(this->cancelButton, SIGNAL(clicked()), find_panel, SLOT(hide()));
 	connect(this->replaceButton, SIGNAL(clicked()), this, SLOT(replace()));
 	connect(this->replaceAllButton, SIGNAL(clicked()), this, SLOT(replaceAll()));
 	connect(this->replaceInputField, SIGNAL(returnPressed()), this->replaceButton, SLOT(animateClick()));
@@ -1465,7 +1465,7 @@ void MainWindow::find()
 	replaceInputField->hide();
 	replaceButton->hide();
 	replaceAllButton->hide();
-    replaceLabel->setVisible(false);
+        replaceLabel->setVisible(false);
 	find_panel->show();
 	if (!editor->selectedText().isEmpty()) {
 		findInputField->setText(editor->selectedText());
@@ -1484,7 +1484,7 @@ void MainWindow::findAndReplace()
 	replaceInputField->show();
 	replaceButton->show();
 	replaceAllButton->show();
-    replaceLabel->setVisible(true);
+        replaceLabel->setVisible(true);
 	find_panel->show();
 	if (!editor->selectedText().isEmpty()) {
 		findInputField->setText(editor->selectedText());

--- a/src/mainwin.cc
+++ b/src/mainwin.cc
@@ -458,9 +458,8 @@ MainWindow::MainWindow(const QString &filename)
 	this->setColorScheme(cs);
 
 	//find and replace panel
-	connect(this->findTypeComboBox, SIGNAL(currentIndexChanged(int)), this, SLOT(selectFindType(int)));
 	connect(this->findInputField, SIGNAL(textChanged(QString)), this, SLOT(findString(QString)));
-	connect(this->findInputField, SIGNAL(returnPressed()), this->nextButton, SLOT(animateClick()));
+    connect(this->findInputField, SIGNAL(returnPressed()), this->findNextButton, SLOT(animateClick()));
 	find_panel->installEventFilter(this);
 	if (QApplication::clipboard()->supportsFindBuffer()) {
 		connect(this->findInputField, SIGNAL(textChanged(QString)), this, SLOT(updateFindBuffer(QString)));
@@ -470,9 +469,9 @@ MainWindow::MainWindow(const QString &filename)
 		this->findInputField->setText(QApplication::clipboard()->text(QClipboard::FindBuffer));
 	}
 
-	connect(this->prevButton, SIGNAL(clicked()), this, SLOT(findPrev()));
-	connect(this->nextButton, SIGNAL(clicked()), this, SLOT(findNext()));
-	connect(this->hideFindButton, SIGNAL(clicked()), find_panel, SLOT(hide()));
+    connect(this->findPrevButton, SIGNAL(clicked()), this, SLOT(findPrev()));
+    connect(this->findNextButton, SIGNAL(clicked()), this, SLOT(findNext()));
+    connect(this->cancelButton, SIGNAL(clicked()), find_panel, SLOT(hide()));
 	connect(this->replaceButton, SIGNAL(clicked()), this, SLOT(replace()));
 	connect(this->replaceAllButton, SIGNAL(clicked()), this, SLOT(replaceAll()));
 	connect(this->replaceInputField, SIGNAL(returnPressed()), this->replaceButton, SLOT(animateClick()));
@@ -1463,10 +1462,10 @@ void MainWindow::pasteViewportRotation()
 
 void MainWindow::find()
 {
-	findTypeComboBox->setCurrentIndex(0);
 	replaceInputField->hide();
 	replaceButton->hide();
 	replaceAllButton->hide();
+    replaceLabel->setVisible(false);
 	find_panel->show();
 	if (!editor->selectedText().isEmpty()) {
 		findInputField->setText(editor->selectedText());
@@ -1482,10 +1481,10 @@ void MainWindow::findString(QString textToFind)
 
 void MainWindow::findAndReplace()
 {
-	findTypeComboBox->setCurrentIndex(1);
 	replaceInputField->show();
 	replaceButton->show();
 	replaceAllButton->show();
+    replaceLabel->setVisible(true);
 	find_panel->show();
 	if (!editor->selectedText().isEmpty()) {
 		findInputField->setText(editor->selectedText());


### PR DESCRIPTION
Current design of panel is not usability(see issue #962), so I suggest redesign.
How it looks:  
_Find..._
![find](https://cloud.githubusercontent.com/assets/10652414/17585378/65d18b74-5fcc-11e6-9404-7817e3487e44.png)

_Find and replace..._
![findandreplace](https://cloud.githubusercontent.com/assets/10652414/17585408/9351ac96-5fcc-11e6-954f-82aa840f67b0.png)


