### PR TITLE
inputdriver 5: expose rotate2 via dbus 

### DIFF
--- a/org.openscad.OpenSCAD.xml
+++ b/org.openscad.OpenSCAD.xml
@@ -1,6 +1,6 @@
 <!DOCTYPE node PUBLIC "-//freedesktop//DTD D-BUS Object Introspection 1.0//EN"
 "http://www.freedesktop.org/standards/dbus/1.0/introspect.dtd">
-<node>
+<node  xmlns:tp="http://telepathy.freedesktop.org/wiki/DbusSpec#extensions-v0http://telepathy.freedesktop.org/wiki/DbusSpec#extensions-v0">
   <interface name="org.openscad.OpenSCAD">
     <method name="zoom">
       <arg name="zoom" type="d" direction="in"/>
@@ -19,6 +19,11 @@
       <arg name="z" type="d" direction="in"/>
     </method>
     <method name="rotateByVector">
+      <tp:docstring>
+        The vector [x,y,z] describes the rotation.
+        The direction of the vector is the angle around which to rotate,
+        and the length of the vector is the angle by which to rotate.
+      </tp:docstring>
       <arg name="x" type="d" direction="in"/>
       <arg name="y" type="d" direction="in"/>
       <arg name="z" type="d" direction="in"/>

--- a/org.openscad.OpenSCAD.xml
+++ b/org.openscad.OpenSCAD.xml
@@ -18,6 +18,11 @@
       <arg name="y" type="d" direction="in"/>
       <arg name="z" type="d" direction="in"/>
     </method>
+    <method name="rotate2">
+      <arg name="x" type="d" direction="in"/>
+      <arg name="y" type="d" direction="in"/>
+      <arg name="z" type="d" direction="in"/>
+    </method>
     <method name="translate">
       <arg name="x" type="d" direction="in"/>
       <arg name="y" type="d" direction="in"/>

--- a/org.openscad.OpenSCAD.xml
+++ b/org.openscad.OpenSCAD.xml
@@ -18,7 +18,7 @@
       <arg name="y" type="d" direction="in"/>
       <arg name="z" type="d" direction="in"/>
     </method>
-    <method name="rotate2">
+    <method name="rotateByVector">
       <arg name="x" type="d" direction="in"/>
       <arg name="y" type="d" direction="in"/>
       <arg name="z" type="d" direction="in"/>

--- a/src/MainWindow.h
+++ b/src/MainWindow.h
@@ -213,6 +213,7 @@ public:
 
         void onTranslateEvent(InputEventTranslate *event);
         void onRotateEvent(InputEventRotate *event);
+        void onRotate2Event(InputEventRotate2 *event);
         void onActionEvent(InputEventAction *event);
         void onZoomEvent(InputEventZoom *event);
 

