### PR TITLE
Extrude and minor tweaks

### DIFF
--- a/openscad.pro
+++ b/openscad.pro
@@ -297,6 +297,7 @@ HEADERS += src/version_check.h \
            src/polyset.h \
            src/printutils.h \
            src/fileutils.h \
+	   src/joiner.h \
            src/value.h \
            src/progress.h \
            src/editor.h \

--- a/openscad.pro
+++ b/openscad.pro
@@ -277,6 +277,7 @@ HEADERS += src/version_check.h \
            src/node.h \
            src/csgnode.h \
            src/offsetnode.h \
+           src/extrudenode.h \
            src/linearextrudenode.h \
            src/rotateextrudenode.h \
            src/projectionnode.h \
@@ -404,6 +405,7 @@ SOURCES += \
            src/dxfdata.cc \
            src/dxfdim.cc \
            src/offset.cc \
+           src/extrude.cc \
            src/linearextrude.cc \
            src/rotateextrude.cc \
            src/printutils.cc \

--- a/src/GeometryEvaluator.h
+++ b/src/GeometryEvaluator.h
@@ -21,6 +21,7 @@ public:
 	virtual Response visit(State &state, const AbstractNode &node);
 	virtual Response visit(State &state, const AbstractIntersectionNode &node);
 	virtual Response visit(State &state, const AbstractPolyNode &node);
+	virtual Response visit(State &state, const ExtrudeNode &node);
 	virtual Response visit(State &state, const LinearExtrudeNode &node);
 	virtual Response visit(State &state, const RotateExtrudeNode &node);
 	virtual Response visit(State &state, const GroupNode &node);

--- a/src/NodeVisitor.h
+++ b/src/NodeVisitor.h
@@ -14,6 +14,7 @@ class NodeVisitor :
 	public Visitor<class LeafNode>,
 	public Visitor<class CgaladvNode>,
 	public Visitor<class CsgOpNode>,
+	public Visitor<class ExtrudeNode>,
 	public Visitor<class LinearExtrudeNode>,
 	public Visitor<class RotateExtrudeNode>,
 	public Visitor<class ImportNode>,
