### PR TITLE
Fix MacOS First Run

### DIFF
--- a/src/openscad.cc
+++ b/src/openscad.cc
@@ -784,6 +784,16 @@ int gui(const vector<string> &inputFiles, const fs::path &original_path, int arg
 }
 #endif // OPENSCAD_QTGUI
 
+std::pair<string, string> customSyntax(const string& s)
+{
+#if defined(Q_OS_MACX)
+	if (s.find("-psn_") == 0)
+		return {"psn", s.substr(5)};
+#endif
+
+	return {};
+}
+
 int main(int argc, char **argv)
 {
 	int rc = 0;
@@ -832,6 +842,9 @@ int main(int argc, char **argv)
 		("d,d", po::value<string>(), "deps-file")
 		("m,m", po::value<string>(), "makefile")
 		("D,D", po::value<vector<string>>(), "var=val")
+#ifdef Q_OS_MACX
+		("psn", po::value<string>(), "process serial number")
+#endif
 #ifdef ENABLE_EXPERIMENTAL
 		("enable", po::value<vector<string>>(), "enable experimental features")
 #endif
@@ -849,7 +862,7 @@ int main(int argc, char **argv)
 
 	po::variables_map vm;
 	try {
-		po::store(po::command_line_parser(argc, argv).options(all_options).allow_unregistered().positional(p).run(), vm);
+		po::store(po::command_line_parser(argc, argv).options(all_options).allow_unregistered().positional(p).extra_parser(customSyntax).run(), vm);
 	}
 	catch(const std::exception &e) { // Catches e.g. unknown options
 		PRINTB("%s\n", e.what());

--- a/src/openscad.h
+++ b/src/openscad.h
@@ -46,3 +46,5 @@ extern std::string openscad_versionnumber;
 extern std::string openscad_displayversionnumber;
 // Version used for detailed display
 extern std::string openscad_detailedversionnumber;
+// Custom argument parser
+std::pair<std::string, std::string> customSyntax(const std::string& s);


### PR DESCRIPTION
Handle the `-psn_*` argument that Finder on OSX sends to apps.

> It looks like Finder appends a process ID argument.
> 
> https://stackoverflow.com/questions/10242115/os-x-strange-psn-command-line-parameter-when-launched-from-finder
> 
> FreeSCAD had the same problem and posted a workaround in this thread.
> 
> https://forum.freecadweb.org/viewtopic.php?t=4447

https://github.com/openscad/openscad/issues/2089#issuecomment-328371812

Fixes #2089.