### PR TITLE
Don't scan for parameters in included files 

### DIFF
--- a/src/AST.cc
+++ b/src/AST.cc
@@ -1,3 +1,3 @@
 #include "AST.h"
 
-const Location Location::NONE(0, 0, 0, 0);
+const Location Location::NONE(0, 0, 0, 0, "");

--- a/src/AST.h
+++ b/src/AST.h
@@ -1,11 +1,16 @@
 #pragma once
+#include<string>
 
 class Location {
+
 public:
-	Location(int firstLine, int firstCol, int lastLine, int lastCol)
-		: first_line(firstLine), first_col(firstCol), last_line(lastLine), last_col(lastCol) {
+	Location(int firstLine, int firstCol, int lastLine, int lastCol,
+			const std::string &filename)
+		: first_line(firstLine), first_col(firstCol), last_line(lastLine),
+		last_col(lastCol), filename(filename) {
 	}
 
+	std::string fileName() const { return filename; }
 	int firstLine() const { return first_line; }
 	int firstColumn() const { return first_col; }
 	int lastLine() const { return last_line; }
@@ -13,18 +18,18 @@ public:
 
 
 	static const Location NONE;
-;
 private:
 	int first_line;
 	int first_col;
 	int last_line;
 	int last_col;
+	std::string filename;
 };
 
-class ASTNode
-{
+class ASTNode {
+
 public:
-  ASTNode(const Location &loc) : loc(loc) {}
+	ASTNode(const Location &loc) : loc(loc) {}
 	virtual ~ASTNode() {}
 
 	const Location &location() const { return loc; }

--- a/src/FileModule.h
+++ b/src/FileModule.h
@@ -28,10 +28,12 @@ public:
 	bool hasIncludes() const { return !this->includes.empty(); }
 	bool usesLibraries() const { return !this->usedlibs.empty(); }
 	bool isHandlingDependencies() const { return this->is_handling_dependencies; }
-
+	void setFilename(const std::string &filename) { this->filename = filename; }
+	const std::string &getFilename() const { return this->filename; }
 	LocalScope scope;
 	typedef std::unordered_set<std::string> ModuleContainer;
 	ModuleContainer usedlibs;
+
 private:
 	struct IncludeFile {
 		std::string filename;
@@ -43,4 +45,5 @@ private:
 	IncludeContainer includes;
 	bool is_handling_dependencies;
 	std::string path;
+	std::string filename;
 };

--- a/src/comment.cpp
+++ b/src/comment.cpp
@@ -279,8 +279,9 @@ void CommentParser::collectParameters(const char *fulltext, FileModule *root_mod
 
 		// get location of assignment node
 		int firstLine = assignment.location().firstLine();
-		if(firstLine>=parseTill ) continue;
-
+		if(firstLine>=parseTill || assignment.location().fileName() != root_module->getFilename()) {
+			continue;
+		}
 		// making list to add annotations
 		AnnotationList *annotationList = new AnnotationList();
  

--- a/src/lexer.l
+++ b/src/lexer.l
@@ -85,12 +85,13 @@ extern FileModule *rootmodule;
 */
 extern YYLTYPE parserlloc;
 int yycolumn = 1;
-#define YY_USER_ACTION {              \
-  parserlloc.first_line = yylineno;   \
-  parserlloc.first_column = yycolumn; \
-  yycolumn = yycolumn + yyleng;       \
-  parserlloc.last_column = yycolumn;  \
-  parserlloc.last_line = yylineno;    \
+#define YY_USER_ACTION {                                   \
+  parserlloc.filename = sourcefile().generic_string();     \
+  parserlloc.first_line = yylineno;                        \
+  parserlloc.first_column = yycolumn;                      \
+  yycolumn = yycolumn + yyleng;                            \
+  parserlloc.last_column = yycolumn;                       \
+  parserlloc.last_line = yylineno;                         \
 }
 
 extern void parsererror(char const *s);

--- a/src/parser.y
+++ b/src/parser.y
@@ -49,7 +49,9 @@
 namespace fs = boost::filesystem;
 
 #define YYMAXDEPTH 20000
-#define LOC(loc) Location(loc.first_line, loc.first_column, loc.last_line, loc.last_column)
+#define LOC(loc)                                    \
+  Location(loc.first_line, loc.first_column,        \
+  loc.last_line, loc.last_column, loc.filename)
   
 int parser_error_pos = -1;
 
@@ -71,6 +73,41 @@ const char *parser_input_buffer;
 fs::path parser_sourcefile;
 
 %}
+
+%code requires{
+
+/* current filename here for the lexer */
+typedef struct YYLTYPE {
+  int first_line;
+  int first_column;
+  int last_line;
+  int last_column;
+  std::string filename;
+} YYLTYPE;
+
+# define YYLTYPE_IS_DECLARED 1
+
+# define YYLLOC_DEFAULT(Current, Rhs, N)                          \
+  do                                                              \
+    if (N)                                                        \
+    {                                                             \
+      (Current).first_line = YYRHSLOC (Rhs, 1).first_line;        \
+      (Current).first_column = YYRHSLOC (Rhs, 1).first_column;    \
+      (Current).last_line= YYRHSLOC (Rhs, N).last_line;           \
+      (Current).last_column = YYRHSLOC (Rhs, N).last_column;      \
+      (Current).filename= YYRHSLOC (Rhs, 1).filename;             \
+    }                                                             \
+    else                                                          \
+    { /* empty RHS */                                             \
+      (Current).first_line = (Current).last_line =                \
+      YYRHSLOC (Rhs, 0).last_line;                                \
+      (Current).first_column = (Current).last_column =            \
+      YYRHSLOC (Rhs, 0).last_column;                              \
+      (Current).filename = " "; /* new */                         \
+    }                                                             \
+  while (0)
+}
+
 
 %union {
   char *text;
@@ -637,6 +674,7 @@ bool parse(FileModule *&module, const char *text, const fs::path &filename, int 
 
   rootmodule = new FileModule();
   rootmodule->setModulePath(filename.parent_path().generic_string());
+  rootmodule->setFilename(filename.generic_string());
   scope_stack.push(&rootmodule->scope);
   //        PRINTB_NOCACHE("New module: %s %p", "root" % rootmodule);
 


### PR DESCRIPTION
In reference to issue #1840 .
It adds the file name to the location of the node and also doesn't scan for parameters in included files.