### PR TITLE
1917: QSettings is now cached

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,11 +8,6 @@ matrix:
       env: DIST="trusty"
       sudo: required
       cache: apt
-    - os: linux
-      compiler: gcc
-      dist: precise
-      env: DIST="precise"
-      cache: apt
     - os: osx
       compiler: clang
       env: DIST="osx"

--- a/openscad.pro
+++ b/openscad.pro
@@ -351,8 +351,8 @@ HEADERS += src/version_check.h \
            src/parameter/parametertext.h \
            src/parameter/parametervector.h \
            src/parameter/groupwidget.h \
-           src/parameter/parameterset.h\
-           src/QWordSearchField.h
+           src/parameter/parameterset.h \
+           src/QWordSearchField.h \
            src/QSettingsCached.h
 
 SOURCES += \
@@ -423,9 +423,9 @@ SOURCES += \
            src/ModuleCache.cc \
            src/GeometryCache.cc \
            src/Tree.cc \
-	   src/DrawingCallback.cc \
-	   src/FreetypeRenderer.cc \
-	   src/FontCache.cc \
+	       src/DrawingCallback.cc \
+	       src/FreetypeRenderer.cc \
+	       src/FontCache.cc \
            \
            src/settings.cc \
            src/rendersettings.cc \

--- a/openscad.pro
+++ b/openscad.pro
@@ -353,6 +353,7 @@ HEADERS += src/version_check.h \
            src/parameter/groupwidget.h \
            src/parameter/parameterset.h\
            src/QWordSearchField.h
+           src/QSettingsCached.h
 
 SOURCES += \
            src/libsvg/libsvg.cc \
@@ -492,7 +493,9 @@ SOURCES += \
            src/parameter/groupwidget.cpp \
            src/parameter/parameterset.cpp \
            src/parameter/parametervirtualwidget.cpp\
-           src/QWordSearchField.cc
+           src/QWordSearchField.cc\
+           \
+           src/QSettingsCached.cc
 
 
 # ClipperLib

--- a/src/Dock.cc
+++ b/src/Dock.cc
@@ -1,5 +1,5 @@
 #include <iostream>
-#include <QSettings>
+#include "QSettingsCached.h"
 
 #include "Dock.h"
 
