### PR TITLE
Inputdriver5: do not overwrite the user settings with the default 

### DIFF
--- a/src/input/ButtonConfigWidget.cc
+++ b/src/input/ButtonConfigWidget.cc
@@ -176,7 +176,7 @@ void ButtonConfigWidget::updateComboBox(QComboBox *comboBox, const Settings::Set
 	if (idx >= 0) {
 		comboBox->setCurrentIndex(idx);
 	} else {
-		comboBox->addItem(text + " (not supported)", text);
+		comboBox->addItem(QIcon::fromTheme("emblem-unreadable"), text + " " + _("(not supported)"), text);
 		int defIdx = comboBox->findData(text);
 		if (defIdx >= 0) {
 			comboBox->setCurrentIndex(defIdx);

--- a/src/input/ButtonConfigWidget.cc
+++ b/src/input/ButtonConfigWidget.cc
@@ -176,9 +176,8 @@ void ButtonConfigWidget::updateComboBox(QComboBox *comboBox, const Settings::Set
 	if (idx >= 0) {
 		comboBox->setCurrentIndex(idx);
 	} else {
-		const Value &defaultValue = entry.defaultValue();
-		QString defaultText = QString::fromStdString(defaultValue.toString());
-		int defIdx = comboBox->findData(defaultText);
+		comboBox->addItem(text + " (not supported)", text);
+		int defIdx = comboBox->findData(text);
 		if (defIdx >= 0) {
 			comboBox->setCurrentIndex(defIdx);
 		} else {


### PR DESCRIPTION
Currently, when we do not know a setting that is set in the preferences, we reset that setting to its default.
This will be an issue, when people start using different versions in parallel. Off course, an old version does not know the new actions, but it could at least "not touch" the users settings.

This is now implemented. To mark the not supported feature, a translatable string and an icon is used:

![1234](https://user-images.githubusercontent.com/24962768/34649423-2a95f4d2-f3af-11e7-9c05-829400d1c838.png)

Discovered while working on #2254

Feel free to squash the commits.