### PR TITLE
inputdriver5 C++11: Use override to mark overridden virtual functions

### DIFF
--- a/src/input/DBusInputDriver.h
+++ b/src/input/DBusInputDriver.h
@@ -37,14 +37,14 @@ class DBusInputDriver : public InputDriver
 
 public:
     DBusInputDriver();
-    virtual ~DBusInputDriver();
-    virtual void run();
-    virtual bool open();
-    virtual void close();
-    virtual bool isOpen();
-    virtual bool openOnce();
+    ~DBusInputDriver();
+    void run() override;
+    bool open() override;
+    void close() override;
+    bool isOpen() override;
+    bool openOnce() override;
 
-    virtual const std::string & get_name() const;
+    const std::string & get_name() const override;
 
 private slots:
     void zoom(double zoom);

--- a/src/input/HidApiInputDriver.h
+++ b/src/input/HidApiInputDriver.h
@@ -46,7 +46,7 @@ public:
     bool open() override;
     void close() override;
 
-    virtual const std::string & get_name() const;
+    const std::string & get_name() const override;
 
     void hidapi_decode_axis1(const unsigned char *buf, unsigned int len);
     void hidapi_decode_button1(const unsigned char *buf, unsigned int len);

--- a/src/input/HidApiInputDriver.h
+++ b/src/input/HidApiInputDriver.h
@@ -41,10 +41,10 @@ class HidApiInputDriver : public InputDriver
 
 public:
     HidApiInputDriver();
-    virtual ~HidApiInputDriver();
-    virtual void run();
-    virtual bool open();
-    virtual void close();
+    ~HidApiInputDriver();
+    void run() override;
+    bool open() override;
+    void close() override;
 
     virtual const std::string & get_name() const;
 

--- a/src/input/JoystickInputDriver.h
+++ b/src/input/JoystickInputDriver.h
@@ -31,12 +31,12 @@ class JoystickInputDriver : public InputDriver
 {
 public:
     JoystickInputDriver();
-    virtual ~JoystickInputDriver();
-    virtual void run();
-    virtual bool open();
-    virtual void close();
+    ~JoystickInputDriver();
+    void run() override;
+    bool open() override;
+    void close() override;
 
-    virtual const std::string & get_name() const;
+    const std::string & get_name() const  override;
 private:
     int fd;
     int version;

--- a/src/input/QGamepadInputDriver.h
+++ b/src/input/QGamepadInputDriver.h
@@ -39,7 +39,7 @@ public:
     bool open() override;
     void close() override;
 
-    virtual const std::string & get_name() const;
+    const std::string & get_name() const override;
 private:
 	std::unique_ptr<QGamepad> gamepad;
 };

--- a/src/input/QGamepadInputDriver.h
+++ b/src/input/QGamepadInputDriver.h
@@ -34,10 +34,10 @@ class QGamepadInputDriver : public InputDriver
 {
 public:
     QGamepadInputDriver();
-    virtual ~QGamepadInputDriver();
-    virtual void run();
-    virtual bool open();
-    virtual void close();
+    ~QGamepadInputDriver();
+    void run() override;
+    bool open() override;
+    void close() override;
 
     virtual const std::string & get_name() const;
 private:

--- a/src/input/SpaceNavInputDriver.h
+++ b/src/input/SpaceNavInputDriver.h
@@ -34,12 +34,12 @@ class SpaceNavInputDriver : public InputDriver
 
 public:
     SpaceNavInputDriver();
-    virtual ~SpaceNavInputDriver();
-    virtual void run();
-    virtual bool open();
-    virtual void close();
+    ~SpaceNavInputDriver();
+    void run() override;
+    bool open() override;
+    void close() override;
 
-    virtual const std::string & get_name() const;
+    const std::string & get_name() const override;
 
 private:
     bool spnav_input();


### PR DESCRIPTION
see #2237 

This pull request is to keep the coding style of our feature branch in line with the main development branch in line.

Feel free to squash all the commits during merge.