### PR TITLE
Successfully make QT5 fix for #1838

### DIFF
--- a/patches/qt5/QTBUG-56004.patch
+++ b/patches/qt5/QTBUG-56004.patch
@@ -1,0 +1,11 @@
+index 0cc8cd6..5df99d1 100644
+--- a/mkspecs/features/mac/default_pre.prf
++++ b/mkspecs/features/mac/default_pre.prf
+@@ -12,7 +12,7 @@ isEmpty(QMAKE_XCODE_DEVELOPER_PATH) {
+         error("Xcode is not installed in $${QMAKE_XCODE_DEVELOPER_PATH}. Please use xcode-select to choose Xcode installation path.")
+ 
+     # Make sure Xcode is set up properly
+-    isEmpty($$list($$system("/usr/bin/xcrun -find xcrun 2>/dev/null"))): \
++    isEmpty($$list($$system("/usr/bin/xcrun -find xcodebuild 2>/dev/null"))): \
+         error("Xcode not set up properly. You may need to confirm the license agreement by running /usr/bin/xcodebuild.")
+ }

--- a/patches/qt5/QTBUG-56004b.patch
+++ b/patches/qt5/QTBUG-56004b.patch
@@ -1,0 +1,11 @@
+--- a/configure	2016-10-29 19:29:27.000000000 -0600
++++ b/configure	2016-10-29 19:29:20.000000000 -0600
+@@ -548,7 +548,7 @@
+         exit 2
+     fi
+ 
+-    if ! /usr/bin/xcrun -find xcrun >/dev/null 2>&1; then
++    if ! /usr/bin/xcrun -find xcodebuild >/dev/null 2>&1; then
+         echo >&2
+         echo "   Xcode not set up properly. You may need to confirm the license" >&2
+         echo "   agreement by running /usr/bin/xcodebuild without arguments." >&2

--- a/scripts/macosx-build-dependencies.sh
+++ b/scripts/macosx-build-dependencies.sh
@@ -216,6 +216,8 @@ build_qt5()
   fi
   tar xzf qt-everywhere-opensource-src-$version.tar.gz
   cd qt-everywhere-opensource-src-$version
+  patch -d qtbase -p1 < $OPENSCADDIR/patches/qt5/QTBUG-56004.patch
+  patch -d qtbase -p1 < $OPENSCADDIR/patches/qt5/QTBUG-56004b.patch
   if ! $USING_CXX11; then
     QT_EXTRA_FLAGS="-no-c++11"
   fi


### PR DESCRIPTION
Successfully make qt5 on MacOS using XCode.  Fix for #1838 .

This corrects QT Bug 56004 in QT 5.7.0 .  It also corrects a similar QT bug in a different file.

After this fix, QT successfully makes.  However, QScintilla fails to build so this patch is not tested to the point of a successful build of openSCAD.
