### PR TITLE
Handle 2 argument translation calls generated by Qt 5.7.1 (fixes #1872).

### DIFF
--- a/src/qtgettext.h
+++ b/src/qtgettext.h
@@ -16,10 +16,16 @@
 
 #define N_(String) String
 
-inline QString _( const char *msgid, int category )
+inline QString _(const char *msgid, int category)
 {
-	Q_UNUSED( category );
-	return QString::fromUtf8( _( msgid ) );
+	Q_UNUSED(category);
+	return QString::fromUtf8(_(msgid));
+}
+
+inline QString _(const char *msgid, const char *disambiguation)
+{
+	Q_UNUSED(disambiguation);
+	return QString::fromUtf8(_(msgid));
 }
 
 #endif


### PR DESCRIPTION
Failed on Debian build servers: http://bugs.debian.org/cgi-bin/bugreport.cgi?bug=844881