### PR TITLE
comment parser refractored

### DIFF
--- a/src/comment.cpp
+++ b/src/comment.cpp
@@ -286,7 +286,7 @@ void CommentParser::collectParameters(const char *fulltext, FileModule *root_mod
  
 		// Extracting the parameter comment
 		std::string comment = getComment(std::string(fulltext), firstLine);
-		// getting the node for parameter annnotataion
+		// getting the node for parameter annotation
 		shared_ptr<Expression> params = CommentParser::parser(comment.c_str());
 		if (!params) {
 			params = shared_ptr<Expression>(new Literal(ValuePtr(std::string(""))));


### PR DESCRIPTION
The current comment parser tries and manages to parse things, it really shouldn't:
```
a=2; // [[1,2,3],[4,5,6],[9,5,4,2,3,1]]
echo(a);
d=4; // [[1,2,3]:a,50:d]
echo(d);
```
Looking into the details, due to the recursive nature, I can imagine that internally, the parse can generate a lot of interesting data-structures (which also makes unclear to a human reading the parser, what the parser is actually supposed to do).

The restructured code should be easier to read.