### PR TITLE
make the IgnoreWheelWhenNotFocused aware of its parent

### DIFF
--- a/src/parameter/ignoreWheelWhenNotFocused.cpp
+++ b/src/parameter/ignoreWheelWhenNotFocused.cpp
@@ -1,5 +1,9 @@
 #include "ignoreWheelWhenNotFocused.h"
 
+IgnoreWheelWhenNotFocused::IgnoreWheelWhenNotFocused(QWidget *parent) : QObject(parent)
+{
+}
+
 //https://stackoverflow.com/questions/5821802/qspinbox-inside-a-qscrollarea-how-to-prevent-spin-box-from-stealing-focus-when
 bool IgnoreWheelWhenNotFocused::eventFilter(QObject *obj, QEvent *event)
 {

--- a/src/parameter/ignoreWheelWhenNotFocused.h
+++ b/src/parameter/ignoreWheelWhenNotFocused.h
@@ -16,6 +16,8 @@
 class IgnoreWheelWhenNotFocused : public QObject
 {
     Q_OBJECT
+public:
+	IgnoreWheelWhenNotFocused(QWidget *parent);
 
 protected:
     bool eventFilter(QObject *obj, QEvent *event);

--- a/src/parameter/parametercombobox.cpp
+++ b/src/parameter/parametercombobox.cpp
@@ -15,7 +15,7 @@ ParameterComboBox::ParameterComboBox(ParameterObject *parameterobject, int showD
 		comboBox->setToolTip(object->description);
 	}
 
-	IgnoreWheelWhenNotFocused *ignoreWheelWhenNotFocused = new IgnoreWheelWhenNotFocused();
+	IgnoreWheelWhenNotFocused *ignoreWheelWhenNotFocused = new IgnoreWheelWhenNotFocused(this);
 	comboBox->installEventFilter(ignoreWheelWhenNotFocused);
 }
 

--- a/src/parameter/parameterslider.cpp
+++ b/src/parameter/parameterslider.cpp
@@ -21,7 +21,7 @@ ParameterSlider::ParameterSlider(ParameterObject *parameterobject, int showDescr
 		slider->setToolTip(object->description);
 	}
 
-	IgnoreWheelWhenNotFocused *ignoreWheelWhenNotFocused = new IgnoreWheelWhenNotFocused();
+	IgnoreWheelWhenNotFocused *ignoreWheelWhenNotFocused = new IgnoreWheelWhenNotFocused(this);
 	slider->installEventFilter(ignoreWheelWhenNotFocused);
 	doubleSpinBox->installEventFilter(ignoreWheelWhenNotFocused);
 }

--- a/src/parameter/parameterspinbox.cpp
+++ b/src/parameter/parameterspinbox.cpp
@@ -14,7 +14,7 @@ ParameterSpinBox::ParameterSpinBox(ParameterObject *parameterobject, int showDes
 	}else {
 		doubleSpinBox->setToolTip(object->description);
 	}
-	IgnoreWheelWhenNotFocused *ignoreWheelWhenNotFocused = new IgnoreWheelWhenNotFocused();
+	IgnoreWheelWhenNotFocused *ignoreWheelWhenNotFocused = new IgnoreWheelWhenNotFocused(this);
 	doubleSpinBox->installEventFilter(ignoreWheelWhenNotFocused);
 }
 

--- a/src/parameter/parametervector.cpp
+++ b/src/parameter/parametervector.cpp
@@ -18,7 +18,7 @@ ParameterVector::ParameterVector(ParameterObject *parameterobject, int showDescr
 		this->setToolTip(object->description);
 	}
 
-	IgnoreWheelWhenNotFocused *ignoreWheelWhenNotFocused = new IgnoreWheelWhenNotFocused();
+	IgnoreWheelWhenNotFocused *ignoreWheelWhenNotFocused = new IgnoreWheelWhenNotFocused(this);
 	doubleSpinBox1->installEventFilter(ignoreWheelWhenNotFocused);
 	doubleSpinBox2->installEventFilter(ignoreWheelWhenNotFocused);
 	doubleSpinBox3->installEventFilter(ignoreWheelWhenNotFocused);


### PR DESCRIPTION
based on a comment(s) by kintel in #2252

> This object should probably receive a parent so it gets deleted at some point.

> On this note, you should be able to pass this to the WheelIgnorer contructor; that's the common way of assigning parents in Qt. Adding a constructor also makes it clear that this is how the object is supposed to be used (e.g. you could require an argument to be passed).