### PR TITLE
fix package name in uni-get-depencies.sh

### DIFF
--- a/scripts/uni-get-dependencies.sh
+++ b/scripts/uni-get-dependencies.sh
@@ -83,7 +83,7 @@ get_debian_deps()
   libeigen3-dev libcgal-dev libopencsg-dev libgmp3-dev libgmp-dev \
   imagemagick libfreetype6-dev \
   gtk-doc-tools libglib2.0-dev gettext xvfb pkg-config ragel
- apt-get -y install libXi-dev libfontconfig-dev
+ apt-get -y install libxi-dev libfontconfig-dev
 }
 
 get_debian_7_deps()


### PR DESCRIPTION
This package must be all lower or it doesn't install on linux mint 18.1 (ubuntu 16.04 based).  I don't think package names ever have captial letters in them on debian based distros.