### PR TITLE
Explicitly destroy QCachedSettings object when last window closed

### DIFF
--- a/src/OpenSCADApp.cc
+++ b/src/OpenSCADApp.cc
@@ -7,6 +7,7 @@
 #include <QProgressDialog>
 #include <iostream>
 #include <boost/foreach.hpp>
+#include "QSettingsCached.h"
 
 OpenSCADApp::OpenSCADApp(int &argc ,char **argv)
 	: QApplication(argc, argv), fontCacheDialog(nullptr)
@@ -71,4 +72,9 @@ void OpenSCADApp::hideFontCacheDialog()
 {
 	assert(this->fontCacheDialog);
 	this->fontCacheDialog->reset();
+}
+
+
+void OpenSCADApp::releaseQSettingsCached() {
+	QSettingsCached{}.release();
 }

--- a/src/OpenSCADApp.h
+++ b/src/OpenSCADApp.h
@@ -17,6 +17,7 @@ public:
 public slots:
 	void showFontCacheDialog();
 	void hideFontCacheDialog();
+	void releaseQSettingsCached();
 
 public:
 	WindowManager windowManager;

--- a/src/QSettingsCached.h
+++ b/src/QSettingsCached.h
@@ -40,6 +40,10 @@ class QSettingsCached {
             return qsettingsPointer->contains(key);
         }
 
+        void release() {
+            delete qsettingsPointer.release();
+        }
+
 
     private:
         static std::unique_ptr<QSettings> qsettingsPointer;

--- a/src/openscad.cc
+++ b/src/openscad.cc
@@ -653,6 +653,8 @@ void dialogInitHandler(FontCacheInitializer *initializer, void *)
 	QMetaObject::invokeMethod(scadApp, "hideFontCacheDialog");
 }
 
+
+
 int gui(vector<string> &inputFiles, const fs::path &original_path, int argc, char ** argv)
 {
 #ifdef Q_OS_MACX
@@ -769,7 +771,7 @@ int gui(vector<string> &inputFiles, const fs::path &original_path, int argc, cha
 	} else {
 	   new MainWindow(assemblePath(original_path, inputFiles[0]));
 	}
-
+    app.connect(&app, SIGNAL(lastWindowClosed()), &app, SLOT(releaseQSettingsCached()));
 	app.connect(&app, SIGNAL(lastWindowClosed()), &app, SLOT(quit()));
 	int rc = app.exec();
 	for (auto &mainw : scadApp->windowManager.getWindows()) delete mainw;


### PR DESCRIPTION
This should resolve the  segmentation fault reported by bug #2182 