### PR TITLE
add missing debian dependency: libzip-dev

### DIFF
--- a/scripts/uni-get-dependencies.sh
+++ b/scripts/uni-get-dependencies.sh
@@ -83,7 +83,7 @@ get_debian_deps()
   libeigen3-dev libcgal-dev libopencsg-dev libgmp3-dev libgmp-dev \
   imagemagick libfreetype6-dev \
   gtk-doc-tools libglib2.0-dev gettext xvfb pkg-config ragel
- apt-get -y install libxi-dev libfontconfig-dev
+ apt-get -y install libxi-dev libfontconfig-dev libzip-dev
 }
 
 get_debian_7_deps()


### PR DESCRIPTION
This was found on Ubuntu 16.04.3 LTS.

If i remember right, this dependency system is deprecated anyway, but.. maybe it will help someone until it is actually replaced, and gain some visibility as a pull request.