### PR TITLE
Travis macos build speed tweaks

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,8 @@ matrix:
       env: DIST="osx"
       cache:
         - ccache
+        - directories:
+          - $HOME/Library/Caches/Homebrew
 
 notifications:
   irc:
@@ -27,7 +29,7 @@ notifications:
 before_install:
  - if [[ "$DIST" == "trusty" ]]; then wget -qO - http://files.openscad.org/OBS-Repository-Key.pub | sudo apt-key add - ; echo 'yes' | sudo add-apt-repository 'deb http://download.opensuse.org/repositories/home:/t-paul:/lib3mf/xUbuntu_14.04/ ./' ; sudo apt-get update -qq ; sudo apt-get purge -qq fglrx ; sudo apt-get install -qq build-essential libqt4-dev libqt4-opengl-dev libxmu-dev cmake bison flex git-core libboost-all-dev libxi-dev libmpfr-dev libboost-dev libglew-dev libeigen3-dev libcgal-dev libgmp3-dev libgmp-dev curl imagemagick libfontconfig-dev libopencsg-dev libharfbuzz-dev libzip-dev lib3mf-dev ; fi
  - if [[ "$DIST" == "precise" ]]; then echo 'yes' | sudo add-apt-repository ppa:chrysn/openscad ; sudo apt-get update -qq ; sudo apt-get purge -qq fglrx ; sudo apt-get install -qq build-essential libqt4-dev libqt4-opengl-dev libxmu-dev cmake bison flex git-core libboost-all-dev libxi-dev libmpfr-dev libboost-dev libglew-dev libeigen3-dev libcgal-dev libgmp3-dev libgmp-dev curl imagemagick libfontconfig-dev ; sudo apt-get install -qq libopencsg-dev ; echo 'yes' | sudo add-apt-repository ppa:mapnik/nightly-trunk ; sudo apt-get update -qq ; sudo apt-get install -qq libharfbuzz-dev libzip-dev ; echo 'yes' | sudo add-apt-repository ppa:oibaf/graphics-drivers ; sudo apt-get update -qq ; sudo apt-get install --install-recommends libgl1-mesa-dev-lts-quantal ; fi
- - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew update ; ./scripts/macosx-build-homebrew.sh ; fi
+ - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then ./scripts/macosx-build-homebrew.sh ; fi
 
 branches:
   only:

--- a/scripts/macosx-build-homebrew.sh
+++ b/scripts/macosx-build-homebrew.sh
@@ -26,10 +26,10 @@ if [ ! -f $OPENSCADDIR/openscad.pro ]; then
 fi
 
 log "Listing homebrew configuration"
-brew config
+time brew config
 
 log "Updating homebrew"
-brew update
+time brew update
 # Install special packages not yet in upstream homebrew repo.
 # Check if there's already an active openscad tap and skip
 # tap/untap in that case.
@@ -52,7 +52,7 @@ done
 
 for formula in gettext qt5 qscintilla2; do
   log "Linking formula $formula"
-  brew link --force $formula
+  time brew link --force $formula
 done
 
 $TAP untap openscad/homebrew-tap

--- a/scripts/travis-ci.sh
+++ b/scripts/travis-ci.sh
@@ -20,8 +20,15 @@ travis_finish() {
   echo -en "\ntravis_time:end:$travis_timer_id:start=$travis_start_time,finish=$travis_end_time,duration=$duration\r\033[0m"
 }
 
+PARALLEL=-j2
+if [[ "$DIST" == "trusty" ]]; then
+    PARALLEL_CTEST=-j1
+else
+    PARALLEL_CTEST=-j2
+fi
+
 travis_start qmake "Building OpenSCAD using qmake"
-qmake CONFIG+=experimental CONFIG+=nogui && make -j2
+qmake CONFIG+=experimental CONFIG+=nogui && make $PARALLEL
 travis_finish qmake
 
 travis_start cmake "Building tests using cmake"
@@ -32,19 +39,13 @@ if [[ $? != 0 ]]; then
   echo "Error configuring test suite"
   exit 1
 fi
-make -j2
+make $PARALLEL
 if [[ $? != 0 ]]; then
   echo "Error building test suite"
   exit 1
 fi
 
 travis_finish cmake
-
-if [[ "$DIST" == "trusty" ]]; then
-    PARALLEL=-j1
-else
-    PARALLEL=-j8
-fi
 
 travis_start ctest "Running tests using ctest"
 
@@ -58,7 +59,7 @@ travis_start ctest "Running tests using ctest"
 # opencsgtest_issue1258
 # throwntogethertest_issue1089
 # throwntogethertest_issue1215
-ctest $PARALLEL -E "\
+ctest $PARALLEL_CTEST -E "\
 opencsgtest_rotate_extrude-tests|\
 opencsgtest_render-tests|\
 opencsgtest_rotate_extrude-hole|\

--- a/scripts/travis-ci.sh
+++ b/scripts/travis-ci.sh
@@ -20,11 +20,11 @@ travis_finish() {
   echo -en "\ntravis_time:end:$travis_timer_id:start=$travis_start_time,finish=$travis_end_time,duration=$duration\r\033[0m"
 }
 
-PARALLEL=-j2
+PARALLEL=-j8
 if [[ "$DIST" == "trusty" ]]; then
     PARALLEL_CTEST=-j1
 else
-    PARALLEL_CTEST=-j2
+    PARALLEL_CTEST=-j8
 fi
 
 travis_start qmake "Building OpenSCAD using qmake"

--- a/scripts/travis-ci.sh
+++ b/scripts/travis-ci.sh
@@ -20,11 +20,11 @@ travis_finish() {
   echo -en "\ntravis_time:end:$travis_timer_id:start=$travis_start_time,finish=$travis_end_time,duration=$duration\r\033[0m"
 }
 
-PARALLEL=-j8
+PARALLEL=-j2
 if [[ "$DIST" == "trusty" ]]; then
     PARALLEL_CTEST=-j1
 else
-    PARALLEL_CTEST=-j8
+    PARALLEL_CTEST=-j2
 fi
 
 travis_start qmake "Building OpenSCAD using qmake"

--- a/scripts/travis-ci.sh
+++ b/scripts/travis-ci.sh
@@ -24,7 +24,7 @@ PARALLEL=-j2
 if [[ "$DIST" == "trusty" ]]; then
     PARALLEL_CTEST=-j1
 else
-    PARALLEL_CTEST=-j2
+    PARALLEL_CTEST=-j4
 fi
 
 travis_start qmake "Building OpenSCAD using qmake"


### PR DESCRIPTION
The macos build often fails due to exceedingt travis-ci's job time limit (50min).  This is an attempt to speed up those jobs somewhat and reduce the probability of timeout failures.

-Cached homebrew, this seems to reduce the homebrew step by roughly 2-3minutes.
-Also added some timing info to homebrew script for "debugging" build times
-Tweaked parallel job count for ctest.  -j4 performed faster than -j8 in my testing.  There are only 2 cores available to us anyways ( https://docs.travis-ci.com/user/reference/overview/ ), running too many threads might cause slowdown due to memory swapping or just 

