### PR TITLE
Add circulate= to linear_extrude for better screw threads

### DIFF
--- a/src/GeometryEvaluator.cc
+++ b/src/GeometryEvaluator.cc
@@ -635,34 +635,37 @@ static void add_slice(PolySet *ps, const Polygon2d &poly,
 	
 	bool splitfirst = sin((rot1 - rot2)*M_PI/180) > 0.0;
 	for(const auto &o : poly.outlines()) {
-		Vector2d prev1 = trans1 * o.vertices[0];
-		Vector2d prev2 = trans2 * o.vertices[0];
+		Vector3d prev1, prev2;
+		prev1 << trans1 * o.vertices[0], h1;
+		prev2 << trans2 * o.vertices[0], h2;
+
 		for (size_t i=1;i<=o.vertices.size();i++) {
-			Vector2d curr1 = trans1 * o.vertices[i % o.vertices.size()];
-			Vector2d curr2 = trans2 * o.vertices[i % o.vertices.size()];
+			Vector3d curr1, curr2;
+			curr1 << trans1 * o.vertices[i % o.vertices.size()], h1;
+			curr2 << trans2 * o.vertices[i % o.vertices.size()], h2;
 			ps->append_poly();
 			
 			// Make sure to split negative outlines correctly
 			if (splitfirst xor !o.positive) {
-				ps->insert_vertex(prev1[0], prev1[1], h1);
-				ps->insert_vertex(curr2[0], curr2[1], h2);
-				ps->insert_vertex(curr1[0], curr1[1], h1);
+				ps->insert_vertex(prev1);
+				ps->insert_vertex(curr2);
+				ps->insert_vertex(curr1);
 				if (scale2[0] > 0 || scale2[1] > 0) {
 					ps->append_poly();
-					ps->insert_vertex(curr2[0], curr2[1], h2);
-					ps->insert_vertex(prev1[0], prev1[1], h1);
-					ps->insert_vertex(prev2[0], prev2[1], h2);
+					ps->insert_vertex(curr2);
+					ps->insert_vertex(prev1);
+					ps->insert_vertex(prev2);
 				}
 			}
 			else {
-				ps->insert_vertex(prev1[0], prev1[1], h1);
-				ps->insert_vertex(prev2[0], prev2[1], h2);
-				ps->insert_vertex(curr1[0], curr1[1], h1);
+				ps->insert_vertex(prev1);
+				ps->insert_vertex(prev2);
+				ps->insert_vertex(curr1);
 				if (scale2[0] > 0 || scale2[1] > 0) {
 					ps->append_poly();
-					ps->insert_vertex(prev2[0], prev2[1], h2);
-					ps->insert_vertex(curr2[0], curr2[1], h2);
-					ps->insert_vertex(curr1[0], curr1[1], h1);
+					ps->insert_vertex(prev2);
+					ps->insert_vertex(curr2);
+					ps->insert_vertex(curr1);
 				}
 			}
 			prev1 = curr1;

--- a/src/linearextrude.cc
+++ b/src/linearextrude.cc
@@ -55,7 +55,7 @@ AbstractNode *LinearExtrudeModule::instantiate(const Context *ctx, const ModuleI
 	LinearExtrudeNode *node = new LinearExtrudeNode(inst);
 
 	AssignmentList args;
-	args += Assignment("file"), Assignment("layer"), Assignment("height"), Assignment("origin"), Assignment("scale"), Assignment("center"), Assignment("twist"), Assignment("slices");
+	args += Assignment("file"), Assignment("layer"), Assignment("height"), Assignment("origin"), Assignment("scale"), Assignment("center"), Assignment("twist"), Assignment("slices"), Assignment("circulate");
 
 	Context c(ctx);
 	c.setVariables(args, evalctx);
@@ -74,6 +74,7 @@ AbstractNode *LinearExtrudeModule::instantiate(const Context *ctx, const ModuleI
 	ValuePtr center = c.lookup_variable("center", true);
 	ValuePtr twist = c.lookup_variable("twist", true);
 	ValuePtr slices = c.lookup_variable("slices", true);
+	ValuePtr circulate = c.lookup_variable("circulate", true);
 
 	if (!file->isUndefined() && file->type() == Value::STRING) {
 		printDeprecation("Support for reading files in linear_extrude will be removed in future releases. Use a child import() instead.");
@@ -113,6 +114,10 @@ AbstractNode *LinearExtrudeModule::instantiate(const Context *ctx, const ModuleI
 	double slicesVal = 0;
 	slices->getFiniteDouble(slicesVal);
 	node->slices = (int)slicesVal;
+
+	double circulateVal = 0;
+	circulate->getFiniteDouble(circulateVal);
+	node->circulate = (int)circulateVal;
 
 	node->twist = 0.0;
 	twist->getFiniteDouble(node->twist);
@@ -156,6 +161,9 @@ std::string LinearExtrudeNode::toString() const
 	}
 	if (this->slices > 1) {
 		stream << ", slices = " << this->slices;
+	}
+	if (this->circulate != 0) {
+		stream << ", circulate = " << this->circulate;
 	}
 	stream << ", scale = [" << this->scale_x << ", " << this->scale_y << "]";
 	stream << ", $fn = " << this->fn << ", $fa = " << this->fa << ", $fs = " << this->fs << ")";

--- a/src/linearextrudenode.h
+++ b/src/linearextrudenode.h
@@ -8,7 +8,7 @@ class LinearExtrudeNode : public AbstractPolyNode
 public:
 	VISITABLE();
 	LinearExtrudeNode(const ModuleInstantiation *mi) : AbstractPolyNode(mi) {
-		convexity = slices = 0;
+		convexity = slices = circulate = 0;
 		fn = fs = fa = height = twist = 0;
 		origin_x = origin_y = 0;
 		scale_x = scale_y = 1;
@@ -17,7 +17,7 @@ public:
 	virtual std::string toString() const;
 	virtual std::string name() const { return "linear_extrude"; }
 
-	int convexity, slices;
+	int convexity, slices, circulate;
 	double fn, fs, fa, height, twist;
 	double origin_x, origin_y, scale_x, scale_y;
 	bool center, has_twist;


### PR DESCRIPTION
I have been considering the problem reported in issue #901 for some time.  This PR adds a parameter `circulate=` to `linear_extrude`, which is the original request in that issue.  As you can see in the attached image, this improves the appearance of a screw thread.

This patch probably needs documentation and an image test before it's suitable for inclusion, not to mention healthy discussion of whether it can even be used safely in enough circumstances to warrant it.  However, it does improve some screw threads quite a bit!

![xtry](https://cloud.githubusercontent.com/assets/1517291/24841006/6fe6587a-1d3f-11e7-94fa-d872d4b5eb15.png)

The (fictional) thread was generated by this openscad program:
````
function frompolar(r, th) = [ cos(th) * r, sin(th) * r ];
function r(th) = 
    let(th = th % 60)
    (th < 10) ? 18 + th / 4 :
    (th < 20) ? 20.5 :
    (th < 30) ? 18 + (30 - th) / 4 :
    18;

module shape() {
    polygon([for(th=[0:1:360]) frompolar(r(th), th)]);
}

TH = 1440;
SL = 1 + TH;
HH = 144;
rotate([0,90,0])
translate([-24,0,0]) 
linear_extrude(twist=TH, height=HH, slices=SL, center=true) shape();
rotate([0,90,0])
translate([ 24,0,0]) 
linear_extrude(circulate=1, twist=TH, height=HH, slices=SL, center=true) shape();
````
