### PR TITLE
Fix recursion check when built with MSYS2.

### DIFF
--- a/mingw-cross-env.pri
+++ b/mingw-cross-env.pri
@@ -33,9 +33,6 @@ CONFIG(mingw-cross-env-shared) {
 
 CONFIG(mingw-cross-env)|CONFIG(mingw-cross-env-shared) {
   QMAKE_CXXFLAGS += -fpermissive
-  WINSTACKSIZE = 8388608 # 8MB # github issue 116
-  QMAKE_CXXFLAGS += -Wl,--stack,$$WINSTACKSIZE
-  LIBS += -Wl,--stack,$$WINSTACKSIZE 
   QMAKE_DEL_FILE = rm -f
   QMAKE_CXXFLAGS_WARN_ON += -Wno-unused-local-typedefs #eigen3
 }

--- a/openscad.pro
+++ b/openscad.pro
@@ -84,10 +84,14 @@ macx {
   QMAKE_MACOSX_DEPLOYMENT_TARGET = 10.8
 }
 
+# Set same stack size for the linker and #define used in PlatformUtils.h
+STACKSIZE = 8388608 # 8MB # github issue 116
+QMAKE_CXXFLAGS += -DSTACKSIZE=$$STACKSIZE
 
 win* {
   RC_FILE = openscad_win32.rc
   QMAKE_CXXFLAGS += -DNOGDI
+  QMAKE_LFLAGS += -Wl,--stack,$$STACKSIZE
 }
 
 mingw* {

--- a/src/PlatformUtils.h
+++ b/src/PlatformUtils.h
@@ -6,7 +6,7 @@
 namespace fs=boost::filesystem;
 
 #define STACK_BUFFER_SIZE (64 * 1024)
-#define STACK_LIMIT_DEFAULT (8 * 1024 * 1024 - STACK_BUFFER_SIZE)
+#define STACK_LIMIT_DEFAULT (STACKSIZE - STACK_BUFFER_SIZE)
 
 namespace PlatformUtils {
         extern const char *OPENSCAD_FOLDER_NAME;

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -47,7 +47,10 @@ set(CMAKE_MODULE_PATH "${CMAKE_SOURCE_DIR}")
 # Set same stack size for the linker and #define used in PlatformUtils.h
 set(STACKSIZE 8388608)
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DSTACKSIZE=${STACKSIZE}")
-set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -Wl,--stack,${STACKSIZE}")
+if(WIN32)
+  set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -Wl,--stack,${STACKSIZE}")
+endif()
+
 # Get GCC version
 if(CMAKE_COMPILER_IS_GNUCXX)
   execute_process(COMMAND ${CMAKE_C_COMPILER} -dumpversion OUTPUT_VARIABLE GCC_VERSION)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -44,7 +44,10 @@ ENDIF(APPLE)
 project(tests)
 
 set(CMAKE_MODULE_PATH "${CMAKE_SOURCE_DIR}")
-
+# Set same stack size for the linker and #define used in PlatformUtils.h
+set(STACKSIZE 8388608)
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DSTACKSIZE=${STACKSIZE}")
+set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -Wl,--stack,${STACKSIZE}")
 # Get GCC version
 if(CMAKE_COMPILER_IS_GNUCXX)
   execute_process(COMMAND ${CMAKE_C_COMPILER} -dumpversion OUTPUT_VARIABLE GCC_VERSION)


### PR DESCRIPTION
Issue #2005. openscad.pro now defines the linker stack size for all Windows builds. It also defines the constant used in platform.h to ensure they match.