### PR TITLE
Fix replace function: when selected string is empty do not replace 

### DIFF
--- a/src/scintillaeditor.cpp
+++ b/src/scintillaeditor.cpp
@@ -532,7 +532,7 @@ bool ScintillaEditor::find(const QString &expr, bool findNext, bool findBackward
 
 void ScintillaEditor::replaceSelectedText(const QString &newText)
 {
-	if (qsci->selectedText() != newText) qsci->replaceSelectedText(newText);
+    if ((qsci->selectedText() != newText)&&(qsci->hasSelectedText())) qsci->replaceSelectedText(newText);
 }
 
 void ScintillaEditor::replaceAll(const QString &findText, const QString &replaceText)


### PR DESCRIPTION
I found the bug. Follow the steps to repeat:

1) **Edit** -> **Find and replace...**
2) Enter **Search string** 
3) Enter **Replacement string**
4) Click **Replace**
_When you finish replacing all strings, go to 5)_
5) Click **Replace** again 
6) And again and again

You will see that replacement string added after ever click. 
It happened because selected empty string. Need check selected string is empty or not  and if yes do not replace 