### PR TITLE
Added --view option #2032

### DIFF
--- a/src/GLView.cc
+++ b/src/GLView.cc
@@ -163,16 +163,13 @@ void GLView::paintGL()
   glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT | GL_STENCIL_BUFFER_BIT);
 
   setupCamera();
-  if (this->cam.type == Camera::CameraType::GIMBAL) {
-    // Only for GIMBAL cam
-    // The crosshair should be fixed at the center of the viewport...
-    if (showcrosshairs) GLView::showCrosshairs();
-    glTranslated(cam.object_trans.x(), cam.object_trans.y(), cam.object_trans.z());
-    // ...the axis lines need to follow the object translation.
-    if (showaxes) GLView::showAxes(axescolor);
-    // mark the scale along the axis lines
-    if (showaxes && showscale) GLView::showScalemarkers(axescolor);
-  }
+	// The crosshair should be fixed at the center of the viewport...
+	if (showcrosshairs) GLView::showCrosshairs();
+	glTranslated(cam.object_trans.x(), cam.object_trans.y(), cam.object_trans.z());
+	// ...the axis lines need to follow the object translation.
+	if (showaxes) GLView::showAxes(axescolor);
+	// mark the scale along the axis lines
+	if (showaxes && showscale) GLView::showScalemarkers(axescolor);
 
   glEnable(GL_LIGHTING);
   glDepthFunc(GL_LESS);
@@ -189,7 +186,6 @@ void GLView::paintGL()
     this->renderer->draw(showfaces, showedges);
   }
 
-  // Only for GIMBAL
   glDisable(GL_LIGHTING);
   if (showaxes) GLView::showSmallaxes(axescolor);
 }

--- a/src/GLView.h
+++ b/src/GLView.h
@@ -43,6 +43,11 @@ public:
 	void setColorScheme(const std::string &cs);
 	void updateColorScheme();
 
+	bool showAxes() const { return this->showaxes; }
+	void setShowAxes(bool enabled) { this->showaxes = enabled; }
+	bool showScaleProportional() const { return this->showscale; }
+	void setShowScaleProportional(bool enabled) { this->showscale = enabled; }
+	
 	virtual bool save(const char *filename) = 0;
 	virtual std::string getRendererInfo() const = 0;
 	virtual float getDPI() { return 1.0f; }

--- a/src/QGLView.h
+++ b/src/QGLView.h
@@ -41,14 +41,10 @@ public:
 	void setShowFaces(bool enabled) { this->showfaces = enabled; }
 	bool showEdges() const { return this->showedges; }
 	void setShowEdges(bool enabled) { this->showedges = enabled; }
-	bool showAxes() const { return this->showaxes; }
-	void setShowAxes(bool enabled) { this->showaxes = enabled; }
 	bool showCrosshairs() const { return this->showcrosshairs; }
 	void setShowCrosshairs(bool enabled) { this->showcrosshairs = enabled; }
 	bool orthoMode() const { return (this->cam.projection == Camera::ProjectionType::ORTHOGONAL); }
 	void setOrthoMode(bool enabled);
-	bool showScaleProportional() const { return this->showscale; }
-	void setShowScaleProportional(bool enabled) { this->showscale = enabled; }
 	std::string getRendererInfo() const;
 #if QT_VERSION >= 0x050100
 	float getDPI() { return this->devicePixelRatio(); }

--- a/src/export.h
+++ b/src/export.h
@@ -28,7 +28,13 @@ void export_nef3(const shared_ptr<const Geometry> &geom, std::ostream &output);
 
 // void exportFile(const class Geometry *root_geom, std::ostream &output, FileFormat format);
 
-bool export_png(const shared_ptr<const class Geometry> &root_geom, Camera &c, std::ostream &output);
-bool export_png(const shared_ptr<const class CGAL_Nef_polyhedron> &root_N, Camera &c, std::ostream &output);
-bool export_png_with_opencsg(Tree &tree, Camera &c, std::ostream &output);
-bool export_png_with_throwntogether(Tree &tree, Camera &c, std::ostream &output);
+enum class Previewer { OPENCSG, THROWNTOGETHER };
+
+struct ViewOptions {
+	bool showAxes;
+	bool showScaleMarkers;
+	Previewer previewer{Previewer::OPENCSG};
+};
+
+bool export_png(const shared_ptr<const class Geometry> &root_geom, Camera &c, const ViewOptions& options, std::ostream &output);
+bool export_preview_png(Tree &tree, Camera &c, const ViewOptions& options, std::ostream &output);

--- a/src/openscad.cc
+++ b/src/openscad.cc
@@ -64,6 +64,7 @@
 
 #include "Camera.h"
 #include <boost/algorithm/string.hpp>
