### PR TITLE
Remove mixed tab characters from python source

### DIFF
--- a/tests/OpenSCAD_Test_Console.py
+++ b/tests/OpenSCAD_Test_Console.py
@@ -27,20 +27,20 @@ print 'searching for ctest.exe'
 ctestpath=''
 for basedir in 'C:/Program Files','C:/Program Files (x86)':
         if os.path.isdir(basedir):
-		pflist = os.listdir(basedir)
-		for subdir in pflist:
-			if 'cmake' in subdir.lower():
-				abssubdir=os.path.join(basedir,subdir)
-				for root,dirs,files in os.walk(abssubdir):
-					if 'ctest.exe' in files:
-						ctestpath=os.path.join(root,'ctest.exe')
+            pflist = os.listdir(basedir)
+            for subdir in pflist:
+                if 'cmake' in subdir.lower():
+                    abssubdir=os.path.join(basedir,subdir)
+                    for root,dirs,files in os.walk(abssubdir):
+                        if 'ctest.exe' in files:
+                            ctestpath=os.path.join(root,'ctest.exe')
 
 if not os.path.isfile(ctestpath):
         print 'error, cant find ctest.exe'
 else:
-	ctestdir = os.pathsep + os.path.dirname(ctestpath)
-	print 'adding ctest dir to PATH:',ctestdir
-	os.environ['PATH'] += ctestdir
+    ctestdir = os.pathsep + os.path.dirname(ctestpath)
+    print 'adding ctest dir to PATH:',ctestdir
+    os.environ['PATH'] += ctestdir
 
 #cmd = 'start "OpenSCAD Test console" /wait /d c:\\temp cmd.exe'
 #cmd = 'start /d "'+starting_dir+'" cmd.exe "OpenSCAD Test Console"'

--- a/tests/export_import_pngtest.py
+++ b/tests/export_import_pngtest.py
@@ -30,10 +30,10 @@ import sys, os, re, subprocess, argparse
 from validatestl import validateSTL
 
 def failquit(*args):
-	if len(args)!=0: print(args)
-	print('export_import_pngtest args:',str(sys.argv))
-	print('exiting export_import_pngtest.py with failure')
-	sys.exit(1)
+    if len(args)!=0: print(args)
+    print('export_import_pngtest args:',str(sys.argv))
+    print('exiting export_import_pngtest.py with failure')
+    sys.exit(1)
 
 def createImport(inputfile, scadfile):
         print ('createImport: ' + inputfile + " " + scadfile)
@@ -64,9 +64,9 @@ pngfile = remaining_args[-1]
 remaining_args = remaining_args[1:-1] # Passed on to the OpenSCAD executable
 
 if not os.path.exists(inputfile):
-	failquit('cant find input file named: ' + inputfile)
+    failquit('cant find input file named: ' + inputfile)
 if not os.path.exists(args.openscad):
-	failquit('cant find openscad executable named: ' + args.openscad)
+    failquit('cant find openscad executable named: ' + args.openscad)
 
 outputdir = os.path.dirname(pngfile)
 inputpath, inputfilename = os.path.split(inputfile)
@@ -97,11 +97,11 @@ print >> sys.stderr, 'Running OpenSCAD #1:'
 print >> sys.stderr, ' '.join(export_cmd)
 result = subprocess.call(export_cmd)
 if result != 0:
-	failquit('OpenSCAD #1 failed with return code ' + str(result))
+    failquit('OpenSCAD #1 failed with return code ' + str(result))
 
 if args.format == 'stl' and args.requiremanifold:
-        if not validateSTL(exportfile):
-                failquit("Error: Non-manifold STL file exported from OpenSCAD")
+    if not validateSTL(exportfile):
+        failquit("Error: Non-manifold STL file exported from OpenSCAD")
 
 
 #
@@ -110,8 +110,8 @@ if args.format == 'stl' and args.requiremanifold:
 newscadfile = exportfile
 # If we didn't export a .csg file, we need to import it
 if args.format != 'csg':
-        newscadfile += '.scad'
-        createImport(exportfile, newscadfile)
+    newscadfile += '.scad'
+    createImport(exportfile, newscadfile)
 
 create_png_cmd = [args.openscad, newscadfile, '-o', pngfile] + remaining_args
 print >> sys.stderr, 'Running OpenSCAD #2:'
@@ -121,10 +121,10 @@ fontenv = os.environ.copy();
 fontenv["OPENSCAD_FONT_PATH"] = fontdir;
 result = subprocess.call(create_png_cmd, env = fontenv);
 if result != 0:
-	failquit('OpenSCAD #2 failed with return code ' + str(result))
+    failquit('OpenSCAD #2 failed with return code ' + str(result))
 
 try:    os.remove(exportfile)
 except: failquit('failure at os.remove('+exportfile+')')
 if newscadfile != exportfile:
-        try:	os.remove(newscadfile)
-        except: failquit('failure at os.remove('+newscadfile+')')
+    try: os.remove(newscadfile)
+    except: failquit('failure at os.remove('+newscadfile+')')

--- a/tests/mingw_convert_ctest.py
+++ b/tests/mingw_convert_ctest.py
@@ -43,11 +43,11 @@ from _winreg import *
 _debug=False
 _undo=False
 def debug(*args):
-	global _debug
-	if _debug:
-		print 'mingw_x_testfile:',
-		for arg in args: print arg,
-		print
+    global _debug
+    if _debug:
+        print 'mingw_x_testfile:',
+        for arg in args: print arg,
+        print
 
 thisfile_abspath=os.path.abspath(__file__)
 
@@ -74,27 +74,27 @@ list32=[]
 imbase=''
 winconv=''
 try:
-	registry = ConnectRegistry(None,HKEY_LOCAL_MACHINE)
-	regkey = OpenKey(registry, r"SOFTWARE\ImageMagick\Current")
-	imbinpath = QueryValueEx(regkey, 'BinPath')[0]
+    registry = ConnectRegistry(None,HKEY_LOCAL_MACHINE)
+    regkey = OpenKey(registry, r"SOFTWARE\ImageMagick\Current")
+    imbinpath = QueryValueEx(regkey, 'BinPath')[0]
 except Exception as e:
-	print "Can't find imagemagick using registry...",
-	print str(type(e))+str(e)
-	pass
+    print "Can't find imagemagick using registry...",
+    print str(type(e))+str(e)
+    pass
 
 print 'Searching for ImageMagick in Program folders'
 for basedir in 'C:/Program Files','C:/Program Files (x86)':
-	if os.path.isdir(basedir):
-		pflist=os.listdir(basedir)
-		for subdir in pflist:
-			if 'ImageMagick' in subdir:
-				imbase = basedir+'/'+subdir
-				winconv = imbase+'/convert.exe'
-				if os.path.isfile(winconv):
-					break
-	if winconv != '': break
+    if os.path.isdir(basedir):
+        pflist=os.listdir(basedir)
+        for subdir in pflist:
+            if 'ImageMagick' in subdir:
+                imbase = basedir+'/'+subdir
+                winconv = imbase+'/convert.exe'
+                if os.path.isfile(winconv):
+                    break
+    if winconv != '': break
 if winconv=='':
-	print 'error, cant find convert.exe'
+    print 'error, cant find convert.exe'
 
 linoslib='OPENSCADPATH='+linbase+'/tests/../libraries'
 winoslib='OPENSCADPATH='+winbase+'/tests/../libraries'
@@ -109,82 +109,82 @@ if '--debug' in string.join(sys.argv): _debug=True
 if '--undo' in string.join(sys.argv): _undo=True
 
 if True:
-	print thisfile_abspath
-	print 'linbase',linbase
-	print 'winbase',winbase
-	print 'linbuild',linbuild
-	print 'winbuild',winbuild
-	print 'lintct',lintct
-	print 'wintct',wintct
-	print 'linpy',linpy
-	print 'winpy',winpy
-	print 'linosng',linosng
-	print 'winosng',winosng
-	print 'linconv',linconv
-	print 'winconv',winconv
-	print 'linoslib',linoslib
-	print 'winoslib',winoslib
-	print 'lintestdata',lintestdata
-	print 'wintestdata',wintestdata
-	print 'linexamples',linexamples
-	print 'winexamples',winexamples
-	
+    print thisfile_abspath
+    print 'linbase',linbase
+    print 'winbase',winbase
+    print 'linbuild',linbuild
+    print 'winbuild',winbuild
+    print 'lintct',lintct
+    print 'wintct',wintct
+    print 'linpy',linpy
+    print 'winpy',winpy
+    print 'linosng',linosng
+    print 'winosng',winosng
+    print 'linconv',linconv
+    print 'winconv',winconv
+    print 'linoslib',linoslib
+    print 'winoslib',winoslib
+    print 'lintestdata',lintestdata
+    print 'wintestdata',wintestdata
+    print 'linexamples',linexamples
+    print 'winexamples',winexamples
+
 def processfile(infilename):