@@ -53,6 +54,9 @@ public:
 	}
   virtual Response visit(class State &state, const class CsgOpNode &node) {
 		return visit(state, (const class AbstractNode &)node);
+	}
+  virtual Response visit(class State &state, const class ExtrudeNode &node) {
+		return visit(state, (const class AbstractPolyNode &)node);
 	}
   virtual Response visit(class State &state, const class LinearExtrudeNode &node) {
 		return visit(state, (const class AbstractPolyNode &)node);

--- a/src/builtin.cc
+++ b/src/builtin.cc
@@ -46,6 +46,7 @@ extern void register_builtin_import();
 extern void register_builtin_projection();
 extern void register_builtin_cgaladv();
 extern void register_builtin_offset();
+extern void register_builtin_extrude();
 extern void register_builtin_dxf_linear_extrude();
 extern void register_builtin_dxf_rotate_extrude();
 extern void register_builtin_text();
@@ -72,6 +73,7 @@ void Builtins::initialize()
 	register_builtin_projection();
 	register_builtin_cgaladv();
 	register_builtin_offset();
+	register_builtin_extrude();
 	register_builtin_dxf_linear_extrude();
 	register_builtin_dxf_rotate_extrude();
 	register_builtin_text();

--- a/src/extrude.cc
+++ b/src/extrude.cc
@@ -1,0 +1,114 @@
+/*
+ *  OpenSCAD (www.openscad.org)
+ *  Copyright (C) 2009-2011 Clifford Wolf <clifford@clifford.at> and
+ *                          Marius Kintel <marius@kintel.net>
+ *
+ *  This program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  As a special exception, you have permission to link this program
+ *  with the CGAL library and distribute executables, as long as you
+ *  follow the requirements of the GNU GPL in regard to all of the
+ *  software in the executable aside from CGAL.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program; if not, write to the Free Software
+ *  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ *
+ */
+
+#include "extrudenode.h"
+
+#include "module.h"
+#include "ModuleInstantiation.h"
+#include "evalcontext.h"
+#include "printutils.h"
+#include "fileutils.h"
+#include "builtin.h"
+#include "calc.h"
+#include "polyset.h"
+#include "joiner.h"
+
+#include <cmath>
+#include <boost/assign/std/vector.hpp>
+using namespace boost::assign; // bring 'operator+=()' into scope
+
+class ExtrudeModule : public AbstractModule
+{
+public:
+	ExtrudeModule() { }
+	virtual AbstractNode *instantiate(const Context *ctx, const ModuleInstantiation *inst, EvalContext *evalctx) const;
+};
+
+AbstractNode *ExtrudeModule::instantiate(const Context *ctx, const ModuleInstantiation *inst, EvalContext *evalctx) const
+{
+	ExtrudeNode *node = new ExtrudeNode(inst);
+
+	AssignmentList args;
+	args += Assignment("path");
+
+	Context c(ctx);
+	c.setVariables(args, evalctx);
+	inst->scope.apply(*evalctx);
+
+	ValuePtr path = c.lookup_variable("path");
+	ValuePtr convexity = c.lookup_variable("convexity", true);
+	ValuePtr flip_faces = c.lookup_variable("flip_faces", true);
+	ValuePtr is_ring = c.lookup_variable("is_ring", true);
+
+	if (path->type() == Value::VECTOR) {
+		const typename Value::VectorType& vpath = path->toVector();
+
+		for (size_t i = 0; i < vpath.size(); ++i)
+		{
+			const ValuePtr& m = vpath[i];
+			Transform3d t;
+
+			if (m->getTransform(t) == false)
+			{
+				node->path.clear();
+				break;
+			}
+
+			node->path.push_back(t);
+		}
+	}
+
+	node->convexity = (int)convexity->toDouble();
+
+	if (node->convexity <= 0)
+		node->convexity = 1;
+
+	node->flip_faces = flip_faces->toBool();
+	node->is_ring = is_ring->toBool();
+
+	std::vector<AbstractNode *> instantiatednodes = inst->instantiateChildren(evalctx);
+	node->children.insert(node->children.end(), instantiatednodes.begin(), instantiatednodes.end());
+
+	return node;
+}
+
+std::string ExtrudeNode::toString() const
+{
+	std::stringstream stream;
+
+	stream << this->name() << "("
+		<< "path = " << vectorizer(this->path) << ", "
+		<< "convexity = " << this->convexity << ", "
+		<< "flip_faces = " << this->flip_faces << ", "
+		<< "is_ring = " << this->is_ring << ")";
+	
+	return stream.str();
+}
+
+void register_builtin_extrude()
+{
+	Builtins::init("extrude", new ExtrudeModule());
+}

--- a/src/extrudenode.h
+++ b/src/extrudenode.h
@@ -1,0 +1,23 @@
+#pragma once
+
+#include "node.h"
+#include "value.h"
+#include "linalg.h"
+#include <vector>
+
+class ExtrudeNode : public AbstractPolyNode
+{
+public:
+	VISITABLE();
+	ExtrudeNode(const ModuleInstantiation *mi) : AbstractPolyNode(mi) {
+		convexity = 0;
+		is_ring = false;
+	}
+	virtual std::string toString() const;
+	virtual std::string name() const { return "extrude"; }
+
+	std::vector<Transform3d> path;
+	int convexity;
+	bool flip_faces;
+	bool is_ring;
+};

--- a/src/highlighter.cc
+++ b/src/highlighter.cc
@@ -226,7 +226,7 @@ Highlighter::Highlighter(QTextDocument *parent)
 	tokentypes["prim2d"] << "square" << "polygon" << "circle";
 	tokentypes["import"] << "include" << "use" << "import_stl" << "import" << "import_dxf" << "dxf_dim" << "dxf_cross" << "surface";
 	tokentypes["special"] << "$children" << "child" << "children" << "$fn" << "$fa" << "$fs" << "$t" << "$vpt" << "$vpr" << "$vpd";
-	tokentypes["extrude"] << "linear_extrude" << "rotate_extrude";
+	tokentypes["extrude"] << "extrude" << "linear_extrude" << "rotate_extrude";
 	tokentypes["bracket"] << "[" << "]" << "(" << ")";
 	tokentypes["curlies"] << "{" << "}";
 	tokentypes["bool"] << "true" << "false";

--- a/src/joiner.h
+++ b/src/joiner.h
@@ -1,0 +1,112 @@
+#pragma once
+
+namespace details {
+	template<typename InputIteratorT, typename SeparatorT, typename PrefixT = void, typename SuffixT = void>
+	struct Joiner
+	{
+		InputIteratorT first, last;
+		const SeparatorT sep;
+		const PrefixT prefix;
+		const SuffixT suffix;
+
+		Joiner(InputIteratorT _first, InputIteratorT _last, const SeparatorT& _sep,
+				const PrefixT& _prefix, const SuffixT& _suffix)
+                	: first(_first), last(_last),  sep(_sep), prefix(_prefix), suffix(_suffix)
+		{
+		}
+
+		void join_on(std::ostream& stream) const
+		{
+			stream << prefix;
+
+			InputIteratorT it = first;
+
+			if (it != last)
+			{
+				stream << *it;
+				++it;
+			}
+
+			for (; it != last; ++it)
+			{
+				stream << sep << *it;
+			}
+
+			stream << suffix;
+		}
+	};
+
+	template<typename InputIteratorT, typename SeparatorT>
+	struct Joiner<InputIteratorT, SeparatorT, void, void>
+	{
+		InputIteratorT first, last;
+		const SeparatorT sep;
+
+		Joiner(InputIteratorT _first, InputIteratorT _last, const SeparatorT &_sep)
+			: first(_first), last(_last),  sep(_sep)
+		{
+		}
+
+		void join_on(std::ostream& stream) const
+		{
+			InputIteratorT it = first;
+
+			if (it != last)
+			{
+				stream << *it;
+				++it;
+			}
+
+			for (; it != last; ++it)
+			{
+				stream << sep << *it;
+			}
+		}
+	};
+};
+
+template <typename InputIteratorT, typename SeparatorT, typename PrefixT, typename SuffixT>
+std::ostream& operator << (std::ostream& stream, const details::Joiner<InputIteratorT, SeparatorT, PrefixT, SuffixT> &joiner)
+{
+	joiner.join_on(stream);
+	return stream;
+}
+
+template <typename InputIteratorT, typename SeparatorT>
+details::Joiner<InputIteratorT, SeparatorT> joiner(InputIteratorT first, InputIteratorT last, const SeparatorT &sep)
+{
+	return details::Joiner<InputIteratorT, SeparatorT>(first, last, sep);
+}
+
+template <typename InputIteratorT, typename SeparatorT, typename PrefixT, typename SuffixT>
+details::Joiner<InputIteratorT, SeparatorT, PrefixT, SuffixT>
+joiner(InputIteratorT first, InputIteratorT last, const SeparatorT &sep, const PrefixT& prefix, const SuffixT& suffix)
+{
+	return details::Joiner<InputIteratorT, SeparatorT, PrefixT, SuffixT>(first, last, sep, prefix, suffix);
+}
+
+template <typename SequenceT, typename SeparatorT>
+details::Joiner<typename SequenceT::const_iterator, SeparatorT>
+joiner(const SequenceT &seq, const SeparatorT &sep)
+{
+	return details::Joiner<typename SequenceT::const_iterator, SeparatorT>(seq.begin(), seq.end(), sep);
+}
+
+template <typename SequenceT, typename SeparatorT, typename PrefixT, typename SuffixT>
+details::Joiner<typename SequenceT::const_iterator, SeparatorT, PrefixT, SuffixT>
+joiner(const SequenceT &seq, const SeparatorT &sep, const PrefixT& prefix, const SuffixT& suffix)
+{
+	return details::Joiner<typename SequenceT::const_iterator, SeparatorT, PrefixT, SuffixT>(seq.begin(), seq.end(), sep, prefix, suffix);
+}
+
+template <typename InputIteratorT>
+details::Joiner<InputIteratorT, const char*, const char*, const char*> vectorizer(InputIteratorT first, InputIteratorT last)
+{
+	return joiner(first, last, (const char *)", ", (const char *)"[", (const char *)"]");
+}
+
+template <typename SequenceT>
+details::Joiner<typename SequenceT::const_iterator, const char*, const char*, const char*> vectorizer(const SequenceT &seq)
+{
+	return vectorizer(seq.begin(), seq.end());
+}

--- a/src/linalg.h
+++ b/src/linalg.h
@@ -5,6 +5,8 @@
 #include <Eigen/Dense>
 #include <cstdint>
 
+#include "value.h"
+
 using Eigen::Vector2d;
 using Eigen::Vector3d;
 using Eigen::Vector3f;
@@ -44,3 +46,32 @@ public:
 
 	bool isValid() const { return this->minCoeff() >= 0.0f; }
 };
