### PR TITLE
use constants for array sizes in the inputdriver

### DIFF
--- a/src/input/InputEventMapper.cc
+++ b/src/input/InputEventMapper.cc
@@ -37,10 +37,10 @@ InputEventMapper::InputEventMapper()
 {
     stopRequest=false;
 
-    for (int a = 0;a < MAX_AXIS;a++) {
+    for (int a = 0;a < max_axis;a++) {
         axisValue[a] = 0;
     }
-    for (int a = 0;a < MAX_BUTTONS;a++) {
+    for (int a = 0;a < max_buttons;a++) {
         button_state[a]=false;
         button_state_last[a]=false;
     }
@@ -117,7 +117,7 @@ void InputEventMapper::onTimer()
     }
 
     //update the UI on time, NOT on event as a joystick can fire a high rate of events
-    for (int i = 0; i < MAX_BUTTONS; i++ ){
+    for (int i = 0; i < max_buttons; i++ ){
         if(button_state[i] != button_state_last[i]){
             button_state_last[i] = button_state[i];
             Preferences::inst()->updateButtonState(i,button_state[i]);
@@ -134,7 +134,7 @@ void InputEventMapper::onButtonChanged(InputEventButtonChanged *event)
 {
     int button = event->button;
 
-    if (button < MAX_BUTTONS) {
+    if (button < max_buttons) {
         if (event->down) {
             this->button_state[button]=true;
         }else{
@@ -184,7 +184,7 @@ int InputEventMapper::parseSettingValue(const std::string val)
 void InputEventMapper::onInputMappingUpdated()
 {
     Settings::Settings *s = Settings::Settings::inst();
-    for (int i = 0; i < MAX_BUTTONS; i++ ){
+    for (int i = 0; i < max_buttons; i++ ){
 		std::string is = std::to_string(i);
 		Settings::SettingsEntry* ent =s->getSettingEntryByName("button" +is);
 		actions[i] =QString::fromStdString(s->get(*ent).toString());

--- a/src/input/InputEventMapper.cc
+++ b/src/input/InputEventMapper.cc
@@ -37,10 +37,10 @@ InputEventMapper::InputEventMapper()
 {
     stopRequest=false;
 
-    for (int a = 0;a < 10;a++) {
+    for (int a = 0;a < MAX_AXIS;a++) {
         axisValue[a] = 0;
     }
-    for (int a = 0;a < 10;a++) {
+    for (int a = 0;a < MAX_BUTTONS;a++) {
         button_state[a]=false;
         button_state_last[a]=false;
     }
@@ -117,7 +117,7 @@ void InputEventMapper::onTimer()
     }
 
     //update the UI on time, NOT on event as a joystick can fire a high rate of events
-    for (int i = 0; i < 10; i++ ){
+    for (int i = 0; i < MAX_BUTTONS; i++ ){
         if(button_state[i] != button_state_last[i]){
             button_state_last[i] = button_state[i];
             Preferences::inst()->updateButtonState(i,button_state[i]);
@@ -134,7 +134,7 @@ void InputEventMapper::onButtonChanged(InputEventButtonChanged *event)
 {
     int button = event->button;
 
-    if (button < 10) {
+    if (button < MAX_BUTTONS) {
         if (event->down) {
             this->button_state[button]=true;
         }else{
@@ -184,7 +184,7 @@ int InputEventMapper::parseSettingValue(const std::string val)
 void InputEventMapper::onInputMappingUpdated()
 {
     Settings::Settings *s = Settings::Settings::inst();
-    for (int i = 0; i < 10; i++ ){
+    for (int i = 0; i < MAX_BUTTONS; i++ ){
 		std::string is = std::to_string(i);
 		Settings::SettingsEntry* ent =s->getSettingEntryByName("button" +is);
 		actions[i] =QString::fromStdString(s->get(*ent).toString());

--- a/src/input/InputEventMapper.h
+++ b/src/input/InputEventMapper.h
@@ -30,17 +30,17 @@
 
 #include "input/InputDriver.h"
 
-#define MAX_AXIS 9
-#define MAX_BUTTONS 10
-
 class InputEventMapper : public QObject, public InputEventHandler
 {
     Q_OBJECT
 
 private:
+    const static int max_axis = 9;
+    const static int max_buttons = 10;
+
     QTimer *timer;
-    double axisValue[MAX_AXIS];
-    QString actions[MAX_BUTTONS];
+    double axisValue[max_axis];
+    QString actions[max_buttons];
     int translate[6];
     int rotate[3];
     int zoom;
@@ -49,9 +49,8 @@ private:
     double scale(double val);
     double getAxisValue(int config);
     int parseSettingValue(const std::string val);
-
-    bool button_state[MAX_BUTTONS];
-    bool button_state_last[MAX_BUTTONS];
+    bool button_state[max_buttons];
+    bool button_state_last[max_buttons];
     
     static InputEventMapper *self;
 

--- a/src/input/InputEventMapper.h
+++ b/src/input/InputEventMapper.h
@@ -30,14 +30,17 @@
 
 #include "input/InputDriver.h"
 
+#define MAX_AXIS 9
+#define MAX_BUTTONS 10
+
 class InputEventMapper : public QObject, public InputEventHandler
 {
     Q_OBJECT
 
 private:
     QTimer *timer;
-    double axisValue[10];
-    QString actions[10];
+    double axisValue[MAX_AXIS];
+    QString actions[MAX_BUTTONS];
     int translate[6];
     int rotate[3];
     int zoom;
@@ -47,8 +50,8 @@ private:
     double getAxisValue(int config);
     int parseSettingValue(const std::string val);
 
-    bool button_state[10];
-    bool button_state_last[10];
+    bool button_state[MAX_BUTTONS];
+    bool button_state_last[MAX_BUTTONS];
     
     static InputEventMapper *self;
 


### PR DESCRIPTION
I think we agree that using constant for array sizes is better then magic numbers.
How ever: I am uncertain how and where in openscad constants shall be declared.
I have no problem to change it how ever you like it.

Note that I lowered the number of axis intentionally from 10 to 9.
The reason is, that the UI currently only supports axis 0..8.
Nine axis has also the benefit, that I can arrange them in the UI in a nice 3x3 grid

This pull request is kind of both a question and a preparation for further code.
(I need these constants for trim and deadzone correction. Will also increase the number of buttons at some point.)