### PR TITLE
Cmake fix

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -92,7 +92,7 @@ if(NOT HEADLESS)
     set(CMAKE_POSITION_INDEPENDENT_CODE ON)
   endif()
 
-  if ("${Qt5_VERSION}" VERSION_GREATER_EQUAL "5.4")
+  if (("${Qt5_VERSION}" VERSION_EQUAL "5.4") OR ("${Qt5_VERSION}" VERSION_GREATER "5.4"))
     add_definitions(-DUSE_QOPENGLWIDGET)
   endif()
 

--- a/src/cgalutils-tess.cc
+++ b/src/cgalutils-tess.cc
@@ -7,7 +7,7 @@
 #undef NDEBUG
 #endif
 #include <CGAL/Constrained_Delaunay_triangulation_2.h>
-#include <CGAL/Triangulation_2_filtered_projection_traits_3.h>
+#include <CGAL/Triangulation_2_projection_traits_3.h>
 #include <CGAL/Triangulation_face_base_with_info_2.h>
 #ifdef PREV_NDEBUG
 #define NDEBUG PREV_NDEBUG


### PR DESCRIPTION
I was getting errors running cmake and I found that the VERSION_GREATER_EQUAL expression used is not supported in (cmake 3.5.1), which is the version in the repos for my Linux Mint 18 computer.
```
...
CMake Error at CMakeLists.txt:95 (if):
  if given arguments:

    "5.5.1" "VERSION_GREATER_EQUAL" "5.4"

  Unknown arguments specified
...
```

I also fixed a minor deprecated header while I was at it, since it shows a warning during every build.

This relates to #2019