### PR TITLE
more elegant way to make the WheelIgnorer aware of its parent

### DIFF
--- a/src/input/AxisConfigWidget.cc
+++ b/src/input/AxisConfigWidget.cc
@@ -110,8 +110,7 @@ void AxisConfigWidget::init() {
 	initCheckBox(this->checkBoxQGamepad, Settings::Settings::inputEnableDriverQGAMEPAD);
 	initCheckBox(this->checkBoxDBus,     Settings::Settings::inputEnableDriverDBUS);
 
-	auto *wheelIgnorer = new WheelIgnorer();
-	wheelIgnorer->setParent(this);
+	auto *wheelIgnorer = new WheelIgnorer(this);
 	auto comboBoxes = this->findChildren<QComboBox *>();
 	for (auto comboBox : comboBoxes) {
 		comboBox->installEventFilter(wheelIgnorer);

--- a/src/input/ButtonConfigWidget.cc
+++ b/src/input/ButtonConfigWidget.cc
@@ -63,8 +63,7 @@ void ButtonConfigWidget::init() {
 		}
 	}
 
-	auto *wheelIgnorer = new WheelIgnorer();
-	wheelIgnorer->setParent(this);
+	auto *wheelIgnorer = new WheelIgnorer(this);
 	auto comboBoxes = this->findChildren<QComboBox *>();
 	for (auto comboBox : comboBoxes) {
 		comboBox->installEventFilter(wheelIgnorer);

--- a/src/input/WheelIgnorer.cc
+++ b/src/input/WheelIgnorer.cc
@@ -1,5 +1,9 @@
 #include "WheelIgnorer.h"
 
+WheelIgnorer::WheelIgnorer(QWidget *parent) : QObject(parent)
+{
+}
+
 bool WheelIgnorer::eventFilter(QObject *obj, QEvent *event)
 {
     if(event->type() == QEvent::Wheel){

--- a/src/input/WheelIgnorer.h
+++ b/src/input/WheelIgnorer.h
@@ -18,6 +18,9 @@ class WheelIgnorer : public QObject
 {
     Q_OBJECT
 
+public:
+	WheelIgnorer(QWidget *parent);
+
 protected:
     bool eventFilter(QObject *obj, QEvent *event);
 };


### PR DESCRIPTION
based on a comment by kintel in #2252
> On this note, you should be able to pass this to the WheelIgnorer contructor; that's the common way of assigning parents in Qt. Adding a constructor also makes it clear that this is how the object is supposed to be used (e.g. you could require an argument to be passed).