### PR TITLE
Make Inputdriver5 an experimental Feature

### DIFF
--- a/openscad.pro
+++ b/openscad.pro
@@ -1,4 +1,3 @@
-CONFIG+=experimental
 # Environment variables which can be set to specify library locations:
 # MPIRDIR
 # MPFRDIR

--- a/openscad.pro
+++ b/openscad.pro
@@ -1,3 +1,4 @@
+CONFIG+=experimental
 # Environment variables which can be set to specify library locations:
 # MPIRDIR
 # MPFRDIR

--- a/src/Preferences.cc
+++ b/src/Preferences.cc
@@ -41,6 +41,7 @@
 #include "colormap.h"
 #include "rendersettings.h"
 #include "QSettingsCached.h"
+#include "input/InputDriverManager.h"
 
 Preferences *Preferences::instance = nullptr;
 
@@ -296,6 +297,11 @@ void Preferences::featuresCheckBoxToggled(bool state)
 	QSettingsCached settings;
 	settings.setValue(QString("feature/%1").arg(QString::fromStdString(feature->get_name())), state);
 	emit ExperimentalChanged();
+
+	if (!Feature::ExperimentalInputDriver.is_enabled()) {
+		this->toolBar->removeAction(prefsActionInput);
+		InputDriverManager::instance()->closeDrivers();
+	}
 }
 
 /**

--- a/src/Preferences.cc
+++ b/src/Preferences.cc
@@ -181,11 +181,13 @@ void Preferences::init() {
 #endif
 #ifdef ENABLE_EXPERIMENTAL
 	addPrefPage(group, prefsActionFeatures, pageFeatures);
+	addPrefPage(group, prefsActionInput, pageInput);
 #else
 	this->toolBar->removeAction(prefsActionFeatures);
+	this->toolBar->removeAction(prefsActionInput);
 #endif
 	addPrefPage(group, prefsActionAdvanced, pageAdvanced);
-	addPrefPage(group, prefsActionInput, pageInput);
+	
 	connect(group, SIGNAL(triggered(QAction*)), this, SLOT(actionTriggered(QAction*)));
 
 	prefsAction3DView->setChecked(true);

--- a/src/feature.cc
+++ b/src/feature.cc
@@ -27,7 +27,7 @@ const Feature Feature::ExperimentalForCExpression("lc-for-c", "Enable C-style <c
 const Feature Feature::ExperimentalAmfImport("amf-import", "Enable AMF import.");
 const Feature Feature::ExperimentalSvgImport("svg-import", "Enable SVG import.");
 const Feature Feature::ExperimentalCustomizer("customizer", "Enable Customizer");
-
+const Feature Feature::ExperimentalInputDriver("input drive", "Enable input drivers (requires restart)");
 
 Feature::Feature(const std::string &name, const std::string &description)
 	: enabled(false), name(name), description(description)

--- a/src/feature.cc
+++ b/src/feature.cc
@@ -27,7 +27,7 @@ const Feature Feature::ExperimentalForCExpression("lc-for-c", "Enable C-style <c
 const Feature Feature::ExperimentalAmfImport("amf-import", "Enable AMF import.");
 const Feature Feature::ExperimentalSvgImport("svg-import", "Enable SVG import.");
 const Feature Feature::ExperimentalCustomizer("customizer", "Enable Customizer");
-const Feature Feature::ExperimentalInputDriver("input-drive", "Enable input drivers (requires restart)");
+const Feature Feature::ExperimentalInputDriver("input-driver", "Enable input drivers (requires restart)");
 
 Feature::Feature(const std::string &name, const std::string &description)
 	: enabled(false), name(name), description(description)

--- a/src/feature.cc
+++ b/src/feature.cc
@@ -27,7 +27,7 @@ const Feature Feature::ExperimentalForCExpression("lc-for-c", "Enable C-style <c
 const Feature Feature::ExperimentalAmfImport("amf-import", "Enable AMF import.");
 const Feature Feature::ExperimentalSvgImport("svg-import", "Enable SVG import.");
 const Feature Feature::ExperimentalCustomizer("customizer", "Enable Customizer");
-const Feature Feature::ExperimentalInputDriver("input drive", "Enable input drivers (requires restart)");
+const Feature Feature::ExperimentalInputDriver("input-drive", "Enable input drivers (requires restart)");
 
 Feature::Feature(const std::string &name, const std::string &description)
 	: enabled(false), name(name), description(description)

--- a/src/feature.h
+++ b/src/feature.h
@@ -22,7 +22,7 @@ public:
         static const Feature ExperimentalAmfImport;
         static const Feature ExperimentalSvgImport;
         static const Feature ExperimentalCustomizer;
-
+        static const Feature ExperimentalInputDriver;
 
 	const std::string& get_name() const;
 	const std::string& get_description() const;

--- a/src/input/InputDriver.h
+++ b/src/input/InputDriver.h
@@ -115,7 +115,7 @@ public:
     const double y;
     const double z;
     const bool relative;
-	const bool viewPortRelative;
+    const bool viewPortRelative;
     InputEventTranslate(const double x, const double y, const double z, const bool relative = true, const bool viewPortRelative=false, const bool activeOnly = true) : InputEvent(activeOnly), x(x), y(y), z(z), relative(relative), viewPortRelative(viewPortRelative) { }
 
     void deliver(InputEventHandler *receiver)

--- a/src/input/InputDriverManager.cc
+++ b/src/input/InputDriverManager.cc
@@ -71,6 +71,8 @@ void InputDriverManager::registerActions(const QList<QAction *> &actions)
     }
 }
 
+
+
 void InputDriverManager::init()
 {
     doOpen(true);
@@ -127,6 +129,18 @@ std::string InputDriverManager::listDrivers()
         sep = ", ";
     }
     return stream.str();
+}
+
+void InputDriverManager::closeDrivers()
+{
+	stopRequest = true;
+	timer->stop();
+	InputEventMapper::instance()->stop();
+
+    for (drivers_t::iterator it = drivers.begin();it != drivers.end();it++) {
+        InputDriver *driver = (*it);
+        driver->close();
+    }
 }
 
 void InputDriverManager::sendEvent(InputEvent *event)

--- a/src/input/InputDriverManager.cc
+++ b/src/input/InputDriverManager.cc
@@ -131,9 +131,9 @@ std::string InputDriverManager::listDrivers()
 
 void InputDriverManager::closeDrivers()
 {
-	stopRequest = true;
-	timer->stop();
-	InputEventMapper::instance()->stop();
+    stopRequest = true;
+    timer->stop();
+    InputEventMapper::instance()->stop();
 
     for (drivers_t::iterator it = drivers.begin();it != drivers.end();it++) {
         InputDriver *driver = (*it);

--- a/src/input/InputDriverManager.cc
+++ b/src/input/InputDriverManager.cc
@@ -71,8 +71,6 @@ void InputDriverManager::registerActions(const QList<QAction *> &actions)
     }
 }
 
-
-
 void InputDriverManager::init()
 {
     doOpen(true);

--- a/src/input/InputDriverManager.cc
+++ b/src/input/InputDriverManager.cc
@@ -80,8 +80,7 @@ void InputDriverManager::init()
 
 void InputDriverManager::onTimeout()
 {
-    for (drivers_t::iterator it = drivers.begin(); it != drivers.end(); it++) {
-        InputDriver *driver = (*it);
+    for (auto driver : drivers) {
         if (driver->openOnce()) {
             continue;
         }
@@ -94,8 +93,7 @@ void InputDriverManager::onTimeout()
 
 void InputDriverManager::doOpen(bool firstOpen)
 {
-    for (drivers_t::iterator it = drivers.begin();it != drivers.end();it++) {
-        InputDriver *driver = (*it);
+    for (auto driver : drivers) {
         if (driver->openOnce()) {
             continue;
         }
@@ -105,8 +103,7 @@ void InputDriverManager::doOpen(bool firstOpen)
     }
 
     if (firstOpen) {
-        for (drivers_t::iterator it = drivers.begin();it != drivers.end();it++) {
-            InputDriver *driver = (*it);
+        for (auto driver : drivers) {
             if (driver->openOnce()) {
                 driver->open();
             }
@@ -118,8 +115,7 @@ std::string InputDriverManager::listDrivers()
 {
     std::stringstream stream;
     const char *sep = "";
-    for (drivers_t::iterator it = drivers.begin();it != drivers.end();it++) {
-        InputDriver *driver = (*it);
+    for (auto driver : drivers) {
         stream << sep << driver->get_name();
         if (driver->isOpen()) {
             stream << "*";
@@ -135,8 +131,7 @@ void InputDriverManager::closeDrivers()
     timer->stop();
     InputEventMapper::instance()->stop();
 
-    for (drivers_t::iterator it = drivers.begin();it != drivers.end();it++) {
-        InputDriver *driver = (*it);
+    for (auto driver : drivers) {
         driver->close();
     }
 }

--- a/src/input/InputDriverManager.h
+++ b/src/input/InputDriverManager.h
@@ -49,6 +49,8 @@ private:
 
     QTimer *timer;
 
+    volatile bool stopRequest;
+
     static InputDriverManager *self;
 
     void postEvent(InputEvent *event);
@@ -63,6 +65,7 @@ public:
     std::string listDrivers();
     void registerDriver(InputDriver *driver);
     void unregisterDriver(InputDriver *driver);
+    void closeDrivers();
     void registerActions(const QList<QAction *> &actions);
 
     static InputDriverManager * instance();

--- a/src/input/InputEventMapper.cc
+++ b/src/input/InputEventMapper.cc
@@ -187,6 +187,6 @@ void InputEventMapper::onInputMappingUpdated()
 }
 
 void InputEventMapper::stop(){
-	stopRequest=true;
-	timer->stop();
+    stopRequest=true;
+    timer->stop();
 }

--- a/src/input/InputEventMapper.cc
+++ b/src/input/InputEventMapper.cc
@@ -30,8 +30,12 @@
 #include <math.h>
 #include <QSettings>
 
+InputEventMapper * InputEventMapper::self = 0;
+
 InputEventMapper::InputEventMapper()
 {
+    stopRequest=false;
+
     for (int a = 0;a < 10;a++) {
         axisValue[a] = 0;
     }
@@ -41,11 +45,21 @@ InputEventMapper::InputEventMapper()
     timer->start(30);
 
     onInputMappingUpdated();
+
+    self=this;
 }
 
 InputEventMapper::~InputEventMapper()
 {
 
+}
+
+InputEventMapper * InputEventMapper::instance()
+{
+    if (!self) {
+        self = new InputEventMapper();
+    }
+    return self;
 }
 
 double InputEventMapper::scale(double val)
@@ -159,4 +173,9 @@ void InputEventMapper::onInputMappingUpdated()
     rotate[1] = parseSettingValue(s->get(Settings::Settings::inputRotateY).toString());
     rotate[2] = parseSettingValue(s->get(Settings::Settings::inputRotateZ).toString());
     zoom = parseSettingValue(s->get(Settings::Settings::inputZoom).toString());
+}
+
+void InputEventMapper::stop(){
+	stopRequest=true;
+	timer->stop();
 }

--- a/src/input/InputEventMapper.h
+++ b/src/input/InputEventMapper.h
@@ -41,14 +41,19 @@ private:
     int translate[3];
     int rotate[3];
     int zoom;
+    volatile bool stopRequest;
 
     double scale(double val);
     double getAxisValue(int config);
     int parseSettingValue(const std::string val);
 
+    static InputEventMapper *self;
+
 public:
     InputEventMapper();
     virtual ~InputEventMapper();
+
+    void stop();
 
     void onAxisChanged(class InputEventAxisChanged *event);
     void onButtonChanged(class InputEventButtonChanged *event);
@@ -59,6 +64,8 @@ public:
     void onZoomEvent(class InputEventZoom *event);
 
     void onInputMappingUpdated();
+
+    static InputEventMapper * instance();
 
 private slots:
     void onTimer();

--- a/src/input/JoystickInputDriver.cc
+++ b/src/input/JoystickInputDriver.cc
@@ -37,7 +37,7 @@ void JoystickInputDriver::run()
 {
     struct js_event js;
 
-    while (read(fd, &js, sizeof(struct js_event)) > 0) {
+    while (read(fd, &js, sizeof(struct js_event)) > 0 && !stopRequest) {
         switch (js.type & ~JS_EVENT_INIT) {
         case JS_EVENT_BUTTON:
             InputDriverManager::instance()->sendEvent(new InputEventButtonChanged(js.number, js.value != 0));
@@ -62,6 +62,8 @@ JoystickInputDriver::~JoystickInputDriver()
 
 bool JoystickInputDriver::open()
 {
+	stopRequest = false;
+
     fd = ::open("/dev/input/js0", O_RDONLY);
     if (fd < 0) {
         return false;
@@ -83,7 +85,7 @@ bool JoystickInputDriver::open()
 
 void JoystickInputDriver::close()
 {
-
+	stopRequest=true;
 }
 
 const std::string & JoystickInputDriver::get_name() const

--- a/src/input/JoystickInputDriver.cc
+++ b/src/input/JoystickInputDriver.cc
@@ -62,7 +62,7 @@ JoystickInputDriver::~JoystickInputDriver()
 
 bool JoystickInputDriver::open()
 {
-	stopRequest = false;
+    stopRequest = false;
 
     fd = ::open("/dev/input/js0", O_RDONLY);
     if (fd < 0) {
@@ -85,7 +85,7 @@ bool JoystickInputDriver::open()
 
 void JoystickInputDriver::close()
 {
-	stopRequest=true;
+    stopRequest=true;
 }
 
 const std::string & JoystickInputDriver::get_name() const

--- a/src/input/JoystickInputDriver.h
+++ b/src/input/JoystickInputDriver.h
@@ -44,4 +44,5 @@ private:
     unsigned char axes;
     unsigned char buttons;
     char name[1024];
+    volatile bool stopRequest;
 };

--- a/src/openscad.cc
+++ b/src/openscad.cc
@@ -785,6 +785,7 @@ int gui(vector<string> &inputFiles, const fs::path &original_path, int argc, cha
 	}
 
 	app.connect(&app, SIGNAL(lastWindowClosed()), &app, SLOT(quit()));
+	if (Feature::ExperimentalInputDriver.is_enabled()) {
 #ifdef ENABLE_HIDAPI
         InputDriverManager::instance()->registerDriver(new HidApiInputDriver());
 #endif
@@ -798,6 +799,7 @@ int gui(vector<string> &inputFiles, const fs::path &original_path, int argc, cha
         InputDriverManager::instance()->registerDriver(new DBusInputDriver());
 #endif
         InputDriverManager::instance()->init();
+    }
 	int rc = app.exec();
 	for (auto &mainw : scadApp->windowManager.getWindows()) delete mainw;
 	return rc;


### PR DESCRIPTION
Added the inputdriver to the list of experimental features.
CONFIG+=experimental as we explicitly work on an experimental feature.
Add code to stop the drivers when the features gets disabled during run time.
Hide the UI when the feature is disabled.

I think it makes sense tobe able to disable the inputdriver(s), even when the feature becomes one day stable.