### PR TITLE
Using gnu.org mirror for mpfr

### DIFF
--- a/scripts/uni-build-dependencies.sh
+++ b/scripts/uni-build-dependencies.sh
@@ -317,7 +317,7 @@ build_mpfr()
   cd $BASEDIR/src
   rm -rf mpfr-$version
   if [ ! -f mpfr-$version.tar.bz2 ]; then
-    curl --insecure -O http://www.mpfr.org/mpfr-$version/mpfr-$version.tar.bz2
+    curl --insecure -O ftp.gnu.org/gnu/mpfr/mpfr-$version.tar.bz2
   fi
   tar xjf mpfr-$version.tar.bz2
   cd mpfr-$version


### PR DESCRIPTION
mpfr.org is down today, causing the build script to fail.  Googling a bit this seems to be relatively common:
* [https://github.com/Homebrew/legacy-homebrew/issues/12371](https://github.com/Homebrew/legacy-homebrew/issues/12371)
* [https://sourceforge.net/p/mspgcc4/bugs/26/](https://sourceforge.net/p/mspgcc4/bugs/26/)

This pr changes the build script to look for mpfr source at the gnu.org mirror.