### PR TITLE
fixing "off by one error" when using /dev/input/js0

### DIFF
--- a/src/Preferences.cc
+++ b/src/Preferences.cc
@@ -221,6 +221,7 @@ void Preferences::init() {
         initComboBox(this->comboBoxRotationY, Settings::Settings::inputRotateY);
         initComboBox(this->comboBoxRotationZ, Settings::Settings::inputRotateZ);
         initComboBox(this->comboBoxZoom, Settings::Settings::inputZoom);
+        initComboBox(this->comboBoxButton0, Settings::Settings::inputButton0);
         initComboBox(this->comboBoxButton1, Settings::Settings::inputButton1);
         initComboBox(this->comboBoxButton2, Settings::Settings::inputButton2);
         initComboBox(this->comboBoxButton3, Settings::Settings::inputButton3);
@@ -229,6 +230,7 @@ void Preferences::init() {
         initComboBox(this->comboBoxButton6, Settings::Settings::inputButton6);
         initComboBox(this->comboBoxButton7, Settings::Settings::inputButton7);
         initComboBox(this->comboBoxButton8, Settings::Settings::inputButton8);
+        initComboBox(this->comboBoxButton9, Settings::Settings::inputButton9);
 
 	SettingsReader settingsReader;
 	Settings::Settings::inst()->visit(settingsReader);
@@ -638,6 +640,12 @@ void Preferences::on_comboBoxZoom_activated(int val)
         emit inputMappingChanged();
 }
 
+void Preferences::on_comboBoxButton0_activated(int val)
+{
+	applyComboBox(comboBoxButton0, val, Settings::Settings::inputButton0);
+        emit inputMappingChanged();
+}
+
 void Preferences::on_comboBoxButton1_activated(int val)
 {
 	applyComboBox(comboBoxButton1, val, Settings::Settings::inputButton1);
@@ -683,6 +691,12 @@ void Preferences::on_comboBoxButton7_activated(int val)
 void Preferences::on_comboBoxButton8_activated(int val)
 {
 	applyComboBox(comboBoxButton8, val, Settings::Settings::inputButton8);
+        emit inputMappingChanged();
+}
+
+void Preferences::on_comboBoxButton9_activated(int val)
+{
+	applyComboBox(comboBoxButton9, val, Settings::Settings::inputButton9);
         emit inputMappingChanged();
 }
 
@@ -819,6 +833,7 @@ void Preferences::updateGUI()
 	updateComboBox(this->comboBoxRotationY, Settings::Settings::inputRotateY);
 	updateComboBox(this->comboBoxRotationZ, Settings::Settings::inputRotateZ);
 	updateComboBox(this->comboBoxZoom, Settings::Settings::inputZoom);
+	updateComboBox(this->comboBoxButton0, Settings::Settings::inputButton0);
 	updateComboBox(this->comboBoxButton1, Settings::Settings::inputButton1);
 	updateComboBox(this->comboBoxButton2, Settings::Settings::inputButton2);
 	updateComboBox(this->comboBoxButton3, Settings::Settings::inputButton3);
@@ -827,6 +842,7 @@ void Preferences::updateGUI()
 	updateComboBox(this->comboBoxButton6, Settings::Settings::inputButton6);
 	updateComboBox(this->comboBoxButton7, Settings::Settings::inputButton7);
 	updateComboBox(this->comboBoxButton8, Settings::Settings::inputButton8);
+	updateComboBox(this->comboBoxButton9, Settings::Settings::inputButton9);
 }
 
 void Preferences::initComboBox(QComboBox *comboBox, const Settings::SettingsEntry& entry)

--- a/src/Preferences.h
+++ b/src/Preferences.h
@@ -80,6 +80,7 @@ public slots:
         void on_comboBoxRotationY_activated(int val);
         void on_comboBoxRotationZ_activated(int val);
         void on_comboBoxZoom_activated(int val);
+        void on_comboBoxButton0_activated(int val);
         void on_comboBoxButton1_activated(int val);
         void on_comboBoxButton2_activated(int val);
         void on_comboBoxButton3_activated(int val);
@@ -88,6 +89,7 @@ public slots:
         void on_comboBoxButton6_activated(int val);
         void on_comboBoxButton7_activated(int val);
         void on_comboBoxButton8_activated(int val);
+        void on_comboBoxButton9_activated(int val);
 
 signals:
 	void requestRedraw() const;

--- a/src/Preferences.ui
+++ b/src/Preferences.ui
@@ -125,9 +125,9 @@
            <property name="geometry">
             <rect>
              <x>0</x>
-             <y>-262</y>
-             <width>639</width>
-             <height>653</height>
+             <y>0</y>
+             <width>536</width>
+             <height>693</height>
             </rect>
            </property>
            <layout class="QGridLayout" name="gridLayout_5">
@@ -244,7 +244,7 @@
                  <widget class="QFontComboBox" name="fontChooser">
                   <property name="currentFont">
                    <font>
-                    <family>TeX Gyre Heros</family>
+                    <family>Nimbus Sans L</family>
                     <pointsize>12</pointsize>
                    </font>
                   </property>
@@ -1220,7 +1220,7 @@
               <rect>
                <x>0</x>
                <y>0</y>
-               <width>82</width>
+               <width>84</width>
                <height>26</height>
               </rect>
              </property>
@@ -1283,8 +1283,8 @@
             <rect>
              <x>0</x>
              <y>0</y>
-             <width>490</width>
-             <height>383</height>
+             <width>485</width>
+             <height>393</height>
             </rect>
            </property>
            <layout class="QVBoxLayout" name="verticalLayout_12">
@@ -1455,7 +1455,16 @@
       </widget>
       <widget class="QWidget" name="pageInput">
        <layout class="QGridLayout" name="gridLayout_13">
-        <property name="margin">
+        <property name="leftMargin">
+         <number>0</number>
+        </property>
+        <property name="topMargin">
+         <number>0</number>
+        </property>
+        <property name="rightMargin">
+         <number>0</number>
+        </property>
+        <property name="bottomMargin">
          <number>0</number>
         </property>
         <item row="3" column="1">
@@ -1467,12 +1476,15 @@
            <property name="geometry">
             <rect>
              <x>0</x>
-             <y>0</y>
-             <width>656</width>
-             <height>489</height>
+             <y>-38</y>
+             <width>655</width>
+             <height>430</height>
             </rect>
            </property>
            <layout class="QGridLayout" name="gridLayout_7" columnstretch="0,1,1,1">
+            <item row="4" column="1" colspan="3">
+             <widget class="QComboBox" name="comboBoxButton0"/>
+            </item>
             <item row="1" column="0">
              <widget class="QLabel" name="labelInputRotation">
               <property name="text">
@@ -1502,67 +1514,65 @@
             <item row="1" column="1">
              <widget class="QComboBox" name="comboBoxRotationX"/>
             </item>
-            <item row="4" column="0">
+            <item row="5" column="0">
              <widget class="QLabel" name="labelInputButton1">
               <property name="text">
                <string>Button 1</string>
               </property>
              </widget>
             </item>
-            <item row="5" column="0">
+            <item row="6" column="0">
              <widget class="QLabel" name="labelInputButton2">
               <property name="text">
                <string>Button 2</string>
               </property>
              </widget>
             </item>
-            <item row="6" column="0">
+            <item row="7" column="0">
              <widget class="QLabel" name="labelInputButton3">
               <property name="text">
                <string>Button 3</string>
               </property>
              </widget>
             </item>
-            <item row="7" column="0">
+            <item row="8" column="0">
              <widget class="QLabel" name="labelInputButton4">
               <property name="text">
                <string>Button 4</string>
               </property>
              </widget>
             </item>
-            <item row="8" column="0">
+            <item row="9" column="0">
              <widget class="QLabel" name="labelInputButton5">
               <property name="text">
                <string>Button 5</string>
               </property>
              </widget>
             </item>
-             <item row="9" column="0">
+            <item row="10" column="0">
              <widget class="QLabel" name="labelInputButton6">
               <property name="text">
                <string>Button 6</string>
               </property>
              </widget>
             </item>
-             <item row="10" column="0">
+            <item row="11" column="0">
              <widget class="QLabel" name="labelInputButton7">
               <property name="text">
                <string>Button 7</string>
               </property>
              </widget>
             </item>
-            <item row="11" column="0">
+            <item row="12" column="0">
              <widget class="QLabel" name="labelInputButton8">
               <property name="text">
                <string>Button 8</string>
               </property>
              </widget>
             </item>
-
             <item row="1" column="2">
              <widget class="QComboBox" name="comboBoxRotationY"/>
             </item>
-
             <item row="1" column="3">
              <widget class="QComboBox" name="comboBoxRotationZ"/>
             </item>
@@ -1573,7 +1583,7 @@
               </property>
              </widget>
             </item>
-            <item row="12" column="0">
+            <item row="14" column="0">
              <spacer name="verticalSpacer_4">
               <property name="orientation">
                <enum>Qt::Vertical</enum>
@@ -1593,29 +1603,46 @@
               </property>
              </widget>
             </item>
-            <item row="4" column="1" colspan="3">
+            <item row="5" column="1" colspan="3">
              <widget class="QComboBox" name="comboBoxButton1"/>
             </item>
-            <item row="5" column="1" colspan="3">
+            <item row="6" column="1" colspan="3">
              <widget class="QComboBox" name="comboBoxButton2"/>
             </item>
-            <item row="6" column="1" colspan="3">
+            <item row="7" column="1" colspan="3">
              <widget class="QComboBox" name="comboBoxButton3"/>
             </item>
-            <item row="7" column="1" colspan="3">
+            <item row="8" column="1" colspan="3">
              <widget class="QComboBox" name="comboBoxButton4"/>
             </item>
-            <item row="8" column="1" colspan="3">
+            <item row="9" column="1" colspan="3">
              <widget class="QComboBox" name="comboBoxButton5"/>
             </item>
-            <item row="9" column="1" colspan="3">
+            <item row="10" column="1" colspan="3">
              <widget class="QComboBox" name="comboBoxButton6"/>
             </item>
-            <item row="10" column="1" colspan="3">
+            <item row="11" column="1" colspan="3">
              <widget class="QComboBox" name="comboBoxButton7"/>
             </item>
-            <item row="11" column="1" colspan="3">
+            <item row="12" column="1" colspan="3">
              <widget class="QComboBox" name="comboBoxButton8"/>
+            </item>
+            <item row="4" column="0">
+             <widget class="QLabel" name="labelInputButton0">
+              <property name="text">
+               <string>Button 0</string>
+              </property>
+             </widget>
+            </item>
+            <item row="13" column="0">
+             <widget class="QLabel" name="labelInputButton9">
+              <property name="text">
+               <string>Button 9</string>
+              </property>
+             </widget>
+            </item>
+            <item row="13" column="1" colspan="3">
+             <widget class="QComboBox" name="comboBoxButton9"/>
             </item>
            </layout>
           </widget>

--- a/src/input/InputEventMapper.cc
+++ b/src/input/InputEventMapper.cc
@@ -141,16 +141,17 @@ int InputEventMapper::parseSettingValue(const std::string val)
 void InputEventMapper::onInputMappingUpdated()
 {
     Settings::Settings *s = Settings::Settings::inst();
-
-    actions[0] = QString(s->get(Settings::Settings::inputButton1).toString().c_str());
-    actions[1] = QString(s->get(Settings::Settings::inputButton2).toString().c_str());
-    actions[2] = QString(s->get(Settings::Settings::inputButton3).toString().c_str());
-    actions[3] = QString(s->get(Settings::Settings::inputButton4).toString().c_str());
-    actions[4] = QString(s->get(Settings::Settings::inputButton5).toString().c_str());
-    actions[5] = QString(s->get(Settings::Settings::inputButton6).toString().c_str());
-    actions[6] = QString(s->get(Settings::Settings::inputButton7).toString().c_str());
-    actions[7] = QString(s->get(Settings::Settings::inputButton8).toString().c_str());
-
+    actions[0] = QString(s->get(Settings::Settings::inputButton0).toString().c_str());
+    actions[1] = QString(s->get(Settings::Settings::inputButton1).toString().c_str());
+    actions[2] = QString(s->get(Settings::Settings::inputButton2).toString().c_str());
+    actions[3] = QString(s->get(Settings::Settings::inputButton3).toString().c_str());
+    actions[4] = QString(s->get(Settings::Settings::inputButton4).toString().c_str());
+    actions[5] = QString(s->get(Settings::Settings::inputButton5).toString().c_str());
+    actions[6] = QString(s->get(Settings::Settings::inputButton6).toString().c_str());
+    actions[7] = QString(s->get(Settings::Settings::inputButton7).toString().c_str());
+    actions[8] = QString(s->get(Settings::Settings::inputButton8).toString().c_str());
+    actions[9] = QString(s->get(Settings::Settings::inputButton9).toString().c_str());
+    
     translate[0] = parseSettingValue(s->get(Settings::Settings::inputTranslationX).toString());
     translate[1] = parseSettingValue(s->get(Settings::Settings::inputTranslationY).toString());
     translate[2] = parseSettingValue(s->get(Settings::Settings::inputTranslationZ).toString());

--- a/src/settings.cc
+++ b/src/settings.cc
@@ -70,24 +70,24 @@ static Value values(std::string s1, std::string s1disp, std::string s2, std::str
 static Value axisValues() {
 	Value::VectorType v;
 	v += ValuePtr(value("None", _("None")));
-	v += ValuePtr(value("+1", _("Axis 1")));
-	v += ValuePtr(value("-1", _("Axis 1 (inverted)")));
-	v += ValuePtr(value("+2", _("Axis 2")));
-	v += ValuePtr(value("-2", _("Axis 2 (inverted)")));
-	v += ValuePtr(value("+3", _("Axis 3")));
-	v += ValuePtr(value("-3", _("Axis 3 (inverted)")));
-	v += ValuePtr(value("+4", _("Axis 4")));
-	v += ValuePtr(value("-4", _("Axis 4 (inverted)")));
-	v += ValuePtr(value("+5", _("Axis 5")));
-	v += ValuePtr(value("-5", _("Axis 5 (inverted)")));
-	v += ValuePtr(value("+6", _("Axis 6")));
-	v += ValuePtr(value("-6", _("Axis 6 (inverted)")));
-	v += ValuePtr(value("+7", _("Axis 7")));
-	v += ValuePtr(value("-7", _("Axis 7 (inverted)")));
-	v += ValuePtr(value("+8", _("Axis 8")));
-	v += ValuePtr(value("-8", _("Axis 8 (inverted)")));
-	v += ValuePtr(value("+9", _("Axis 9")));
-	v += ValuePtr(value("-9", _("Axis 9 (inverted)")));
+	v += ValuePtr(value("+1", _("Axis 0")));
+	v += ValuePtr(value("-1", _("Axis 0 (inverted)")));
+	v += ValuePtr(value("+2", _("Axis 1")));
+	v += ValuePtr(value("-2", _("Axis 1 (inverted)")));
+	v += ValuePtr(value("+3", _("Axis 2")));
+	v += ValuePtr(value("-3", _("Axis 2 (inverted)")));
+	v += ValuePtr(value("+4", _("Axis 3")));
+	v += ValuePtr(value("-4", _("Axis 3 (inverted)")));
+	v += ValuePtr(value("+5", _("Axis 4")));
+	v += ValuePtr(value("-5", _("Axis 4 (inverted)")));
+	v += ValuePtr(value("+6", _("Axis 5")));
+	v += ValuePtr(value("-6", _("Axis 5 (inverted)")));
+	v += ValuePtr(value("+7", _("Axis 6")));
+	v += ValuePtr(value("-7", _("Axis 6 (inverted)")));
+	v += ValuePtr(value("+8", _("Axis 7")));
+	v += ValuePtr(value("-8", _("Axis 7 (inverted)")));
+	v += ValuePtr(value("+9", _("Axis 8")));
+	v += ValuePtr(value("-9", _("Axis 8 (inverted)")));
 	return v;
 }
 
@@ -259,6 +259,7 @@ SettingsEntry Settings::inputRotateX("input", "rotateX", axisValues(), Value("+4
 SettingsEntry Settings::inputRotateY("input", "rotateY", axisValues(), Value("-5"));
 SettingsEntry Settings::inputRotateZ("input", "rotateZ", axisValues(), Value("-6"));
 SettingsEntry Settings::inputZoom("input", "zoom", axisValues(), Value("None"));
+SettingsEntry Settings::inputButton0("input", "button0", buttonValues(), Value("None"));
 SettingsEntry Settings::inputButton1("input", "button1", buttonValues(), Value("viewActionResetView"));
 SettingsEntry Settings::inputButton2("input", "button2", buttonValues(), Value("None"));
 SettingsEntry Settings::inputButton3("input", "button3", buttonValues(), Value("None"));
@@ -267,4 +268,5 @@ SettingsEntry Settings::inputButton5("input", "button5", buttonValues(), Value("
 SettingsEntry Settings::inputButton6("input", "button6", buttonValues(), Value("None"));
 SettingsEntry Settings::inputButton7("input", "button7", buttonValues(), Value("None"));
 SettingsEntry Settings::inputButton8("input", "button8", buttonValues(), Value("None"));
+SettingsEntry Settings::inputButton9("input", "button9", buttonValues(), Value("None"));
 }

--- a/src/settings.h
+++ b/src/settings.h
@@ -59,6 +59,7 @@ public:
     static SettingsEntry inputRotateY;
     static SettingsEntry inputRotateZ;
     static SettingsEntry inputZoom;
+    static SettingsEntry inputButton0;
     static SettingsEntry inputButton1;
     static SettingsEntry inputButton2;
     static SettingsEntry inputButton3;
@@ -67,6 +68,7 @@ public:
     static SettingsEntry inputButton6;
     static SettingsEntry inputButton7;
     static SettingsEntry inputButton8;
+    static SettingsEntry inputButton9;
 
     static Settings *inst(bool erase = false);
 


### PR DESCRIPTION
add button 0 and button 9 (/dev/input/js0 numbers the first button 0. button 9 is to have an even number of buttons)

renumber the axis starting from 0 to confirm with low-level tools like jstest-gtk

(maybe we should make the numbering OS dependent?)