### PR TITLE
Fix for #1961: Warnings and errors only shown five times

### DIFF
--- a/src/mainwin.cc
+++ b/src/mainwin.cc
@@ -1748,7 +1748,7 @@ bool MainWindow::fileChangedOnDisk()
 */
 void MainWindow::compileTopLevelDocument()
 {
-	resetPrintedDeprecations();
+	resetSuppressedMessages();
 
 	this->last_compiled_doc = editor->toPlainText();
 

--- a/src/printutils.cc
+++ b/src/printutils.cc
@@ -119,7 +119,8 @@ void printDeprecation(const std::string &str)
 	}
 }
 
-void resetPrintedDeprecations()
+void resetSuppressedMessages()
 {
 	printedDeprecations.clear();
+	lastmessages.clear();
 }

--- a/src/printutils.h
+++ b/src/printutils.h
@@ -23,7 +23,7 @@ extern std::list<std::string> print_messages_stack;
 void print_messages_push();
 void print_messages_pop();
 void printDeprecation(const std::string &str);
-void resetPrintedDeprecations();
+void resetSuppressedMessages();
 
 #define PRINT_DEPRECATION(_fmt, _arg) do { printDeprecation(str(boost::format(_fmt) % _arg)); } while (0)
 


### PR DESCRIPTION
lastmessages now cleared at the start of the compilation.