### PR TITLE
show the pressed button in the preference UI

### DIFF
--- a/src/Preferences.cc
+++ b/src/Preferences.cc
@@ -942,6 +942,18 @@ void Preferences::create(QStringList colorSchemes)
     instance->updateGUI();
 }
 
+void Preferences::ButtonPressed(int nr, bool pressed) const{
+	QString Style = Preferences::EmptyString;
+	if(pressed){
+		Style=Preferences::ActiveStyleString;
+	}
+	std::string number = std::to_string(nr);
+
+	QLabel* label = this->centralwidget->findChild<QLabel *>(QString::fromStdString("labelInputButton"+number));
+	if(label==0) return;
+	label->setStyleSheet(Style);
+}
+
 Preferences *Preferences::inst() {
     assert(instance != nullptr);
     

--- a/src/Preferences.cc
+++ b/src/Preferences.cc
@@ -942,7 +942,7 @@ void Preferences::create(QStringList colorSchemes)
     instance->updateGUI();
 }
 
-void Preferences::ButtonPressed(int nr, bool pressed) const{
+void Preferences::updateButtonState(int nr, bool pressed) const{
 	QString Style = Preferences::EmptyString;
 	if(pressed){
 		Style=Preferences::ActiveStyleString;

--- a/src/Preferences.h
+++ b/src/Preferences.h
@@ -21,6 +21,7 @@ public:
 	void init();
 	void apply() const;
 	void fireEditorConfigChanged() const;
+	void ButtonPressed(int,bool) const;
 
 public slots:
 	void actionTriggered(class QAction *);
@@ -131,4 +132,7 @@ private:
 
 	static Preferences *instance;
 	static const char *featurePropertyName;
+
+	const QString EmptyString= QString("");
+	const QString ActiveStyleString= QString("font-weight: bold; color: red");
 };

--- a/src/Preferences.h
+++ b/src/Preferences.h
@@ -21,7 +21,7 @@ public:
 	void init();
 	void apply() const;
 	void fireEditorConfigChanged() const;
-	void ButtonPressed(int,bool) const;
+	void updateButtonState(int,bool) const;
 
 public slots:
 	void actionTriggered(class QAction *);

--- a/src/input/InputEventMapper.cc
+++ b/src/input/InputEventMapper.cc
@@ -36,7 +36,11 @@ InputEventMapper::InputEventMapper()
     for (int a = 0;a < 10;a++) {
         axisValue[a] = 0;
     }
-
+    for (int a = 0;a < 10;a++) {
+        button_state[a]=false;
+        button_state_last[a]=false;
+    }
+    
     timer = new QTimer(this);
     connect(timer, SIGNAL(timeout()), this, SLOT(onTimer()));
     timer->start(30);
@@ -102,7 +106,7 @@ void InputEventMapper::onTimer()
     for (int i = 0; i < 10; i++ ){
         if(button_state[i] != button_state_last[i]){
             button_state_last[i] = button_state[i];
-            Preferences::inst()->ButtonPressed(i,button_state[i]);
+            Preferences::inst()->updateButtonState(i,button_state[i]);
         }
     }
 }

--- a/src/input/InputEventMapper.h
+++ b/src/input/InputEventMapper.h
@@ -46,6 +46,9 @@ private:
     double getAxisValue(int config);
     int parseSettingValue(const std::string val);
 
+    bool button_state[10];
+    bool button_state_last[10];
+
 public:
     InputEventMapper();
     virtual ~InputEventMapper();


### PR DESCRIPTION
Showing which button the user is currently is pressing greatly simplifies the input mapping for the user.

It has to be "on time" and not "on event", as my cheap gamepad with turbo function managed to glitch and then crash the UI. Updating the UI "on time" naturally limits and bottlenecks this kind of abuse.
In order tobe able to do something "on time" I need to store the button state. To only update the UI when needed, I compare the current button state to the previous button state. In order to not constantly create QStrings, I use constants for the QStrings.

Note that I use findChild to find the label to be affected. The benefit is, that we can easily scale to more buttons. The drawback is, that the compiler can not check it.

Note that I use seperate for-loops for buttons and axis, despite both of them iterating to 10.
This is intentional. 10 axis is plenty for a controller, but 10 buttons is limiting.