+#include <boost/algorithm/string/split.hpp>
 #include <boost/program_options.hpp>
 #include <boost/filesystem.hpp>
 
@@ -318,7 +319,7 @@ void set_render_color_scheme(const std::string color_scheme, const bool exit_if_
 
 #include <QCoreApplication>
 
-int cmdline(const char *deps_output_file, const std::string &filename, Camera &camera, const char *output_file, const fs::path &original_path, RenderType renderer,const std::string &parameterFile,const std::string &setName, int argc, char ** argv )
+int cmdline(const char *deps_output_file, const std::string &filename, Camera &camera, const char *output_file, const fs::path &original_path, RenderType renderer,const std::string &parameterFile,const std::string &setName, ViewOptions& viewOptions, int argc, char ** argv )
 {
 #ifdef OPENSCAD_QTGUI
 	QCoreApplication app(argc, argv);
@@ -550,11 +551,10 @@ int cmdline(const char *deps_output_file, const std::string &filename, Camera &c
 			}
 			else {
 				if (renderer == RenderType::CGAL || renderer == RenderType::GEOMETRY) {
-					success = export_png(root_geom, camera, fstream);
-				} else if (renderer == RenderType::THROWNTOGETHER) {
-					success = export_png_with_throwntogether(tree, camera, fstream);
+					success = export_png(root_geom, camera, viewOptions, fstream);
 				} else {
-					success = export_png_with_opencsg(tree, camera, fstream);
+					viewOptions.previewer = (renderer == RenderType::THROWNTOGETHER) ? Previewer::THROWNTOGETHER : Previewer::OPENCSG;
+					success = export_preview_png(tree, camera, viewOptions, fstream);
 				}
 				fstream.close();
 			}
@@ -784,6 +784,21 @@ int gui(const vector<string> &inputFiles, const fs::path &original_path, int arg
 }
 #endif // OPENSCAD_QTGUI
 
+/*!
+	This makes boost::program_option parse comma-separated values
+ */
+struct CommaSeparatedVector
+{
+	std::vector<std::string> values;
+
+	friend std::istream &operator>>(std::istream &in, CommaSeparatedVector &value) {
+		std::string token;
+		in >> token;
+		boost::split(value.values, token, boost::is_any_of(","));
+		return in;
+	}
+};
+
 int main(int argc, char **argv)
 {
 	int rc = 0;
@@ -815,6 +830,7 @@ int main(int argc, char **argv)
 		("info", "print information about the building process")
 		("render", po::value<string>()->implicit_value(""), "if exporting a png image, do a full geometry evaluation")
 		("preview", po::value<string>()->implicit_value(""), "if exporting a png image, do an OpenCSG(default) or ThrownTogether preview")
+		("view", po::value<CommaSeparatedVector>()->value_name("axes|scalemarkers"), "view options")
 		("csglimit", po::value<unsigned int>(), "if exporting a png image, stop rendering at the given number of CSG elements")
 		("camera", po::value<string>(), "parameters for camera when exporting png")
 		("autocenter", "adjust camera to look at object center")
@@ -876,6 +892,17 @@ int main(int argc, char **argv)
 	else if (vm.count("render")) {
 		if (vm["render"].as<string>() == "cgal") renderer = RenderType::CGAL;
 		else renderer = RenderType::GEOMETRY;
+	}
+
+	ViewOptions viewOptions{};
+	if (vm.count("view")) {
+		const auto &viewOptionValues = vm["view"].as<CommaSeparatedVector>();
+		std::cout << "View options:\n";
+		for (const auto &option : viewOptionValues.values) {
+			if (option == "axes") viewOptions.showAxes = true;
+			else if (option == "scaleMarkers") viewOptions.showScaleMarkers = true;
+			std::cout << option << "\n";
+		}
 	}
 
 	if (vm.count("csglimit")) {
@@ -969,7 +996,7 @@ int main(int argc, char **argv)
 
 	if (arg_info || cmdlinemode) {
 		if (inputFiles.size() > 1) help(argv[0], true);
-		rc = cmdline(deps_output_file, inputFiles[0], camera, output_file, original_path, renderer, parameterFile, parameterSet, argc, argv);
+		rc = cmdline(deps_output_file, inputFiles[0], camera, output_file, original_path, renderer, parameterFile, parameterSet, viewOptions, argc, argv);
 	}
 	else if (QtUseGUI()) {
 		rc = gui(inputFiles, original_path, argc, argv);


### PR DESCRIPTION
Added --view option taking a comma-separated list of options as parameter.
This should solve most of #2032.

Example:
`openscad test.scad --view axes,scaleMarkers -o out.png`

TODO:
* [ ] Consider further low hanging fruits in this domain
* [ ] Tests
* [ ] Doc