-	backup_filename = infilename+'.backup'
-	if _undo:
-		open(infilename,'wb').write(open(backup_filename,'rb').read())
-		print 'restored ',infilename,'from backup'
-		return
-	open(backup_filename,'wb').write(open(infilename,'rb').read())
-	debug ('wrote backup of ',infilename,' to ',backup_filename)
+    backup_filename = infilename+'.backup'
+    if _undo:
+        open(infilename,'wb').write(open(backup_filename,'rb').read())
+        print 'restored ',infilename,'from backup'
+        return
+    open(backup_filename,'wb').write(open(infilename,'rb').read())
+    debug ('wrote backup of ',infilename,' to ',backup_filename)
 
-	outfilename = infilename.replace('.cmake','.win.cmake')
-	fin=open(infilename,'rb')
-	lines=fin.readlines()
-	fout=open(outfilename,'wb')
-	fout.write('#'+os.linesep)
-	fout.write('# modified by mingw_x_testfile.py'+os.linesep)
-	fout.write('#'+os.linesep)
+    outfilename = infilename.replace('.cmake','.win.cmake')
+    fin=open(infilename,'rb')
+    lines=fin.readlines()
+    fout=open(outfilename,'wb')
+    fout.write('#'+os.linesep)
+    fout.write('# modified by mingw_x_testfile.py'+os.linesep)
+    fout.write('#'+os.linesep)
 
-	debug('inputname',infilename)
-	debug('outputname',outfilename)
+    debug('inputname',infilename)
+    debug('outputname',outfilename)
 
-	for line in lines:
-		debug('input:',line)
+    for line in lines:
+        debug('input:',line)
 
-		# special for CTestCustom.template + ctest bugs w arguments
-		line=line.replace('--builddir='+linbuild,'')
-		
-		line=line.replace(linbuild,winbuild)
-		line=line.replace(lintct,wintct)
-		line=line.replace(linpy,winpy)
-		line=line.replace(linosng,winosng)
-		line=line.replace(linconv,winconv)
-		line=line.replace(linoslib,winoslib)
-		line=line.replace(lintestdata,wintestdata)
-		line=line.replace(linexamples,winexamples)
+        # special for CTestCustom.template + ctest bugs w arguments
+        line=line.replace('--builddir='+linbuild,'')
 
-		line=line.replace(linbase,winbase)
+        line=line.replace(linbuild,winbuild)
+        line=line.replace(lintct,wintct)
+        line=line.replace(linpy,winpy)
+        line=line.replace(linosng,winosng)
+        line=line.replace(linconv,winconv)
+        line=line.replace(linoslib,winoslib)
+        line=line.replace(lintestdata,wintestdata)
+        line=line.replace(linexamples,winexamples)
 
-		line=line.replace('\\"','__ESCAPE_WIN_QUOTE_MECHANISM__')
-		line=line.replace('\\','/')
-		line=line.replace('__ESCAPE_WIN_QUOTE_MECHANISM__','\\"')
+        line=line.replace(linbase,winbase)
 
-		debug('output:',line)
+        line=line.replace('\\"','__ESCAPE_WIN_QUOTE_MECHANISM__')
+        line=line.replace('\\','/')
+        line=line.replace('__ESCAPE_WIN_QUOTE_MECHANISM__','\\"')
 
-		fout.write(line)
+        debug('output:',line)
 
-	print 'backed up',infilename, 'to', backup_filename
-	print 'processed',infilename, 'to', outfilename
-	fin.close()
-	fout.close()
-	open(infilename,'wb').write(open(outfilename,'rb').read())
-	print 'new version of',infilename,'written'
+        fout.write(line)
+
+    print 'backed up',infilename, 'to', backup_filename
+    print 'processed',infilename, 'to', outfilename
+    fin.close()
+    fout.close()
+    open(infilename,'wb').write(open(outfilename,'rb').read())
+    print 'new version of',infilename,'written'
 
 def run():
-	processfile('CTestTestfile.cmake')
-	processfile('CTestCustom.cmake')
+    processfile('CTestTestfile.cmake')
+    processfile('CTestCustom.cmake')
 
 if __name__=='__main__':
-	run()
+    run()
 

--- a/tests/shouldfail.py
+++ b/tests/shouldfail.py
@@ -12,22 +12,22 @@
 import sys, os, re, subprocess, argparse
 
 def failquit(*args):
