### PR TITLE
correct typos in parametric examples

### DIFF
--- a/examples/Parametric/candleStand.scad
+++ b/examples/Parametric/candleStand.scad
@@ -122,4 +122,3 @@ module make_ring_of(radius, count){
 // You should have received a copy of the CC0 Public Domain
 // Dedication along with this software.
 // If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
-

--- a/examples/Parametric/candleStand.scad
+++ b/examples/Parametric/candleStand.scad
@@ -1,5 +1,5 @@
 /*[ Candle Stand ]*/
-//Lenght of candle stand
+//Length of candle stand
 length=50; // [70:large,50:medium,30:small]
 
 // Center stand

--- a/examples/Parametric/sign.scad
+++ b/examples/Parametric/sign.scad
@@ -11,7 +11,7 @@
 //
 
 
-//Below comment tells the group to which a varaible will belong
+//Below comment tells the group to which a variable will belong
 /*[ properties of Sign]*/
 
 //The resolution of the curves. Higher values give smoother curves but may increase the model render time.


### PR DESCRIPTION
Lenght -> Length
varaible -> variable