### PR TITLE
InputDriver5: Toggle Perspective

### DIFF
--- a/src/MainWindow.h
+++ b/src/MainWindow.h
@@ -251,6 +251,7 @@ public slots:
 	void viewCenter();
 	void viewPerspective();
 	void viewOrthogonal();
+	void viewTogglePerspective();
 	void viewResetView();
 	void viewAll();
 	void animateUpdateDocChanged();

--- a/src/mainwin.cc
+++ b/src/mainwin.cc
@@ -473,7 +473,6 @@ MainWindow::MainWindow(const QString &filename)
 	addKeyboardShortCut(this->editortoolbar->actions());
 
         InputDriverManager::instance()->registerActions(this->menuBar()->actions());
-	
 	initActionIcon(fileActionNew, ":/images/blackNew.png", ":/images/Document-New-128.png");
 	initActionIcon(fileActionOpen, ":/images/Open-32.png", ":/images/Open-128.png");
 	initActionIcon(fileActionSave, ":/images/Save-32.png", ":/images/Save-128.png");
@@ -662,11 +661,12 @@ void MainWindow::onRotateEvent(InputEventRotate *event)
 
 void MainWindow::onActionEvent(InputEventAction *event)
 {
-    QAction *action = findAction(this->menuBar()->actions(), event->action);
-    if (!action) {
-        return;
-    }
-    action->trigger();
+	QAction *action = findAction(this->menuBar()->actions(), event->action);
+	if (action) {
+		action->trigger();
+	}else if("viewActionTogglePerspective" == event->action){
+		viewTogglePerspective();
+	}
 }
 
 QAction * MainWindow::findAction(const QList<QAction *> &actions, const std::string &name)
@@ -2602,6 +2602,15 @@ void MainWindow::viewOrthogonal()
 	this->qglview->updateGL();
 }
 
+void MainWindow::viewTogglePerspective()
+{
+	QSettingsCached settings;
+	if (settings.value("view/orthogonalProjection").toBool()) {
+		viewPerspective();
+	} else {
+		viewOrthogonal();
+	}
+}
 void MainWindow::viewResetView()
 {
 	this->qglview->resetView();

--- a/src/settings.cc
+++ b/src/settings.cc
@@ -158,6 +158,7 @@ static Value buttonValues() {
 	v += ValuePtr(value("viewActionLeft", _("viewActionLeft")));
 	v += ValuePtr(value("viewActionOrthogonal", _("viewActionOrthogonal")));
 	v += ValuePtr(value("viewActionPerspective", _("viewActionPerspective")));
+	v += ValuePtr(value("viewActionTogglePerspective", _("viewActionTogglePerspective")));
 	v += ValuePtr(value("viewActionPreview", _("viewActionPreview")));
 	v += ValuePtr(value("viewActionResetView", _("viewActionResetView")));
 	v += ValuePtr(value("viewActionRight", _("viewActionRight")));


### PR DESCRIPTION
#2130 "add toggle version of actions for use with buttons, e.g. viewActionOrthogonal v's viewActionPerspective"

This approach does work, but I am not really happy with it.
This Action is breaking the structure of calling actions on the menu bar.
Adding an option to toggle to the menubar would be redundant there.
Adding the option "hidden" would be confusing.
So, this implementation is the best compromise I was I able to comeup with.

Not beeing in the menu bar also means, that it is not know to the InputDriverManager via registerActions();.
Now, the currently, "QStringList actions;" is unused, but that might change (or we should remove that list).
On the other hand: The list is usefull to check for the completeness of the preferences. (Which also could be automated in the test scripts)
We could add an registerAction methode (singular) to register this kind of actions.

On a side not: This development pointed me to an issue in regards to forward/backward compatibly:
Currently, when we do not know a setting that is set in the preferences, we reset that setting to its default.
This will be an issue, when people start using different versions in parallel. Off course, an old version does not now the new actions, but it could at least "not touch" the users settings. (#2255)
  