### PR TITLE
Mac High Sierra 10.13.2 build

### DIFF
--- a/c++11.pri
+++ b/c++11.pri
@@ -3,7 +3,8 @@ macx {
   # We attempt to auto-detect it by inspecting Boost
   dirs = $${BOOSTDIR} $${QMAKE_LIBDIR}
   for(dir, dirs) {
-    system(grep -q __112basic_string $${dir}/libboost_thread* >& /dev/null) {
+    #system(grep -q __112basic_string $${dir}/libboost_thread* >& /dev/null) {
+    system(otool -L /usr/local/lib/libboost_thread*  | grep libc++ >& /dev/null ) {
       message("Using libc++11")
       CONFIG += libc++
     }

--- a/c++11.pri
+++ b/c++11.pri
@@ -3,8 +3,7 @@ macx {
   # We attempt to auto-detect it by inspecting Boost
   dirs = $${BOOSTDIR} $${QMAKE_LIBDIR}
   for(dir, dirs) {
-    #system(grep -q __112basic_string $${dir}/libboost_thread* >& /dev/null) {
-    system(otool -L /usr/local/lib/libboost_thread*  | grep libc++ >& /dev/null ) {
+    system(otool -L $${dir}/libboost_thread*  | grep libc++ >& /dev/null ) {
       message("Using libc++11")
       CONFIG += libc++
     }

--- a/openscad.pro
+++ b/openscad.pro
@@ -87,6 +87,7 @@ macx {
 # Set same stack size for the linker and #define used in PlatformUtils.h
 STACKSIZE = 8388608 # 8MB # github issue 116
 QMAKE_CXXFLAGS += -DSTACKSIZE=$$STACKSIZE
+DEFINES += STACKSIZE=$$STACKSIZE
 
 win* {
   RC_FILE = openscad_win32.rc

--- a/src/EventFilter.h
+++ b/src/EventFilter.h
@@ -5,12 +5,12 @@
 #include "OpenSCADApp.h"
 #include "launchingscreen.h"
 
-class EventFilter : public QObject
+class SCADEventFilter : public QObject
 {
 	Q_OBJECT;
 	
 public:
-	EventFilter(QObject *parent) : QObject(parent) {}
+	SCADEventFilter(QObject *parent) : QObject(parent) {}
 protected:
 	bool eventFilter(QObject *obj, QEvent *event) override {
 		// Handle Apple event for opening files, only available on OS X

--- a/src/OpenSCADApp.cc
+++ b/src/OpenSCADApp.cc
@@ -13,7 +13,7 @@ OpenSCADApp::OpenSCADApp(int &argc ,char **argv)
 	: QApplication(argc, argv), fontCacheDialog(nullptr)
 {
 #ifdef Q_OS_MAC
-	this->installEventFilter(new EventFilter(this));
+	this->installEventFilter(new SCADEventFilter(this));
 #endif
 }
 


### PR DESCRIPTION
I had three issues building OpenScad on my mac. 

The first issue related to the identification of using libc++ vs libstdc++. Boost was build with libc++ but the qmake profile was unable to identify it properly. 

I also had an issue where STACKSIZE was undefined for some reason. Added it to the DEFINES section in the qmake project and everything worked. 

Finally, clang was getting confused with EventFilter. It kept looking for a function as opposed to the class: 
```
src/OpenSCADApp.cc:16:31: error: cannot initialize a new value of type 'EventFilter' (aka 'bool (*)(void *, long *)') with an rvalue of type
      'OpenSCADApp *'
        this->installEventFilter(new EventFilter(this));
                                     ^           ~~~~
1 error generated.
```
Renaming the EventFilter class fixed this particular issue. 