--- a/src/input/AxisConfigWidget.cc
+++ b/src/input/AxisConfigWidget.cc
@@ -66,6 +66,9 @@ void AxisConfigWidget::init() {
 	initComboBox(this->comboBoxRotationX, Settings::Settings::inputRotateX);
 	initComboBox(this->comboBoxRotationY, Settings::Settings::inputRotateY);
 	initComboBox(this->comboBoxRotationZ, Settings::Settings::inputRotateZ);
+	initComboBox(this->comboBoxRotationXVPRel, Settings::Settings::inputRotateXVPRel);
+	initComboBox(this->comboBoxRotationYVPRel, Settings::Settings::inputRotateYVPRel);
+	initComboBox(this->comboBoxRotationZVPRel, Settings::Settings::inputRotateZVPRel);
 	initComboBox(this->comboBoxZoom, Settings::Settings::inputZoom);
 	initComboBox(this->comboBoxZoom2, Settings::Settings::inputZoom2);
 
@@ -192,6 +195,24 @@ void AxisConfigWidget::on_comboBoxRotationY_activated(int val)
 void AxisConfigWidget::on_comboBoxRotationZ_activated(int val)
 {
 	applyComboBox(comboBoxRotationZ, val, Settings::Settings::inputRotateZ);
+        emit inputMappingChanged();
+}
+
+void AxisConfigWidget::on_comboBoxRotationXVPRel_activated(int val)
+{
+	applyComboBox(comboBoxRotationXVPRel, val, Settings::Settings::inputRotateXVPRel);
+        emit inputMappingChanged();
+}
+
+void AxisConfigWidget::on_comboBoxRotationYVPRel_activated(int val)
+{
+	applyComboBox(comboBoxRotationYVPRel, val, Settings::Settings::inputRotateYVPRel);
+        emit inputMappingChanged();
+}
+
+void AxisConfigWidget::on_comboBoxRotationZVPRel_activated(int val)
+{
+	applyComboBox(comboBoxRotationZVPRel, val, Settings::Settings::inputRotateZVPRel);
         emit inputMappingChanged();
 }
 

--- a/src/input/AxisConfigWidget.h
+++ b/src/input/AxisConfigWidget.h
@@ -28,6 +28,9 @@ public slots:
         void on_comboBoxRotationX_activated(int val);
         void on_comboBoxRotationY_activated(int val);
         void on_comboBoxRotationZ_activated(int val);
+        void on_comboBoxRotationXVPRel_activated(int val);
+        void on_comboBoxRotationYVPRel_activated(int val);
+        void on_comboBoxRotationZVPRel_activated(int val);
         void on_comboBoxZoom_activated(int val);
         void on_comboBoxZoom2_activated(int val);
 

--- a/src/input/AxisConfigWidget.ui
+++ b/src/input/AxisConfigWidget.ui
@@ -34,7 +34,7 @@
         <x>0</x>
         <y>0</y>
         <width>599</width>
-        <height>570</height>
+        <height>610</height>
        </rect>
       </property>
       <layout class="QGridLayout" name="gridLayout_7" columnstretch="0,0">
@@ -745,14 +745,14 @@
            </property>
           </widget>
          </item>
-         <item row="5" column="0">
+         <item row="6" column="0">
           <widget class="QLabel" name="labelInputZoom">
            <property name="text">
             <string>Zoom</string>
            </property>
           </widget>
          </item>
-         <item row="5" column="1">
+         <item row="6" column="1">
           <widget class="QComboBox" name="comboBoxZoom">
            <property name="sizePolicy">
             <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
@@ -870,7 +870,7 @@
            </property>
           </widget>
          </item>
-         <item row="5" column="4">
+         <item row="6" column="4">
           <widget class="QDoubleSpinBox" name="doubleSpinBoxZoomGain">
            <property name="minimum">
             <double>0.100000000000000</double>
@@ -969,7 +969,7 @@
            </property>
           </widget>
          </item>
-         <item row="5" column="2">
+         <item row="6" column="2">
           <widget class="QComboBox" name="comboBoxZoom2">
            <property name="sizePolicy">
             <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
@@ -979,10 +979,66 @@
            </property>
           </widget>
          </item>
-         <item row="4" column="1" colspan="3">
+         <item row="5" column="1" colspan="3">
           <widget class="Line" name="line_2">
            <property name="orientation">
             <enum>Qt::Horizontal</enum>
+           </property>
+          </widget>
+         </item>
+         <item row="4" column="1">
+          <widget class="QComboBox" name="comboBoxRotationXVPRel">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+             <horstretch>1</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
+          </widget>
+         </item>
+         <item row="4" column="0">
+          <widget class="QLabel" name="labelInputRotationViewPortRelative">
+           <property name="text">
+            <string>ViewPortrel.&lt;br /&gt;Rotation</string>
+           </property>
+          </widget>
+         </item>
+         <item row="4" column="2">
+          <widget class="QComboBox" name="comboBoxRotationYVPRel">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+             <horstretch>1</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
+          </widget>
+         </item>
+         <item row="4" column="3">
+          <widget class="QComboBox" name="comboBoxRotationZVPRel">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+             <horstretch>1</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
+          </widget>
+         </item>
+         <item row="4" column="4">
+          <widget class="QDoubleSpinBox" name="doubleSpinBoxRotateVPRelGain">
+           <property name="correctionMode">
+            <enum>QAbstractSpinBox::CorrectToNearestValue</enum>
+           </property>
+           <property name="minimum">
+            <double>0.100000000000000</double>
+           </property>
+           <property name="maximum">
+            <double>9.990000000000000</double>
+           </property>
+           <property name="singleStep">
+            <double>0.100000000000000</double>
+           </property>
+           <property name="value">
+            <double>1.000000000000000</double>
            </property>
           </widget>
          </item>

--- a/src/input/DBusInputDriver.cc
+++ b/src/input/DBusInputDriver.cc
@@ -102,6 +102,11 @@ void DBusInputDriver::rotateTo(double x, double y, double z)
     InputDriverManager::instance()->sendEvent(new InputEventRotate(x, y, z, false, false));
 }
 
