### PR TITLE
Add clang-format script

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -2,3 +2,5 @@
 BasedOnStyle: Google
 IndentWidth: 4
 AccessModifierOffset: -4
+UseTab: ForIndentation
+TabWidth: 4

--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,4 @@
+---
+BasedOnStyle: Google
+IndentWidth: 4
+AccessModifierOffset: -4

--- a/.clang-format
+++ b/.clang-format
@@ -4,3 +4,4 @@ IndentWidth: 4
 AccessModifierOffset: -4
 UseTab: ForIndentation
 TabWidth: 4
+BreakBeforeBraces: Linux

--- a/.clang-format
+++ b/.clang-format
@@ -1,7 +1,21 @@
 ---
-BasedOnStyle: Google
-IndentWidth: 4
-AccessModifierOffset: -4
-UseTab: ForIndentation
-TabWidth: 4
-BreakBeforeBraces: Linux
+Language:     Cpp
+BasedOnStyle: LLVM
+
+AlignEscapedNewlinesLeft: true
+AllowShortFunctionsOnASingleLine: Inline
+AllowShortIfStatementsOnASingleLine: true
+AllowShortLoopsOnASingleLine: true
+AlwaysBreakTemplateDeclarations: true
+BraceWrapping:
+   AfterClass:            true
+   AfterFunction:         true
+BreakBeforeBraces: Custom
+ColumnLimit:     100
+ConstructorInitializerIndentWidth: 2
+NamespaceIndentation: All
+PenaltyReturnTypeOnItsOwnLine: 1000
+SortIncludes: false
+TabWidth:        2
+UseTab:          ForContinuationAndIndentation
+...

--- a/.uncrustify.cfg
+++ b/.uncrustify.cfg
@@ -1,0 +1,15 @@
+indent_with_tabs=2
+input_tab_size=2
+output_tab_size=2
+indent_columns=output_tab_size
+indent_class=true
+indent_namespace=false
+indent_extern=true
+
+nl_func_leave_one_liners=true
+
+sp_angle_shift=remove
+sp_permit_cpp11_shift=true
+
+sp_after_semi_for=ignore
+sp_before_semi_for=ignore

