### PR TITLE
 Add circulate= to linear_extrude for better screw threads

### DIFF
--- a/src/GeometryEvaluator.cc
+++ b/src/GeometryEvaluator.cc
@@ -624,11 +624,23 @@ static void translate_PolySet(PolySet &ps, const Vector3d &translation)
 	}
 }
 
+namespace
+{
+template<class T>
+const typename T::value_type &modulo_index(const T &container, typename T::size_type idx) {
+	ssize_t size = container.size();
+	idx %= size;
+	if(idx < 0) idx += size;
+	return container.at(idx);
+}
+}
+
 static void add_slice(PolySet *ps, const Polygon2d &poly, 
 											double rot1, double rot2, 
 											double h1, double h2, 
 											const Vector2d &scale1,
-											const Vector2d &scale2)
+											const Vector2d &scale2,
+											long int circulate1, long int circulate2)
 {
 	Eigen::Affine2d trans1(Eigen::Scaling(scale1) * Eigen::Rotation2D<double>(-rot1*M_PI/180));
 	Eigen::Affine2d trans2(Eigen::Scaling(scale2) * Eigen::Rotation2D<double>(-rot2*M_PI/180));
@@ -636,13 +648,13 @@ static void add_slice(PolySet *ps, const Polygon2d &poly,
 	bool splitfirst = sin((rot1 - rot2)*M_PI/180) > 0.0;
 	for(const auto &o : poly.outlines()) {
 		Vector3d prev1, prev2;
-		prev1 << trans1 * o.vertices[0], h1;
-		prev2 << trans2 * o.vertices[0], h2;
+		prev1 << trans1 * modulo_index(o.vertices, circulate1), h1;
+		prev2 << trans2 * modulo_index(o.vertices, circulate2), h2;
 
 		for (size_t i=1;i<=o.vertices.size();i++) {
 			Vector3d curr1, curr2;
-			curr1 << trans1 * o.vertices[i % o.vertices.size()], h1;
-			curr2 << trans2 * o.vertices[i % o.vertices.size()], h2;
+			curr1 << trans1 * modulo_index(o.vertices, circulate1 + i), h1;
+			curr2 << trans2 * modulo_index(o.vertices, circulate2 + i), h2;
 			ps->append_poly();
 			
 			// Make sure to split negative outlines correctly
@@ -716,17 +728,20 @@ static Geometry *extrudePolygon(const LinearExtrudeNode &node, const Polygon2d &
 		delete ps_top;
 	}
     size_t slices = node.slices;
+	int circulate = node.circulate;
 
 	for (unsigned int j = 0; j < slices; j++) {
 		double rot1 = node.twist*j / slices;
 		double rot2 = node.twist*(j+1) / slices;
 		double height1 = h1 + (h2-h1)*j / slices;
 		double height2 = h1 + (h2-h1)*(j+1) / slices;
+		auto circulate1 = circulate < 0 ? -circulate : 0;
+		auto circulate2 = circulate > 0 ? circulate : 0;
 		Vector2d scale1(1 - (1-node.scale_x)*j / slices,
 										1 - (1-node.scale_y)*j / slices);
 		Vector2d scale2(1 - (1-node.scale_x)*(j+1) / slices,
 										1 - (1-node.scale_y)*(j+1) / slices);
-		add_slice(ps, poly, rot1, rot2, height1, height2, scale1, scale2);
+		add_slice(ps, poly, rot1, rot2, height1, height2, scale1, scale2, circulate1, circulate2);
 	}
 
 	return ps;

--- a/src/GeometryEvaluator.cc
+++ b/src/GeometryEvaluator.cc
@@ -635,34 +635,37 @@ static void add_slice(PolySet *ps, const Polygon2d &poly,
 	
 	bool splitfirst = sin((rot1 - rot2)*M_PI/180) > 0.0;
 	for(const auto &o : poly.outlines()) {
-		Vector2d prev1 = trans1 * o.vertices[0];
-		Vector2d prev2 = trans2 * o.vertices[0];
+		Vector3d prev1, prev2;
+		prev1 << trans1 * o.vertices[0], h1;
+		prev2 << trans2 * o.vertices[0], h2;
+
 		for (size_t i=1;i<=o.vertices.size();i++) {
-			Vector2d curr1 = trans1 * o.vertices[i % o.vertices.size()];
-			Vector2d curr2 = trans2 * o.vertices[i % o.vertices.size()];
+			Vector3d curr1, curr2;
+			curr1 << trans1 * o.vertices[i % o.vertices.size()], h1;
+			curr2 << trans2 * o.vertices[i % o.vertices.size()], h2;
 			ps->append_poly();
 			
 			// Make sure to split negative outlines correctly
 			if (splitfirst xor !o.positive) {
-				ps->insert_vertex(prev1[0], prev1[1], h1);
-				ps->insert_vertex(curr2[0], curr2[1], h2);
-				ps->insert_vertex(curr1[0], curr1[1], h1);
+				ps->insert_vertex(prev1);
+				ps->insert_vertex(curr2);
+				ps->insert_vertex(curr1);
 				if (scale2[0] > 0 || scale2[1] > 0) {
 					ps->append_poly();
-					ps->insert_vertex(curr2[0], curr2[1], h2);
-					ps->insert_vertex(prev1[0], prev1[1], h1);
-					ps->insert_vertex(prev2[0], prev2[1], h2);
+					ps->insert_vertex(curr2);
+					ps->insert_vertex(prev1);
+					ps->insert_vertex(prev2);
 				}
 			}
 			else {
-				ps->insert_vertex(prev1[0], prev1[1], h1);
-				ps->insert_vertex(prev2[0], prev2[1], h2);
-				ps->insert_vertex(curr1[0], curr1[1], h1);
+				ps->insert_vertex(prev1);
+				ps->insert_vertex(prev2);
+				ps->insert_vertex(curr1);
 				if (scale2[0] > 0 || scale2[1] > 0) {
 					ps->append_poly();
-					ps->insert_vertex(prev2[0], prev2[1], h2);
-					ps->insert_vertex(curr2[0], curr2[1], h2);
-					ps->insert_vertex(curr1[0], curr1[1], h1);
+					ps->insert_vertex(prev2);
+					ps->insert_vertex(curr2);
+					ps->insert_vertex(curr1);
 				}
 			}
 			prev1 = curr1;

--- a/src/linearextrude.cc
+++ b/src/linearextrude.cc
@@ -55,7 +55,7 @@ AbstractNode *LinearExtrudeModule::instantiate(const Context *ctx, const ModuleI
 	LinearExtrudeNode *node = new LinearExtrudeNode(inst);
 
 	AssignmentList args;
-	args += Assignment("file"), Assignment("layer"), Assignment("height"), Assignment("origin"), Assignment("scale"), Assignment("center"), Assignment("twist"), Assignment("slices");
+	args += Assignment("file"), Assignment("layer"), Assignment("height"), Assignment("origin"), Assignment("scale"), Assignment("center"), Assignment("twist"), Assignment("slices"), Assignment("circulate");
 
 	Context c(ctx);
 	c.setVariables(args, evalctx);
@@ -74,6 +74,7 @@ AbstractNode *LinearExtrudeModule::instantiate(const Context *ctx, const ModuleI
 	ValuePtr center = c.lookup_variable("center", true);
 	ValuePtr twist = c.lookup_variable("twist", true);
 	ValuePtr slices = c.lookup_variable("slices", true);
+	ValuePtr circulate = c.lookup_variable("circulate", true);
 
 	if (!file->isUndefined() && file->type() == Value::STRING) {
 		printDeprecation("Support for reading files in linear_extrude will be removed in future releases. Use a child import() instead.");
@@ -113,6 +114,10 @@ AbstractNode *LinearExtrudeModule::instantiate(const Context *ctx, const ModuleI
 	double slicesVal = 0;
 	slices->getFiniteDouble(slicesVal);
 	node->slices = (int)slicesVal;
+
+	double circulateVal = 0;
+	circulate->getFiniteDouble(circulateVal);
+	node->circulate = (int)circulateVal;
 
 	node->twist = 0.0;
 	twist->getFiniteDouble(node->twist);
@@ -156,6 +161,9 @@ std::string LinearExtrudeNode::toString() const
 	}
 	if (this->slices > 1) {
 		stream << ", slices = " << this->slices;
+	}
+	if (this->circulate != 0) {
+		stream << ", circulate = " << this->circulate;
 	}
 	stream << ", scale = [" << this->scale_x << ", " << this->scale_y << "]";
 	stream << ", $fn = " << this->fn << ", $fa = " << this->fa << ", $fs = " << this->fs << ")";

--- a/src/linearextrudenode.h
+++ b/src/linearextrudenode.h
@@ -8,7 +8,7 @@ class LinearExtrudeNode : public AbstractPolyNode
 public:
 	VISITABLE();
 	LinearExtrudeNode(const ModuleInstantiation *mi) : AbstractPolyNode(mi) {
-		convexity = slices = 0;
+		convexity = slices = circulate = 0;
 		fn = fs = fa = height = twist = 0;
 		origin_x = origin_y = 0;
 		scale_x = scale_y = 1;
@@ -17,7 +17,7 @@ public:
 	virtual std::string toString() const;
 	virtual std::string name() const { return "linear_extrude"; }
 
-	int convexity, slices;
+	int convexity, slices, circulate;
 	double fn, fs, fa, height, twist;
 	double origin_x, origin_y, scale_x, scale_y;
 	bool center, has_twist;


### PR DESCRIPTION
I have been considering the problem reported in issue #901 for some time.  This PR adds a parameter `circulate=` to `linear_extrude`, which is the original request in that issue.  As you can see in the attached image, this improves the appearance of a screw thread.

This patch probably needs documentation and an image test before it's suitable for inclusion, not to mention healthy discussion of whether it can even be used safely in enough circumstances to warrant it.  However, it does improve some screw threads quite a bit!

The (fictional) thread below was generated by this openscad program:
````
function frompolar(r, th) = [ cos(th) * r, sin(th) * r ];
function r(th) = 
    let(th = th % 120)
    (th < 32) ? 18 + th / 8 :
    (th < 64) ? 22 :
    (th < 96) ? 18 + (96 - th) / 8 :
    18;

function points() = [for(th=[0:8:359]) frompolar(r(th), th)];

module shape() {
    polygon(points());
}

TH = 720;
SL = 1 + TH/8;
HH = 96;

translate([-24,0,0]) 
linear_extrude(twist=TH, height=HH, slices=SL, center=true) shape();

translate([ 24,0,0]) 
linear_extrude(circulate=1, twist=TH, height=HH, slices=SL, center=true) shape();

translate([ 72,0,0]) 
linear_extrude(circulate=-1, twist=-TH, height=HH, slices=SL, center=true) shape();
````

The leftmost solid is the "original" linear_extrude, showing the issue #901 problem clearly; the middle duplicates it with an appropriate `circulate` parameter, and the third shows that `circulate` can be used for both signs of `twist`.

![xtry](https://cloud.githubusercontent.com/assets/1517291/24843104/0e2ce966-1d65-11e7-9064-a24f6f61b167.png)
