### PR TITLE
Green Refactoring: Rewrote Annotation to work directly on an Expression object

### DIFF
--- a/src/Assignment.h
+++ b/src/Assignment.h
@@ -41,25 +41,15 @@ typedef std::vector<Assignment> AssignmentList;
        
 class Annotation
 {
-protected:
-    Annotation(const std::string name, const AssignmentList assignments, const AssignmentList args);
-    
 public:
+    Annotation(const std::string &name, shared_ptr<class Expression> expr);
     virtual ~Annotation();
 
     std::string dump() const;
-    const std::string & get_name();
-    virtual ValuePtr evaluate(class Context *ctx, const std::string& var) const;
-    
-    Annotation& operator=(const Annotation&);
+    const std::string &getName() const;
+    virtual ValuePtr evaluate(class Context *ctx) const;
 
-    static const Annotation * create(const std::string name, const AssignmentList assignments);
-
-//private:
-    std::string name;
-    /** Defines the names and values parsed from the script */
-    AssignmentList assignments;
 private:
-    /** Defines the names of the positional parameters */
-    AssignmentList args;
-};                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                     	
+    std::string name;
+    shared_ptr<Expression> expr;
+};

--- a/src/annotation.cc
+++ b/src/annotation.cc
@@ -28,13 +28,9 @@
 #include "Assignment.h"
 #include "expression.h"
 #include "context.h"
-#include "evalcontext.h"
-#include <boost/assign/std/vector.hpp>
 
-using namespace boost::assign; // bring 'operator+=()' into scope
-
-Annotation::Annotation(const std::string name, const AssignmentList assignments, const AssignmentList args)
-	: name(name), assignments(assignments), args(args)
+Annotation::Annotation(const std::string &name, shared_ptr<class Expression> expr)
+	: name(name), expr(expr)
 {
 }
 
@@ -42,53 +38,19 @@ Annotation::~Annotation()
 {
 }
 
-const Annotation * Annotation::create(const std::string name, const AssignmentList assignments)
+ValuePtr Annotation::evaluate(class Context *ctx) const
 {
-
-    
-    AssignmentList args;	
-	if (name == "Description") {
-		args += Assignment("text");
-	} else if (name == "Parameter") {
-		args += Assignment("values");
-	}
-	else if (name == "Group") {
-		args += Assignment("text");
-	}
-
-	return new Annotation(name, assignments, args);
+	return this->expr->evaluate(ctx);
 }
 
-Annotation& Annotation::operator=(const Annotation& other)
-{
-	name = other.name;
-	assignments = other.assignments;
-	return *this;
-}
-
-ValuePtr Annotation::evaluate(class Context *ctx, const std::string& var) const
-{
-	Context c(ctx);
-	EvalContext ec(&c, assignments);
-	c.setVariables(args, &ec);
-	const ValuePtr v = c.lookup_variable(var, true);
-	return v;
-}
-
-const std::string & Annotation::get_name()
+const std::string & Annotation::getName() const
 {
 	return name;
 }
 
 std::string Annotation::dump() const
 {
-    std::stringstream dump;
-	dump << "@" << name << "(";
-	for(const auto &ass : this->assignments) {
-		dump << *ass.expr <<")"<< std::endl;
-    }
-    if(this->assignments.empty()){
-        dump <<")"<< std::endl;
-    }
+	std::stringstream dump;
+	dump << "@" << name << "(" << *this->expr << ")" << std::endl;
 	return dump.str();
 }

--- a/src/assignment.cc
+++ b/src/assignment.cc
@@ -31,7 +31,7 @@
 void Assignment::add_annotations(AnnotationList *annotations)
 {
 	for (AnnotationList::iterator it = annotations->begin();it != annotations->end();it++) {
-		this->annotations.insert(std::pair<const std::string, Annotation *>((*it).get_name(), &(*it)));
+		this->annotations.insert(std::pair<const std::string, Annotation *>((*it).getName(), &(*it)));
 	}
 }
 

--- a/src/comment.cpp
+++ b/src/comment.cpp
@@ -193,30 +193,20 @@ void CommentParser::addParameter(const char *fulltext, FileModule *root_module)
     // Extracting the parameter comment 
     std::string comment = getComment(std::string(fulltext), firstLine);
     // getting the node for parameter annnotataion
