### PR TITLE
Multithreaded CGAL geometry evaluation

### DIFF
--- a/openscad.pro
+++ b/openscad.pro
@@ -128,6 +128,8 @@ netbsd* {
 *g++* {
   QMAKE_CXXFLAGS *= -fno-strict-aliasing
   QMAKE_CXXFLAGS_WARN_ON += -Wno-unused-local-typedefs # ignored before 4.8
+  # debug: turn off optimization in debug builds
+  debug: QMAKE_LFLAGS += -rdynamic -O0
 }
 
 *clang* {
@@ -301,6 +303,7 @@ HEADERS += src/version_check.h \
            src/progress.h \
            src/editor.h \
            src/NodeVisitor.h \
+           src/ThreadedNodeVisitor.h \
            src/state.h \
            src/nodecache.h \
            src/nodedumper.h \
@@ -416,6 +419,7 @@ SOURCES += \
            \
            src/nodedumper.cc \
            src/NodeVisitor.cc \
+           src/ThreadedNodeVisitor.cc \
            src/GeometryEvaluator.cc \
            src/ModuleCache.cc \
            src/GeometryCache.cc \

--- a/src/CGAL_Nef_polyhedron.cc
+++ b/src/CGAL_Nef_polyhedron.cc
@@ -65,7 +65,7 @@ PolySet *CGAL_Nef_polyhedron::convertToPolyset() const
 {
 	if (this->isEmpty()) return new PolySet(3);
 	PolySet *ps = NULL;
-	CGAL::Failure_behaviour old_behaviour = CGAL::set_error_behaviour(CGAL::THROW_EXCEPTION);
+	CGALUtils::lockErrors(CGAL::THROW_EXCEPTION);
 	ps = new PolySet(3);
 	ps->setConvexity(this->convexity);
 	bool err = true;
@@ -88,7 +88,7 @@ PolySet *CGAL_Nef_polyhedron::convertToPolyset() const
 		if (errmsg!="") PRINTB("ERROR: %s",errmsg);
 		delete ps; ps = NULL;
 	}
-	CGAL::set_error_behaviour(old_behaviour);
+	CGALUtils::unlockErrors();
 	return ps;
 }
 #endif

--- a/src/GeometryEvaluator.cc
+++ b/src/GeometryEvaluator.cc
@@ -32,8 +32,86 @@
 #include <CGAL/convex_hull_2.h>
 #include <CGAL/Point_2.h>
 
-GeometryEvaluator::GeometryEvaluator(const class Tree &tree):
-	tree(tree)
+#include <boost/thread/mutex.hpp>
+
+namespace {
+	// a global mutex to guard access to the cache and visited children
+	boost::mutex cacheLock;
+}
+
+// determines if kid is contained by parent
+bool containsChild(const AbstractNode *parent, const AbstractNode *kid)
+{
+	if (parent == kid)
+		return true;
+	for (auto child : parent->getChildren())
+		if (containsChild(child, kid))
+			return true;
+	return false;
+}
+
+// gets the direct child of parent containing kid
+const AbstractNode *childContaining(const AbstractNode *parent, const AbstractNode *kid)
+{
+	for (auto child : parent->getChildren())
+		if (containsChild(child, kid))
+			return child;
+	return NULL;
+}
+
+// compares the direct children of parent containing a and b
+// returns true if the child indices are in order
+// this is used via a lambda to std::sort in sortGeometries
+bool compareAncestors(const AbstractNode *parent, const AbstractNode *a, const AbstractNode *b)
+{
+	auto ca = childContaining(parent, a);
+	auto cb = childContaining(parent, b);
+	if (ca->index() < cb->index())
+		return true;
+	return false;
+}
+
+// sorts children into result given a common parent node
+void sortGeometries(const AbstractNode &parent, const Geometry::Geometries &children, Geometry::Geometries &result)
+{
+	result.clear();
+	// early outs
+	if (children.empty())
+		return;
+	if (children.size() == 1)
+	{
+		result.push_back(children.front());
+		return;
+	}
+	// std::list is not sortable, but std::vector is
+	std::vector<Geometry::GeometryItem> childVec{ std::begin(children), std::end(children) };
+	auto comp = [&parent](const Geometry::GeometryItem &a, const Geometry::GeometryItem &b) -> bool
+	{
+		return compareAncestors(&parent, a.first, b.first);
+	};
+	// sort the vector
+	std::sort(childVec.begin(), childVec.end(), comp);
+	// put the vector into the output list
+	result.assign(std::begin(childVec), std::end(childVec));
+}
+
+// gets the Polygon2d*'s from children's shared_ptr's
+void getPolygons(const Geometry::Geometries &children, std::vector<shared_ptr<const Polygon2d>> &polys, std::vector<const Polygon2d *> &raw_polys)
+{
+	for (const auto &child : children)
+	{
+		shared_ptr<const Polygon2d> poly = dynamic_pointer_cast<const Polygon2d>(child.second);
+		if (poly != NULL)
+		{
+			polys.push_back(poly);
+			raw_polys.push_back(poly.get());
+		}
+	}
+}
+
+GeometryEvaluator::GeometryEvaluator(const class Tree &tree, bool threaded /*=false*/)
+	: ThreadedNodeVisitor(tree, threaded)
+	, tree(tree)
 {
 }
 
@@ -43,18 +121,28 @@ GeometryEvaluator::GeometryEvaluator(const class Tree &tree):
 shared_ptr<const Geometry> GeometryEvaluator::evaluateGeometry(const AbstractNode &node, 
 																															 bool allownef)
 {
-	if (!GeometryCache::instance()->contains(this->tree.getIdString(node))) {
+	cacheLock.lock();
+	std::string idString = this->tree.getIdString(node);
+	if (!GeometryCache::instance()->contains(idString)) {
 		shared_ptr<const CGAL_Nef_polyhedron> N;
-		if (CGALCache::instance()->contains(this->tree.getIdString(node))) {
-			N = CGALCache::instance()->get(this->tree.getIdString(node));
+		if (CGALCache::instance()->contains(idString)) {
+			N = CGALCache::instance()->get(idString);
 		}
+		cacheLock.unlock();
 
 		// If not found in any caches, we need to evaluate the geometry
 		if (N) {
 			this->root = N;
 		}	
-    else {
-			this->traverse(node);
+		else {
+			if (Feature::ExperimentalThreadedTraversal.is_enabled())
+			{
+				this->traverseThreaded(node);
+			}
+			else
+			{
+				this->traverse(node);
+			}
 		}
 
 		if (!allownef) {
@@ -73,27 +161,44 @@ shared_ptr<const Geometry> GeometryEvaluator::evaluateGeometry(const AbstractNod
 		smartCacheInsert(node, this->root);
 		return this->root;
 	}
-	return GeometryCache::instance()->get(this->tree.getIdString(node));
+	shared_ptr<const Geometry> result = GeometryCache::instance()->get(idString);
+	cacheLock.unlock();
+	return result;
 }
 
+/*!
+	Gets the processed children of the given node.
+	When multithreaded, the children were processed in a non-deterministic order. 
+	They need to be sorted so difference, minkowski and others(?) work correctly.
+*/
+const Geometry::Geometries &GeometryEvaluator::getVisitedChildren(const AbstractNode &node)
+{
+	// check the sorted children first
+	Geometry::Geometries &result = sortedchildren[node.index()];
+	// if that's empty, sort the visited children into the sorted children
+	if (result.empty())
+		sortGeometries(node, visitedchildren[node.index()], result);
+	return result;
+}
+
+
+/*!
+	Applies the operator to all child nodes of the given node.
+	Note: this applies the operator to either 2D or 3D objects, whichever is encountered first
+	
+	Returns whatever applyToChildren2D/applyToChildren3D returns, depending on the note above
+*/
 GeometryEvaluator::ResultObject GeometryEvaluator::applyToChildren(const AbstractNode &node, OpenSCADOperator op)
 {
-	unsigned int dim = 0;
-	for(const auto &item : this->visitedchildren[node.index()]) {
-		if (!item.first->modinst->isBackground() && item.second) {
-			if (!dim) dim = item.second->getDimension();
-			else if (dim != item.second->getDimension()) {
-				PRINT("WARNING: Mixing 2D and 3D objects is not supported.");
-				break;
-			}
-		}
-	}
+	Geometry::Geometries dim2;
+	Geometry::Geometries dim3;
+	auto dim = collectChildren(node, dim2, dim3);
     if (dim == 2) {
-        Polygon2d *p2d = applyToChildren2D(node, op);
+        Polygon2d *p2d = applyToChildren2D(dim2, op);
         assert(p2d);
         return ResultObject(p2d);
     }
-    else if (dim == 3) return applyToChildren3D(node, op);
+    else if (dim == 3) return applyToChildren3D(dim3, op);
 	return ResultObject();
 }
 
@@ -102,9 +207,8 @@ GeometryEvaluator::ResultObject GeometryEvaluator::applyToChildren(const Abstrac
 	
 	May return NULL or any 3D Geometry object (can be either PolySet or CGAL_Nef_polyhedron)
 */
-GeometryEvaluator::ResultObject GeometryEvaluator::applyToChildren3D(const AbstractNode &node, OpenSCADOperator op)
+GeometryEvaluator::ResultObject GeometryEvaluator::applyToChildren3D(const Geometry::Geometries &children, OpenSCADOperator op)
 {
-	Geometry::Geometries children = collectChildren3D(node);
 	if (children.size() == 0) return ResultObject();
 
 	if (op == OPENSCAD_HULL) {
@@ -144,15 +248,18 @@ GeometryEvaluator::ResultObject GeometryEvaluator::applyToChildren3D(const Abstr
 
 	May return an empty geometry but will not return NULL.
 */
-Polygon2d *GeometryEvaluator::applyHull2D(const AbstractNode &node)
+Polygon2d *GeometryEvaluator::applyHull2D(const Geometry::Geometries &children)
 {
-	std::vector<const Polygon2d *> children = collectChildren2D(node);
+	std::vector<shared_ptr<const Polygon2d>> polys;
+	std::vector<const Polygon2d *> raw_polys;
+	getPolygons(children, polys, raw_polys);
+
 	Polygon2d *geometry = new Polygon2d();
 
 	typedef CGAL::Point_2<CGAL::Cartesian<double>> CGALPoint2;
 	// Collect point cloud
 	std::list<CGALPoint2> points;
-	for(const auto &p : children) {
+	for(const auto &p : polys) {
 		for(const auto &o : p->outlines()) {
 			for(const auto &v : o.vertices) {
 				points.push_back(CGALPoint2(v[0], v[1]));
@@ -174,10 +281,8 @@ Polygon2d *GeometryEvaluator::applyHull2D(const AbstractNode &node)
 	return geometry;
 }
 
-Geometry *GeometryEvaluator::applyHull3D(const AbstractNode &node)
+Geometry *GeometryEvaluator::applyHull3D(const Geometry::Geometries &children)
 {
-	Geometry::Geometries children = collectChildren3D(node);
-
 	PolySet *P = new PolySet(3);
 	if (CGALUtils::applyHull(children, *P)) {
 		return P;
@@ -186,23 +291,23 @@ Geometry *GeometryEvaluator::applyHull3D(const AbstractNode &node)
 	return NULL;
 }
 
-Polygon2d *GeometryEvaluator::applyMinkowski2D(const AbstractNode &node)
+Polygon2d *GeometryEvaluator::applyMinkowski2D(const Geometry::Geometries &children)
 {
-	std::vector<const Polygon2d *> children = collectChildren2D(node);
-	if (!children.empty()) {
-		return ClipperUtils::applyMinkowski(children);
+	std::vector<shared_ptr<const Polygon2d>> polys;
+	std::vector<const Polygon2d *> raw_polys;
+	getPolygons(children, polys, raw_polys);
+	if (!polys.empty()) {
+		return ClipperUtils::applyMinkowski(raw_polys);
 	}
 	return NULL;
 }
 
-/*!
-	Returns a list of Polygon2d children of the given node.
-	May return empty Polygon2d object, but not NULL objects
-*/
-std::vector<const class Polygon2d *> GeometryEvaluator::collectChildren2D(const AbstractNode &node)
+unsigned int GeometryEvaluator::collectChildren(const AbstractNode &node, Geometry::Geometries &dim2, Geometry::Geometries &dim3)
 {
-	std::vector<const Polygon2d *> children;
-	for(const auto &item : this->visitedchildren[node.index()]) {
+	bool mixed = false;
+	unsigned int dim = 0;
+	cacheLock.lock();
+	for (const auto &item : getVisitedChildren(node)) {
 		const AbstractNode *chnode = item.first;
 		const shared_ptr<const Geometry> &chgeom = item.second;
 		if (chnode->modinst->isBackground()) continue;
@@ -212,19 +317,28 @@ std::vector<const class Polygon2d *> GeometryEvaluator::collectChildren2D(const 
 		// cache could have been modified before we reach this point due to a large
 		// sibling object. 
 		smartCacheInsert(*chnode, chgeom);
-		
+
 		if (chgeom) {
 			if (chgeom->getDimension() == 2) {
-				const Polygon2d *polygons = dynamic_cast<const Polygon2d *>(chgeom.get());
-				assert(polygons);
-				children.push_back(polygons);
+				if (dim == 0)
+					dim = 2;
+				else if (dim != 2)
+					mixed = true;
+				dim2.push_back(item);
 			}
 			else {
-				PRINT("WARNING: Ignoring 3D child object for 2D operation");
+				if (dim == 0)
+					dim = 3;
+				else if (dim != 3)
+					mixed = true;
+				dim3.push_back(item);
 			}
 		}
 	}
-	return children;
+	cacheLock.unlock();
+	if (mixed)
+		PRINT("WARNING: Mixing 2D and 3D objects is not supported.");
+	return dim;
 }
 
 /*!
@@ -252,72 +366,46 @@ void GeometryEvaluator::smartCacheInsert(const AbstractNode &node,
 
 bool GeometryEvaluator::isSmartCached(const AbstractNode &node)
 {
+	cacheLock.lock();
 	const std::string &key = this->tree.getIdString(node);
-	return (GeometryCache::instance()->contains(key) ||
+	bool result = (GeometryCache::instance()->contains(key) ||
 					CGALCache::instance()->contains(key));
+	cacheLock.unlock();
+	return result;
 }
 
 shared_ptr<const Geometry> GeometryEvaluator::smartCacheGet(const AbstractNode &node, bool preferNef)
 {
+	cacheLock.lock();
 	const std::string &key = this->tree.getIdString(node);
 	shared_ptr<const Geometry> geom;
 	bool hasgeom = GeometryCache::instance()->contains(key);
 	bool hascgal = CGALCache::instance()->contains(key);
 	if (hascgal && (preferNef || !hasgeom)) geom = CGALCache::instance()->get(key);
 	else if (hasgeom) geom = GeometryCache::instance()->get(key);
+	cacheLock.unlock();
 	return geom;
-}
-
-/*!
-	Returns a list of 3D Geometry children of the given node.
-	May return empty geometries, but not NULL objects
-*/
-Geometry::Geometries GeometryEvaluator::collectChildren3D(const AbstractNode &node)
-{
-	Geometry::Geometries children;
-	for(const auto &item : this->visitedchildren[node.index()]) {
-		const AbstractNode *chnode = item.first;
-		const shared_ptr<const Geometry> &chgeom = item.second;
-		if (chnode->modinst->isBackground()) continue;
-
-		// NB! We insert into the cache here to ensure that all children of
-		// a node is a valid object. If we inserted as we created them, the 
-		// cache could have been modified before we reach this point due to a large
-		// sibling object. 
-		smartCacheInsert(*chnode, chgeom);
-		
-		if (chgeom) {
-			if (chgeom->getDimension() == 2) {
-				PRINT("WARNING: Ignoring 2D child object for 3D operation");
-			}
-			else if (chgeom->isEmpty() || chgeom->getDimension() == 3) {
-				children.push_back(item);
-			}
-		}
-	}
-	return children;
 }
 
 /*!
 	
 */
-Polygon2d *GeometryEvaluator::applyToChildren2D(const AbstractNode &node, OpenSCADOperator op)
+Polygon2d *GeometryEvaluator::applyToChildren2D(const Geometry::Geometries &children, OpenSCADOperator op)
 {
 	if (op == OPENSCAD_MINKOWSKI) {
-		return applyMinkowski2D(node);
+		return applyMinkowski2D(children);
 	}
 	else if (op == OPENSCAD_HULL) {
-		return applyHull2D(node);
+		return applyHull2D(children);
 	}
-
-	std::vector<const Polygon2d *> children = collectChildren2D(node);
 
 	if (children.empty()) {
 		return NULL;
 	}
 
 	if (children.size() == 1) {
-		return new Polygon2d(*children[0]); // Copy
+		const Polygon2d *poly = dynamic_cast<const Polygon2d*>(children.front().second.get());
+		return new Polygon2d(*poly); // Copy
 	}
 
 	ClipperLib::ClipType clipType;
@@ -337,7 +425,10 @@ Polygon2d *GeometryEvaluator::applyToChildren2D(const AbstractNode &node, OpenSC
 		break;
 	}
 
-	return ClipperUtils::apply(children, clipType);
+	std::vector<shared_ptr<const Polygon2d>> polys;
+	std::vector<const Polygon2d*> raw_polys;
+	getPolygons(children, polys, raw_polys);
+	return ClipperUtils::apply(raw_polys, clipType);
 }
 
 /*!
@@ -353,15 +444,27 @@ void GeometryEvaluator::addToParent(const State &state,
 																		const AbstractNode &node, 
 																		const shared_ptr<const Geometry> &geom)
 {
-	this->visitedchildren.erase(node.index());
+	cacheLock.lock();
 	if (state.parent()) {
+		// erase the sorted children for this node's parent so they will be sorted when accessed
+		this->sortedchildren.erase(state.parent()->index());
+		// put this node's geometry pointer into its parent's geometry list
 		this->visitedchildren[state.parent()->index()].push_back(std::make_pair(&node, geom));
+		// now, erase this node's copies of shared pointers
+		this->visitedchildren.erase(node.index());
+		this->sortedchildren.erase(node.index());
 	}
 	else {
 		// Root node
 		this->root = geom;
+		// now, erase this node's copies of shared pointers
+		this->visitedchildren.erase(node.index());
+		this->sortedchildren.erase(node.index());
+		// there shouldn't be any unvisited children!!!
 		assert(this->visitedchildren.empty());
+		assert(this->sortedchildren.empty());
 	}
+	cacheLock.unlock();
 }
 
 /*!
@@ -405,7 +508,10 @@ Response GeometryEvaluator::visit(State &state, const OffsetNode &node)
 	if (state.isPostfix()) {
 		shared_ptr<const Geometry> geom;
 		if (!isSmartCached(node)) {
-			const Geometry *geometry = applyToChildren2D(node, OPENSCAD_UNION);
+			Geometry::Geometries dim2;
+			Geometry::Geometries dim3;
+			collectChildren(node, dim2, dim3);
+			const Geometry *geometry = applyToChildren2D(dim2, OPENSCAD_UNION);
 			if (geometry) {
 				const Polygon2d *polygon = dynamic_cast<const Polygon2d*>(geometry);
 				// ClipperLib documentation: The formula for the number of steps in a full
@@ -508,7 +614,7 @@ Response GeometryEvaluator::visit(State &state, const TextNode &node)
 			}
 			geom.reset(ClipperUtils::apply(polygonlist, ClipperLib::ctUnion));
 		}
-		else geom = GeometryCache::instance()->get(this->tree.getIdString(node));
+		else geom = smartCacheGet(node, state.preferNef());
 		addToParent(state, node, geom);
 	}
 	return PruneTraversal;
@@ -680,7 +786,7 @@ static Geometry *extrudePolygon(const LinearExtrudeNode &node, const Polygon2d &
 	bool cvx = poly.is_convex();
 	PolySet *ps = new PolySet(3, !cvx ? boost::tribool(false) : node.twist == 0 ? boost::tribool(true) : unknown);
 	ps->setConvexity(node.convexity);
-	if (node.height <= 0) return ps;
+	if (node.height <= 0) return new PolySet(*ps);
 
 	double h1, h2;
 
@@ -692,16 +798,17 @@ static Geometry *extrudePolygon(const LinearExtrudeNode &node, const Polygon2d &
 		h2 = node.height;
 	}
 
-	PolySet *ps_bottom = poly.tessellate(); // bottom
-	
+	// bottom
+	PolySet *ps_bottom = poly.tessellate();	
 	// Flip vertex ordering for bottom polygon
 	for(auto &p : ps_bottom->polygons) {
 		std::reverse(p.begin(), p.end());
 	}
 	translate_PolySet(*ps_bottom, Vector3d(0,0,h1));
-
 	ps->append(*ps_bottom);
 	delete ps_bottom;
+
+	// top
 	if (node.scale_x > 0 || node.scale_y > 0) {
 		Polygon2d top_poly(poly);
 		Eigen::Affine2d trans(Eigen::Scaling(node.scale_x, node.scale_y) *
@@ -712,17 +819,18 @@ static Geometry *extrudePolygon(const LinearExtrudeNode &node, const Polygon2d &
 		ps->append(*ps_top);
 		delete ps_top;
 	}
-    size_t slices = node.slices;
 
-	for (unsigned int j = 0; j < slices; j++) {
+	// slices
+    size_t slices = node.slices;
+	for (unsigned int j = 0, k = 1; j < slices; j++, k++) {
 		double rot1 = node.twist*j / slices;
-		double rot2 = node.twist*(j+1) / slices;
+		double rot2 = node.twist*k / slices;
 		double height1 = h1 + (h2-h1)*j / slices;
-		double height2 = h1 + (h2-h1)*(j+1) / slices;
+		double height2 = h1 + (h2-h1)*k / slices;
 		Vector2d scale1(1 - (1-node.scale_x)*j / slices,
 										1 - (1-node.scale_y)*j / slices);
-		Vector2d scale2(1 - (1-node.scale_x)*(j+1) / slices,
-										1 - (1-node.scale_y)*(j+1) / slices);
+		Vector2d scale2(1 - (1-node.scale_x)*k / slices,
+										1 - (1-node.scale_y)*k / slices);
 		add_slice(ps, poly, rot1, rot2, height1, height2, scale1, scale2);
 	}
 
@@ -751,7 +859,10 @@ Response GeometryEvaluator::visit(State &state, const LinearExtrudeNode &node)
 				delete p2d;
 			}
 			else {
-				geometry = applyToChildren2D(node, OPENSCAD_UNION);
+				Geometry::Geometries dim2;
+				Geometry::Geometries dim3;
+				collectChildren(node, dim2, dim3);
+				geometry = applyToChildren2D(dim2, OPENSCAD_UNION);
 			}
 			if (geometry) {
 				const Polygon2d *polygons = dynamic_cast<const Polygon2d*>(geometry);
@@ -907,7 +1018,10 @@ Response GeometryEvaluator::visit(State &state, const RotateExtrudeNode &node)
 				delete p2d;
 			}
 			else {
-				geometry = applyToChildren2D(node, OPENSCAD_UNION);
+				Geometry::Geometries dim2;
+				Geometry::Geometries dim3;
+				collectChildren(node, dim2, dim3);
+				geometry = applyToChildren2D(dim2, OPENSCAD_UNION);
 			}
 			if (geometry) {
 				const Polygon2d *polygons = dynamic_cast<const Polygon2d*>(geometry);
@@ -949,7 +1063,7 @@ Response GeometryEvaluator::visit(State &state, const ProjectionNode &node)
 
 			if (!node.cut_mode) {
 				ClipperLib::Clipper sumclipper;
-				for(const auto &item : this->visitedchildren[node.index()]) {
+				for (const auto &item : getVisitedChildren(node)) {
 					const AbstractNode *chnode = item.first;
 					const shared_ptr<const Geometry> &chgeom = item.second;
 					// FIXME: Don't use deep access to modinst members
@@ -1020,7 +1134,10 @@ Response GeometryEvaluator::visit(State &state, const ProjectionNode &node)
 				if (sumresult.Total() > 0) geom.reset(ClipperUtils::toPolygon2d(sumresult));
 			}
 			else {
-				shared_ptr<const Geometry> newgeom = applyToChildren3D(node, OPENSCAD_UNION).constptr();
+				Geometry::Geometries dim2;
+				Geometry::Geometries dim3;
+				collectChildren(node, dim2, dim3);
+				shared_ptr<const Geometry> newgeom = applyToChildren3D(dim3, OPENSCAD_UNION).constptr();
 				if (newgeom) {
 					shared_ptr<const CGAL_Nef_polyhedron> Nptr = dynamic_pointer_cast<const CGAL_Nef_polyhedron>(newgeom);
 					if (!Nptr) {

--- a/src/NodeVisitor.h
+++ b/src/NodeVisitor.h
@@ -89,6 +89,6 @@ public:
 	}
 	// Add visit() methods for new visitable subtypes of AbstractNode here
 
-private:
+protected:
 	static State nullstate;
 };

--- a/src/Polygon2d-CGAL.cc
+++ b/src/Polygon2d-CGAL.cc
@@ -1,6 +1,7 @@
 #include "Polygon2d-CGAL.h"
 #include "polyset.h"
 #include "printutils.h"
+#include "cgalutils.h"
 
 #include <CGAL/Exact_predicates_inexact_constructions_kernel.h>
 #include <CGAL/Constrained_Delaunay_triangulation_2.h>
@@ -85,17 +86,17 @@ mark_domains(CDT &cdt)
 }
 
 #define OPENSCAD_CGAL_ERROR_BEGIN \
-	CGAL::Failure_behaviour old_behaviour = CGAL::set_error_behaviour(CGAL::THROW_EXCEPTION); \
+	CGALUtils::lockErrors(CGAL::THROW_EXCEPTION); \
 	try {
 
 #define OPENSCAD_CGAL_ERROR_END(errorstr, onerror) \
   } \
 	catch (const CGAL::Precondition_exception &e) { \
 		PRINTB(errorstr ": %s", e.what()); \
-		CGAL::set_error_behaviour(old_behaviour); \
+		CGALUtils::unlockErrors(); \
 		onerror; \
 	} \
-	CGAL::set_error_behaviour(old_behaviour);
+	CGALUtils::unlockErrors();
   
 
 /*!
@@ -120,7 +121,7 @@ PolySet *Polygon2d::tessellate() const
 			}
 		}
 	}
-	OPENSCAD_CGAL_ERROR_END("CGAL error in Polygon2d::tesselate()", return NULL);
+	OPENSCAD_CGAL_ERROR_END("CGAL error in Polygon2d::tesselate()", delete polyset; return NULL);
 
 	// To extract triangles which is part of our polygon, we need to filter away
 	// triangles inside holes.

--- a/src/ThreadedNodeVisitor.cc
+++ b/src/ThreadedNodeVisitor.cc
@@ -1,0 +1,418 @@
+#include "ThreadedNodeVisitor.h"
+#include "node.h"
+#include "state.h"
+#include "feature.h"
+#include "printutils.h"
+#include <algorithm>
+
+#include <boost/thread.hpp>
+#include <atomic>
+#include <stack>
+#include <map>
+#include <string>
+
+#include "Tree.h"
+#include "progress.h"
+#include "cgalutils.h"
+
+const char *ResponseStr[3] = { "Continue", "Abort", "Prune" };
+
+std::atomic<int> numRunning;
+
+class TraverseRunner
+{
+public:
+	TraverseData *data;
+	boost::thread *thread;
+
+	TraverseRunner(TraverseData *_data) : data(_data), thread(NULL) { }
+	~TraverseRunner()
+	{
+		if (thread)
+		{
+			delete thread;
+			thread = NULL;
+		}
+	}
+
+	template <class ThreadFunc>
+	void startRunner(ThreadFunc f)
+	{
+		thread = new boost::thread(f);
+	}
+};
+
+class TraverseData
+{
+	enum TraverseDataState
+	{
+		NONE,
+		PREFIXED,
+		RUNNING,
+		FINISHED
+	};
+	TraverseData *parent;
+	std::string idString;
+	const AbstractNode *node;
+	State state;
+	size_t depth;
+	Response response;
+	TraverseDataState dataState;
+	std::list<TraverseData*> children;
+
+public:
+	TraverseData(const std::string &_idString, const AbstractNode *_node, const State &_state, size_t _depth)
+		: parent(NULL)
+		, idString(_idString)
+		, node(_node)
+		, state(_state)
+		, depth(_depth)
+		, response(ContinueTraversal)
+		, dataState(NONE)
+	{
+	}
+
+	~TraverseData()
+	{
+		for (auto child : children)
+			delete child;
+	}
+
+	TraverseData *getParent() const { return parent; }
+	const std::string &getIdString() const { return idString; }
+	const AbstractNode *getNode() const { return node; }
+	int getId() const { return node->index(); }
+	size_t getDepth() const { return depth; }
+	Response getResponse() const { return response; }
+
+	void addChild(TraverseData *data)
+	{
+		data->parent = this;
+		children.push_back(data);
+	}
+
+	TraverseRunner *getRunner(ThreadedNodeVisitor *traverser, bool &lastLeaf)
+	{
+		TraverseRunner *result = NULL;
+		lastLeaf = false;
+		if (dataState < RUNNING)
+		{
+			bool hasUnfinishedChild = false;
+			for (auto child : children)
+			{
+				if (child->dataState != FINISHED)
+					hasUnfinishedChild = true;
+				bool dummy = false;
+				result = child->getRunner(traverser, dummy);
+				if (result != NULL)
+					break;
+			}
+			if (!hasUnfinishedChild && result == NULL)
+			{
+				//PRINTB(" No unfinished children: %s", toString());
+				if (!traverser->isRunning(this))
+				{
+					//PRINTB("++ Creating runner: %s", toString());
+					dataState = RUNNING;
+					result = new TraverseRunner(this);
+					lastLeaf = true;
+				}
+			}
+		}
+		return result;
+	}
+
+	size_t countTotalLeaves() const
+	{
+		size_t result = 1;
+		for (auto child : children)
+			result += child->countTotalLeaves();
+		return result;
+	}
+
+	size_t countLeafGeometries(const AbstractNode *node = NULL) const
+	{
+		auto kids = node == NULL ? this->node->getChildren() : node->getChildren();
+		if (kids.empty())
+			return 1;
+		size_t result = 0;
+		for (auto child : kids)
+			result += countLeafGeometries(child);
+		return result;
+	}
+
+	Response accept(bool postfix, BaseVisitor &visitor)
+	{
+		try
+		{
+			if (response != AbortTraversal)
+			{
+				state.setPrefix(!postfix);
+				state.setPostfix(postfix);
+				response = node->accept(state, visitor);
+			}
+		}
+		catch (const ProgressCancelException &c)
+		{
+			PRINT("!!! Cancelling node traversal !!!");
+			response = AbortTraversal;
+		}
+		catch (const std::exception &ex)
+		{
+			PRINTB("!!! Exception traversing node: %s", ex.what());
+			response = AbortTraversal;
+		}
+		catch (...)
+		{
+			PRINT("!!! Unhandled exception traversing node");
+			response = AbortTraversal;
+		}
+		if (postfix)
+			dataState = FINISHED;
+		else
+			dataState = PREFIXED;
+		return response;
+	}
+
+	std::string toNodeIdString() const
+	{
+		std::stringstream str;
+		if (parent != NULL)
+			str << parent->toNodeIdString() << ":";
+		str << node->index();
+		return str.str();
+	}
+
+	std::string toString() const
+	{
+		std::stringstream str;
+		str << node->name() << " #" << toNodeIdString() << " at depth " << depth;
+		return str.str();
+	}
+};
+
+Response ThreadedNodeVisitor::traverseThreaded(const AbstractNode &node, const State &state /*= NodeVisitor::nullstate*/, TraverseData *parentData /*= NULL*/, size_t currentDepth /*= 0*/)
+{
+	if (!threaded)
+		return traverse(node, state);
+
+	Response response = ContinueTraversal;
+	State newstate = state;
+	newstate.setNumChildren(node.getChildren().size());
+
+	std::string idString = tree.getIdString(node);
+	TraverseData *nodeData = new TraverseData(idString, &node, newstate, currentDepth);
+	if (parentData != NULL)
+		parentData->addChild(nodeData);
+
+	if (currentDepth == 0)
+	{
+		size_t geomCount = nodeData->countLeafGeometries();
+		PRINTB("Threaded traversal phase 1: Generating %d leaf geometries", geomCount);
+	}
+		
+	//PRINTB("  (%d) Running prefix", nodeData->getId());
+	response = nodeData->accept(false, *this);
+	//PRINTB("  (%d) Finished prefix: %s", nodeData->getId() % ResponseStr[nodeData->getResponse()]);
+		
+	// abort if the node aborted [prefix]
+	if (response == AbortTraversal)
+	{
+		if (currentDepth == 0) // whoops!
+			delete nodeData;
+		return response;
+	}
+
+	const auto &kids = node.getChildren();
+	// Pruned traversals mean don't traverse children
+	if (response == ContinueTraversal && !kids.empty())
+	{
+		newstate.setParent(&node);
+		for (const AbstractNode *chnode : kids) {
+			response = traverseThreaded(*chnode, newstate, nodeData, currentDepth + 1);
+			if (response == AbortTraversal)
+				break;
+		}
+	}
+
+	// abort if any child aborted [prefix]
+	if (response == AbortTraversal)
+	{
+		if (currentDepth == 0) // whoops!
+			delete nodeData;
+		return response;
+	}
+
+	if (currentDepth == 0)
+	{
+		// multithreaded postfixing
+		response = waitForIt(nodeData);
+		//PRINT("DONE!!! Deleting the root traversal data");
+		delete nodeData;
+	}
+
+	if (response != AbortTraversal) response = ContinueTraversal;
+	return response;
+}
+
+// start runners using the available cores and wait for them to finish
+Response ThreadedNodeVisitor::waitForIt(TraverseData *nodeData)
+{
+	Response response = ContinueTraversal;
+	// lock CGAL errors on the main thread
+	// this allows the spawned threads to catch their CGAL exceptions and not crash the whole app
+	// Response::AbortTraversal is "bubbled-up" when it occurs
+	CGALUtils::lockErrors(CGAL::THROW_EXCEPTION);
+	size_t maxThreads = boost::thread::hardware_concurrency();
+	size_t leafCount = nodeData->countTotalLeaves();
+	PRINTB("Threaded traversal phase 2: Spawning %d threads on %d cores", leafCount % maxThreads);
+	size_t leafCounter = 0;
+	size_t totalJoinCount = 0;
+	size_t runningCount = 0;
+	bool lastLeaf = false;
+	// wait loop
+	while (true)
+	{
+		// step 1: start runners unless aborted or found the last leaf or enough are running
+		if (response != AbortTraversal && !lastLeaf && maxThreads - runningCount > 0)
+		{
+			while (!lastLeaf && maxThreads - runningCount > 0)
+			{
+				TraverseRunner *runner = nodeData->getRunner(this, lastLeaf);
+				if (runner == NULL)
+				{
+					assert(!lastLeaf && "Why doesn't the last leaf have data???");
+					// we get here when a single parent is waiting on one or more children to complete
+					break;
+				}
+				leafCounter++;
+				if (lastLeaf)
+				{
+					//PRINTB("That's the last leaf (erm, the root)!!! counted=%d, count=%d", leafCounter % leafCount);
+					assert(leafCount == leafCounter && "Why don't the leaf counts match???");
+					assert(nodeData == runner->data && "Why isn't the last leaf its own data???");
+				}
+				auto f = [this, runner]
+				{
+					auto data = runner->data;
+					auto running = std::atomic_fetch_add(&numRunning, 1);
+					//PRINTB(">> Started thread %d (r=%d) %s", data->getId() % running % data->toString());
+					//PRINTB("  (%d) Running postfix", data->getId());
+					data->accept(true, *this);
+					//PRINTB("  (%d) Finished postfix: %s", data->getId() % ResponseStr[data->getResponse()]);
+					running = std::atomic_fetch_sub(&numRunning, 1);
+					//PRINTB("<< Finished thread %d (r=%d) with result '%s' %s", data->getId() % running % ResponseStr[data->getResponse()] % data->toString());
+				};
+				// start the runner
+				startRunner(f, runner);
+				// increment the running thread count
+				runningCount++;
+			}
+		}
+		// if the running count is zero, no threads are running and no new threads were added = done!
+		if (runningCount == 0)
+		{
+			//PRINT("No more pending children");
+			assert(totalJoinCount == leafCounter && "Why weren't as many threads joined as started???");
+			break;
+		}
+		// step 2: wait for any children to finish and do housekeeping
+		//PRINT("Waiting for finished children");
+		std::list<TraverseRunner*> finished;
+		std::list<TraverseRunner*> stillRunning;
+		waitForAny(finished, stillRunning);
+		size_t joinCount = 0;
+		for (auto runner : finished)
+		{
+			// check for abort
+			if (runner->data->getResponse() == AbortTraversal)
+				response = AbortTraversal;
+			// release the memory
+			delete runner;
+			// decrement the running thread count, et.al.
+			runningCount--;
+			joinCount++;
+			totalJoinCount++;
+		}
+		/*
+		if (joinCount > 0 && runningCount != 0)
+		{
+			std::stringstream ss;
+			bool first = true;
+			for (auto runner : stillRunning)
+			{
+				if (!first)
+					ss << ", ";
+				ss << runner->data->getId();
+				first = false;
+			}
+			PRINTB("Joined %d threads (%d/%d), still running: (%d) %s", joinCount % totalJoinCount % leafCount % runningCount % ss.str());
+		}
+		*/
+	} // while(true) // wait loop
+
+	CGALUtils::lockErrors(CGAL::THROW_EXCEPTION);
+	return response;
+}
+
+// starts the runner with the given thread func
+// called on the main thread
+template <class ThreadFunc>
+void ThreadedNodeVisitor::startRunner(ThreadFunc f, TraverseRunner *runner)
+{
+	// use a wrapper lambda function to additionally call finishRunner on the runner's thread
+	auto wrapper = [this, f, runner]
+	{
+		f();
+		finishRunner(runner);
+	};
+
+	// put the runner into the running map
+	runner_lock.wait();
+	running[runner->data->getIdString()] = runner;
+	runner_lock.post();
+
+	// now, start the thread
+	runner->startRunner(wrapper);
+}
+
+// finishes runner: pulls it from running and moves it to finished
+// called on the runner thread
+void ThreadedNodeVisitor::finishRunner(TraverseRunner *runner)
+{
+	runner_lock.wait();
+	// post ready_event if this is the first runner to finish
+	if (finished.empty())
+		ready_event.post();
+	// move it to finished
+	finished.push_back(runner);
+	// pull it from running
+	running.erase(runner->data->getIdString());
+	runner_lock.post();
+}
+
+// waits for any runners to finish and fills finished with 'em
+// fills stillRunning with the rest
+// called on the main thread
+void ThreadedNodeVisitor::waitForAny(std::list<TraverseRunner*> &finished, std::list<TraverseRunner*> &stillRunning)
+{
+	ready_event.wait();
+	// ready_event was posted; fill the result lists
+	runner_lock.wait();
+	finished.assign(this->finished.begin(), this->finished.end());
+	this->finished.clear();
+	for (auto r : running)
+		stillRunning.push_back(r.second);
+	runner_lock.post();
+}
+
+// checks if the given data is running
+// called on the main thread
+bool ThreadedNodeVisitor::isRunning(TraverseData *data)
+{
+	const std::string &id = data->getIdString();
+	runner_lock.wait();
+	bool result = running.find(id) != running.end();
+	runner_lock.post();
+	return result;
+}

--- a/src/ThreadedNodeVisitor.h
+++ b/src/ThreadedNodeVisitor.h
@@ -1,0 +1,63 @@
+#pragma once
+
+#include <stdint.h>
+#include <map>
+#include <list>
+#include <stack>
+#include "NodeVisitor.h"
+#include "Tree.h"
+
+// MinGW defines sprintf to libintl_sprintf which breaks usage of the
+// Qt sprintf in QString. This is skipped if sprintf and _GL_STDIO_H
+// is already defined, so the workaround defines sprintf as itself.
+#ifdef __MINGW32__
+#define _GL_STDIO_H
+#define sprintf sprintf
+#endif
+#include <boost/interprocess/sync/interprocess_semaphore.hpp>
+
+// forward declaration: node specific data for threaded traversal
+class TraverseData;
+// forward declaration: encapsulates a "runner" for TraverseData objects
+class TraverseRunner;
+
+class ThreadedNodeVisitor : public NodeVisitor
+{
+	bool threaded;												// indicates this visitor should actually use threads
+	boost::interprocess::interprocess_semaphore runner_lock;	// locks access to the runners
+	boost::interprocess::interprocess_semaphore ready_event;	// set when the first runner has finished
+	std::list<TraverseRunner*> finished;						// a list of finished runners
+	std::map<std::string, TraverseRunner*> running;				// the current runners indexed by TraverseData::idString
+
+	const Tree &tree;
+
+	// starts the runner with the given thread func
+	// called on the main thread
+	template <class ThreadFunc> 
+	void startRunner(ThreadFunc f, TraverseRunner *runner);
+
+	// finishes runner: pulls it from running and moves it to finished
+	// called on the runner thread
+	void finishRunner(TraverseRunner *runner);
+
+	// waits for any runners to finish and fills finished with 'em
+	// fills stillRunning with the rest
+	// called on the main thread
+	void waitForAny(std::list<TraverseRunner*> &finished, std::list<TraverseRunner*> &stillRunning);
+
+	// start runners using the available cores and wait for them to finish
+	Response waitForIt(TraverseData *nodeData);
+public:
+  ThreadedNodeVisitor(const Tree &_tree, bool _threaded = false)
+	  : threaded(_threaded), runner_lock(1), ready_event(0), tree(_tree) {
+  }
+  virtual ~ThreadedNodeVisitor() { }
+
+  Response traverseThreaded(const AbstractNode &node, const class State &state = NodeVisitor::nullstate, TraverseData *parentData = NULL, size_t currentDepth = 0);
+
+  // checks if the given data is running
+  // called on the main thread
+  bool isRunning(TraverseData *data);
+
+  const Tree &getTree() const { return tree; }
+};

--- a/src/cgalutils-applyops.cc
+++ b/src/cgalutils-applyops.cc
@@ -34,7 +34,40 @@
 #include <queue>
 #include <unordered_set>
 
+#include <boost/thread/mutex.hpp>
+
 namespace CGALUtils {
+
+	// manage changes to CGAL::set_error_behaviour:
+	//  a mutex to guard access
+	boost::mutex lockedErrorsLock;
+	//  the number of times lockErrors has been called (without corresponding unlockErrors)
+	size_t lockedErrorsCount = 0;
+	//  the original error state
+	CGAL::Failure_behaviour lockedErrors = CGAL::Failure_behaviour::ABORT;
+
+	// increments lockedErrorsCount and calls CGAL::set_error_behavior if this is the first [unlocked] call
+	void lockErrors(CGAL::Failure_behaviour behavior)
+	{
+		lockedErrorsLock.lock();
+		if (lockedErrorsCount == 0)
+			lockedErrors = CGAL::set_error_behaviour(behavior);
+		lockedErrorsCount++;
+		lockedErrorsLock.unlock();
+	}
+
+	// decrements lockedErrorsCount and calls CGAL::set_error_behavior if this is the last [locked] call
+	void unlockErrors()
+	{
+		lockedErrorsLock.lock();
+		if (lockedErrorsCount > 0)
+		{
+			lockedErrorsCount--;
+			if (lockedErrorsCount == 0)
+				CGAL::set_error_behaviour(lockedErrors);
+		}
+		lockedErrorsLock.unlock();
+	}
 
 	template<typename Polyhedron>
 	bool is_weakly_convex(Polyhedron const& p) {
@@ -72,6 +105,40 @@ namespace CGALUtils {
 		return visited.size() == p.size_of_facets();
 	}
 
+	/*!
+		Applies UNION to all children and returns the result.
+	*/
+	CGAL_Nef_polyhedron *applyUnion(const Geometry::Geometries &children)
+	{
+		CGAL_Nef_polyhedron *N = NULL;
+		// Speeds up n-ary union operations significantly
+		CGAL::Nef_nary_union_3<CGAL_Nef_polyhedron3> nary_union;
+		int nary_union_num_inserted = 0;
+
+		for (const auto &item : children) {
+			item.first->progress_report(); // report here in case of early continue in the loop
+			const shared_ptr<const Geometry> &chgeom = item.second;
+			shared_ptr<const CGAL_Nef_polyhedron> chN =
+				dynamic_pointer_cast<const CGAL_Nef_polyhedron>(chgeom);
+			if (!chN) {
+				const PolySet *chps = dynamic_cast<const PolySet*>(chgeom.get());
+				if (chps) chN.reset(createNefPolyhedronFromGeometry(*chps));
+			}
+
+			if (!chN->isEmpty()) {
+				// nary_union.add_polyhedron() can issue assertion errors:
+				// https://github.com/openscad/openscad/issues/802
+				nary_union.add_polyhedron(*chN->p3);
+				nary_union_num_inserted++;
+			}
+		}
+		
+		if (nary_union_num_inserted > 0) {
+			N = new CGAL_Nef_polyhedron(new CGAL_Nef_polyhedron3(nary_union.get_union()));
+		}
+		return N;
+	}
+
 /*!
 	Applies op to all children and returns the result.
 	The child list should be guaranteed to contain non-NULL 3D or empty Geometry objects
@@ -79,71 +146,62 @@ namespace CGALUtils {
 	CGAL_Nef_polyhedron *applyOperator(const Geometry::Geometries &children, OpenSCADOperator op)
 	{
 		CGAL_Nef_polyhedron *N = NULL;
-		CGAL::Failure_behaviour old_behaviour = CGAL::set_error_behaviour(CGAL::THROW_EXCEPTION);
+		lockErrors(CGAL::THROW_EXCEPTION);
 		try {
-			// Speeds up n-ary union operations significantly
-			CGAL::Nef_nary_union_3<CGAL_Nef_polyhedron3> nary_union;
-			int nary_union_num_inserted = 0;
-			
-			for(const auto &item : children) {
-				const shared_ptr<const Geometry> &chgeom = item.second;
-				shared_ptr<const CGAL_Nef_polyhedron> chN = 
-					dynamic_pointer_cast<const CGAL_Nef_polyhedron>(chgeom);
-				if (!chN) {
-					const PolySet *chps = dynamic_cast<const PolySet*>(chgeom.get());
-					if (chps) chN.reset(createNefPolyhedronFromGeometry(*chps));
-				}
-				
-				if (op == OPENSCAD_UNION) {
-					if (!chN->isEmpty()) {
-						// nary_union.add_polyhedron() can issue assertion errors:
-						// https://github.com/openscad/openscad/issues/802
-						nary_union.add_polyhedron(*chN->p3);
-						nary_union_num_inserted++;
-					}
-					continue;
-				}
-				// Initialize N with first expected geometric object
-				if (!N) {
-					N = new CGAL_Nef_polyhedron(*chN);
-					continue;
-				}
-				
-				// Intersecting something with nothing results in nothing
-				if (chN->isEmpty()) {
-					if (op == OPENSCAD_INTERSECTION) *N = *chN;
-					continue;
-				}
-				
-				// empty op <something> => empty
-				if (N->isEmpty()) continue;
-				
-				switch (op) {
-				case OPENSCAD_INTERSECTION:
-					*N *= *chN;
-					break;
-				case OPENSCAD_DIFFERENCE:
-					*N -= *chN;
-					break;
-				case OPENSCAD_MINKOWSKI:
-					N->minkowski(*chN);
-					break;
-				default:
-					PRINTB("ERROR: Unsupported CGAL operator: %d", op);
-				}
-				item.first->progress_report();
+			if (op == OPENSCAD_UNION)
+			{
+				// Speeds up n-ary union operations significantly
+				N = applyUnion(children);
 			}
+			else
+			{
+				for (const auto &item : children) {
+					item.first->progress_report(); // report here in case of early continue in the loop
+					const shared_ptr<const Geometry> &chgeom = item.second;
+					shared_ptr<const CGAL_Nef_polyhedron> chN =
+						dynamic_pointer_cast<const CGAL_Nef_polyhedron>(chgeom);
+					if (!chN) {
+						const PolySet *chps = dynamic_cast<const PolySet*>(chgeom.get());
+						if (chps) chN.reset(createNefPolyhedronFromGeometry(*chps));
+					}
 
-			if (op == OPENSCAD_UNION && nary_union_num_inserted > 0) {
-				N = new CGAL_Nef_polyhedron(new CGAL_Nef_polyhedron3(nary_union.get_union()));
+					// Initialize N with first expected geometric object
+					if (!N) {
+						N = new CGAL_Nef_polyhedron(*chN);
+						continue;
+					}
+
+					// Intersecting something with nothing results in nothing
+					if (chN->isEmpty()) {
+						if (op == OPENSCAD_INTERSECTION) *N = *chN;
+						continue;
+					}
+
+					// empty op <something> => empty
+					if (N->isEmpty()) continue;
+
+					switch (op) {
+					case OPENSCAD_INTERSECTION:
+						*N *= *chN;
+						break;
+					case OPENSCAD_DIFFERENCE:
+						*N -= *chN;
+						break;
+					case OPENSCAD_MINKOWSKI:
+						N->minkowski(*chN);
+						break;
+					default:
+						PRINTB("ERROR: Unsupported CGAL operator: %d", op);
+					}
+				}
 			}
 		}
-	// union && difference assert triggered by testdata/scad/bugs/rotate-diff-nonmanifold-crash.scad and testdata/scad/bugs/issue204.scad
+		// union && difference assert triggered by testdata/scad/bugs/rotate-diff-nonmanifold-crash.scad and testdata/scad/bugs/issue204.scad
 		catch (const CGAL::Failure_exception &e) {
 			std::string opstr = op == OPENSCAD_INTERSECTION ? "intersection" : op == OPENSCAD_DIFFERENCE ? "difference" : op == OPENSCAD_UNION ? "union" : "UNKNOWN";
 			PRINTB("ERROR: CGAL error in CGALUtils::applyBinaryOperator %s: %s", opstr % e.what());
 		}
-		CGAL::set_error_behaviour(old_behaviour);
+		unlockErrors();
 		return N;
 	}
 
@@ -183,7 +241,7 @@ namespace CGALUtils {
 		// Apply hull
 		bool success = false;
 		if (points.size() >= 4) {
-			CGAL::Failure_behaviour old_behaviour = CGAL::set_error_behaviour(CGAL::THROW_EXCEPTION);
+			lockErrors(CGAL::THROW_EXCEPTION);
 			try {
 				CGAL::Polyhedron_3<K> r;
 				CGAL::convex_hull_3(points.begin(), points.end(), r);
@@ -196,7 +254,7 @@ namespace CGALUtils {
 			catch (const CGAL::Failure_exception &e) {
 				PRINTB("ERROR: CGAL error in applyHull(): %s", e.what());
 			}
-			CGAL::set_error_behaviour(old_behaviour);
+			unlockErrors();
 		}
 		return success;
 	}
@@ -207,7 +265,7 @@ namespace CGALUtils {
 	*/
 	Geometry const * applyMinkowski(const Geometry::Geometries &children)
 	{
-		CGAL::Failure_behaviour old_behaviour = CGAL::set_error_behaviour(CGAL::THROW_EXCEPTION);
+		lockErrors(CGAL::THROW_EXCEPTION);
 		CGAL::Timer t,t_tot;
 		assert(children.size() >= 2);
 		Geometry::Geometries::const_iterator it = children.begin();
@@ -398,7 +456,7 @@ namespace CGALUtils {
 			t_tot.stop();
 			PRINTDB("Minkowski: Total execution time %f s", t_tot.time());
 			t_tot.reset();
-			CGAL::set_error_behaviour(old_behaviour);
+			unlockErrors();
 			return operands[0];
 		}
 		catch (...) {
@@ -406,7 +464,7 @@ namespace CGALUtils {
 			PRINTD("Minkowski: Falling back to Nef Minkowski");
 
 			CGAL_Nef_polyhedron *N = applyOperator(children, OPENSCAD_MINKOWSKI);
-			CGAL::set_error_behaviour(old_behaviour);
+			unlockErrors();
 			return N;
 		}
 	}

--- a/src/cgalutils-polyhedron.cc
+++ b/src/cgalutils-polyhedron.cc
@@ -246,7 +246,7 @@ namespace CGALUtils {
 	bool createPolyhedronFromPolySet(const PolySet &ps, Polyhedron &p)
 	{
 		bool err = false;
-		CGAL::Failure_behaviour old_behaviour = CGAL::set_error_behaviour(CGAL::THROW_EXCEPTION);
+		CGALUtils::lockErrors(CGAL::THROW_EXCEPTION);
 		try {
 			CGAL_Build_PolySet<Polyhedron> builder(ps);
 			p.delegate(builder);
@@ -255,7 +255,7 @@ namespace CGALUtils {
 			PRINTB("CGAL error in CGALUtils::createPolyhedronFromPolySet: %s", e.what());
 			err = true;
 		}
-		CGAL::set_error_behaviour(old_behaviour);
+		CGALUtils::unlockErrors();
 		return err;
 	}
 

--- a/src/cgalutils-project.cc
+++ b/src/cgalutils-project.cc
@@ -187,7 +187,7 @@ namespace CGALUtils {
 
 		CGAL_Nef_polyhedron newN;
 		if (cut) {
-			CGAL::Failure_behaviour old_behaviour = CGAL::set_error_behaviour(CGAL::THROW_EXCEPTION);
+			CGALUtils::lockErrors(CGAL::THROW_EXCEPTION);
 			try {
 				CGAL_Nef_polyhedron3::Plane_3 xy_plane = CGAL_Nef_polyhedron3::Plane_3(0,0,1,0);
 				newN.p3.reset(new CGAL_Nef_polyhedron3(N.p3->intersection(xy_plane, CGAL_Nef_polyhedron3::PLANE_ONLY)));
@@ -215,7 +215,7 @@ namespace CGALUtils {
 			}
 				
 			if (!newN.p3 || newN.p3->is_empty()) {
-				CGAL::set_error_behaviour(old_behaviour);
+				CGALUtils::unlockErrors();
 				PRINT("WARNING: projection() failed.");
 				return poly;
 			}
@@ -242,7 +242,7 @@ namespace CGALUtils {
 			}
 			PRINTD("</svg>");
 				
-			CGAL::set_error_behaviour(old_behaviour);
+			CGALUtils::unlockErrors();
 		}
 		// In projection mode all the triangles are projected manually into the XY plane
 		else {

--- a/src/cgalutils-tess-old.cc
+++ b/src/cgalutils-tess-old.cc
@@ -357,13 +357,13 @@ namespace CGALUtils {
 			for (size_t k=0;k<vhandles.size();k++) {
 				int vindex1 = (k+0);
 				int vindex2 = (k+1)%vhandles.size();
-				CGAL::Failure_behaviour old_behaviour = CGAL::set_error_behaviour(CGAL::THROW_EXCEPTION);
+				CGALUtils::lockErrors(CGAL::THROW_EXCEPTION);
 				try {
 					cdt.insert_constraint( vhandles[vindex1], vhandles[vindex2] );
 				} catch (const CGAL::Failure_exception &e) {
 					PRINTB("WARNING: Constraint insertion failure %s", e.what());
 				}
-				CGAL::set_error_behaviour(old_behaviour);
+				CGALUtils::unlockErrors();
 			}
 		}
 
@@ -476,13 +476,13 @@ namespace CGALUtils {
 			for (size_t k=0;k<vhandles.size();k++) {
 				int vindex1 = (k+0);
 				int vindex2 = (k+1)%vhandles.size();
-				CGAL::Failure_behaviour old_behaviour = CGAL::set_error_behaviour(CGAL::THROW_EXCEPTION);
+				CGALUtils::lockErrors(CGAL::THROW_EXCEPTION);
 				try {
 					cdt.insert_constraint( vhandles[vindex1], vhandles[vindex2] );
 				} catch (const CGAL::Failure_exception &e) {
 					PRINTB("WARNING: Constraint insertion failure %s", e.what());
 				}
-				CGAL::set_error_behaviour(old_behaviour);
+				CGALUtils::unlockErrors();
 			}
 		}
 

--- a/src/cgalutils.cc
+++ b/src/cgalutils.cc
@@ -70,7 +70,7 @@ static CGAL_Nef_polyhedron *createNefPolyhedronFromPolySet(const PolySet &ps)
 
 	CGAL_Nef_polyhedron3 *N = NULL;
 	bool plane_error = false;
-	CGAL::Failure_behaviour old_behaviour = CGAL::set_error_behaviour(CGAL::THROW_EXCEPTION);
+	CGALUtils::lockErrors(CGAL::THROW_EXCEPTION);
 	try {
 		CGAL_Polyhedron P;
 		bool err = CGALUtils::createPolyhedronFromPolySet(psq, P);
@@ -102,7 +102,7 @@ static CGAL_Nef_polyhedron *createNefPolyhedronFromPolySet(const PolySet &ps)
 		catch (const CGAL::Assertion_exception &e) {
 			PRINTB("ERROR: Alternate construction failed. CGAL error in CGAL_Nef_polyhedron3(): %s", e.what());
 		}
-	CGAL::set_error_behaviour(old_behaviour);
+	CGALUtils::unlockErrors();
 	return new CGAL_Nef_polyhedron(N);
 }
 

--- a/src/cgalutils.h
+++ b/src/cgalutils.h
@@ -4,6 +4,7 @@
 #include "polyset.h"
 #include "CGAL_Nef_polyhedron.h"
 #include "enums.h"
+#include "node.h"
 
 #include <CGAL/Exact_predicates_inexact_constructions_kernel.h>
 typedef CGAL::Epick K;
@@ -46,4 +47,7 @@ namespace CGALUtils {
 	bool tessellate3DFaceWithHoles(std::vector<CGAL_Polygon_3> &polygons, 
 																 std::vector<CGAL_Polygon_3> &triangles,
 																 CGAL::Plane_3<CGAL_Kernel3> &plane);
+
+	void lockErrors(CGAL::Failure_behaviour behavior);
+	void unlockErrors();
 };

--- a/src/cgalworker.cc
+++ b/src/cgalworker.cc
@@ -29,7 +29,7 @@ void CGALWorker::work()
 {
 	shared_ptr<const Geometry> root_geom;
 	try {
-		GeometryEvaluator evaluator(*this->tree);
+		GeometryEvaluator evaluator(*this->tree, true);
 		root_geom = evaluator.evaluateGeometry(*this->tree->root(), true);
 	}
 	catch (const ProgressCancelException &e) {

--- a/src/export_amf.cc
+++ b/src/export_amf.cc
@@ -55,7 +55,7 @@ static void append_amf(const CGAL_Nef_polyhedron &root_N, std::ostream &output)
 		PRINT("WARNING: Export failed, the object isn't a valid 2-manifold.");
 		return;
 	}
-	CGAL::Failure_behaviour old_behaviour = CGAL::set_error_behaviour(CGAL::THROW_EXCEPTION);
+	CGALUtils::lockErrors(CGAL::THROW_EXCEPTION);
 	try {
 		CGAL_Polyhedron P;
 		root_N.p3->convert_to_Polyhedron(P);
@@ -151,7 +151,7 @@ static void append_amf(const CGAL_Nef_polyhedron &root_N, std::ostream &output)
 	} catch (CGAL::Assertion_exception e) {
 		PRINTB("ERROR: CGAL error in CGAL_Nef_polyhedron3::convert_to_Polyhedron(): %s", e.what());
 	}
-	CGAL::set_error_behaviour(old_behaviour);
+	CGALUtils::unlockErrors();
 }
 
 static void append_amf(const shared_ptr<const Geometry> &geom, std::ostream &output)

--- a/src/export_stl.cc
+++ b/src/export_stl.cc
@@ -160,7 +160,7 @@ static void append_stl(const CGAL_Nef_polyhedron &root_N, std::ostream &output)
 		}
 	}
 	else {
-		CGAL::Failure_behaviour old_behaviour = CGAL::set_error_behaviour(CGAL::THROW_EXCEPTION);
+		CGALUtils::lockErrors(CGAL::THROW_EXCEPTION);
 		try {
 			CGAL_Polyhedron P;
 			//root_N.p3->convert_to_Polyhedron(P);
@@ -177,7 +177,7 @@ static void append_stl(const CGAL_Nef_polyhedron &root_N, std::ostream &output)
 		catch (...) {
 			PRINT("ERROR: CGAL unknown error in CGAL_Nef_polyhedron3::convert_to_Polyhedron()");
 		}
-		CGAL::set_error_behaviour(old_behaviour);
+		CGALUtils::unlockErrors();
 	}
 }
 

--- a/src/feature.cc
+++ b/src/feature.cc
@@ -27,7 +27,7 @@ const Feature Feature::ExperimentalForCExpression("lc-for-c", "Enable C-style <c
 const Feature Feature::ExperimentalAmfImport("amf-import", "Enable AMF import.");
 const Feature Feature::ExperimentalSvgImport("svg-import", "Enable SVG import.");
 const Feature Feature::ExperimentalCustomizer("customizer", "Enable Customizer");
-
+const Feature Feature::ExperimentalThreadedTraversal("thread-traversal", "Enable threaded traversal.");
 
 Feature::Feature(const std::string &name, const std::string &description)
 	: enabled(false), name(name), description(description)

--- a/src/feature.h
+++ b/src/feature.h
@@ -22,7 +22,7 @@ public:
         static const Feature ExperimentalAmfImport;
         static const Feature ExperimentalSvgImport;
         static const Feature ExperimentalCustomizer;
-
+	static const Feature ExperimentalThreadedTraversal;
 
 	const std::string& get_name() const;
 	const std::string& get_description() const;

--- a/src/openscad.cc
+++ b/src/openscad.cc
@@ -330,7 +330,7 @@ int cmdline(const char *deps_output_file, const std::string &filename, Camera &c
 
 	Tree tree;
 #ifdef ENABLE_CGAL
-	GeometryEvaluator geomevaluator(tree);
+	GeometryEvaluator geomevaluator(tree, true);
 #endif
 	if (arg_info) {
 	    info();
@@ -783,12 +783,42 @@ int gui(const vector<string> &inputFiles, const fs::path &original_path, int arg
 }
 #endif // OPENSCAD_QTGUI
 
+#include <execinfo.h>
+#include <signal.h>
+
+#include <boost/thread/mutex.hpp>
+boost::mutex traceLock;
+bool handledSig = false;
+
+void sighandler(int signum)
+{
+	void *array[20];
+	size_t size;
+
+	// get void*'s for all entries on the stack
+	size = backtrace(array, 20);
+
+	// print out all the frames to stderr
+	traceLock.lock();
+	fprintf(stderr, "ERROR: signal %d:\n", signum);
+	if (!handledSig)
+	{
+		fprintf(stderr, "!!! Attach debugger now: pid=%d\nPress a key to continue.\n", getpid());
+		fgetc(stdin);
+		handledSig = true;
+	}
+	//backtrace_symbols_fd(array, size, STDERR_FILENO);
+	traceLock.unlock();
+	//exit(1);
+}
+
+
 int main(int argc, char **argv)
 {
 	int rc = 0;
 	bool isGuiLaunched = getenv("GUI_LAUNCHED") != 0;
 	StackCheck::inst()->init();
-	
+		
 #ifdef Q_OS_MAC
 	if (isGuiLaunched) set_output_handler(CocoaUtils::nslog, NULL);
 #else
@@ -838,6 +868,7 @@ int main(int argc, char **argv)
 
 	po::options_description hidden("Hidden options");
 	hidden.add_options()
+		("segv,g", "catch SIGSEGV and pause (attach debugger)")
 		("input-file", po::value< vector<string>>(), "input file");
 
 	po::positional_options_description p;
@@ -862,6 +893,9 @@ int main(int argc, char **argv)
 	}
 	if (vm.count("quiet")) {
 		OpenSCAD::quiet = true;
+	}
+	if (vm.count("segv")) {
+		signal(SIGSEGV, sighandler);
 	}
 	if (vm.count("help")) help(argv[0]);
 	if (vm.count("version")) version();

--- a/src/polyset-utils-old.cc
+++ b/src/polyset-utils-old.cc
@@ -148,7 +148,7 @@ namespace PolysetUtils {
 	bool triangulate_polygon( const PolySet::Polygon &pgon, std::vector<PolySet::Polygon> &triangles, projection_t projection )
 	{
 		bool err = false;
-		CGAL::Failure_behaviour old_behaviour = CGAL::set_error_behaviour(CGAL::THROW_EXCEPTION);
+		CGALUtils::lockErrors(CGAL::THROW_EXCEPTION);
 		try {
 			CDT cdt;
 			std::vector<Vertex_handle> vhandles;
@@ -203,7 +203,7 @@ namespace PolysetUtils {
 			PRINTB("CGAL error in triangulate_polygon(): %s", e.what());
 			err = true;
 		}
-		CGAL::set_error_behaviour(old_behaviour);
+		CGALUtils::unlockErrors();
 		return err;
 	}
 


### PR DESCRIPTION
I have implemented a solution for #391. My solution consists of a new class, ThreadedNodeVisitor, deriving from NodeVisitor. In turn, GeometryEvaluator now derives from ThreadedNodeVisitor. ThreadedNodeVisitor is fully documented.

ThreadedNodeVisitor takes a constructor parameter named "threaded" which determines whether the visitor is actually multi-threaded. The flag is false except from CGALWorker and main() so multi-threading is only used for CGAL evaluation.

The one other "big" change I made outside ThreadedNodeVisitor and GeometryEvaluator is the implementation of CGALUtils::lockErrors/::unlockErrors. This wraps CGAL::set_error_behavior so multiple threads don't stomp on each other. I updated all the respective calls for consistency.

This feature can be enabled via the "threaded traversal" experimental feature.

Please review the code and let me know if there any issues. Otherwise, how do I go about claiming that bounty??? 8-D