### PR TITLE
Fix for #1996 DIFFERENCE clashes with winuser.h

### DIFF
--- a/src/enums.h
+++ b/src/enums.h
@@ -1,4 +1,5 @@
 #pragma once
+#undef DIFFERENCE //#defined in winuser.h
 
 enum class OpenSCADOperator {
 	UNION, 


### PR DESCRIPTION
C++11 might prefer scoped enums but they don't play well with #define.