-    AssignmentList *assignmentList = CommentParser::parser(comment.c_str());
-    if (assignmentList == NULL) {
-      assignmentList = new AssignmentList();
-      Expression *expr = new Literal(ValuePtr(std::string("")));
-      Assignment *assignment = new Assignment("", shared_ptr<Expression>(expr));
-      assignmentList->push_back(*assignment);
+    shared_ptr<Expression> params = CommentParser::parser(comment.c_str());
+    if (!params) {
+      params = shared_ptr<Expression>(new Literal(ValuePtr(std::string(""))));
     }
-    const Annotation *parameter = Annotation::create("Parameter", *assignmentList);
 
     // adding parameter to the list
-    annotationList->push_back(*parameter);
+    annotationList->push_back(Annotation("Parameter", params));
         
     //extracting the description 
     std::string descr = getDescription(std::string(fulltext), firstLine - 1);
     if (descr != "") {
       //creating node for description
-      assignmentList = new AssignmentList();
-      Expression *expr = new Literal(ValuePtr(std::string(descr.c_str())));
-            
-      Assignment *assignment = new Assignment("", shared_ptr<Expression>(expr));
-      assignmentList->push_back(*assignment);
-                
-      const Annotation *description = Annotation::create("Description", *assignmentList);
-      annotationList->push_back(*description);
+      shared_ptr<Expression> expr(new Literal(ValuePtr(std::string(descr.c_str()))));
+      annotationList->push_back(Annotation("Description", expr));
     }
         
     // Look for the group to which the given assignment belong
@@ -226,14 +216,8 @@ void CommentParser::addParameter(const char *fulltext, FileModule *root_module)
          
     if (i >= 0) {
       //creating node for description
-      assignmentList = new AssignmentList();
-      Expression *expr = new Literal(ValuePtr(groupList[i].commentString));
-            
-      Assignment *assignment = new Assignment("", shared_ptr<Expression>(expr));
-      assignmentList->push_back(*assignment);
-                
-      const Annotation * description = Annotation::create("Group", *assignmentList);
-      annotationList->push_back(*description);
+      shared_ptr<Expression> expr(new Literal(ValuePtr(groupList[i].commentString)));
+      annotationList->push_back(Annotation("Group", expr));
     }
     assignment.add_annotations(annotationList);
   }

--- a/src/comment.h
+++ b/src/comment.h
@@ -6,7 +6,7 @@
 
 namespace CommentParser {
 
-	AssignmentList *parser(const char *text);
+	shared_ptr<Expression> parser(const char *text);
 	void addParameter(const char *fulltext, FileModule *root_module);
 
 }

--- a/src/comment_parser.y
+++ b/src/comment_parser.y
@@ -8,18 +8,15 @@
     #include "comment.h" 
     void yyerror(char *);
     int yylex(void);
-    AssignmentList *argument;
-      extern void yy_scan_string ( const char *str );
+    extern void yy_scan_string ( const char *str );
+    Expression *params;
 %}
 %union {
     char *text;
     char ch;
     double num;
-    class Expression *expr;
     class Vector *vec;
-    Assignment *arg;
-    AssignmentList *args;
-    
+    class Expression *expr;
 };
 
 
@@ -28,33 +25,22 @@
 %token<text> WORD
 %type <text> word
 %type <expr> expr
-%type <args> arguments_call
-%type <arg> argument_call
+%type <expr> params
 %type <vec> vector_expr
 %type <vec> labled_vector
 
 %%
 
 
-arguments_call:
-        argument_call
-            {
-                $$ = new AssignmentList();
-                $$->push_back(*$1);
-                 argument=$$;
-                delete $1;
-            }
-        ;
-
-
-argument_call:
+params:
           expr
             {
-                $$ = new Assignment("", shared_ptr<Expression>($1));
+                $$ = $1;
+                params = $$;
             }			
             ;
             
-expr		: 
+expr: 
          NUM 
             {
                 $$ = new Literal(ValuePtr($1));
@@ -148,13 +134,13 @@ word:
 
 void yyerror(char *msg) {
     PRINTD("ERROR IN PARAMETER: Parser error in comments of file \n "); 
-    argument=NULL;
+    params = NULL;
 }
 
-AssignmentList *CommentParser::parser(const char *text)
+shared_ptr<Expression> CommentParser::parser(const char *text)
 {
   yy_scan_string(text);
   int parserretval = yyparse();
   if (parserretval != 0) return NULL;
-  return argument;
+  return shared_ptr<Expression>(params);
 }

--- a/src/parameter/ParameterWidget.cc
+++ b/src/parameter/ParameterWidget.cc
@@ -303,20 +303,15 @@ void ParameterWidget::applyParameterSet(string setName){
                     entry->second->value=ValuePtr(v.second.get_value<bool>());
                 }else{
 
-                    AssignmentList *assignmentList;
-                    assignmentList=CommentParser::parser(v.second.data().c_str());
-                    if(assignmentList==NULL){
-                        continue ;
-                    }
+									shared_ptr<Expression> params = CommentParser::parser(v.second.data().c_str());
+									if (!params) continue;
 
                     ModuleContext ctx;
                     Assignment *assignment;
-                    for(int i=0; i<assignmentList->size(); i++) {
-                        ValuePtr newValue=assignmentList[i].data()->expr.get()->evaluate(&ctx);
-                        if(entry->second->dvt==newValue->type()){
-                            entry->second->value=newValue;
-                        }
-                    }
+										ValuePtr newValue = params->evaluate(&ctx);
+										if (entry->second->dvt == newValue->type()) {
+											entry->second->value = newValue;
+										}
                 }
         }
     }