--- a/scripts/beautify.sh
+++ b/scripts/beautify.sh
@@ -22,7 +22,7 @@ function reformat_all() {
 DIFFBASE="origin/master"
 function reformat_changed() {
     ANCESTOR=$(git merge-base HEAD "$DIFFBASE")
-    FILES=$(git --no-pager diff --name-only $ANCESTOR | grep -E "\.h|\.hpp|\.cc|\.cpp" | $FILTER_CMD)
+    FILES=$(git --no-pager diff --name-only $ANCESTOR | grep -E "\.(h|hpp|cc|cpp)" | $FILTER_CMD)
     if [ $? -ne 0 ]; then
         echo "No files to format, exiting..."
     else

--- a/scripts/beautify.sh
+++ b/scripts/beautify.sh
@@ -7,14 +7,14 @@
 FORMAT_CMD="clang-format -i -style=file"
 
 function reformat_all() {
-    find . -name "*.h" -o -name "*.cc" | xargs $FORMAT_CMD
+    find . -name "*.h" -o -name "*.hpp" -o -name "*.cc" -o -name "*.cpp" | xargs $FORMAT_CMD
 }
 
 # reformat files that differ from master.
 DIFFBASE="origin/master"
 function reformat_changed() {
     ANCESTOR=$(git merge-base HEAD "$DIFFBASE")
-    FILES=$(git --no-pager diff --name-only $ANCESTOR | grep -E "\.cc|\.h")
+    FILES=$(git --no-pager diff --name-only $ANCESTOR | grep -E "\.h|\.hpp|\.cc|\.cpp")
     if [ $? -ne 0 ]; then
         echo "No files to format, exiting..."
     else

--- a/scripts/beautify.sh
+++ b/scripts/beautify.sh
@@ -4,13 +4,15 @@
 
 # note: with the -style=file option, clang-format reads the config from ./.clang-format
 # See here for the full list of supported options: https://clang.llvm.org/docs/ClangFormatStyleOptions.html
-FORMAT_CMD="clang-format -i -style=file"
+FORMAT_CMD_CLANG_FORMAT="clang-format -i -style=file"
+FORMAT_CMD_UNCRUSTIFY="uncrustify -c .uncrustify.cfg --no-backup"
+FORMAT_CMD=$FORMAT_CMD_CLANG_FORMAT
 
 # Filter out any files that shouldn't be auto-formatted.
 # note: -v flag inverts selection - this tells grep to *filter out* anything
 #       that matches the pattern. For testing, you can remove the -v to ssee
 #       which files would have been excluded.
-FILTER_CMD="grep -v -E objects|src/polyclipping|src/CGAL_Nef3_workaround.h|src/CGAL_workaround_Mark_bounded_volumes.h|src/convex_hull_3_bugfix.h|src/OGL_helper.h"
+FILTER_CMD="grep -v -E objects|src/libsvg|src/libtess2|src/polyclipping|src/CGAL_Nef3_workaround.h|src/CGAL_workaround_Mark_bounded_volumes.h|src/convex_hull_3_bugfix.h|src/OGL_helper.h"
 
 function reformat_all() {
     find src -name "*.h" -o -name "*.hpp" -o -name "*.cc" -o -name "*.cpp" \
@@ -32,7 +34,10 @@ function reformat_changed() {
 }
 
 # main
-if [[ "$#" -eq 1 && "$1" == "--all" ]]; then
+if [ "`echo $* | grep uncrust`" ]; then
+    FORMAT_CMD=$FORMAT_CMD_UNCRUSTIFY
+fi
+if [ "`echo $* | grep -- --all`" ]; then
     echo "Reformatting all files..."
     reformat_all
 else

--- a/scripts/beautify.sh
+++ b/scripts/beautify.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+
+# Reformat C++ code using clang-format
+
+# note: with the -style=file option, clang-format reads the config from ./.clang-format
+# See here for the full list of supported options: https://clang.llvm.org/docs/ClangFormatStyleOptions.html
+FORMAT_CMD="clang-format -i -style=file"
+
+function reformat_all() {
+    find . -name "*.h" -o -name "*.cc" | xargs $FORMAT_CMD
+}
+
+# reformat files that differ from master.
+DIFFBASE="origin/master"
+function reformat_changed() {
+    ANCESTOR=$(git merge-base HEAD "$DIFFBASE")
+    FILES=$(git --no-pager diff --name-only $ANCESTOR | grep -E "\.cc|\.h")
+    if [ $? -ne 0 ]; then
+        echo "No files to format, exiting..."
+    else
+        echo -e "Reformatting files:\n$FILES"
+        echo $FILES | xargs $FORMAT_CMD
+    fi
+}
+
+# main
+if [[ "$#" -eq 1 && "$1" == "--all" ]]; then
+    echo "Reformatting all files..."
+    reformat_all
+else
+    echo "Reformatting files that differ from $DIFFBASE..."
+    reformat_changed
+fi

--- a/scripts/beautify.sh
+++ b/scripts/beautify.sh
@@ -13,7 +13,7 @@ FORMAT_CMD="clang-format -i -style=file"
 FILTER_CMD="grep -v -E objects|src/polyclipping|src/CGAL_Nef3_workaround.h|src/CGAL_workaround_Mark_bounded_volumes.h|src/convex_hull_3_bugfix.h|src/OGL_helper.h"
 
 function reformat_all() {
-    find . -name "*.h" -o -name "*.hpp" -o -name "*.cc" -o -name "*.cpp" \
+    find src -name "*.h" -o -name "*.hpp" -o -name "*.cc" -o -name "*.cpp" \
         | $FILTER_CMD \
         | xargs $FORMAT_CMD
 }

--- a/scripts/beautify.sh
+++ b/scripts/beautify.sh
@@ -12,11 +12,8 @@ FORMAT_CMD="clang-format -i -style=file"
 #       which files would have been excluded.
 FILTER_CMD="grep -v -E objects|src/polyclipping|src/CGAL_Nef3_workaround.h|src/CGAL_workaround_Mark_bounded_volumes.h|src/convex_hull_3_bugfix.h|src/OGL_helper.h"
 
-# C++ file extensions
-SRC_PATTERN=".*\.(h|hpp|cc|cpp)"
-
 function reformat_all() {
-    find . -regextype posix-extended -regex "$SRC_PATTERN" \
+    find . -name "*.h" -o -name "*.hpp" -o -name "*.cc" -o -name "*.cpp" \
         | $FILTER_CMD \
         | xargs $FORMAT_CMD
 }
@@ -25,7 +22,7 @@ function reformat_all() {
 DIFFBASE="origin/master"
 function reformat_changed() {
     ANCESTOR=$(git merge-base HEAD "$DIFFBASE")
-    FILES=$(git --no-pager diff --name-only $ANCESTOR | grep -E "$SRC_PATTERN" | $FILTER_CMD)
+    FILES=$(git --no-pager diff --name-only $ANCESTOR | grep -E "\.h|\.hpp|\.cc|\.cpp" | $FILTER_CMD)
     if [ $? -ne 0 ]; then
         echo "No files to format, exiting..."
     else

--- a/scripts/beautify.sh
+++ b/scripts/beautify.sh
@@ -6,15 +6,26 @@
 # See here for the full list of supported options: https://clang.llvm.org/docs/ClangFormatStyleOptions.html
 FORMAT_CMD="clang-format -i -style=file"
 
+# Filter out any files that shouldn't be auto-formatted.
+# note: -v flag inverts selection - this tells grep to *filter out* anything
+#       that matches the pattern. For testing, you can remove the -v to ssee
+#       which files would have been excluded.
+FILTER_CMD="grep -v -E objects|src/polyclipping|src/CGAL_Nef3_workaround.h|src/CGAL_workaround_Mark_bounded_volumes.h|src/convex_hull_3_bugfix.h|src/OGL_helper.h"
+
+# C++ file extensions
+SRC_PATTERN=".*\.(h|hpp|cc|cpp)"
+
 function reformat_all() {
-    find . -name "*.h" -o -name "*.hpp" -o -name "*.cc" -o -name "*.cpp" | xargs $FORMAT_CMD
+    find . -regextype posix-extended -regex "$SRC_PATTERN" \
+        | $FILTER_CMD \
+        | xargs $FORMAT_CMD
 }
 
 # reformat files that differ from master.
 DIFFBASE="origin/master"
 function reformat_changed() {
     ANCESTOR=$(git merge-base HEAD "$DIFFBASE")
-    FILES=$(git --no-pager diff --name-only $ANCESTOR | grep -E "\.h|\.hpp|\.cc|\.cpp")
+    FILES=$(git --no-pager diff --name-only $ANCESTOR | grep -E "$SRC_PATTERN" | $FILTER_CMD)
     if [ $? -ne 0 ]; then
         echo "No files to format, exiting..."
     else


### PR DESCRIPTION
I'm not sure how interested you all are in having a set code format, but I've seen it discussed on a few issues on this project and have personally found these tools to be really useful, especially on projects with many contributors. Having consistent formatting across files improves readability and the tools available, such as clang-format, make this really easy.

This PR adds a basic script for running clang-format on this project's code. By default, it only re-formats files that differ from the master branch, which prevents spurious diffs from showing up in irrelevant files. It also provides a `--all` flag that will instead reformat *all* .h and .cc files in the repo.

### config

clang-format reads from the `.clang-format` file for formatting options. I set this to default to the Google style for most things, but made a couple minor changes based on the current code style. Please check out the clang-format docs site and see if there are other options that would better suit the current/desired format: https://clang.llvm.org/docs/ClangFormatStyleOptions.html.


### try it out!

(Save your current work first, then...) Run `./scripts/beautify.sh --all` to reformat everything, then `git diff` to see what changes were made. If you see changes that you dislike, there may be config options (linked above) to change them.

### usage

Initially, you'll want to reformat the whole repository. This is easy to do, but has some downsides:
* lots of extra diffs with open pull requests
  * these are reduced if you run the formatter on each PR branch before attempting to merge, but the extra diffs still make it harder for git to figure out what happened in some situations.
* Sometimes the auto-formatted version of the code is worse than the original.
  * Code comments may need to be re-wrapped - sometimes the auto-formatter wrapping does weird things
  * On occasion, you may need to add `// clang-format off` and `// clang-format on` comments before and after, respectively, some code pieces that you'd prefer manual formatting for.

After the initial formatting, you only need to re-run the formatter on files as they change. In practice, this means encouraging pull-request submitters to run the formatting script and/or running it before merging the pull requests.

Here's a diff showing an initial formatting run on the whole repo. There are a lot of diffs, but most of them are just whitespace. https://github.com/justbuchanan/openscad/commit/02d505ccbad72771603a37c6f15264592e184fd9.

TODO
- [ ] Add note to contributing guide
- [ ] Allow running from within the `scripts` dir. Needs to `cd` to the root directory of the repo before running