### PR TITLE
Laser cutter SVG output

### DIFF
--- a/src/Preferences.cc
+++ b/src/Preferences.cc
@@ -196,13 +196,13 @@ void Preferences::init() {
 
   // Advanced pane	
 	QValidator *intValidator = new QIntValidator(this);
-	QValidator *floatValidator = new QDoubleValidator(this);
+	QValidator *doubleValidator = new QDoubleValidator(this);
 #ifdef ENABLE_CGAL
 	this->cgalCacheSizeEdit->setValidator(intValidator);
 #endif
 	this->polysetCacheSizeEdit->setValidator(intValidator);
 	this->opencsgLimitEdit->setValidator(intValidator);
-	this->laserOffset->setValidator(floatValidator);
+	this->laserOffset->setValidator(doubleValidator);
 
 	initComboBox(this->comboBoxIndentUsing, Settings::Settings::indentStyle);
 	initComboBox(this->comboBoxLineWrap, Settings::Settings::lineWrap);

--- a/src/Preferences.cc
+++ b/src/Preferences.cc
@@ -168,6 +168,8 @@ void Preferences::init() {
 	this->defaultmap["advanced/reorderWindows"] = true;
 	this->defaultmap["launcher/showOnStartup"] = true;
 	this->defaultmap["advanced/localization"] = true;
+	this->defaultmap["advanced/laserColors"] = false;
+	this->defaultmap["advanced/laserOffset"] = 0.0;
 
 	// Toolbar
 	QActionGroup *group = new QActionGroup(this);
@@ -193,12 +195,14 @@ void Preferences::init() {
 	this->defaultmap["3dview/colorscheme"] = "Cornfield";
 
   // Advanced pane	
-	QValidator *validator = new QIntValidator(this);
+	QValidator *intValidator = new QIntValidator(this);
+	QValidator *floatValidator = new QDoubleValidator(this);
 #ifdef ENABLE_CGAL
-	this->cgalCacheSizeEdit->setValidator(validator);
+	this->cgalCacheSizeEdit->setValidator(intValidator);
 #endif
-	this->polysetCacheSizeEdit->setValidator(validator);
-	this->opencsgLimitEdit->setValidator(validator);
+	this->polysetCacheSizeEdit->setValidator(intValidator);
+	this->opencsgLimitEdit->setValidator(intValidator);
+	this->laserOffset->setValidator(floatValidator);
 
 	initComboBox(this->comboBoxIndentUsing, Settings::Settings::indentStyle);
 	initComboBox(this->comboBoxLineWrap, Settings::Settings::lineWrap);
@@ -450,6 +454,18 @@ void Preferences::on_polysetCacheSizeEdit_textChanged(const QString &text)
 	GeometryCache::instance()->setMaxSize(text.toULong());
 }
 
+void Preferences::on_laserOffset_textChanged(const QString &text)
+{
+	QSettingsCached settings;
+	settings.setValue("advanced/laserOffset", text);
+}
+
+void Preferences::on_laserColors_toggled(bool state)
+{
+	QSettingsCached settings;
+	settings.setValue("advanced/laserColors", state);
+}
+
 void Preferences::on_opencsgLimitEdit_textChanged(const QString &text)
 {
 	QSettingsCached settings;
@@ -682,6 +698,8 @@ void Preferences::updateGUI()
 	this->undockCheckBox->setChecked(getValue("advanced/undockableWindows").toBool());
 	this->undockCheckBox->setEnabled(this->reorderCheckBox->isChecked());
 	this->launcherBox->setChecked(getValue("launcher/showOnStartup").toBool());
+	this->laserColors->setChecked(getValue("advanced/laserColors").toBool());
+	this->laserOffset->setText(getValue("advanced/laserOffset").toString());
 
 	Settings::Settings *s = Settings::Settings::inst();
 	updateComboBox(this->comboBoxLineWrap, Settings::Settings::lineWrap);

--- a/src/Preferences.h
+++ b/src/Preferences.h
@@ -45,6 +45,8 @@ public slots:
 	void on_checkNowButton_clicked();
 	void on_launcherBox_toggled(bool);
 	void on_editorType_currentIndexChanged(const QString &);
+	void on_laserOffset_textChanged(const QString &);
+	void on_laserColors_toggled(bool);
 
 	void on_checkBoxShowWarningsIn3dView_toggled(bool);
   //

--- a/src/Preferences.ui
+++ b/src/Preferences.ui
@@ -1434,6 +1434,33 @@
               </property>
              </widget>
             </item>
+	    <item>
+             <widget class="QCheckBox" name="laserColors">
+              <property name="text">
+               <string>SVG output for laser cutting</string>
+              </property>
+              <property name="checked">
+               <bool>false</bool>
+              </property>
+             </widget>
+            </item>
+             <item>
+             <layout class="QHBoxLayout" name="horizontalLayout_4">
+              <property name="bottomMargin">
+               <number>0</number>
+              </property>
+              <item>
+               <widget class="QLabel" name="label_7">
+                <property name="text">
+                 <string>Offset for SVG output (kerf)</string>
+                </property>
+               </widget>
+              </item>
+              <item>
+               <widget class="QLineEdit" name="laserOffset"/>
+              </item>
+             </layout>
+            </item>
             <item>
              <spacer name="verticalSpacer">
               <property name="orientation">

--- a/src/clipper-utils.cc
+++ b/src/clipper-utils.cc
@@ -16,6 +16,16 @@ namespace ClipperUtils {
 		return p;
 	}
 
+	bool orientation(const Outline2d &outline)
+	{
+		// Returns true if this is an exterior polygon (counter-clockwise)
+		ClipperLib::Path p;
+		for (const auto &v : outline.vertices) {
+			p.emplace_back(v[0]*CLIPPER_SCALE, v[1]*CLIPPER_SCALE);
+		}
+		return ClipperLib::Orientation(p);
+	}
+
 	ClipperLib::Paths fromPolygon2d(const Polygon2d &poly)
 	{
 		ClipperLib::Paths result;

--- a/src/clipper-utils.h
+++ b/src/clipper-utils.h
@@ -18,5 +18,6 @@ namespace ClipperUtils {
 	Polygon2d *applyMinkowski(const std::vector<const Polygon2d*> &polygons);
 	Polygon2d *apply(const std::vector<const Polygon2d*> &polygons, ClipperLib::ClipType);
 	Polygon2d *apply(const std::vector<ClipperLib::Paths> &pathsvector, ClipperLib::ClipType);
+	bool orientation(const Outline2d &outline);
 
 };


### PR DESCRIPTION
This adds an option to make the SVG export more useful for laser cutters. The first option is to add different colours to interior and exterior polygons, which then allows laser cutters to cut interior polygons first. The second allows general offsetting of all polygons to account for the width of the laser beam (kerf). 

In order to allow different colours, the 'laser output' option has to output SVGs with separate <path> elements for each polygon, rather than one path for all output, as the current one does. This has also raised a slight issue with the preferences system; since the preferences can't be accessed without Qt, I've had to #ifdef out the code which uses them, so this new export option won't work in headless builds, or in the tests.

Apologies if the code is a bit rough; I haven't done c++ for a while. Tested on Ubuntu 16.04.2.