--- a/src/parameter/parameterobject.cpp
+++ b/src/parameter/parameterobject.cpp
@@ -46,12 +46,12 @@ int ParameterObject::setValue(const class ValuePtr defaultValue, const class Val
 void ParameterObject::setAssignment(Context *ctx, const Assignment *assignment, const ValuePtr defaultValue){
     name = assignment->name;
     const Annotation *param = assignment->annotation("Parameter");
-    const ValuePtr values = param->evaluate(ctx, "values");
+    const ValuePtr values = param->evaluate(ctx);
     setValue(defaultValue, values);
     const Annotation *desc = assignment->annotation("Description");
 
     if (desc) {
-        const ValuePtr v = desc->evaluate(ctx, "text");
+        const ValuePtr v = desc->evaluate(ctx);
         if (v->type() == Value::STRING) {
             description=QString::fromStdString(v->toString());
         }
@@ -59,7 +59,7 @@ void ParameterObject::setAssignment(Context *ctx, const Assignment *assignment, 
 
     const Annotation *group = assignment->annotation("Group");
     if (group) {
-            const ValuePtr v = group->evaluate(ctx, "text");
+            const ValuePtr v = group->evaluate(ctx);
             if (v->type() == Value::STRING) {
                 groupName=v->toString();
             }

--- a/src/parameter/parameterset.cpp
+++ b/src/parameter/parameterset.cpp
@@ -70,16 +70,11 @@ void ParameterSet::applyParameterSet(FileModule *fileModule,string setName)
                        assignment->expr = shared_ptr<Expression>(new Literal(ValuePtr(v.second.get_value<bool>())));
                     }else{
 
-                        AssignmentList *assignmentList;
-                        assignmentList=CommentParser::parser(v.second.data().c_str());
-                        if(assignmentList==NULL){
-                            continue ;
-                        }
+                      shared_ptr<Expression> params = CommentParser::parser(v.second.data().c_str());
+                      if (!params) continue;
                         ModuleContext ctx;
-                        for(int i=0; i<assignmentList->size(); i++) {
-                             if(defaultValue->type()== assignmentList[i].data()->expr.get()->evaluate(&ctx)->type()){
-                                assignment->expr=assignmentList[i].data()->expr;
-                             }
+                        if (defaultValue->type() == params->evaluate(&ctx)->type()) {
+                          assignment->expr = params;
                         }
                     }
                 }

--- a/src/parameter/parametertext.cpp
+++ b/src/parameter/parametertext.cpp
@@ -24,16 +24,11 @@ void ParameterText::onChanged(QString)
     }
     else{
         ModuleContext ctx;
-        AssignmentList *assignmentList;
-        assignmentList=CommentParser::parser(lineEdit->text().toStdString().c_str());
-        if(assignmentList==NULL){
-            return ;
-        }
-        for(unsigned int i=0; i<assignmentList->size(); i++) {
-            ValuePtr newValue=assignmentList[i].data()->expr.get()->evaluate(&ctx);
-            if(object->dvt==newValue->type()){
-                object->value=newValue;
-            }
+        shared_ptr<Expression> params = CommentParser::parser(lineEdit->text().toStdString().c_str());
+        if (!params) return;
+        ValuePtr newValue = params->evaluate(&ctx);
+        if (object->dvt == newValue->type()) {
+          object->value = newValue;
         }
     }
     object->focus=true;


### PR DESCRIPTION
@amarjeetkapoor1 @t-paul 
Could you take a look at this patch?

During code review, I struggled with understanding the Annotation
class, but I eventually realized that it's just storing an Expression
object, but has a pretty convoluted way of retrieving it. To make this
simpler and more readable, I've refactored the Annotation class down
to the bare minimum.

All tests should still be green.

I might have misunderstood something, so please comment if there is something I've left out.
@amarjeetkapoor1 If this looks OK, could just merge it into the gsoc2016-refactored branch.
