### PR TITLE
BUGFIX: customizer crashes with empty vector, refractored checkVectorWidget() method

### DIFF
--- a/src/parameter/parameterobject.cpp
+++ b/src/parameter/parameterobject.cpp
@@ -29,7 +29,7 @@ int ParameterObject::setValue(const class ValuePtr defaultValue, const class Val
   if (dvt == Value::ValueType::BOOL) {
     target = CHECKBOX;
   } else if ((dvt == Value::ValueType::VECTOR) && (defaultValue->toVector().size() <= 4)) {
-    checkVectorWidget();
+    target = checkVectorWidget();
   } else if ((vt == Value::ValueType::VECTOR) && ((dvt == Value::ValueType::NUMBER) || (dvt == Value::ValueType::STRING))) {
     target = COMBOBOX;
   } else if ((vt == Value::ValueType::RANGE) && (dvt == Value::ValueType::NUMBER)) {
@@ -75,14 +75,15 @@ bool ParameterObject::operator == (const ParameterObject &second)
           this->description == second.description && this->groupName == second.groupName);
 }
 
-void ParameterObject::checkVectorWidget()
+ParameterObject::parameter_type_t ParameterObject::checkVectorWidget()
 {
+  parameter_type_t ret;
   Value::VectorType vec = defaultValue->toVector();
+  if(vec.size()==0) return TEXT;
   for (unsigned int i = 0;i < vec.size();i++) {
     if (vec[i]->type() != Value::ValueType::NUMBER) {
-      target = TEXT;
-      return;
+      return TEXT;
     }
   }
-  target = VECTOR;
+  return VECTOR;
 }

--- a/src/parameter/parameterobject.cpp
+++ b/src/parameter/parameterobject.cpp
@@ -77,7 +77,6 @@ bool ParameterObject::operator == (const ParameterObject &second)
 
 ParameterObject::parameter_type_t ParameterObject::checkVectorWidget()
 {
-  parameter_type_t ret;
   Value::VectorType vec = defaultValue->toVector();
   if(vec.size()==0) return TEXT;
   for (unsigned int i = 0;i < vec.size();i++) {

--- a/src/parameter/parameterobject.h
+++ b/src/parameter/parameterobject.h
@@ -24,7 +24,7 @@ public:
 
 private:
 	Value::ValueType vt;
-	void checkVectorWidget();
+	parameter_type_t checkVectorWidget();
 	
 public:
 	ParameterObject();


### PR DESCRIPTION
How to reproduce:
  * open OpenSCAD
  * enable customizer
  * enter
    * vector0=[];
  * press F5
![crash](https://user-images.githubusercontent.com/24962768/32455899-075fa55a-c324-11e7-8c3a-c8cfa137c0b1.png)

The refactoring is not necessary for the fix, but it makes sense to do it as that was the reason why I found that bug.
