### PR TITLE
[WPI] DPI Normalized Wireframe Rendering

### DIFF
--- a/src/CGALRenderer.cc
+++ b/src/CGALRenderer.cc
@@ -44,6 +44,7 @@
 
 CGALRenderer::CGALRenderer(shared_ptr<const class Geometry> geom)
 {
+	this->dpi = 1;
 	if (auto ps = dynamic_pointer_cast<const PolySet>(geom)) {
 		assert(ps->getDimension() == 3);
 		// We need to tessellate here, in case the generated PolySet contains concave polygons
@@ -66,6 +67,11 @@ CGALRenderer::CGALRenderer(shared_ptr<const class Geometry> geom)
 
 CGALRenderer::~CGALRenderer()
 {
+}
+
+void CGALRenderer::setDPI(float dpi)
+{
+	this->dpi = dpi;
 }
 
 shared_ptr<class CGAL_OGL_Polyhedron> CGALRenderer::getPolyhedron() const

--- a/src/CGALRenderer.cc
+++ b/src/CGALRenderer.cc
@@ -87,6 +87,7 @@ void CGALRenderer::buildPolyhedron() const
 	CGAL::OGL::Nef3_Converter<CGAL_Nef_polyhedron3>::convert_to_OGLPolyhedron(*this->N->p3, this->polyhedron.get());
 	// CGAL_NEF3_MARKED_FACET_COLOR <- CGAL_FACE_BACK_COLOR
 	// CGAL_NEF3_UNMARKED_FACET_COLOR <- CGAL_FACE_FRONT_COLOR
+	this->polyhedron->set_dpi(this->dpi);
 	this->polyhedron->init();
 	PRINTD("buildPolyhedron() end");
 }

--- a/src/CGALRenderer.h
+++ b/src/CGALRenderer.h
@@ -11,6 +11,7 @@ public:
 	virtual void draw(bool showfaces, bool showedges) const;
 	virtual void setColorScheme(const ColorScheme &cs);
 	virtual BoundingBox getBoundingBox() const;
+	void setDPI(float dpi);
 
 private:
 	shared_ptr<class CGAL_OGL_Polyhedron> getPolyhedron() const;
@@ -19,4 +20,5 @@ private:
 	mutable shared_ptr<class CGAL_OGL_Polyhedron> polyhedron;
 	shared_ptr<const CGAL_Nef_polyhedron> N;
 	shared_ptr<const class PolySet> polyset;
+	float dpi;
 };

--- a/src/OGL_helper.h
+++ b/src/OGL_helper.h
@@ -286,6 +286,8 @@ namespace OGL {
 
     int style;
     std::vector<bool> switches;
+    
+    float dpi;
 
     typedef std::list<DPoint>::const_iterator   Vertex_iterator;
     typedef std::list<DSegment>::const_iterator Edge_iterator;
@@ -297,6 +299,7 @@ namespace OGL {
       init_ = false;
       style = SNC_BOUNDARY;
       switches[SNC_AXES] = false; 
+      dpi = 1;
     }
 
     /*
@@ -420,6 +423,10 @@ namespace OGL {
       glVertex3d(p.x(), p.y(), p.z());
       glVertex3d(q.x(), q.y(), q.z());
       glEnd();
+    }
+
+    void set_dpi(float dpi) {
+      this->dpi = dpi;
     }
 
 

--- a/src/OGL_helper.h
+++ b/src/OGL_helper.h
@@ -386,8 +386,7 @@ namespace OGL {
       PRINTD("draw( Vertex_iterator )");
       //      CGAL_NEF_TRACEN("drawing vertex "<<*v);
       CGAL::Color c = getVertexColor(v);
-      glPointSize(10);
-      //glPointSize(1);
+      glPointSize(3*dpi);
       glColor3ub(c.red(), c.green(), c.blue());
       glBegin(GL_POINTS);
       glVertex3d(v->x(),v->y(),v->z());
@@ -416,8 +415,7 @@ namespace OGL {
       //      CGAL_NEF_TRACEN("drawing edge "<<*e);
       Double_point p = e->source(), q = e->target();
       CGAL::Color c = getEdgeColor(e);
-      glLineWidth(5);
-      //glLineWidth(1);
+      glLineWidth(1*dpi);
       glColor3ub(c.red(),c.green(),c.blue());
       glBegin(GL_LINE_STRIP);
       glVertex3d(p.x(), p.y(), p.z());

--- a/src/mainwin.cc
+++ b/src/mainwin.cc
@@ -1988,6 +1988,7 @@ void MainWindow::actionRenderDone(shared_ptr<const Geometry> root_geom)
 
 		this->root_geom = root_geom;
 		this->cgalRenderer = new CGALRenderer(root_geom);
+		this->cgalRenderer->setDPI(qglview->getDPI());
 		// Go to CGAL view mode
 		if (viewActionWireframe->isChecked()) viewModeWireframe();
 		else viewModeSurface();


### PR DESCRIPTION
Use the screen's DPI when calculating the line width and point size of wireframes.

See #2091 

This improves upon #2096 by passing the DPI from `MainWindow::qglview::getDPI()` to `CGALRenderer::setDPI()` to `Polyhedron::set_dpi()` to address the concerns raised in https://github.com/openscad/openscad/pull/2096#issuecomment-323648424.

In response to https://github.com/openscad/openscad/pull/2096#issuecomment-323868456 I opted to "minimize how much we touch [OGL_helpers]", because "rewriting it completely" seems disproportionate to the scope of the issue (and my familiarity with the code base :wink:).

<details>
<summary>1x DPI Wireframe</summary>

![screen shot 2017-08-19 at 9 47 33 pm](https://user-images.githubusercontent.com/3108007/29491697-be1b1304-8528-11e7-8525-1d08acd0b8a3.png)


> Note: The "DPR" value in this screenshot was for debugging and is not included in the PR.
</details>

<details>
<summary>2x DPI Wireframe</summary>

![screen shot 2017-08-19 at 9 47 33 pm](https://user-images.githubusercontent.com/3108007/29491696-b67d8ab4-8528-11e7-82e4-0580027c1a6b.png)


> Note: The "DPR" value in this screenshot was for debugging and is not included in the PR.
</details>