### PR TITLE
Fixed version going wrong on Windows when the day is less than 10.

### DIFF
--- a/version.pri
+++ b/version.pri
@@ -19,10 +19,10 @@ isEmpty(VERSION) {
 
     QDATE = $$_DATE_
     QDATE_SPLIT = $$split(QDATE)
-    QDAY = $$member(QDATE_SPLIT,2)
+    QDAY = $$num_add($$member(QDATE_SPLIT,2))
     
     !isEmpty(TEST1) { 
-      contains( QDAY, $$DATE_Z ) { 
+      equals( QDAY, $$num_add($$DATE_Z) ) {
         # message("Assuming YYYY/MM/DD format")
         VERSION_YEAR = $$DATE_X 
         VERSION_MONTH = $$DATE_Y
@@ -30,7 +30,7 @@ isEmpty(VERSION) {
       } 
     } else {
       !isEmpty(TEST2) { 
-        contains( DATE_X, $$QDAY ) {
+        equals( QDAY, $$num_add($$DATE_X) ) {
           # message("Assuming DD/MM/YYYY format" $$DATE_X $$DATE_Y $$DATE_Z )
           VERSION_DAY = $$DATE_X
           VERSION_MONTH = $$DATE_Y
@@ -63,11 +63,11 @@ VERSION_YEAR=$$member(VERSION_SPLIT, 0)
 VERSION_MONTH=$$member(VERSION_SPLIT, 1)
 VERSION_DAY=$$member(VERSION_SPLIT, 2)
 
-# Fix for problem with integers with leading zeros
-# being interpreted by C++ as octals. Now they're doubles.
-VERSION_YEAR=$${VERSION_YEAR}.0
-VERSION_MONTH=$${VERSION_MONTH}.0
-VERSION_DAY=$${VERSION_DAY}.0
+# Strip leading zeros to prevent integers with leading zeros
+# being interpreted by C++ as octals. 
+VERSION_YEAR=$$num_add($$VERSION_YEAR)
+VERSION_MONTH=$$num_add($$VERSION_MONTH)
+VERSION_DAY=$$num_add($$VERSION_DAY)
 
 DEFINES += OPENSCAD_VERSION=$$VERSION OPENSCAD_SHORTVERSION=$$SHORTVERSION OPENSCAD_YEAR=$$VERSION_YEAR OPENSCAD_MONTH=$$VERSION_MONTH
 !isEmpty(VERSION_DAY): DEFINES += OPENSCAD_DAY=$$VERSION_DAY


### PR DESCRIPTION
Now strips leading zeros instead of appending .0 to prevent integers being interpreted as octal.