+void DBusInputDriver::rotate2(double x, double y, double z)
+{
+    InputDriverManager::instance()->sendEvent(new InputEventRotate2(x, y, z, false));
+}
+
 void DBusInputDriver::translate(double x, double y, double z)
 {
     InputDriverManager::instance()->sendEvent(new InputEventTranslate(x, y, z, true, false, false));

--- a/src/input/DBusInputDriver.cc
+++ b/src/input/DBusInputDriver.cc
@@ -102,9 +102,6 @@ void DBusInputDriver::rotateTo(double x, double y, double z)
     InputDriverManager::instance()->sendEvent(new InputEventRotate(x, y, z, false, false));
 }
 
-// The vector [x,y,z] describes the rotation.
-// The direction of the vector is the angle around which to rotate,
-// and the length of the vector is the angle by which to rotate.
 void DBusInputDriver::rotateByVector(double x, double y, double z)
 {
     InputDriverManager::instance()->sendEvent(new InputEventRotate2(x, y, z, false));

--- a/src/input/DBusInputDriver.cc
+++ b/src/input/DBusInputDriver.cc
@@ -102,7 +102,10 @@ void DBusInputDriver::rotateTo(double x, double y, double z)
     InputDriverManager::instance()->sendEvent(new InputEventRotate(x, y, z, false, false));
 }
 
-void DBusInputDriver::rotate2(double x, double y, double z)
+// The vector [x,y,z] describes the rotation.
+// The direction of the vector is the angle around which to rotate,
+// and the length of the vector is the angle by which to rotate.
+void DBusInputDriver::rotateByVector(double x, double y, double z)
 {
     InputDriverManager::instance()->sendEvent(new InputEventRotate2(x, y, z, false));
 }

--- a/src/input/DBusInputDriver.h
+++ b/src/input/DBusInputDriver.h
@@ -51,7 +51,7 @@ private slots:
     void zoomTo(double zoom);
     void rotate(double x, double y, double z);
     void rotateTo(double x, double y, double z);
-    void rotate2(double x, double y, double z);
+    void rotateByVector(double x, double y, double z);
     void translate(double x, double y, double z);
     void translateTo(double x, double y, double z);
     void action(QString action);

--- a/src/input/DBusInputDriver.h
+++ b/src/input/DBusInputDriver.h
@@ -51,6 +51,7 @@ private slots:
     void zoomTo(double zoom);
     void rotate(double x, double y, double z);
     void rotateTo(double x, double y, double z);
+    void rotate2(double x, double y, double z);
     void translate(double x, double y, double z);
     void translateTo(double x, double y, double z);
     void action(QString action);

--- a/src/input/InputDriver.h
+++ b/src/input/InputDriver.h
@@ -39,6 +39,7 @@ public:
 
     virtual void onTranslateEvent(class InputEventTranslate *event) = 0;
     virtual void onRotateEvent(class InputEventRotate *event) = 0;
+    virtual void onRotate2Event(class InputEventRotate2 *event) = 0;
     virtual void onActionEvent(class InputEventAction *event) = 0;
     virtual void onZoomEvent(class InputEventZoom *event) = 0;
 };
@@ -137,6 +138,21 @@ public:
     void deliver(InputEventHandler *receiver)
     {
         receiver->onRotateEvent(this);
+    }
+};
+
+class InputEventRotate2 : public InputEvent
+{
+public:
+    const double x;
+    const double y;
+    const double z;
+
+    InputEventRotate2(const double x, const double y, const double z, const bool activeOnly = true) : InputEvent(activeOnly), x(x), y(y), z(z) { }
+
+    void deliver(InputEventHandler *receiver)
+    {
+        receiver->onRotate2Event(this);
     }
 };
 

--- a/src/input/InputEventMapper.cc
+++ b/src/input/InputEventMapper.cc
@@ -52,6 +52,7 @@ InputEventMapper::InputEventMapper()
     translationGain=1.00;
     translationVPRelGain=1.00;
     rotateGain=1.00;
