### PR TITLE
Fix for angle argument in rotate_extrude

### DIFF
--- a/src/rotateextrude.cc
+++ b/src/rotateextrude.cc
@@ -52,7 +52,7 @@ AbstractNode *RotateExtrudeModule::instantiate(const Context *ctx, const ModuleI
 	RotateExtrudeNode *node = new RotateExtrudeNode(inst);
 
 	AssignmentList args;
-	args += Assignment("file"), Assignment("layer"), Assignment("origin"), Assignment("scale");
+	args += Assignment("file"), Assignment("layer"), Assignment("origin"), Assignment("scale"), Assignment("angle");
 
 	Context c(ctx);
 	c.setVariables(args, evalctx);


### PR DESCRIPTION
rotate_extrude is ignoring the angle argument