### PR TITLE
Fix build on Fedora 27

### DIFF
--- a/scripts/check-dependencies.sh
+++ b/scripts/check-dependencies.sh
@@ -202,9 +202,16 @@ qt_sysver()
     qtver=`grep 'define  *QT_VERSION_STR  *' "$qtpath"/qglobal.h`
     # fix for Qt 5.7
     if [ -z "$qtver" ]; then
-	  qtver=`grep 'define  *QT_VERSION_STR  *' "$qtpath"/qconfig.h`
+      if [ -e "$qtpath/qconfig-32.h" ]; then
+        QCONFIG="qconfig-32.h"
+      elif [ -e "$qtpath/qconfig-64.h" ]; then
+        QCONFIG="qconfig-64.h"
+      else
+        QCONFIG="qconfig.h"
+      fi
+      qtver=`grep 'define  *QT_VERSION_STR  *' "$qtpath"/$QCONFIG`
     fi
-    
+
     qtver=`echo $qtver | awk '{print $3}' | sed s/'"'//g`
   fi
   qt_sysver_result=$qtver

--- a/scripts/uni-get-dependencies.sh
+++ b/scripts/uni-get-dependencies.sh
@@ -21,7 +21,7 @@ get_fedora_deps_dnf()
   boost-devel mpfr-devel gmp-devel glew-devel CGAL-devel gcc gcc-c++ pkgconfig \
   opencsg-devel git libXmu-devel curl ImageMagick glib2-devel make \
   xorg-x11-server-Xvfb gettext qscintilla-devel qscintilla-qt5-devel \
-  mesa-dri-drivers
+  mesa-dri-drivers libzip-devel ccache
  dnf -y install libxml2-devel
  dnf -y install libffi-devel
  dnf -y install redhat-rpm-config


### PR DESCRIPTION
In order to properly build OpenSCAD on Fedora 27 a couple of fixes
are required:

* Check for QT VERSION in arch-specific header files
* Install lizip-devel and ccache as build dependencies