### PR TITLE
Fixed imports and surface files missing from dependencies.

### DIFF
--- a/src/dxfdata.cc
+++ b/src/dxfdata.cc
@@ -27,7 +27,6 @@
 #include "dxfdata.h"
 #include "grid.h"
 #include "printutils.h"
-#include "handle_dep.h"
 #include "calc.h"
 
 #include <fstream>
@@ -79,8 +78,6 @@ DxfData::DxfData(double fn, double fs, double fa,
 								 const std::string &filename, const std::string &layername, 
 								 double xorigin, double yorigin, double scale)
 {
-	handle_dep(filename); // Register ourselves as a dependency
-
 	std::ifstream stream(filename.c_str());
 	if (!stream.good()) {
 		PRINTB("WARNING: Can't open DXF file '%s'.", filename);

--- a/src/dxfdim.cc
+++ b/src/dxfdim.cc
@@ -32,6 +32,7 @@
 #include "printutils.h"
 #include "fileutils.h"
 #include "evalcontext.h"
+#include "handle_dep.h"
 
 #include <cmath>
 #include <sstream>
@@ -59,7 +60,7 @@ ValuePtr builtin_dxf_dim(const Context *ctx, const EvalContext *evalctx)
 		ValuePtr v = evalctx->getArgValue(i);
 		if (evalctx->getArgName(i) == "file") {
 			filename = lookup_file(v->toString(), 
-														 evalctx->documentPath(), ctx->documentPath());
+			evalctx->documentPath(), ctx->documentPath());
 		}
 		if (n == "layer") layername = v->toString();
 		if (n == "origin") v->getVec2(xorigin, yorigin);
@@ -81,7 +82,7 @@ ValuePtr builtin_dxf_dim(const Context *ctx, const EvalContext *evalctx)
 	std::string key = keystream.str();
 	if (dxf_dim_cache.find(key) != dxf_dim_cache.end())
 		return dxf_dim_cache.find(key)->second;
-
+	handle_dep(filepath.string());
 	DxfData dxf(36, 0, 0, filename, layername, xorigin, yorigin, scale);
 
 	for (size_t i = 0; i < dxf.dims.size(); i++)
@@ -170,10 +171,9 @@ ValuePtr builtin_dxf_cross(const Context *ctx, const EvalContext *evalctx)
 						<< "|" << filesize;
 	std::string key = keystream.str();
 
-	if (dxf_cross_cache.find(key) != dxf_cross_cache.end()) {
+	if (dxf_cross_cache.find(key) != dxf_cross_cache.end())
 		return dxf_cross_cache.find(key)->second;
-	}
-
+	handle_dep(filepath.string());
 	DxfData dxf(36, 0, 0, filename, layername, xorigin, yorigin, scale);
 
 	double coords[4][2];

--- a/src/handle_dep.cc
+++ b/src/handle_dep.cc
@@ -13,10 +13,7 @@ const char *make_command = nullptr;
 void handle_dep(const std::string &filename)
 {
 	fs::path filepath(filename);
-	std::string dep;
-	if (filepath.is_absolute()) dep = filename;
-	else dep = (fs::current_path() / filepath).string();
-	dependencies.insert(boost::regex_replace(filename, boost::regex("\\ "), "\\\\ "));
+	dependencies.insert(boost::regex_replace(filepath.generic_string(), boost::regex("\\ "), "\\\\ "));
 
 	if (!fs::exists(filepath) && make_command) {
 		std::stringstream buf;

--- a/src/handle_dep.cc
+++ b/src/handle_dep.cc
@@ -13,9 +13,12 @@ const char *make_command = nullptr;
 void handle_dep(const std::string &filename)
 {
 	fs::path filepath(filename);
-	dependencies.insert(boost::regex_replace(filepath.generic_string(), boost::regex("\\ "), "\\\\ "));
+	std::string dep = boost::regex_replace(filepath.generic_string(), boost::regex("\\ "), "\\\\ ");
+	if(dependencies.find(dep) != dependencies.end())
+		return; // included and used files are very likely to be added many times by the parser
+	dependencies.insert(dep);
 
-	if (!fs::exists(filepath) && make_command) {
+	if (make_command && !fs::exists(filepath)) {
 		std::stringstream buf;
 		buf << make_command << " '" << boost::regex_replace(filename, boost::regex("'"), "'\\''") << "'";
 		system(buf.str().c_str()); // FIXME: Handle error

--- a/src/import.cc
+++ b/src/import.cc
@@ -100,7 +100,8 @@ AbstractNode *ImportModule::instantiate(const Context *ctx, const ModuleInstanti
 		}
 	}
 	std::string filename = lookup_file(v->isUndefined() ? "" : v->toString(), inst->path(), ctx->documentPath());
-	handle_dep(filename);
+	if(!filename.empty())
+		handle_dep(filename);
 	ImportType actualtype = this->type;
 	if (actualtype == ImportType::UNKNOWN) {
 		std::string extraw = fs::path(filename).extension().generic_string();

--- a/src/import.cc
+++ b/src/import.cc
@@ -40,6 +40,7 @@
 #include "printutils.h"
 #include "fileutils.h"
 #include "feature.h"
+#include "handle_dep.h"
 
 #include <sys/types.h>
 #include <sstream>
@@ -99,6 +100,7 @@ AbstractNode *ImportModule::instantiate(const Context *ctx, const ModuleInstanti
 		}
 	}
 	std::string filename = lookup_file(v->isUndefined() ? "" : v->toString(), inst->path(), ctx->documentPath());
+	handle_dep(filename);
 	ImportType actualtype = this->type;
 	if (actualtype == ImportType::UNKNOWN) {
 		std::string extraw = fs::path(filename).extension().generic_string();

--- a/src/import_nef.cc
+++ b/src/import_nef.cc
@@ -1,6 +1,5 @@
 #include "import.h"
 #include "printutils.h"
-#include "handle_dep.h" // handle_dep()
 
 #ifdef ENABLE_CGAL
 #include "CGAL_Nef_polyhedron.h"
@@ -11,7 +10,6 @@ CGAL_Nef_polyhedron *import_nef3(const std::string &filename)
 {
 	CGAL_Nef_polyhedron *N = new CGAL_Nef_polyhedron;
 
-	handle_dep(filename);
 	// Open file and position at the end
 	std::ifstream f(filename.c_str(), std::ios::in | std::ios::binary);
 	if (!f.good()) {

--- a/src/import_stl.cc
+++ b/src/import_stl.cc
@@ -1,6 +1,5 @@
 #include "import.h"
 #include "polyset.h"
-#include "handle_dep.h" // handle_dep()
 #include "printutils.h"
 
 #include <boost/algorithm/string.hpp>
@@ -57,7 +56,6 @@ PolySet *import_stl(const std::string &filename)
 {
 	PolySet *p = new PolySet(3);
 
-	handle_dep(filename);
 	// Open file and position at the end
 	std::ifstream f(filename.c_str(), std::ios::in | std::ios::binary | std::ios::ate);
 	if (!f.good()) {

--- a/src/linearextrude.cc
+++ b/src/linearextrude.cc
@@ -34,6 +34,7 @@
 #include "builtin.h"
 #include "calc.h"
 #include "polyset.h"
+#include "handle_dep.h"
 
 #include <cmath>
 #include <sstream>
@@ -76,7 +77,9 @@ AbstractNode *LinearExtrudeModule::instantiate(const Context *ctx, const ModuleI
 
 	if (!file->isUndefined() && file->type() == Value::ValueType::STRING) {
 		printDeprecation("Support for reading files in linear_extrude will be removed in future releases. Use a child import() instead.");
-		node->filename = lookup_file(file->toString(), inst->path(), c.documentPath());
+		std::string filename = lookup_file(file->toString(), inst->path(), c.documentPath());
+		node->filename = filename;
+		handle_dep(filename);
 	}
 
 	// if height not given, and first argument is a number,

--- a/src/openscad.cc
+++ b/src/openscad.cc
@@ -437,6 +437,17 @@ int cmdline(const char *deps_output_file, const std::string &filename, Camera &c
 	}
 	tree.setRoot(root_node);
 
+	if (deps_output_file) {
+		fs::current_path(original_path);
+		std::string deps_out(deps_output_file);
+		std::string geom_out(output_file);
+		int result = write_deps(deps_out, geom_out);
+		if (!result) {
+			PRINT("error writing deps");
+			return 1;
+		}
+	}
+
 	if (csg_output_file) {
 		fs::current_path(original_path);
 		std::ofstream fstream(csg_output_file);
@@ -499,27 +510,6 @@ int cmdline(const char *deps_output_file, const std::string &filename, Camera &c
 		}
 
 		fs::current_path(original_path);
-
-		if (deps_output_file) {
-			std::string deps_out(deps_output_file);
-			std::string geom_out;
-			if (stl_output_file) geom_out = std::string(stl_output_file);
-			else if (off_output_file) geom_out = std::string(off_output_file);
-			else if (amf_output_file) geom_out = std::string(amf_output_file);
-			else if (dxf_output_file) geom_out = std::string(dxf_output_file);
-			else if (svg_output_file) geom_out = std::string(svg_output_file);
-			else if (png_output_file) geom_out = std::string(png_output_file);
-			else {
-				PRINTB("Output file:%s\n",output_file);
-				PRINT("Sorry, don't know how to write deps for that file type. Exiting\n");
-				return 1;
-			}
-			int result = write_deps(deps_out, geom_out);
-			if (!result) {
-				PRINT("error writing deps");
-				return 1;
-			}
-		}
 
 		if (stl_output_file) {
 			if (!checkAndExport(root_geom, 3, FileFormat::STL, stl_output_file)) {

--- a/src/rotateextrude.cc
+++ b/src/rotateextrude.cc
@@ -32,6 +32,7 @@
 #include "fileutils.h"
 #include "builtin.h"
 #include "polyset.h"
+#include "handle_dep.h"
 
 #include <sstream>
 #include <boost/assign/std/vector.hpp>
@@ -71,7 +72,9 @@ AbstractNode *RotateExtrudeModule::instantiate(const Context *ctx, const ModuleI
     
 	if (!file->isUndefined()) {
 		printDeprecation("Support for reading files in rotate_extrude will be removed in future releases. Use a child import() instead.");
-		node->filename = lookup_file(file->toString(), inst->path(), c.documentPath());
+		std::string filename = lookup_file(file->toString(), inst->path(), c.documentPath());
+		node->filename = filename;
+		handle_dep(filename);
 	}
 
 	node->layername = layer->isUndefined() ? "" : layer->toString();

--- a/src/surface.cc
+++ b/src/surface.cc
@@ -32,7 +32,7 @@
 #include "builtin.h"
 #include "printutils.h"
 #include "fileutils.h"
-#include "handle_dep.h" // handle_dep()
+#include "handle_dep.h"
 #include "lodepng.h"
 
 #include <cstdint>
@@ -93,7 +93,9 @@ AbstractNode *SurfaceModule::instantiate(const Context *ctx, const ModuleInstant
 	c.setVariables(args, evalctx);
 
 	auto fileval = c.lookup_variable("file");
-	node->filename = lookup_file(fileval->isUndefined() ? "" : fileval->toString(), inst->path(), c.documentPath());
+	std::string filename = lookup_file(fileval->isUndefined() ? "" : fileval->toString(), inst->path(), c.documentPath());
+	node->filename = filename;
+	handle_dep(fs::path(filename).generic_string());
 
 	auto center = c.lookup_variable("center", true);
 	if (center->type() == Value::ValueType::BOOL) {


### PR DESCRIPTION
Fix for #2024.

Dependencies can now be written for all file types, e.g. echo because they are added at module instantiation time rather than when the file is read to create geometry.