### PR TITLE
Add render color theme Cornfield Dark

### DIFF
--- a/color-schemes/render/cornfield-dark.json
+++ b/color-schemes/render/cornfield-dark.json
@@ -1,0 +1,19 @@
+{
+    "name" : "Cornfield Dark",
+    "index" : 1050,
+    "show-in-gui" : true,
+
+    "colors" : {
+        "background" :         "#000000",
+        "axes-color" :         "#e5e5e5",
+        "opencsg-face-front" : "#f9d72c",
+        "opencsg-face-back" :  "#9dcb51",
+        "cgal-face-front" :    "#f9d72c",
+        "cgal-face-back" :     "#9dcb51",
+        "cgal-face-2d" :       "#00bf99",
+        "cgal-edge-front" :    "#ffec5e",
+        "cgal-edge-back" :     "#abd856",
+        "cgal-edge-2d" :       "#ff0000",
+        "crosshair" :          "#f0f0f0"
+    }
+}


### PR DESCRIPTION
Version of the trademark Cornfield render color theme with dark background