### PR TITLE
Better timing and folding of Travis CI logs

### DIFF
--- a/scripts/travis-ci.sh
+++ b/scripts/travis-ci.sh
@@ -1,9 +1,30 @@
 #!/bin/bash
 
-set -x
+set -e
 
-qmake CONFIG+=experimental CONFIG+=nogui
-make
+travis_nanoseconds() {
+  python -c 'import time; print("{:d}".format(int(time.time()*1000000000)))'
+}
+
+travis_start() {
+  travis_timer_id=`printf %08x $(( RANDOM * RANDOM ))`
+  travis_start_time=`travis_nanoseconds`
+  echo -e "travis_time:start:$travis_timer_id\r\033[0m$2"
+  echo -e "travis_fold:start:$1\n$2"
+}
+
+travis_finish() {
+  echo "travis_fold:end:$1"
+  travis_end_time=`travis_nanoseconds`
+  local duration=$(( $travis_end_time - $travis_start_time ))
+  echo -en "\ntravis_time:end:$travis_timer_id:start=$travis_start_time,finish=$travis_end_time,duration=$duration\r\033[0m"
+}
+
+travis_start qmake "Building OpenSCAD using qmake"
+qmake CONFIG+=experimental CONFIG+=nogui && make -j2
+travis_finish qmake
+
+travis_start cmake "Building tests using cmake"
 
 cd tests
 cmake . 
@@ -17,11 +38,15 @@ if [[ $? != 0 ]]; then
   exit 1
 fi
 
+travis_finish cmake
+
 if [[ "$DIST" == "trusty" ]]; then
     PARALLEL=-j1
 else
     PARALLEL=-j8
 fi
+
+travis_start ctest "Running tests using ctest"
 
 # Exclude tests known the cause issues on Travis
 # opencsgtest_rotate_extrude-tests - Fails on Ubuntu 12.04 using Gallium 0.4 drivers
@@ -61,3 +86,5 @@ if [[ $? != 0 ]]; then
   echo "Test failure"
   exit 1
 fi
+
+travis_finish ctest


### PR DESCRIPTION
Better timing and folding of Travis CI logs
<img width="904" alt="screen shot 2017-11-09 at 8 26 11 am" src="https://user-images.githubusercontent.com/186094/32607654-aeec2b40-c527-11e7-89c2-cf9aef7daccd.png">