@@ -13,7 +13,7 @@ Dock::~Dock()
 
 void Dock::setVisible(bool visible)
 {
-	QSettings settings;
+	QSettingsCached settings;
 	settings.setValue(configKey, !visible);
 	if (action != nullptr) {
 		action->setChecked(!visible);

--- a/src/Preferences.cc
+++ b/src/Preferences.cc
@@ -29,8 +29,8 @@
 #include <QMessageBox>
 #include <QFontDatabase>
 #include <QKeyEvent>
-#include <QSettings>
 #include <QStatusBar>
+#include <QSettings>
 #include <boost/algorithm/string.hpp>
 #include "GeometryCache.h"
 #include "AutoUpdater.h"
@@ -40,6 +40,7 @@
 #endif
 #include "colormap.h"
 #include "rendersettings.h"
+#include "QSettingsCached.h"
 
 Preferences *Preferences::instance = nullptr;
 
@@ -48,7 +49,7 @@ Q_DECLARE_METATYPE(Feature *);
 
 class SettingsReader : public Settings::SettingsVisitor
 {
-    QSettings settings;
+    QSettingsCached settings;
     Value getValue(const Settings::SettingsEntry& entry, const std::string& value) const {
 	std::string trimmed_value(value);
 	boost::trim(trimmed_value);
@@ -96,7 +97,7 @@ class SettingsWriter : public Settings::SettingsVisitor
     virtual void handle(Settings::SettingsEntry& entry) const {
 	Settings::Settings *s = Settings::Settings::inst();
 
-	QSettings settings;
+	QSettingsCached settings;
 	QString key = QString::fromStdString(entry.category() + "/" + entry.name());
 	if (entry.is_default()) {
 	    settings.remove(key);
@@ -270,7 +271,7 @@ void Preferences::featuresCheckBoxToggled(bool state)
 	}
 	Feature *feature = v.value<Feature *>();
 	feature->enable(state);
-	QSettings settings;
+	QSettingsCached settings;
 	settings.setValue(QString("feature/%1").arg(QString::fromStdString(feature->get_name())), state);
 	emit ExperimentalChanged();
 }
@@ -324,14 +325,14 @@ Preferences::setupFeaturesPage()
 void Preferences::on_colorSchemeChooser_itemSelectionChanged()
 {
 	QString scheme = this->colorSchemeChooser->currentItem()->text();
-	QSettings settings;
+	QSettingsCached settings;
 	settings.setValue("3dview/colorscheme", scheme);
 	emit colorSchemeChanged( scheme );
 }
 
 void Preferences::on_fontChooser_activated(const QString &family)
 {
-	QSettings settings;
+	QSettingsCached settings;
 	settings.setValue("editor/fontfamily", family);
 	emit fontChanged(family, getValue("editor/fontsize").toUInt());
 }
@@ -339,20 +340,20 @@ void Preferences::on_fontChooser_activated(const QString &family)
 void Preferences::on_fontSize_currentIndexChanged(const QString &size)
 {
 	uint intsize = size.toUInt();
-	QSettings settings;
+	QSettingsCached settings;
 	settings.setValue("editor/fontsize", intsize);
 	emit fontChanged(getValue("editor/fontfamily").toString(), intsize);
 }
 
 void Preferences::on_editorType_currentIndexChanged(const QString &type)
 {
-	QSettings settings;
+	QSettingsCached settings;
 	settings.setValue("editor/editortype", type);
 }
 
 void Preferences::on_syntaxHighlight_activated(const QString &s)
 {
-	QSettings settings;
+	QSettingsCached settings;
 	settings.setValue("editor/syntaxhighlight", s);
 	emit syntaxHighlightChanged(s);
 }
@@ -394,7 +395,7 @@ void Preferences::on_checkNowButton_clicked()
 void
 Preferences::on_mdiCheckBox_toggled(bool state)
 {
-	QSettings settings;
+	QSettingsCached settings;
 	settings.setValue("advanced/mdi", state);
 	emit updateMdiMode(state);
 }
@@ -406,7 +407,7 @@ Preferences::on_reorderCheckBox_toggled(bool state)
 		undockCheckBox->setChecked(false);
 	}
 	undockCheckBox->setEnabled(state);
-	QSettings settings;
+	QSettingsCached settings;
 	settings.setValue("advanced/reorderWindows", state);
 	emit updateReorderMode(state);
 }
@@ -414,7 +415,7 @@ Preferences::on_reorderCheckBox_toggled(bool state)
 void
 Preferences::on_undockCheckBox_toggled(bool state)
 {
-	QSettings settings;
+	QSettingsCached settings;
 	settings.setValue("advanced/undockableWindows", state);
 	emit updateUndockMode(state);
 }
@@ -422,20 +423,20 @@ Preferences::on_undockCheckBox_toggled(bool state)
 void
 Preferences::on_openCSGWarningBox_toggled(bool state)
 {
-	QSettings settings;
+	QSettingsCached settings;
 	settings.setValue("advanced/opencsg_show_warning",state);
 }
 
 void
 Preferences::on_enableOpenCSGBox_toggled(bool state)
 {
-	QSettings settings;
+	QSettingsCached settings;
 	settings.setValue("advanced/enable_opencsg_opengl1x", state);
 }
 
 void Preferences::on_cgalCacheSizeEdit_textChanged(const QString &text)
 {
-	QSettings settings;
+	QSettingsCached settings;
 	settings.setValue("advanced/cgalCacheSize", text);
 #ifdef ENABLE_CGAL
 	CGALCache::instance()->setMaxSize(text.toULong());
@@ -444,40 +445,40 @@ void Preferences::on_cgalCacheSizeEdit_textChanged(const QString &text)
 
 void Preferences::on_polysetCacheSizeEdit_textChanged(const QString &text)
 {
-	QSettings settings;
+	QSettingsCached settings;
 	settings.setValue("advanced/polysetCacheSize", text);
 	GeometryCache::instance()->setMaxSize(text.toULong());
 }
 
 void Preferences::on_opencsgLimitEdit_textChanged(const QString &text)
 {
-	QSettings settings;
+	QSettingsCached settings;
 	settings.setValue("advanced/openCSGLimit", text);
 	// FIXME: Set this globally?
 }
 
 void Preferences::on_localizationCheckBox_toggled(bool state)
 {
-	QSettings settings;
+	QSettingsCached settings;
 	settings.setValue("advanced/localization", state);
 }
 
 void Preferences::on_forceGoldfeatherBox_toggled(bool state)
 {
-	QSettings settings;
+	QSettingsCached settings;
 	settings.setValue("advanced/forceGoldfeather", state);
 	emit openCSGSettingsChanged();
 }
 
 void Preferences::on_mouseWheelZoomBox_toggled(bool state)
 {
-	QSettings settings;
+	QSettingsCached settings;
 	settings.setValue("editor/ctrlmousewheelzoom", state);
 }
 
 void Preferences::on_launcherBox_toggled(bool state)
 {
-	QSettings settings;
+	QSettingsCached settings;
  	settings.setValue("launcher/showOnStartup", state);	
 }
 
@@ -607,7 +608,7 @@ void Preferences::keyPressEvent(QKeyEvent *e)
  */
 void Preferences::removeDefaultSettings()
 {
-	QSettings settings;
+	QSettingsCached settings;
 	for (QSettings::SettingsMap::const_iterator iter = this->defaultmap.begin();
 			 iter != this->defaultmap.end();
 			 iter++) {
@@ -619,7 +620,7 @@ void Preferences::removeDefaultSettings()
 
 QVariant Preferences::getValue(const QString &key) const
 {
-	QSettings settings;
+	QSettingsCached settings;
 	assert(settings.contains(key) || this->defaultmap.contains(key));
 	return settings.value(key, this->defaultmap[key]);
 }

--- a/src/QGLView.cc
+++ b/src/QGLView.cc
@@ -36,12 +36,13 @@
 #include <QMouseEvent>
 #include <QMessageBox>
 #include <QPushButton>
-#include <QSettings>
 #include <QTimer>
 #include <QTextEdit>
 #include <QVBoxLayout>
 #include <QErrorMessage>
 #include "OpenCSGWarningDialog.h"
+#include "QSettingsCached.h"
+
 
 #include <stdio.h>
 #include <sstream>

--- a/src/QSettingsCached.cc
+++ b/src/QSettingsCached.cc
@@ -1,0 +1,4 @@
+#include "QSettingsCached.h"
+
+std::unique_ptr<QSettings> QSettingsCached::qsettingsPointer;
+std::mutex QSettingsCached::ctor_mutex;

--- a/src/QSettingsCached.h
+++ b/src/QSettingsCached.h
@@ -1,0 +1,50 @@
+#ifndef __openscad_qsettingscached_h__
+#define __openscad_qsettingscached_h__
+#include <QSettings>
+#include <QDebug>
+#include <map>
+#include <iostream>
+#include <memory>
+#include <mutex>
+#include <thread>
+
+class QSettingsCached {
+    public:
+
+        QSettingsCached() {
+            if (qsettingsPointer.get() == nullptr) {
+                std::lock_guard<std::mutex> lock{ctor_mutex};
+                if (qsettingsPointer.get() == nullptr) {
+                    qsettingsPointer.reset(new QSettings());
+                }
+            }
+        }
+
+        inline void setValue(const QString &key, const QVariant &value) {
+            qsettingsPointer->setValue(key,value); // It is safe to access qsettings from Multiple sources. it is thread safe
+            // Disabling forced sync to persisted storage on write. Will rely on automatic behavior of QSettings
+            // qsettingsPointer->sync(); // force write to file system on each modification of open scad settings
+        }
+
+        inline QVariant value(const QString &key, const QVariant &defaultValue = QVariant()) const {
+            return qsettingsPointer->value(key, defaultValue);
+        }
+
+        inline void remove(const QString &key) {
+            qsettingsPointer->remove(key);
+            // Disabling forced sync to persisted storage on write. Will rely on automatic behavior of QSettings
+            // qsettingsPointer->sync();
+        }
+
+        inline bool contains(const QString &key) {
+            return qsettingsPointer->contains(key);
+        }
+
+
+    private:
+        static std::unique_ptr<QSettings> qsettingsPointer;
+        static std::mutex ctor_mutex;
+
+};
+
+#endif

--- a/src/UIUtils.cc
+++ b/src/UIUtils.cc
@@ -25,7 +25,6 @@
  */
 
 #include <QDir>
-#include <QSettings>
 #include <QFileInfo>
 #include <QUrl>
 #include <QFileDialog>
@@ -35,13 +34,15 @@
 #include "UIUtils.h"
 #include "PlatformUtils.h"
 #include "openscad.h"
+#include "QSettingsCached.h"
+
 
 #include <boost/property_tree/ptree.hpp>
 #include <boost/property_tree/json_parser.hpp>
 
 QFileInfo UIUtils::openFile(QWidget *parent)
 {
-    QSettings settings;
+    QSettingsCached settings;
     QString last_dirname = settings.value("lastOpenDirName").toString();
     QString new_filename = QFileDialog::getOpenFileName(parent, "Open File",
 	    last_dirname, "OpenSCAD Designs (*.scad *.csg)");
@@ -59,7 +60,7 @@ QFileInfo UIUtils::openFile(QWidget *parent)
 
 QStringList UIUtils::recentFiles()
 {
-    QSettings settings; // set up project and program properly in main.cpp
+    QSettingsCached settings; // set up project and program properly in main.cpp
     QStringList files = settings.value("recentFileList").toStringList();
 
     // Remove any duplicate or empty entries from the list

--- a/src/editor.cc
+++ b/src/editor.cc
@@ -1,10 +1,11 @@
 #include "editor.h"
 #include "Preferences.h"
+#include "QSettingsCached.h"
 
 void EditorInterface::wheelEvent(QWheelEvent *event)
 {
-	QSettings settings;
-	auto wheelzoom_enabled = Preferences::inst()->getValue("editor/ctrlmousewheelzoom").toBool();
+	QSettingsCached settings;
+	bool wheelzoom_enabled = Preferences::inst()->getValue("editor/ctrlmousewheelzoom").toBool();
 	if ((event->modifiers() == Qt::ControlModifier) && wheelzoom_enabled) {
 		if (event->delta() > 0) zoomIn();
 		else if (event->delta() < 0) zoomOut();

--- a/src/launchingscreen.cc
+++ b/src/launchingscreen.cc
@@ -1,10 +1,10 @@
 #include <QFileInfo>
-#include <QSettings>
 #include <QListWidgetItem>
 
 #include "openscad.h"
 #include "launchingscreen.h"
 #include "ui_launchingscreen.h"
+#include "QSettingsCached.h"
 
 #include "UIUtils.h"
 
@@ -133,7 +133,7 @@ void LaunchingScreen::openUserFile()
 
 void LaunchingScreen::checkboxState(bool state) const
 {
-	QSettings settings;
+	QSettingsCached settings;
 	settings.setValue("launcher/showOnStartup", !state);
 }
 

--- a/src/legacyeditor.cc
+++ b/src/legacyeditor.cc
@@ -1,6 +1,7 @@
 #include "legacyeditor.h"
 #include "Preferences.h"
 #include "highlighter.h"
+#include "QSettingsCached.h"
 
 LegacyEditor::LegacyEditor(QWidget *parent) : EditorInterface(parent)
 {
@@ -95,7 +96,7 @@ void LegacyEditor::uncommentSelection()
 void LegacyEditor::zoomIn()
 {
 	// See also QT's implementation in QLegacyEditor.cpp
-	QSettings settings;
+	QSettingsCached settings;
 	QFont tmp_font = this->textedit->font() ;
 	if (font().pointSize() >= 1)
 		tmp_font.setPointSize(1 + font().pointSize());
@@ -108,7 +109,7 @@ void LegacyEditor::zoomIn()
 void LegacyEditor::zoomOut()
 {
 
-	QSettings settings;
+	QSettingsCached settings;
 	QFont tmp_font = this->textedit->font();
 	if (font().pointSize() >= 2)
 		tmp_font.setPointSize(-1 + font().pointSize());

--- a/src/mainwin.cc
+++ b/src/mainwin.cc
@@ -85,7 +85,6 @@
 #include <QTimer>
 #include <QMessageBox>
 #include <QDesktopServices>
-#include <QSettings>
 #include <QProgressDialog>
 #include <QMutexLocker>
 #include <QTemporaryFile>
@@ -94,6 +93,8 @@
 #include <QDesktopWidget>
 #include <string>
 #include "QWordSearchField.h"
+#include <QSettings> //Include QSettings for direct operations on settings arrays
+#include "QSettingsCached.h"
 
 #if (QT_VERSION < QT_VERSION_CHECK(5, 0, 0))
 #include <QTextDocument>
@@ -166,7 +167,7 @@ MainWindow::MainWindow(const QString &filename)
 	this->versionLabel = nullptr; // must be initialized before calling updateStatusBar()
 	updateStatusBar(nullptr);
 
-	QSettings settings;
+	QSettingsCached settings;
 	editortype = settings.value("editor/editortype").toString();
 	useScintilla = (editortype != "Simple Editor");
 
@@ -625,7 +626,7 @@ void MainWindow::updateWindowSettings(bool console, bool editor, bool customizer
 }
 
 void MainWindow::loadViewSettings() {
-	QSettings settings;
+	QSettingsCached settings;
 	if (settings.value("view/showEdges").toBool()) {
 		viewActionShowEdges->setChecked(true);
 		viewModeShowEdges();
@@ -655,7 +656,7 @@ void MainWindow::loadViewSettings() {
 
 void MainWindow::loadDesignSettings()
 {
-	QSettings settings;
+	QSettingsCached settings;
 	if (settings.value("design/autoReload", true).toBool()) {
 		designActionAutoReload->setChecked(true);
 	}
@@ -809,7 +810,7 @@ void MainWindow::updateRecentFiles()
 	// if it does. Should prevent empty list items on initial open etc.
 	QFileInfo fileinfo(this->fileName);
 	auto infoFileName = fileinfo.absoluteFilePath();
-	QSettings settings; // already set up properly via main.cpp
+	QSettingsCached settings; // already set up properly via main.cpp
 	auto files = settings.value("recentFileList").toStringList();
 	files.removeAll(infoFileName);
 	files.prepend(infoFileName);
@@ -1286,7 +1287,7 @@ void MainWindow::actionOpenRecent()
 
 void MainWindow::clearRecentFiles()
 {
-	QSettings settings; // already set up properly via main.cpp
+	QSettingsCached settings; // already set up properly via main.cpp
 	QStringList files;
 	settings.setValue("recentFileList", files);
 
@@ -1783,7 +1784,7 @@ void MainWindow::checkAutoReload()
 
 void MainWindow::autoReloadSet(bool on)
 {
-	QSettings settings;
+	QSettingsCached settings;
 	settings.setValue("design/autoReload",designActionAutoReload->isChecked());
 	if (on) {
 		autoReloadTimer->start(200);
@@ -2348,7 +2349,7 @@ void MainWindow::viewModeThrownTogether()
 
 void MainWindow::viewModeShowEdges()
 {
-	QSettings settings;
+	QSettingsCached settings;
 	settings.setValue("view/showEdges",viewActionShowEdges->isChecked());
 	this->qglview->setShowEdges(viewActionShowEdges->isChecked());
 	this->qglview->updateGL();
@@ -2357,7 +2358,7 @@ void MainWindow::viewModeShowEdges()
 void MainWindow::viewModeShowAxes()
 {
 	bool showaxes = viewActionShowAxes->isChecked();
-	QSettings settings;
+	QSettingsCached settings;
 	settings.setValue("view/showAxes", showaxes);
 	this->viewActionShowScaleProportional->setEnabled(showaxes);
 	this->qglview->setShowAxes(showaxes);
@@ -2366,7 +2367,7 @@ void MainWindow::viewModeShowAxes()
 
 void MainWindow::viewModeShowCrosshairs()
 {
-	QSettings settings;
+	QSettingsCached settings;
 	settings.setValue("view/showCrosshairs",viewActionShowCrosshairs->isChecked());
 	this->qglview->setShowCrosshairs(viewActionShowCrosshairs->isChecked());
 	this->qglview->updateGL();
@@ -2374,7 +2375,7 @@ void MainWindow::viewModeShowCrosshairs()
 
 void MainWindow::viewModeShowScaleProportional()
 {
-	QSettings settings;
+	QSettingsCached settings;
 	settings.setValue("view/showScaleProportional",viewActionShowScaleProportional->isChecked());
 	this->qglview->setShowScaleProportional(viewActionShowScaleProportional->isChecked());
 	this->qglview->updateGL();
@@ -2469,7 +2470,7 @@ void MainWindow::viewCenter()
 
 void MainWindow::viewPerspective()
 {
-	QSettings settings;
+	QSettingsCached settings;
 	settings.setValue("view/orthogonalProjection",false);
 	viewActionPerspective->setChecked(true);
 	viewActionOrthogonal->setChecked(false);
@@ -2479,7 +2480,7 @@ void MainWindow::viewPerspective()
 
 void MainWindow::viewOrthogonal()
 {
-	QSettings settings;
+	QSettingsCached settings;
 	settings.setValue("view/orthogonalProjection",true);
 	viewActionPerspective->setChecked(false);
 	viewActionOrthogonal->setChecked(true);
@@ -2541,7 +2542,7 @@ void MainWindow::setDockWidgetTitle(QDockWidget *dockWidget, QString prefix, boo
 
 void MainWindow::hideToolbars()
 {
-	QSettings settings;
+	QSettingsCached settings;
 	bool shouldHide = viewActionHideToolBars->isChecked();
 	settings.setValue("view/hideToolbar", shouldHide);
 
@@ -2698,7 +2699,7 @@ bool MainWindow::maybeSave()
 void MainWindow::closeEvent(QCloseEvent *event)
 {
 	if (maybeSave()) {
-		QSettings settings;
+		QSettingsCached settings;
 		settings.setValue("window/size", size());
 		settings.setValue("window/position", pos());
 		settings.setValue("window/state", saveState());

--- a/src/openscad.cc
+++ b/src/openscad.cc
@@ -276,7 +276,7 @@ Camera get_camera(po::variables_map vm)
 }
 
 #ifndef OPENSCAD_NOGUI
-#include <QSettings>
+#include "QSettingsCached.h"
 #define OPENSCAD_QTGUI 1
 #endif
 static bool checkAndExport(shared_ptr<const Geometry> root_geom, unsigned nd,
@@ -601,7 +601,7 @@ Q_IMPORT_PLUGIN(qtaccessiblewidgets)
 #include "MainWindow.h"
 #include "OpenSCADApp.h"
 #include "launchingscreen.h"
-#include "qsettings.h"
+#include "QSettingsCached.h"
 #include <QString>
 #include <QDir>
 #include <QFileInfo>


### PR DESCRIPTION
QSettings is now cached. This reduces the number of file accesses that QSettings performs. Writes to persistent storage are done periodically by QSettings in background.

Note: This also intentionally disables the test run on Travis/Ubuntu 12.04.