+    rotateVPRelGain=1.00;
     zoomGain=1.00;
 
     timer = new QTimer(this);
@@ -132,7 +133,16 @@ void InputEventMapper::onTimer()
         InputEvent *inputEvent = new InputEventRotate(rx, ry, rz);
         InputDriverManager::instance()->postEvent(inputEvent);
     }
-
+    
+    double rxVPRel = getAxisValue(rotate[3])*rotateVPRelGain;
+    double ryVPRel = getAxisValue(rotate[4])*rotateVPRelGain;
+    double rzVPRel = getAxisValue(rotate[5])*rotateVPRelGain;
+    if ((fabs(rxVPRel) > threshold) || (fabs(ryVPRel) > threshold) || (fabs(rzVPRel) > threshold)) {
+        //FIXME
+        InputEvent *inputEvent = new InputEventRotate(rxVPRel, ryVPRel, rzVPRel);
+        InputDriverManager::instance()->postEvent(inputEvent);
+    }
+    
     double z = (getAxisValue(zoom)+getAxisValue(zoom2))*zoomGain;
     if (fabs(z) > threshold) {
         InputEvent *inputEvent = new InputEventZoom(z);
@@ -226,6 +236,9 @@ void InputEventMapper::onInputMappingUpdated()
     rotate[0] = parseSettingValue(s->get(Settings::Settings::inputRotateX).toString());
     rotate[1] = parseSettingValue(s->get(Settings::Settings::inputRotateY).toString());
     rotate[2] = parseSettingValue(s->get(Settings::Settings::inputRotateZ).toString());
+    rotate[3] = parseSettingValue(s->get(Settings::Settings::inputRotateXVPRel).toString());
+    rotate[4] = parseSettingValue(s->get(Settings::Settings::inputRotateYVPRel).toString());
+    rotate[5] = parseSettingValue(s->get(Settings::Settings::inputRotateZVPRel).toString());
     zoom = parseSettingValue(s->get(Settings::Settings::inputZoom).toString());
     zoom2 = parseSettingValue(s->get(Settings::Settings::inputZoom2).toString());
 }
@@ -239,6 +252,8 @@ void InputEventMapper::onInputGainUpdated()
     translationVPRelGain = (double)s->get(Settings::Settings::inputTranslationVPRelGain).toDouble();
 
     rotateGain = (double)s->get(Settings::Settings::inputRotateGain).toDouble();
+
+    rotateVPRelGain = (double)s->get(Settings::Settings::inputRotateVPRelGain).toDouble();
 
     zoomGain = (double)s->get(Settings::Settings::inputZoomGain).toDouble();
 }

--- a/src/input/InputEventMapper.cc
+++ b/src/input/InputEventMapper.cc
@@ -138,8 +138,7 @@ void InputEventMapper::onTimer()
     double ryVPRel = getAxisValue(rotate[4])*rotateVPRelGain;
     double rzVPRel = getAxisValue(rotate[5])*rotateVPRelGain;
     if ((fabs(rxVPRel) > threshold) || (fabs(ryVPRel) > threshold) || (fabs(rzVPRel) > threshold)) {
-        //FIXME
-        InputEvent *inputEvent = new InputEventRotate(rxVPRel, ryVPRel, rzVPRel);
+        InputEvent *inputEvent = new InputEventRotate2(rxVPRel, ryVPRel, rzVPRel);
         InputDriverManager::instance()->postEvent(inputEvent);
     }
     
@@ -196,6 +195,11 @@ void InputEventMapper::onTranslateEvent(InputEventTranslate *event)
 }
 
 void InputEventMapper::onRotateEvent(InputEventRotate *event)
+{
+    InputDriverManager::instance()->postEvent(event);
+}
+
+void InputEventMapper::onRotate2Event(InputEventRotate2 *event)
 {
     InputDriverManager::instance()->postEvent(event);
 }

--- a/src/input/InputEventMapper.h
+++ b/src/input/InputEventMapper.h
@@ -44,7 +44,7 @@ private:
     double axisDeadzone[max_axis];
     QString actions[max_buttons];
     int translate[6];
-    int rotate[3];
+    int rotate[6];
     int zoom;
     int zoom2;
     volatile bool stopRequest;
@@ -60,6 +60,7 @@ private:
 	double translationGain;
 	double translationVPRelGain;
 	double rotateGain;
