### PR TITLE
disable HTML support  in descriptions of the costumizer

### DIFF
--- a/src/parameter/ParameterEntryWidget.ui
+++ b/src/parameter/ParameterEntryWidget.ui
@@ -312,23 +312,26 @@
       <number>0</number>
      </property>
      <item>
-      <layout class="QVBoxLayout" name="verticalLayout">
-       <property name="spacing">
-        <number>2</number>
-       </property>
+      <layout class="QFormLayout" name="formLayout">
        <property name="topMargin">
         <number>0</number>
        </property>
        <property name="bottomMargin">
         <number>0</number>
        </property>
-       <item>
+       <item row="0" column="0">
         <widget class="QLabel" name="labelParameter">
          <property name="sizePolicy">
           <sizepolicy hsizetype="Minimum" vsizetype="Preferred">
            <horstretch>0</horstretch>
            <verstretch>0</verstretch>
           </sizepolicy>
+         </property>
+         <property name="font">
+          <font>
+           <weight>75</weight>
+           <bold>true</bold>
+          </font>
          </property>
          <property name="lineWidth">
           <number>0</number>
@@ -337,14 +340,14 @@
           <string>Parameter</string>
          </property>
          <property name="textFormat">
-          <enum>Qt::RichText</enum>
+          <enum>Qt::PlainText</enum>
          </property>
          <property name="wordWrap">
           <bool>false</bool>
          </property>
         </widget>
        </item>
-       <item>
+       <item row="1" column="0" colspan="2">
         <widget class="QLabel" name="labelDescription">
          <property name="sizePolicy">
           <sizepolicy hsizetype="Minimum" vsizetype="Preferred">
@@ -362,6 +365,36 @@
          </property>
          <property name="text">
           <string>Description</string>
+         </property>
+         <property name="textFormat">
+          <enum>Qt::PlainText</enum>
+         </property>
+         <property name="wordWrap">
+          <bool>true</bool>
+         </property>
+        </widget>
+       </item>
+       <item row="0" column="1">
+        <widget class="QLabel" name="labelInline">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Minimum" vsizetype="Preferred">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+         <property name="font">
+          <font>
+           <pointsize>11</pointsize>
+          </font>
+         </property>
+         <property name="lineWidth">
+          <number>0</number>
+         </property>
+         <property name="text">
+          <string>Description</string>
+         </property>
+         <property name="textFormat">
+          <enum>Qt::PlainText</enum>
          </property>
          <property name="wordWrap">
           <bool>true</bool>

--- a/src/parameter/parametervirtualwidget.cpp
+++ b/src/parameter/parametervirtualwidget.cpp
@@ -14,13 +14,13 @@ ParameterVirtualWidget::~ParameterVirtualWidget(){
 void ParameterVirtualWidget::setName(QString name) {
 	this->labelDescription->hide();
 	name.replace(QRegExp("([_]+)"), " ");
-	this->labelParameter->setText("<b>"+name+"</b>");
+	this->labelParameter->setText(name);
+	this->labelInline->setText("");
 }
 
 void ParameterVirtualWidget::addInline(QString addTxt) {
-	QString txt = this->labelParameter->text();
 	if(addTxt!=""){
-		this->labelParameter->setText(txt + " - " + addTxt);
+		this->labelInline->setText(" - "+ addTxt);
 	}
 }
 


### PR DESCRIPTION
see #2184

With this change, re-enabling HTML support requires changes just two properties in the UI file from "plaintext" to "richtext".