+
+template<typename Derived>
+std::ostream& operator << (std::ostream &stream, const Eigen::MatrixBase<Derived>& x)
+{
+#if 0
+	static Eigen::IOFormat fmt(Eigen::StreamPrecision, Eigen::DontAlignCols, ", ", ", ", "[", "]", "[", "]");
+	return stream << x.template cast<Value>().format(fmt);
+#else
+	const size_t rows = x.rows(),  cols = x.cols();
+
+	stream << "[";
+	for (size_t row = 0; row < rows; ++row) {
+		stream << "[";
+		for (size_t col = 0; col < cols; ++col) {
+			stream << Value(x(row, col));
+			if (col != cols - 1) stream << ", ";
+		}
+		stream << "]";
+		if (row != rows - 1) stream << ", ";
+	}
+	return stream << "]";
+#endif
+}
+
+template<typename Scalar, int Dim, int Mode, int Options>
+std::ostream& operator << (std::ostream &stream, const Eigen::Transform<Scalar, Dim, Mode, Options>& m)
+{
+	return stream << m.matrix();
+}

--- a/src/scadlexer.cpp
+++ b/src/scadlexer.cpp
@@ -27,7 +27,7 @@ ScadLexer::ScadLexer(QObject *parent) : QsciLexerCPP(parent)
 		"minkowski hull resize child children echo union difference "
 		"intersection linear_extrude rotate_extrude import group  "
 		"projection render surface scale rotate mirror translate "
