### PR TITLE
avoid caching of trivially different/identical meshes

### DIFF
--- a/src/cache.h
+++ b/src/cache.h
@@ -59,6 +59,7 @@ class Cache
 	};
 	typedef typename std::unordered_map<Key, Node> map_type;
 	typedef typename map_type::iterator iterator_type;
+	typedef typename map_type::const_iterator const_iterator_type;
 	typedef typename map_type::value_type value_type;
 
 	std::unordered_map<Key, Node> hash;
@@ -117,6 +118,9 @@ public:
 
 	bool remove(const Key &key);
 	T *take(const Key &key);
+
+	const_iterator_type begin() const {return hash.cbegin(); }
+	const_iterator_type end() const {return hash.cend(); }
 
 private:
 	void trim(int m);


### PR DESCRIPTION
In general, the CGAL memory cache contains multiple copies of the same mesh. The reason for this are trivially differences in the cache key (the geometry), that are caused by eg. implicit unions or modifications that aren't changing the mesh at all (eg. color or render).

For example (maybe exaggerated, but to make the point): 

module dstar(r = 30, R = 50) {
    difference() {
        sphere(r = R);
        rotate([0, -30, -45]) translate([R + 0.7*r, 0, 0]) sphere(r = r);
    }
}

for( tx = [-60, 60], ty = [-60, 60]) 
    color([0.5 + tx/120, 0.5 + ty/120, 0]) 
        render() translate([tx, ty, 0]) dstar();

This results in 14 copies of the same, or only trivially different mesh in the cache [1]

This patch prevents duplicate copies by, comparing size and key (substring) with objects already in the cache. I haven't observed any noticeable negative effect on computation time so far.

[1] pre patch output (14 copies cached)
CGAL Cache insert: difference(){sphere($fn=0,$fa=12,$fs=2,r (1183344 bytes)
CGAL Cache insert: group(){difference(){sphere($fn=0,$fa=12 (1183344 bytes)
CGAL Cache insert: multmatrix([[1,0,0,-60],[0,1,0,-60],[0,0 (1183344 bytes)
CGAL Cache insert: render(convexity=1){multmatrix([[1,0,0,- (1183344 bytes)
CGAL Cache hit: group(){difference(){sphere($fn=0,$fa=12 (1183344 bytes)
CGAL Cache insert: multmatrix([[1,0,0,-60],[0,1,0,60],[0,0, (1183344 bytes)
CGAL Cache insert: render(convexity=1){multmatrix([[1,0,0,- (1183344 bytes)
CGAL Cache hit: group(){difference(){sphere($fn=0,$fa=12 (1183344 bytes)
CGAL Cache insert: multmatrix([[1,0,0,60],[0,1,0,-60],[0,0, (1183344 bytes)
CGAL Cache insert: render(convexity=1){multmatrix([[1,0,0,6 (1183344 bytes)
CGAL Cache hit: group(){difference(){sphere($fn=0,$fa=12 (1183344 bytes)
CGAL Cache insert: multmatrix([[1,0,0,60],[0,1,0,60],[0,0,1 (1183344 bytes)
CGAL Cache insert: render(convexity=1){multmatrix([[1,0,0,6 (1183344 bytes)
CGAL Cache insert: color([0,0,0,1]){render(convexity=1){mul (1183344 bytes)
CGAL Cache insert: color([0,1,0,1]){render(convexity=1){mul (1183344 bytes)
CGAL Cache insert: color([1,0,0,1]){render(convexity=1){mul (1183344 bytes)
CGAL Cache insert: color([1,1,0,1]){render(convexity=1){mul (1183344 bytes)
CGAL Cache insert: group(){color([0,0,0,1]){render(convexit (4733112 bytes)

[2] post patch output (1 copy cached)
CGAL Cache insert: difference(){sphere($fn=0,$fa=12,$fs=2,r (1160912 bytes)
CGAL Cache trivial: group(){difference(){sphere($fn=0,$fa=12 (1160912 bytes)
CGAL Cache trivial: multmatrix([[1,0,0,-60],[0,1,0,-60],[0,0 (1160912 bytes)
CGAL Cache trivial: render(convexity=1){multmatrix([[1,0,0,- (1160912 bytes)
CGAL Cache hit: difference(){sphere($fn=0,$fa=12,$fs=2,r (1160912 bytes)
CGAL Cache trivial: group(){difference(){sphere($fn=0,$fa=12 (1160912 bytes)
CGAL Cache trivial: multmatrix([[1,0,0,-60],[0,1,0,60],[0,0, (1160912 bytes)
CGAL Cache trivial: render(convexity=1){multmatrix([[1,0,0,- (1160912 bytes)
CGAL Cache hit: difference(){sphere($fn=0,$fa=12,$fs=2,r (1160912 bytes)
CGAL Cache trivial: group(){difference(){sphere($fn=0,$fa=12 (1160912 bytes)
CGAL Cache trivial: multmatrix([[1,0,0,60],[0,1,0,-60],[0,0, (1160912 bytes)
CGAL Cache trivial: render(convexity=1){multmatrix([[1,0,0,6 (1160912 bytes)
CGAL Cache hit: difference(){sphere($fn=0,$fa=12,$fs=2,r (1160912 bytes)
CGAL Cache trivial: group(){difference(){sphere($fn=0,$fa=12 (1160912 bytes)
CGAL Cache trivial: multmatrix([[1,0,0,60],[0,1,0,60],[0,0,1 (1160912 bytes)
CGAL Cache trivial: render(convexity=1){multmatrix([[1,0,0,6 (1160912 bytes)
CGAL Cache trivial: color([0,0,0,1]){render(convexity=1){mul (1160912 bytes)
CGAL Cache trivial: color([0,1,0,1]){render(convexity=1){mul (1160912 bytes)
CGAL Cache trivial: color([1,0,0,1]){render(convexity=1){mul (1160912 bytes)
CGAL Cache trivial: color([1,1,0,1]){render(convexity=1){mul (1160912 bytes)
CGAL Cache insert: group(){color([0,0,0,1]){render(convexit (4643384 bytes)
