### PR TITLE
listDrivers() regardless whether SCINTILLA_EDITOR is used or not

### DIFF
--- a/src/LibraryInfo.cc
+++ b/src/LibraryInfo.cc
@@ -3,8 +3,8 @@
 #include <vector>
 #ifdef USE_SCINTILLA_EDITOR
 #include <Qsci/qsciglobal.h>
-#include "input/InputDriverManager.h"
 #endif
+#include "input/InputDriverManager.h"
 
 #include "version_check.h"
 #include "PlatformUtils.h"
@@ -105,8 +105,8 @@ std::string LibraryInfo::info()
 	  << "\nQt version: " << qtVersion
 #ifdef USE_SCINTILLA_EDITOR
 	  << "\nQScintilla version: " << QSCINTILLA_VERSION_STR
-          << "\nInputDrivers: " << InputDriverManager::instance()->listDrivers()
 #endif
+	  << "\nInputDrivers: " << InputDriverManager::instance()->listDrivers()
 	  << "\nMingW build: " << mingwstatus
 	  << "\nGLib version: "       << GLIB_MAJOR_VERSION << "." << GLIB_MINOR_VERSION << "." << GLIB_MICRO_VERSION
 	  << "\nlibzip version: " << LIBZIP_VERSION


### PR DESCRIPTION
i do see no reason for the "#ifdef USE_SCINTILLA_EDITOR" in context of the InputDriverManager.