-	if len(args)!=0: print(args)
-	print('export_import_pngtest args:',str(sys.argv))
-	print('exiting export_import_pngtest.py with failure')
-	sys.exit(1)
+    if len(args)!=0: print(args)
+    print('export_import_pngtest args:',str(sys.argv))
+    print('exiting export_import_pngtest.py with failure')
+    sys.exit(1)
 
 def createImport(inputfile, scadfile):
-        print ('createImport: ' + inputfile + " " + scadfile)
-        outputdir = os.path.dirname(scadfile)
-        try:
-                if outputdir and not os.path.exists(outputdir): os.mkdir(outputdir)
-                f = open(scadfile,'w')
-                f.write('import("'+inputfile+'");'+os.linesep)
-                f.close()
-        except:
-                failquit('failure while opening/writing ' + scadfile + ': ' + str(sys.exc_info()))
-        
+    print ('createImport: ' + inputfile + " " + scadfile)
+    outputdir = os.path.dirname(scadfile)
+    try:
+        if outputdir and not os.path.exists(outputdir): os.mkdir(outputdir)
+        f = open(scadfile,'w')
+        f.write('import("'+inputfile+'");'+os.linesep)
+        f.close()
+    except:
+        failquit('failure while opening/writing ' + scadfile + ': ' + str(sys.exc_info()))
+
 
 #
 # Parse arguments
@@ -41,9 +41,9 @@ inputfile = remaining_args[0]         # Can be .scad file or a file to be import
 remaining_args = remaining_args[1:]    # Passed on to the OpenSCAD executable
 
 if not os.path.exists(inputfile):
-	failquit('cant find input file named: ' + inputfile)
+    failquit('cant find input file named: ' + inputfile)
 if not os.path.exists(args.openscad):
-	failquit('cant find openscad executable named: ' + args.openscad)
+    failquit('cant find openscad executable named: ' + args.openscad)
 
 inputpath, inputfilename = os.path.split(inputfile)
 inputbasename,inputsuffix = os.path.splitext(inputfilename)
@@ -53,4 +53,4 @@ print('Running OpenSCAD:')
 print(' '.join(export_cmd))
 result = subprocess.call(export_cmd)
 if str(result) != str(args.retval):
-	failquit('OpenSCAD failed with unexpected return value ' + str(result) + ' (should be ' + str(args.retval) + ')')
+    failquit('OpenSCAD failed with unexpected return value ' + str(result) + ' (should be ' + str(args.retval) + ')')

--- a/tests/test_cmdline_tool.py
+++ b/tests/test_cmdline_tool.py
@@ -39,9 +39,9 @@ _debug_tcct = False
 def debug(*args):
     global _debug_tcct
     if _debug_tcct:
-	print 'test_cmdline_tool:',
-	for a in args: print a,
-	print
+        print 'test_cmdline_tool:',
+        for a in args: print a,
+        print
 
 def initialize_environment():
     if not options.generate: options.generate = bool(os.getenv("TEST_GENERATE"))
@@ -138,7 +138,7 @@ def compare_default(resultfilename):
     expected_text = get_normalized_text(expectedfilename)
     actual_text = get_normalized_text(resultfilename)
     if not expected_text == actual_text:
-	if resultfilename: 
+        if resultfilename: 
             differences = difflib.unified_diff(
                 [line.strip() for line in expected_text.splitlines()],
                 [line.strip() for line in actual_text.splitlines()])
@@ -187,11 +187,11 @@ def compare_png(resultfilename):
     (retval, output) = execute_and_redirect(options.comparison_exec, args, subprocess.PIPE)
     print "Image comparison return:", retval, "output:", output
     if retval == 0:
-	if compare_method=='pixel':
+        if compare_method=='pixel':
             pixelerr = int(float(output.strip()))
             if pixelerr < 32: return True
             else: print >> sys.stderr, pixelerr, ' pixel errors'
-	elif compare_method=='NCC':
+        elif compare_method=='NCC':
             thresh = 0.95
             ncc_err = float(output.strip())
             if ncc_err > thresh or ncc_err==0.0: return True
@@ -237,7 +237,7 @@ def run_test(testname, cmd, args):
         print 'using font directory:', fontdir
         sys.stdout.flush()
         proc = subprocess.Popen(cmdline, env = fontenv, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
-	comresult = proc.communicate()
+        comresult = proc.communicate()
         stdouttext, errtext = comresult[0],comresult[1]
         if errtext != None and len(errtext) > 0:
             print >> sys.stderr, "stderr output: " + errtext


### PR DESCRIPTION
whitespace-only changes.

.py source files had tabs mixed with spaces, all tabs removed and indented to the appropriate multiple of 4 spaces