### PR TITLE
Fixed bad axis labeling at small zoom levels. #2020

### DIFF
--- a/src/GLView.cc
+++ b/src/GLView.cc
@@ -514,16 +514,11 @@ void GLView::showScalemarkers(const Color4f &col)
 	// Take log of l, discretize, then exponentiate. This is done so that the tick
 	// denominations change every time the viewport gets 10x bigger or smaller,
 	// but stays constant in-between. l_adjusted is a step function of l.
-	const int log_l = static_cast<int>(log10(l));
+	const int log_l = static_cast<int>(floor(log10(l)));
 	const double l_adjusted = pow(10, log_l);
 
-	// Calculate tick width. Make them smaller if the viewport is small.
-	double tick_width;
-	if (l < 1.5){
-		tick_width = l_adjusted / 100.0;
-	} else {
-		tick_width = l_adjusted / 10.0;
-	}
+	// Calculate tick width.
+	const double tick_width = l_adjusted / 10.0;
 
 	const int size_div_sm = 60; // divisor for l to determine minor tick size
 	int line_cnt = 0;


### PR DESCRIPTION
There was an issue that caused the labels to be closely bunched up at
small zoom levels. This was because the axis scale calculation wasn't quite right.
We adjust the scale whenever the viewport changes in
size by a factor of ten by doing:

scale_length = 10**truncate(log10(viewport_size))

truncate(0.99) and truncate(-0.99) and everything in-between map to
zero, giving us a range twice as large between scale changes. Using floor() instead of truncate() fixes the problem.