### PR TITLE
Add qscintalla2_qt5 to cmake search names

### DIFF
--- a/cmake/Modules/FindQt5QScintilla.cmake
+++ b/cmake/Modules/FindQt5QScintilla.cmake
@@ -80,7 +80,7 @@ endif ()
 
 
 find_library ( QT5QSCINTILLA_LIBRARY
-  NAMES qt5scintilla2 qscintilla2-qt5 qscintilla2
+  NAMES qt5scintilla2 qscintilla2-qt5 qscintilla2 qscintilla2_qt5
   HINTS ${Qt5Widgets_LIBRARIES}
 )
 


### PR DESCRIPTION
Building with cmake initially didn't work for me because it couldn't find the qscintilla library. I'm on Arch Linux and the library lives at `/usr/lib/libqscintilla2_qt5.so`, which seems to be different from some other distros. I added the new name to cmake to fix.