### PR TITLE
Fixed a long-standing typo in the lexer 

### DIFF
--- a/src/lexer.l
+++ b/src/lexer.l
@@ -123,7 +123,7 @@ UNICODE {U2}{U}|{U3}{U}{U}|{U4}{U}{U}{U}
 
 %%
 
-include[ \t\r\n>]*"<"	{ BEGIN(cond_include); filepath = filename = ""; }
+include[ \t\r\n]*"<"	{ BEGIN(cond_include); filepath = filename = ""; }
 <cond_include>{
 [^\t\r\n>]*"/"	{ filepath = yytext; }
 [^\t\r\n>/]+	{ filename = yytext; }
@@ -131,7 +131,7 @@ include[ \t\r\n>]*"<"	{ BEGIN(cond_include); filepath = filename = ""; }
 }
 
 
-use[ \t\r\n>]*"<"	{ BEGIN(cond_use); }
+use[ \t\r\n]*"<"	{ BEGIN(cond_use); }
 <cond_use>{
 [^\t\r\n>]+	{ filename = yytext; }
  ">"		{

--- a/testdata/scad/templates/include-tests-template.scad
+++ b/testdata/scad/templates/include-tests-template.scad
@@ -13,9 +13,6 @@ include <include-test5.scad>
 //Test without preceding space
 include<include-test5.scad>
 
-//Test with other strange character that is allowed
-include>>>>><include-test5.scad>
-
 //Test that filenames with spaces work
 include <include test6.scad>
 

--- a/testdata/scad/templates/use-tests-template.scad
+++ b/testdata/scad/templates/use-tests-template.scad
@@ -13,9 +13,6 @@ use <use-test5.scad>
 //Test without preceding space
 use<use-test5.scad>
 
-//Test with other strange character that is allowed
-use>>>>><use-test5.scad>
-
 //Test that filenames with spaces work
 use <use test6.scad>
 


### PR DESCRIPTION
allowing a weird use/include syntax; `include>>><file.scad>`