-		"multmatrix color offset ";
+		"multmatrix color offset extrude";
 
     setFoldComments(true);
     setFoldAtElse(true);

--- a/src/transform.cc
+++ b/src/transform.cc
@@ -191,18 +191,7 @@ std::string TransformNode::toString() const
 {
 	std::stringstream stream;
 
-	stream << "multmatrix([";
-	for (int j=0;j<4;j++) {
-		stream << "[";
-		for (int i=0;i<4;i++) {
-			Value v(this->matrix(j, i));
-			stream << v;
-			if (i != 3) stream << ", ";
-		}
-		stream << "]";
-		if (j != 3) stream << ", ";
-	}
-	stream << "])";
+	stream << "multmatrix(" << this->matrix << ")";
 
 	return stream.str();
 }

--- a/src/transform.cc
+++ b/src/transform.cc
@@ -166,19 +166,7 @@ AbstractNode *TransformModule::instantiate(const Context *ctx, const ModuleInsta
 	}
 	else if (this->type == MULTMATRIX)
 	{
-		ValuePtr v = c.lookup_variable("m");
-		if (v->type() == Value::VECTOR) {
-			Matrix4d rawmatrix = Matrix4d::Identity();
-			for (int i = 0; i < 16; i++) {
-				size_t x = i / 4, y = i % 4;
-				if (y < v->toVector().size() && v->toVector()[y]->type() == 
-						Value::VECTOR && x < v->toVector()[y]->toVector().size())
-					v->toVector()[y]->toVector()[x]->getDouble(rawmatrix(y, x));
-			}
-			double w = rawmatrix(3,3);
-			if (w != 1.0) node->matrix = rawmatrix / w;
-			else node->matrix = rawmatrix;
-		}
+		c.lookup_variable("m")->getTransform(node->matrix);
 	}
 
 	std::vector<AbstractNode *> instantiatednodes = inst->instantiateChildren(evalctx);

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -723,6 +723,7 @@ set(CORE_SOURCES
   ../src/dxfdata.cc 
   ../src/dxfdim.cc 
   ../src/offset.cc 
+  ../src/extrude.cc 
   ../src/linearextrude.cc 
   ../src/rotateextrude.cc 
   ../src/text.cc 


### PR DESCRIPTION
Hi,
I would like to propose these some small changes set.
There are minor changes to offer some tools to simplify some printing code, and a big change that add a generalized extrude. The last one is based on rotate_extrude, but use a list of transformation matrix to describe the extrusion path. Since it is a general extrude, I think it really should be named 'extrude'.
It is not a perfect tool, and might generate some broken volumes. But I consider it an advanced command like 'polygon' or 'polyhedron' which can also generate bad volumes. So it should not be a big deal.