+	double rotateVPRelGain;
 	double zoomGain;
 
 public:

--- a/src/input/InputEventMapper.h
+++ b/src/input/InputEventMapper.h
@@ -74,6 +74,7 @@ public:
 
     void onTranslateEvent(class InputEventTranslate *event);
     void onRotateEvent(class InputEventRotate *event);
+    void onRotate2Event(class InputEventRotate2 *event);
     void onActionEvent(class InputEventAction *event);
     void onZoomEvent(class InputEventZoom *event);
 

--- a/src/mainwin.cc
+++ b/src/mainwin.cc
@@ -659,7 +659,12 @@ void MainWindow::onTranslateEvent(InputEventTranslate *event)
 
 void MainWindow::onRotateEvent(InputEventRotate *event)
 {
-    qglview->rotate(event->x, event->y, event->z, event->relative);
+	qglview->rotate(event->x, event->y, event->z, event->relative);
+}
+
+void MainWindow::onRotate2Event(InputEventRotate2 *event)
+{
+	qglview->rotate2(event->x, event->y, event->z);
 }
 
 void MainWindow::onActionEvent(InputEventAction *event)

--- a/src/settings.cc
+++ b/src/settings.cc
@@ -193,12 +193,16 @@ SettingsEntry Settings::inputTranslationZVPRel("input", "translationZVPRel", axi
 SettingsEntry Settings::inputRotateX("input", "rotateX", axisValues(), Value("+4"));
 SettingsEntry Settings::inputRotateY("input", "rotateY", axisValues(), Value("-5"));
 SettingsEntry Settings::inputRotateZ("input", "rotateZ", axisValues(), Value("-6"));
+SettingsEntry Settings::inputRotateXVPRel("input", "rotateXVPRel", axisValues(), Value(""));
+SettingsEntry Settings::inputRotateYVPRel("input", "rotateYVPRel", axisValues(), Value(""));
+SettingsEntry Settings::inputRotateZVPRel("input", "rotateZVPRel", axisValues(), Value(""));
 SettingsEntry Settings::inputZoom("input", "zoom", axisValues(), Value("None"));
 SettingsEntry Settings::inputZoom2("input", "zoom2", axisValues(), Value("None"));
 
 SettingsEntry Settings::inputTranslationGain("input", "translationGain", Value(RangeType(0.01, 0.01, 9.99)), Value(1.00));
 SettingsEntry Settings::inputTranslationVPRelGain("input", "translationVPRelGain", Value(RangeType(0.01, 0.01, 9.99)), Value(1.00));
 SettingsEntry Settings::inputRotateGain("input", "rotateGain", Value(RangeType(0.01, 0.01, 9.99)), Value(1.00));
+SettingsEntry Settings::inputRotateVPRelGain("input", "rotateVPRelGain", Value(RangeType(0.01, 0.01, 9.99)), Value(1.00));
 SettingsEntry Settings::inputZoomGain("input", "zoomGain", Value(RangeType(0.1, 0.1, 99.9)), Value(1.00));
 
 SettingsEntry Settings::inputButton0("input", "button0", buttonValues(), Value("None"));

--- a/src/settings.h
+++ b/src/settings.h
@@ -68,11 +68,15 @@ public:
     static SettingsEntry inputRotateX;
     static SettingsEntry inputRotateY;
     static SettingsEntry inputRotateZ;
+    static SettingsEntry inputRotateXVPRel;
+    static SettingsEntry inputRotateYVPRel;
+    static SettingsEntry inputRotateZVPRel;
     static SettingsEntry inputZoom;
     static SettingsEntry inputZoom2;
     static SettingsEntry inputTranslationGain;
     static SettingsEntry inputTranslationVPRelGain;
     static SettingsEntry inputRotateGain;
+    static SettingsEntry inputRotateVPRelGain;
     static SettingsEntry inputZoomGain;
     static SettingsEntry inputButton0;
     static SettingsEntry inputButton1;


### PR DESCRIPTION
this is building on #2280 (which are the first two commits in this pull request)

Naming it rotate2 is not ideal, but I am unable to come up with a better one.

The name rotate2 comes from the method of the same name that was unused in qglview.

Naming it relative rotate would be confusing with the relative flag of the normal rotate function.

On the other-hand: Rotate2 could be confused with RotateTo which is not ideal either.