### PR TITLE
Add ccache to cmake. #2109

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,10 +7,14 @@ matrix:
       dist: trusty
       env: DIST="trusty"
       sudo: required
-      cache: apt
+      cache:
+        - apt
+        - ccache
     - os: osx
       compiler: clang
       env: DIST="osx"
+      cache:
+        - ccache
 
 notifications:
   irc:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -128,6 +128,15 @@ add_definitions(-DENABLE_EXPERIMENTAL)
 # Stack size 8MB; github issue 116
 add_definitions(-DSTACKSIZE=8388608)
 
+# Setup ccache (if available) to speed up recompiles. It's especially useful
+# when switching back and forth between branches where large numbers of files
+# would otherwise need to be re-compiled each time.
+find_program(CCACHE_PATH ccache)
+if (CCACHE_PATH)
+  set_property(GLOBAL PROPERTY RULE_LAUNCH_COMPILE ${CCACHE_PATH})
+  set_property(GLOBAL PROPERTY RULE_LAUNCH_LINK ${CCACHE_PATH})
+endif()
+
 #
 # Version
 #

--- a/openscad.pro
+++ b/openscad.pro
@@ -147,6 +147,8 @@ netbsd* {
   QMAKE_CXXFLAGS_WARN_ON += -Wno-sign-compare
 }
 
+!lessThan(QT_VERSION, 5.9): CONFIG += ccache
+
 CONFIG(skip-version-check) {
   # force the use of outdated libraries
   DEFINES += OPENSCAD_SKIP_VERSION_CHECK

--- a/scripts/macosx-build-homebrew.sh
+++ b/scripts/macosx-build-homebrew.sh
@@ -44,7 +44,7 @@ $TAP tap openscad/homebrew-tap
 # FIXME: We used to require unlinking boost, but doing so also causes us to lose boost.
 # Disabling until we can figure out why we unlinked in the first place
 # brew unlink boost
-for formula in eigen boost cgal glew glib opencsg freetype libzip libxml2 fontconfig harfbuzz qt5 qscintilla2 imagemagick; do
+for formula in eigen boost cgal glew glib opencsg freetype libzip libxml2 fontconfig harfbuzz qt5 qscintilla2 imagemagick ccache; do
   log "Installing formula $formula"
   brew ls --versions $formula
   time brew install $formula

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -91,6 +91,15 @@ else()
   endforeach()
 endif()
 
+# Setup ccache (if available) to speed up recompiles. It's especially useful
+# when switching back and forth between branches where large numbers of files
+# would otherwise need to be re-compiled each time.
+find_program(CCACHE_PATH ccache)
+if (CCACHE_PATH)
+  set_property(GLOBAL PROPERTY RULE_LAUNCH_COMPILE ${CCACHE_PATH})
+  set_property(GLOBAL PROPERTY RULE_LAUNCH_LINK ${CCACHE_PATH})
+endif()
+
 # MCAD
 if(NOT EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/../libraries/MCAD/__init__.py)
   message(FATAL_ERROR "MCAD not found. You can install from the OpenSCAD root as follows: \n  git submodule update --init")


### PR DESCRIPTION
This caches compiled object files, which can significantly speed up partial re-builds. This is most useful when switching between git branches. Normally, any changed files and dependencies would need to be re-compiled each time you switch branches. With ccache, any file that was previously compiled with the same inputs can be re-used from the cache.

I added a check so that it will only use ccache if it is installed.