### PR TITLE
Drop underscore from syntax table in scad-mode

### DIFF
--- a/contrib/scad-mode.el
+++ b/contrib/scad-mode.el
@@ -142,9 +142,6 @@
     (modify-syntax-entry ?=  "." st)
     (modify-syntax-entry ?\;  "." st)
 
-    ;; _ allowed in word (alternatively "_" as symbol constituent?)
-    (modify-syntax-entry ?_  "w" st)
-
     st)
   "Syntax table for `scad-mode'.")
 


### PR DESCRIPTION
This allows meta-b/f to work properly when navigating variable names that
contain underscores.