### PR TITLE
Add full git URL for MCAD to .gitmodules

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "libraries/MCAD"]
 	path = libraries/MCAD
-	url = ../MCAD.git
+	url = https://github.com/openscad/MCAD.git


### PR DESCRIPTION
This existing .gitmodules file uses a relative path, rather than a full URL.  When a user forks the openscad repo and tries to `git submodule update --init`, it tries to download from `git://github.com/<user>/MCAD.git` rather than the upstream MCAD library.

This is probably not desirable behavior, since most new OpenSCAD contributors won't have (or want) their own fork of MCAD.