### PR TITLE
DPI Normalized Wireframe Rendering

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,3 +50,4 @@ src/*.org
 src/*.old
 src/*.debug
 /Testing
+.DS_Store

--- a/src/OGL_helper.h
+++ b/src/OGL_helper.h
@@ -27,7 +27,7 @@
 #include "system-gl.h"
 #include <cstdlib>
 #include <QScreen>
-#include <QGuiApplication>
+#include <QApplication>
 
 // Overridden in CGAL_renderer
 /*
@@ -365,8 +365,12 @@ namespace OGL {
     }
     
     qreal get_dpi() const {
-      QScreen *screen = QGuiApplication::primaryScreen();
-      return screen->devicePixelRatio();
+      #if QT_VERSION >= QT_VERSION_CHECK(5, 0, 0)
+        QScreen *screen = QGuiApplication::primaryScreen();
+        return screen->devicePixelRatio();
+      #else
+        return 1;
+      #endif
     }
 
     bool is_initialized() const { return init_; }

--- a/src/OGL_helper.h
+++ b/src/OGL_helper.h
@@ -26,6 +26,8 @@
 #include <CGAL/Nef_3/SNC_decorator.h>
 #include "system-gl.h"
 #include <cstdlib>
+#include <QScreen>
+#include <QGuiApplication>
 
 // Overridden in CGAL_renderer
 /*
@@ -361,6 +363,11 @@ namespace OGL {
     void set_style(int index) {
       style = index;
     }
+    
+    qreal get_dpi() const {
+      QScreen *screen = QGuiApplication::primaryScreen();
+      return screen->devicePixelRatio();
+    }
 
     bool is_initialized() const { return init_; }
 
@@ -383,8 +390,7 @@ namespace OGL {
       PRINTD("draw( Vertex_iterator )");
       //      CGAL_NEF_TRACEN("drawing vertex "<<*v);
       CGAL::Color c = getVertexColor(v);
-      glPointSize(10);
-      //glPointSize(1);
+      glPointSize(3*get_dpi());
       glColor3ub(c.red(), c.green(), c.blue());
       glBegin(GL_POINTS);
       glVertex3d(v->x(),v->y(),v->z());
@@ -413,8 +419,7 @@ namespace OGL {
       //      CGAL_NEF_TRACEN("drawing edge "<<*e);
       Double_point p = e->source(), q = e->target();
       CGAL::Color c = getEdgeColor(e);
-      glLineWidth(5);
-      //glLineWidth(1);
+      glLineWidth(get_dpi());
       glColor3ub(c.red(),c.green(),c.blue());
       glBegin(GL_LINE_STRIP);
       glVertex3d(p.x(), p.y(), p.z());


### PR DESCRIPTION
Use the screen's DPI when calculating the line width and point size of wireframes.

See #2091 

<details>
<summary>1x DPI Wireframe</summary>

![screen shot 2017-08-19 at 9 47 33 pm](https://user-images.githubusercontent.com/3108007/29491697-be1b1304-8528-11e7-8525-1d08acd0b8a3.png)


> Note: The "DPR" value in this screenshot was for debugging and is not included in the PR.
</details>

<details>
<summary>2x DPI Wireframe</summary>

![screen shot 2017-08-19 at 9 47 33 pm](https://user-images.githubusercontent.com/3108007/29491696-b67d8ab4-8528-11e7-82e4-0580027c1a6b.png)


> Note: The "DPR" value in this screenshot was for debugging and is not included in the PR.
</details>