### PR TITLE
Make used file paths generic in the dependency file.

### DIFF
--- a/src/lexer.l
+++ b/src/lexer.l
@@ -145,7 +145,7 @@ use[ \t\r\n]*"<"	{ BEGIN(cond_use); }
           PRINTB("WARNING: Can't open library '%s'.", filename);
           parserlval.text = strdup(filename.c_str());
 	} else {
-          handle_dep(fullpath.string());
+          handle_dep(fullpath.generic_string());
           parserlval.text = strdup(fullpath.string().c_str());
 	}
         return TOK_USE;


### PR DESCRIPTION
Uses fs::path::generic_string() for used files so they have the same format as included files.

Before this fix used paths would be in Windows format and included files in Unix format in the dependency file.