### PR TITLE
Fix finding qscintilla2.prf on ubuntu.

### DIFF
--- a/scintilla.pri
+++ b/scintilla.pri
@@ -18,6 +18,16 @@ scintilla {
     }
   }
 
+  # The above looks in too specific paths, use QT_* variables to find where things really should be.
+  isEmpty(QSCILOADED) {
+      exists($$[QT_INSTALL_DATA]/mkspecs/features/qscintilla2.prf) {
+      include($$[QT_INSTALL_DATA]/mkspecs/features/qscintilla2.prf)
+      INCLUDEPATH = $$[QT_INSTALL_HEADERS] $$INCLUDEPATH
+      LIBS = -L$$[QT_INSTALL_LIBS] $$LIBS
+      QSCILOADED=yes
+    }
+  }
+
   # The qscintilla2.prf which ships with QScintilla is broken for Mac/Windows
   # debug builds, so we supply our own
   isEmpty(QSCILOADED) {


### PR DESCRIPTION
qscintilla2.prf is part of package libqt5scintilla2-dev
but not found without this patch, as it is installed in,
for example when using qt5, /usr/share/qt5/mkspecs/features.
However, since this path completely depends on which qmake
is in your PATH, one should really just use qmake (variables)
to find the prf files.

prf files are installed in
$(qmake -query QT_INSTALL_DATA)/mkspecs/features

For example,

sean:~>ls -l "$(qmake -query QT_INSTALL_DATA)/mkspecs/features"
total 4
-rw-r--r-- 1 root root 491 Jul 15  2014 qscintilla2.prf

sean:~>cd /usr/src/debian/qgroundcontrol
History changed from "/home/carlo" to "/"
Environment changed from "/" to "/usr/src/debian/qgroundcontrol"
sean:/usr/src/debian/qgroundcontrol>which qmake
/usr/src/qt-5/5.5/gcc_64/bin/qmake
sean:/usr/src/debian/qgroundcontrol>
  ls -l "$(qmake -query QT_INSTALL_DATA)/mkspecs/features"
total 420
drwxrwxr-x 2 carlo carlo  4096 Aug  2 22:24 android/
-rw-rw-r-- 1 carlo carlo    23 Oct 13  2015 build_pass.prf
-rw-rw-r-- 1 carlo carlo   362 Oct 13  2015 c++11.prf
... etc
