### PR TITLE
inputdriver5, dbus: methode to get the name of supported actions

### DIFF
--- a/org.openscad.OpenSCAD.xml
+++ b/org.openscad.OpenSCAD.xml
@@ -34,5 +34,8 @@
     <method name="buttonPress">
       <arg name="idx" type="u" direction="in"/>
     </method>
+    <method name="actions">
+      <arg name="names" type="s" direction="out"/>
+    </method>
   </interface>
 </node>

--- a/org.openscad.OpenSCAD.xml
+++ b/org.openscad.OpenSCAD.xml
@@ -35,7 +35,8 @@
       <arg name="idx" type="u" direction="in"/>
     </method>
     <method name="actions">
-      <arg name="names" type="s" direction="out"/>
+      <arg name="names" type="as" direction="out"/>
+      <annotation name="org.qtproject.QtDBus.QtTypeName.Out0" value="QStringList&gt;"/>
     </method>
   </interface>
 </node>

--- a/org.openscad.OpenSCAD.xml
+++ b/org.openscad.OpenSCAD.xml
@@ -34,7 +34,7 @@
     <method name="buttonPress">
       <arg name="idx" type="u" direction="in"/>
     </method>
-    <method name="actions">
+    <method name="getActions">
       <arg name="names" type="as" direction="out"/>
       <annotation name="org.qtproject.QtDBus.QtTypeName.Out0" value="QStringList&gt;"/>
     </method>

--- a/src/input/DBusInputDriver.cc
+++ b/src/input/DBusInputDriver.cc
@@ -117,6 +117,18 @@ void DBusInputDriver::action(QString name)
     InputDriverManager::instance()->sendEvent(new InputEventAction(name.toStdString(), false));
 }
 
+QString DBusInputDriver::actions()
+{
+	QString ret="";
+	InputDriverManager* manager = InputDriverManager::instance();
+	std::list<actionStruct> actions = manager->actions;
+
+	for (std::list<actionStruct>::iterator action=actions.begin(); action != actions.end(); ++action){
+		ret += (*action).name + "\n";
+	}
+	return ret;
+}
+
 void DBusInputDriver::buttonPress(uint idx)
 {
     InputDriverManager::instance()->sendEvent(new InputEventButtonChanged(idx, true, false));

--- a/src/input/DBusInputDriver.cc
+++ b/src/input/DBusInputDriver.cc
@@ -117,7 +117,7 @@ void DBusInputDriver::action(QString name)
     InputDriverManager::instance()->sendEvent(new InputEventAction(name.toStdString(), false));
 }
 
-QStringList DBusInputDriver::actions()
+QStringList DBusInputDriver::getActions()
 {
 	QStringList ret;
 	InputDriverManager* manager = InputDriverManager::instance();

--- a/src/input/DBusInputDriver.cc
+++ b/src/input/DBusInputDriver.cc
@@ -117,14 +117,14 @@ void DBusInputDriver::action(QString name)
     InputDriverManager::instance()->sendEvent(new InputEventAction(name.toStdString(), false));
 }
 
-QString DBusInputDriver::actions()
+QStringList DBusInputDriver::actions()
 {
-	QString ret="";
+	QStringList ret;
 	InputDriverManager* manager = InputDriverManager::instance();
 	std::list<actionStruct> actions = manager->actions;
 
 	for (std::list<actionStruct>::iterator action=actions.begin(); action != actions.end(); ++action){
-		ret += (*action).name + "\n";
+		ret << (*action).name;
 	}
 	return ret;
 }

--- a/src/input/DBusInputDriver.h
+++ b/src/input/DBusInputDriver.h
@@ -55,4 +55,5 @@ private slots:
     void translateTo(double x, double y, double z);
     void action(QString action);
     void buttonPress(uint idx);
+    QString actions();
 };

--- a/src/input/DBusInputDriver.h
+++ b/src/input/DBusInputDriver.h
@@ -55,5 +55,5 @@ private slots:
     void translateTo(double x, double y, double z);
     void action(QString action);
     void buttonPress(uint idx);
-    QStringList actions();
+    QStringList getActions();
 };

--- a/src/input/DBusInputDriver.h
+++ b/src/input/DBusInputDriver.h
@@ -55,5 +55,5 @@ private slots:
     void translateTo(double x, double y, double z);
     void action(QString action);
     void buttonPress(uint idx);
-    QString actions();
+    QStringList actions();
 };


### PR DESCRIPTION
usage/example see https://github.com/MichaelPFrey/openscad-dbus-reference/pull/1

I am not to sure about the data type.
I could use array or QStringList, but QString maps to String which should be easy to use in any programming language. Using newline and splitting on it is also simple and easy.