### PR TITLE
C++11: Use nullptr instead of 0 or NULL

### DIFF
--- a/src/AppleEvents.cc
+++ b/src/AppleEvents.cc
@@ -26,7 +26,7 @@ OSErr eventHandler(const AppleEvent *, AppleEvent *, SRefCon )
 void installAppleEventHandlers()
 {
 	// Reload handler
-  auto err = AEInstallEventHandler('SCAD', 'relo', NewAEEventHandlerUPP(eventHandler), 0, true);
+  auto err = AEInstallEventHandler('SCAD', 'relo', NewAEEventHandlerUPP(eventHandler), nullptr, true);
   __Require_noErr(err, CantInstallAppleEventHandler);
 	return;
 

--- a/src/FontCache.cc
+++ b/src/FontCache.cc
@@ -193,7 +193,7 @@ void FontCache::add_font_dir(const std::string &path)
 
 FontInfoList *FontCache::list_fonts() const
 {
-	FcObjectSet *object_set = FcObjectSetBuild(FC_FAMILY, FC_STYLE, FC_FILE, (char *) 0);
+	FcObjectSet *object_set = FcObjectSetBuild(FC_FAMILY, FC_STYLE, FC_FILE, nullptr);
 	FcPattern *pattern = FcPatternCreate();
 	init_pattern(pattern);
 	FcFontSet *font_set = FcFontList(this->config, pattern, object_set);

--- a/src/GeometryUtils.cc
+++ b/src/GeometryUtils.cc
@@ -265,7 +265,7 @@ bool GeometryUtils::tessellatePolygonWithHoles(const Vector3f *vertices,
   }
 
   TESSalloc ma;
-  TESStesselator* tess = 0;
+  TESStesselator* tess = nullptr;
 
   memset(&ma, 0, sizeof(ma));
   ma.memalloc = stdAlloc;

--- a/src/LibraryInfo.cc
+++ b/src/LibraryInfo.cc
@@ -78,9 +78,9 @@ std::string LibraryInfo::info()
 	std::string cgal_2d_kernelEx = typeid(CGAL_ExactKernel2).name();
 #if defined(__openscad_info_demangle__)
 	int status;
-	cgal_3d_kernel = std::string( abi::__cxa_demangle( cgal_3d_kernel.c_str(), 0, 0, &status ) );
-	cgal_2d_kernel = std::string( abi::__cxa_demangle( cgal_2d_kernel.c_str(), 0, 0, &status ) );
-	cgal_2d_kernelEx = std::string( abi::__cxa_demangle( cgal_2d_kernelEx.c_str(), 0, 0, &status ) );
+	cgal_3d_kernel = std::string( abi::__cxa_demangle( cgal_3d_kernel.c_str(), nullptr, nullptr, &status ) );
+	cgal_2d_kernel = std::string( abi::__cxa_demangle( cgal_2d_kernel.c_str(), nullptr, nullptr, &status ) );
+	cgal_2d_kernelEx = std::string( abi::__cxa_demangle( cgal_2d_kernelEx.c_str(), nullptr, nullptr, &status ) );
 #endif // demangle
 	boost::replace_all( cgal_3d_kernel, "CGAL::", "" );
 	boost::replace_all( cgal_2d_kernel, "CGAL::", "" );

--- a/src/OffscreenContextAll.hpp
+++ b/src/OffscreenContextAll.hpp
@@ -56,16 +56,16 @@ bool save_framebuffer_common(OffscreenContext *ctx, std::ostream &output)
 //	Called by create_offscreen_context() from platform-specific code.
 OffscreenContext *create_offscreen_context_common(OffscreenContext *ctx)
 {
-	if (!ctx) return NULL;
+	if (!ctx) return nullptr;
 	GLenum err = glewInit(); // must come after Context creation and before FBO c$
 	if (GLEW_OK != err) {
 		std::cerr << "Unable to init GLEW: " << glewGetErrorString(err) << "\n";
-		return NULL;
+		return nullptr;
 	}
 
 	ctx->fbo = fbo_new();
 	if (!fbo_init(ctx->fbo, ctx->width, ctx->height)) {
-		return NULL;
+		return nullptr;
 	}
 
 	return ctx;

--- a/src/OffscreenContextCGL.mm
+++ b/src/OffscreenContextCGL.mm
@@ -73,7 +73,7 @@ OffscreenContext *create_offscreen_context(int w, int h)
   ctx->openGLContext = [[NSOpenGLContext alloc] initWithFormat:pixFormat shareContext:nil];
   if (!ctx->openGLContext) {
     std::cerr << "Unable to create NSOpenGLContext\n";
-    return NULL;
+    return nullptr;
   }
 
   [ctx->openGLContext makeCurrentContext];
@@ -82,13 +82,13 @@ OffscreenContext *create_offscreen_context(int w, int h)
   GLenum err = glewInit();
   if (GLEW_OK != err) {
     std::cerr << "Unable to init GLEW: " << glewGetErrorString(err) << std::endl;
-    return NULL;
+    return nullptr;
   }
   glew_dump();
 
   ctx->fbo = fbo_new();
   if (!fbo_init(ctx->fbo, w, h)) {
-    return NULL;
+    return nullptr;
   }
 
   return ctx;

--- a/src/OpenSCADApp.cc
+++ b/src/OpenSCADApp.cc
@@ -64,7 +64,7 @@ void OpenSCADApp::showFontCacheDialog()
 	this->fontCacheDialog->setLabelText(_("Fontconfig needs to update its font cache.\nThis can take up to a couple of minutes."));
 	this->fontCacheDialog->setMinimum(0);
 	this->fontCacheDialog->setMaximum(0);
-	this->fontCacheDialog->setCancelButton(0);
+	this->fontCacheDialog->setCancelButton(nullptr);
 	this->fontCacheDialog->exec();
 }
 

--- a/src/PlatformUtils-mac.mm
+++ b/src/PlatformUtils-mac.mm
@@ -51,14 +51,14 @@ std::string PlatformUtils::sysinfo(bool extended)
   size_t length64 = sizeof(int64_t);
   size_t length32 = sizeof(int32_t);;
   
-  sysctlbyname("hw.memsize", &physical_memory, &length64, NULL, 0);
-  sysctlbyname("hw.physicalcpu", &numcpu, &length32, NULL, 0);
+  sysctlbyname("hw.memsize", &physical_memory, &length64, nullptr, 0);
+  sysctlbyname("hw.physicalcpu", &numcpu, &length32, nullptr, 0);
   
   size_t modellen = 0;
-  sysctlbyname("hw.model", NULL, &modellen, NULL, 0);
+  sysctlbyname("hw.model", nullptr, &modellen, nullptr, 0);
   if (modellen) {
     char *model = (char *)malloc(modellen*sizeof(char));
-    sysctlbyname("hw.model", model, &modellen, NULL, 0);
+    sysctlbyname("hw.model", model, &modellen, nullptr, 0);
     result += " ";
     result += model;
     free(model);

--- a/src/UIUtils.h
+++ b/src/UIUtils.h
@@ -31,7 +31,7 @@
 namespace UIUtils {
     static const int maxRecentFiles = 10;
 
-    QFileInfo openFile(QWidget *parent = 0);
+    QFileInfo openFile(QWidget *parent = nullptr);
     
     QStringList recentFiles();
     

--- a/src/cache.h
+++ b/src/cache.h
@@ -52,9 +52,9 @@ template <class Key, class T>
 class Cache
 {
 	struct Node {
-		inline Node() : keyPtr(0) {}
+		inline Node() : keyPtr(nullptr) {}
 		inline Node(T *data, int cost)
-			: keyPtr(0), t(data), c(cost), p(0), n(0) {}
+			: keyPtr(nullptr), t(data), c(cost), p(nullptr), n(nullptr) {}
 		const Key *keyPtr; T *t; int c; Node *p,*n;
 	};
 	typedef typename std::unordered_map<Key, Node> map_type;
@@ -78,14 +78,14 @@ class Cache
 	}
 	inline T *relink(const Key &key) {
 		iterator_type i = hash.find(key);
-		if (i == hash.end()) return 0;
+		if (i == hash.end()) return nullptr;
 
 		Node &n = i->second;
 		if (f != &n) {
 			if (n.p) n.p->n = n.n;
 			if (n.n) n.n->p = n.p;
 			if (l == &n) l = n.p;
-			n.p = 0;
+			n.p = nullptr;
 			n.n = f;
 			f->p = &n;
 			f = &n;
@@ -95,7 +95,7 @@ class Cache
 
 public:
 	inline explicit Cache(int maxCost = 100)
-		: f(0), l(0), unused(0), mx(maxCost), total(0) { }
+		: f(nullptr), l(nullptr), unused(nullptr), mx(maxCost), total(0) { }
 	inline ~Cache() { clear(); }
 
 	inline int maxCost() const { return mx; }
@@ -107,7 +107,7 @@ public:
 
 	void clear() {
 		while (f) { delete f->t; f = f->n; }
-		hash.clear(); l = 0; total = 0;
+		hash.clear(); l = nullptr; total = 0;
 	}
 
 	bool insert(const Key &key, T *object, int cost = 1);

--- a/src/colormap.cc
+++ b/src/colormap.cc
@@ -281,7 +281,7 @@ void ColorMap::enumerateColorSchemesInPath(colorscheme_set_t &result_set, const 
 	    }
 	    
 	    RenderColorScheme *colorScheme = new RenderColorScheme(path);
-	    if (colorScheme->valid() && (findColorScheme(colorScheme->name()) == 0)) {
+	    if (colorScheme->valid() && (findColorScheme(colorScheme->name()) == nullptr)) {
 		result_set.insert(colorscheme_set_t::value_type(colorScheme->index(), shared_ptr<RenderColorScheme>(colorScheme)));
 		PRINTDB("Found file '%s' with color scheme '%s' and index %d",
 			colorScheme->path() % colorScheme->name() % colorScheme->index());

--- a/src/func.cc
+++ b/src/func.cc
@@ -67,7 +67,7 @@ int process_id = getpid();
 #endif
 
 boost::mt19937 deterministic_rng;
-boost::mt19937 lessdeterministic_rng( std::time(0) + process_id );
+boost::mt19937 lessdeterministic_rng( std::time(nullptr) + process_id );
 
 #define M_SQRT3   1.73205080756887719318 /* sqrt(3)   */
 #define M_SQRT3_4 0.86602540378443859659 /* sqrt(3/4) == sqrt(3)/2 */

--- a/src/legacyeditor.cc
+++ b/src/legacyeditor.cc
@@ -243,7 +243,7 @@ void LegacyEditor::replaceAll(const QString &findText, const QString &replaceTex
 
 bool LegacyEditor::findString(const QString & exp, bool findBackwards) const
 {
-	return this->textedit->find(exp, findBackwards ? QTextDocument::FindBackward : QTextDocument::FindFlags(0));
+	return this->textedit->find(exp, findBackwards ? QTextDocument::FindBackward : QTextDocument::FindFlags(nullptr));
 }
 
 int LegacyEditor::resetFindIndicators(const QString & /*findText*/, bool /*visibility*/)//incomplete-place-holder

--- a/src/libsvg/libsvg.cc
+++ b/src/libsvg/libsvg.cc
@@ -47,8 +47,7 @@ attr_map_t read_attributes(xmlTextReaderPtr reader)
 void processNode(xmlTextReaderPtr reader)
 {
 	const char *name = reinterpret_cast<const char *> (xmlTextReaderName(reader));
-	if (name == NULL)
-		name = reinterpret_cast<const char *> (xmlStrdup(BAD_CAST "--"));
+	if (name == nullptr) name = reinterpret_cast<const char *> (xmlStrdup(BAD_CAST "--"));
 
 	bool isEmpty;
 	xmlChar *value = xmlTextReaderValue(reader);
@@ -120,7 +119,7 @@ int streamFile(const char *filename)
 	in_defs = false;
 	reader = xmlNewTextReaderFilename(filename);
 	xmlTextReaderSetParserProp(reader, XML_PARSER_SUBST_ENTITIES, 1);
-	if (reader != NULL) {
+	if (reader != nullptr) {
 		int ret = xmlTextReaderRead(reader);
 		while (ret == 1) {
 			processNode(reader);

--- a/src/libsvg/shape.cc
+++ b/src/libsvg/shape.cc
@@ -21,7 +21,7 @@
 
 namespace libsvg {
 
-shape::shape() : parent(NULL), x(0), y(0)
+shape::shape() : parent(nullptr), x(0), y(0)
 {
 }
 
@@ -55,7 +55,7 @@ shape::create_from_name(const char *name)
 	} else if (group::name == name) {
 		return new group();
 	} else {
-		return NULL;
+		return nullptr;
 	}
 }
 
@@ -138,14 +138,14 @@ shape::collect_transform_matrices(std::vector<Eigen::Matrix3d>& matrices, shape 
 	boost::char_separator<char> sep(" ,()", commands.c_str());
 	tokenizer tokens(transform_arg, sep);
 
-	transformation *t = NULL;
+	transformation *t = nullptr;
 	std::vector<transformation *> transformations;
 	for (tokenizer::iterator it = tokens.begin();it != tokens.end();++it) {
 		std::string v = (*it);
 		if ((v.length() == 1) && (commands.find(v) != std::string::npos)) {
-			if (t != NULL) {
+			if (t != nullptr) {
 				transformations.push_back(t);
-				t = NULL;
+				t = nullptr;
 			}
 			switch (v[0]) {
 			case 'm':
@@ -168,7 +168,7 @@ shape::collect_transform_matrices(std::vector<Eigen::Matrix3d>& matrices, shape 
 				break;
 			default:
 				std::cout << "unknown transform op " << v << std::endl;
-				t = NULL;
+				t = nullptr;
 			}
 		} else {
 			if (t) {
@@ -176,7 +176,7 @@ shape::collect_transform_matrices(std::vector<Eigen::Matrix3d>& matrices, shape 
 			}
 		}
 	}
-	if (t != NULL) {
+	if (t != nullptr) {
 		transformations.push_back(t);
 	}
 	
@@ -192,7 +192,7 @@ void
 shape::apply_transform()
 {
 	std::vector<Eigen::Matrix3d> matrices;
-	for (shape *s = this;s->get_parent() != NULL;s = s->get_parent()) {
+	for (shape *s = this;s->get_parent() != nullptr;s = s->get_parent()) {
 		collect_transform_matrices(matrices, s);
 	}
 

--- a/src/mainwin.cc
+++ b/src/mainwin.cc
@@ -699,9 +699,9 @@ void MainWindow::updateUndockMode(bool undockMode)
 void MainWindow::updateReorderMode(bool reorderMode)
 {
 	MainWindow::reorderMode = reorderMode;
-	editorDock->setTitleBarWidget(reorderMode ? 0 : editorDockTitleWidget);
-	consoleDock->setTitleBarWidget(reorderMode ? 0 : consoleDockTitleWidget);
-	parameterDock->setTitleBarWidget(reorderMode ? 0 : parameterDockTitleWidget);
+	editorDock->setTitleBarWidget(reorderMode ? nullptr : editorDockTitleWidget);
+	consoleDock->setTitleBarWidget(reorderMode ? nullptr : consoleDockTitleWidget);
+	parameterDock->setTitleBarWidget(reorderMode ? nullptr : parameterDockTitleWidget);
 }
 
 MainWindow::~MainWindow()

--- a/src/openscad.cc
+++ b/src/openscad.cc
@@ -802,7 +802,7 @@ int main(int argc, char **argv)
 	StackCheck::inst()->init();
 	
 #ifdef Q_OS_MAC
-	bool isGuiLaunched = getenv("GUI_LAUNCHED") != 0;
+	bool isGuiLaunched = getenv("GUI_LAUNCHED") != nullptr;
 	if (isGuiLaunched) set_output_handler(CocoaUtils::nslog, nullptr);
 #else
 	PlatformUtils::ensureStdIO();

--- a/src/parameter/ParameterWidget.cc
+++ b/src/parameter/ParameterWidget.cc
@@ -173,7 +173,7 @@ void ParameterWidget::cleanScrollArea()
 {
 	this->scrollAreaWidgetContents->layout()->setAlignment(Qt::AlignTop);
 	QLayoutItem *child;
-	while ((child = this->scrollAreaWidgetContents->layout()->takeAt(0)) != 0) {
+	while ((child = this->scrollAreaWidgetContents->layout()->takeAt(0)) != nullptr) {
 		QWidget *w = child->widget();
 		this->scrollAreaWidgetContents->layout()->removeWidget(w);
 		delete w;

--- a/src/parameter/ParameterWidget.h
+++ b/src/parameter/ParameterWidget.h
@@ -59,7 +59,7 @@ private:
 	void setComboBoxPresetForSet();
 
 public:
-	ParameterWidget(QWidget *parent = 0);
+	ParameterWidget(QWidget *parent = nullptr);
 	virtual ~ParameterWidget();
 	void readFile(QString scadFile);
 	void writeFileIfNotEmpty(QString scadFile);

--- a/src/parameter/groupwidget.cpp
+++ b/src/parameter/groupwidget.cpp
@@ -15,8 +15,8 @@ GroupWidget::GroupWidget(bool &show, const QString & title, QWidget *parent) : Q
 	mainLayout.setContentsMargins(0, 0, 0, 0);
     contentArea.setContentsMargins(0, 0, 0, 0);
 
-	mainLayout.addWidget(&toggleButton, 0, 0, 0);
-	mainLayout.addWidget(&contentArea, 1, 0, 0);
+	mainLayout.addWidget(&toggleButton, 0, 0, nullptr);
+	mainLayout.addWidget(&contentArea, 1, 0, nullptr);
 	setSizePolicy(QSizePolicy::Minimum,QSizePolicy::Maximum);
 	setLayout(&mainLayout);
 	QObject::connect(&toggleButton, SIGNAL(toggled(bool)),this, SLOT(onclicked(bool)));

--- a/src/parameter/groupwidget.h
+++ b/src/parameter/groupwidget.h
@@ -17,7 +17,7 @@ private:
 	bool *show;
 
 public:
-	explicit GroupWidget(bool &show,const QString & title = "", QWidget *parent = 0);
+	explicit GroupWidget(bool &show,const QString & title = "", QWidget *parent = nullptr);
 	void setContentLayout(QLayout & contentLayout);
 
 private slots:

--- a/src/parameter/parameterset.cpp
+++ b/src/parameter/parameterset.cpp
@@ -92,7 +92,7 @@ void ParameterSet::writeParameterSet(const std::string &filename)
 
 void ParameterSet::applyParameterSet(FileModule *fileModule, const std::string &setName)
 {
-	if (fileModule == NULL || this->root.empty()) return;
+	if (fileModule == nullptr || this->root.empty()) return;
 	try {
 		ModuleContext ctx;
 		boost::optional<pt::ptree &> set = getParameterSet(setName);

--- a/src/parameter/parametervirtualwidget.h
+++ b/src/parameter/parametervirtualwidget.h
@@ -16,7 +16,7 @@ protected:
 	ParameterObject *object;
 
 public:
-	ParameterVirtualWidget(QWidget *parent = 0);
+	ParameterVirtualWidget(QWidget *parent = nullptr);
 	virtual ~ParameterVirtualWidget();
 	virtual void setParameterFocus() = 0;
 	virtual void setValue() = 0;

--- a/src/scadlexer.cpp
+++ b/src/scadlexer.cpp
@@ -60,7 +60,7 @@ void ScadLexer::setKeywords(int set, const std::string& keywords)
 const char *ScadLexer::keywords(int set) const
 {
 	if ((set < 1) || (set > 4)) {
-		return 0;
+		return nullptr;
 	}
 	return keywordSet[set - 1].c_str();
 }

--- a/src/stackcheck.cc
+++ b/src/stackcheck.cc
@@ -32,7 +32,7 @@ bool StackCheck::check()
 
 StackCheck *StackCheck::inst()
 {
-	if (self == 0) {
+	if (self == nullptr) {
 		self = new StackCheck();
 	}
 	return self;


### PR DESCRIPTION
C++ Core Guidelines ES.47:
https://github.com/isocpp/CppCoreGuidelines/blob/master/CppCoreGuidelines.md#Res-nullptr

Note: These were found by clang-tidy (see #2239)