### PR TITLE
Indicate failure to create offscreen buffer for PNG export with non-zero exit status.

### DIFF
--- a/src/export.h
+++ b/src/export.h
@@ -28,7 +28,7 @@ void export_nef3(const shared_ptr<const Geometry> &geom, std::ostream &output);
 
 // void exportFile(const class Geometry *root_geom, std::ostream &output, FileFormat format);
 
-void export_png(const shared_ptr<const class Geometry> &root_geom, Camera &c, std::ostream &output);
-void export_png(const shared_ptr<const class CGAL_Nef_polyhedron> &root_N, Camera &c, std::ostream &output);
-void export_png_with_opencsg(Tree &tree, Camera &c, std::ostream &output);
-void export_png_with_throwntogether(Tree &tree, Camera &c, std::ostream &output);
+bool export_png(const shared_ptr<const class Geometry> &root_geom, Camera &c, std::ostream &output);
+bool export_png(const shared_ptr<const class CGAL_Nef_polyhedron> &root_N, Camera &c, std::ostream &output);
+bool export_png_with_opencsg(Tree &tree, Camera &c, std::ostream &output);
+bool export_png_with_throwntogether(Tree &tree, Camera &c, std::ostream &output);

--- a/src/export_png.cc
+++ b/src/export_png.cc
@@ -19,7 +19,7 @@ static void setupCamera(Camera &cam, const BoundingBox &bbox)
 	if (cam.viewall) cam.viewAll(bbox);
 }
 
-void export_png(const shared_ptr<const Geometry> &root_geom, Camera &cam, std::ostream &output)
+bool export_png(const shared_ptr<const Geometry> &root_geom, Camera &cam, std::ostream &output)
 {
 	PRINTD("export_png geom");
 	OffscreenView *glview;
@@ -27,7 +27,7 @@ void export_png(const shared_ptr<const Geometry> &root_geom, Camera &cam, std::o
 		glview = new OffscreenView(cam.pixel_width, cam.pixel_height);
 	} catch (int error) {
 		fprintf(stderr,"Can't create OpenGL OffscreenView. Code: %i.\n", error);
-		return;
+		return false;
 	}
 	CGALRenderer cgalRenderer(root_geom);
 
@@ -39,6 +39,7 @@ void export_png(const shared_ptr<const Geometry> &root_geom, Camera &cam, std::o
 	glview->setColorScheme(RenderSettings::inst()->colorscheme);
 	glview->paintGL();
 	glview->save(output);
+	return true;
 }
 
 enum Previewer { OPENCSG, THROWNTOGETHER } previewer;
@@ -49,18 +50,18 @@ enum Previewer { OPENCSG, THROWNTOGETHER } previewer;
 #endif
 #include "ThrownTogetherRenderer.h"
 
-void export_png_preview_common(Tree &tree, Camera &cam, std::ostream &output, Previewer previewer = OPENCSG)
+bool export_png_preview_common(Tree &tree, Camera &cam, std::ostream &output, Previewer previewer = OPENCSG)
 {
 	PRINTD("export_png_preview_common");
 	CsgInfo csgInfo = CsgInfo();
-  csgInfo.compile_products(tree);
+	csgInfo.compile_products(tree);
 
 	OffscreenView *glview;
 	try {
 		glview = new OffscreenView(cam.pixel_width, cam.pixel_height);
 	} catch (int error) {
 		fprintf(stderr,"Can't create OpenGL OffscreenView. Code: %i.\n", error);
-		return;
+		return false;
 	}
 
 #ifdef ENABLE_OPENCSG
@@ -85,22 +86,24 @@ void export_png_preview_common(Tree &tree, Camera &cam, std::ostream &output, Pr
 	glview->setColorScheme(RenderSettings::inst()->colorscheme);
 	glview->paintGL();
 	glview->save(output);
+	return true;
 }
 
-void export_png_with_opencsg(Tree &tree, Camera &cam, std::ostream &output)
+bool export_png_with_opencsg(Tree &tree, Camera &cam, std::ostream &output)
 {
 	PRINTD("export_png_w_opencsg");
 #ifdef ENABLE_OPENCSG
-	export_png_preview_common(tree, cam, output, OPENCSG);
+	return export_png_preview_common(tree, cam, output, OPENCSG);
 #else
 	fprintf(stderr,"This openscad was built without OpenCSG support\n");
+	return false;
 #endif
 }
 
-void export_png_with_throwntogether(Tree &tree, Camera &cam, std::ostream &output)
+bool export_png_with_throwntogether(Tree &tree, Camera &cam, std::ostream &output)
 {
 	PRINTD("export_png_w_thrown");
-	export_png_preview_common(tree, cam, output, THROWNTOGETHER);
+	return export_png_preview_common(tree, cam, output, THROWNTOGETHER);
 }
 
 #endif // ENABLE_CGAL

--- a/src/openscad.cc
+++ b/src/openscad.cc
@@ -525,20 +525,23 @@ int cmdline(const char *deps_output_file, const std::string &filename, Camera &c
 		}
 
 		if (png_output_file) {
+			bool success = true;
 			std::ofstream fstream(png_output_file,std::ios::out|std::ios::binary);
 			if (!fstream.is_open()) {
 				PRINTB("Can't open file \"%s\" for export", png_output_file);
+				success = false;
 			}
 			else {
 				if (renderer==Render::CGAL || renderer==Render::GEOMETRY) {
-					export_png(root_geom, camera, fstream);
+					success = export_png(root_geom, camera, fstream);
 				} else if (renderer==Render::THROWNTOGETHER) {
-					export_png_with_throwntogether(tree, camera, fstream);
+					success = export_png_with_throwntogether(tree, camera, fstream);
 				} else {
-					export_png_with_opencsg(tree, camera, fstream);
+					success = export_png_with_opencsg(tree, camera, fstream);
 				}
 				fstream.close();
 			}
+			return success ? 0 : 1;
 		}
 
 		if (nefdbg_output_file) {


### PR DESCRIPTION
Mentioned in #1798.