### PR TITLE
Inputdriver5 ignore mousewheel on the combo boxes

### DIFF
--- a/openscad.pro
+++ b/openscad.pro
@@ -363,7 +363,8 @@ HEADERS += src/version_check.h \
            src/input/InputEventMapper.h \
            src/input/InputDriverManager.h \
            src/input/AxisConfigWidget.h \
-           src/input/ButtonConfigWidget.h
+           src/input/ButtonConfigWidget.h \
+           src/input/WheelIgnorer.h
 
 SOURCES += \
            src/libsvg/libsvg.cc \
@@ -512,7 +513,8 @@ SOURCES += \
            src/input/InputEventMapper.cc \
            src/input/InputDriverManager.cc \
            src/input/AxisConfigWidget.cc \
-           src/input/ButtonConfigWidget.cc
+           src/input/ButtonConfigWidget.cc \
+           src/input/WheelIgnorer.cc
 
 # CGAL
 HEADERS += src/ext/CGAL/convex_hull_3_bugfix.h \

--- a/src/input/AxisConfigWidget.cc
+++ b/src/input/AxisConfigWidget.cc
@@ -31,6 +31,7 @@
 #include "QSettingsCached.h"
 #include "input/InputDriverManager.h"
 #include "SettingsWriter.h"
+#include "WheelIgnorer.h"
 
 AxisConfigWidget::AxisConfigWidget(QWidget *parent) : QWidget(parent)
 {
@@ -67,6 +68,12 @@ void AxisConfigWidget::init() {
 	initComboBox(this->comboBoxRotationZ, Settings::Settings::inputRotateZ);
 	initComboBox(this->comboBoxZoom, Settings::Settings::inputZoom);
 	initComboBox(this->comboBoxZoom2, Settings::Settings::inputZoom2);
+
+	WheelIgnorer *wheelIgnorer = new WheelIgnorer();
+	QList<QComboBox *> widgets = this->findChildren<QComboBox *>();
+	foreach (QComboBox* b, widgets) {
+		b->installEventFilter(wheelIgnorer);
+	}
 
 	for (int i = 0; i < InputEventMapper::getMaxAxis(); i++ ){
 		std::string s = std::to_string(i);

--- a/src/input/AxisConfigWidget.cc
+++ b/src/input/AxisConfigWidget.cc
@@ -69,10 +69,11 @@ void AxisConfigWidget::init() {
 	initComboBox(this->comboBoxZoom, Settings::Settings::inputZoom);
 	initComboBox(this->comboBoxZoom2, Settings::Settings::inputZoom2);
 
-	WheelIgnorer *wheelIgnorer = new WheelIgnorer();
-	QList<QComboBox *> widgets = this->findChildren<QComboBox *>();
-	foreach (QComboBox* b, widgets) {
-		b->installEventFilter(wheelIgnorer);
+	auto *wheelIgnorer = new WheelIgnorer();
+	wheelIgnorer->setParent(this);
+	auto comboBoxes = this->findChildren<QComboBox *>();
+	for (auto comboBox : comboBoxes) {
+		comboBox->installEventFilter(wheelIgnorer);
 	}
 
 	for (int i = 0; i < InputEventMapper::getMaxAxis(); i++ ){

--- a/src/input/ButtonConfigWidget.cc
+++ b/src/input/ButtonConfigWidget.cc
@@ -30,6 +30,7 @@
 #include "QSettingsCached.h"
 #include "input/InputDriverManager.h"
 #include "SettingsWriter.h"
+#include "WheelIgnorer.h"
 
 ButtonConfigWidget::ButtonConfigWidget(QWidget *parent) : QWidget(parent)
 {
@@ -60,6 +61,12 @@ void ButtonConfigWidget::init() {
 		if(box && ent){
 			initComboBox(box,*ent);
 		}
+	}
+
+	WheelIgnorer *wheelIgnorer = new WheelIgnorer();
+	QList<QComboBox *> widgets = this->findChildren<QComboBox *>();
+	foreach (QComboBox* b, widgets) {
+		b->installEventFilter(wheelIgnorer);
 	}
 }
 

--- a/src/input/ButtonConfigWidget.cc
+++ b/src/input/ButtonConfigWidget.cc
@@ -63,10 +63,11 @@ void ButtonConfigWidget::init() {
 		}
 	}
 
-	WheelIgnorer *wheelIgnorer = new WheelIgnorer();
-	QList<QComboBox *> widgets = this->findChildren<QComboBox *>();
-	foreach (QComboBox* b, widgets) {
-		b->installEventFilter(wheelIgnorer);
+	auto *wheelIgnorer = new WheelIgnorer();
+	wheelIgnorer->setParent(this);
+	auto comboBoxes = this->findChildren<QComboBox *>();
+	for (auto comboBox : comboBoxes) {
+		comboBox->installEventFilter(wheelIgnorer);
 	}
 }
 

--- a/src/input/WheelIgnorer.cc
+++ b/src/input/WheelIgnorer.cc
@@ -1,0 +1,9 @@
+#include "WheelIgnorer.h"
+
+bool WheelIgnorer::eventFilter(QObject *obj, QEvent *event)
+{
+    if(event->type() == QEvent::Wheel){
+                return true;
+    }
+    return QObject::eventFilter(obj, event);
+}

--- a/src/input/WheelIgnorer.h
+++ b/src/input/WheelIgnorer.h
@@ -1,0 +1,13 @@
+//https://stackoverflow.com/questions/3241830/qt-how-to-disable-mouse-scrolling-of-qcombobox
+//https://stackoverflow.com/questions/5821802/qspinbox-inside-a-qscrollarea-how-to-prevent-spin-box-from-stealing-focus-when
+//http://doc.qt.io/archives/qt-4.8/qobject.html#installEventFilter
+#include <QWidget>
+#include <QMouseEvent>
+
+class WheelIgnorer : public QObject
+{
+    Q_OBJECT
+
+protected:
+    bool eventFilter(QObject *obj, QEvent *event);
+};

--- a/src/input/WheelIgnorer.h
+++ b/src/input/WheelIgnorer.h
@@ -1,6 +1,16 @@
+//This event filter ignores Mouse Wheel events.
+//A lot of elements in OpenSCAD are in Scroll Areas.
+//This causes a conflict, as some elements within the Scroll Areas are
+//also reacting to the mousewheel.
+//Especially in the settings, where the user might spend a considerable
+//amount of time to get it just right, it is annoying when simply
+//scrowling down unintentionally changes various settings.
+
+//for reference:
 //https://stackoverflow.com/questions/3241830/qt-how-to-disable-mouse-scrolling-of-qcombobox
 //https://stackoverflow.com/questions/5821802/qspinbox-inside-a-qscrollarea-how-to-prevent-spin-box-from-stealing-focus-when
 //http://doc.qt.io/archives/qt-4.8/qobject.html#installEventFilter
+
 #include <QWidget>
 #include <QMouseEvent>
 


### PR DESCRIPTION
A lot of GUI elements in OpenSCAD are in Scroll Areas.
This causes a conflict, as some elements within the Scroll Areas are also reacting to the mousewheel.
Especially in the settings, where the user might spend a considerable amount of time to get it just right, it is annoying when simply scrowling down unintentionally changes various settings.

for reference:
   * https://stackoverflow.com/questions/3241830/qt-how-to-disable-mouse-scrolling-of-qcombobox
   * https://stackoverflow.com/questions/5821802/qspinbox-inside-a-qscrollarea-how-to-prevent-spin-box-from-stealing-focus-when
   * http://doc.qt.io/archives/qt-4.8/qobject.html#installEventFilter