### PR TITLE
Optimize NodeDumper string building

### DIFF
--- a/src/nodedumper.cc
+++ b/src/nodedumper.cc
@@ -39,33 +39,35 @@ void NodeDumper::handleIndent(const State &state)
 	including braces and indentation.
 	All children are assumed to be cached already.
  */
-void NodeDumper::dumpChildBlock(const AbstractNode &node, std::stringstream &dump)
+void NodeDumper::dumpChildBlock(const AbstractNode &node, std::stringstream &dump) const
 {
-	if (!this->visitedchildren[node.index()].empty()) {
+	const auto &it = this->visitedchildren.find(node.index());
+
+	if (it == this->visitedchildren.end() || it->second.empty()) {
+		dump << ";";
+	} else {
 		dump << " {\n";
 		dumpChildren(node, dump);
 		dump << this->currindent << "}";
 	}
-	else {
-		dump << ";";
-	}
 }
 
-void NodeDumper::dumpChildren(const AbstractNode &node, std::stringstream &dump)
+void NodeDumper::dumpChildren(const AbstractNode &node, std::stringstream &dump) const
 {
-	bool empty = true;
-	for (auto child : this->visitedchildren[node.index()]) {
+	const auto &it = this->visitedchildren.find(node.index());
+	if (it == this->visitedchildren.end()) return;
+	
+	for (auto child : it->second) {
 		assert(isCached(*child));
 		const auto &str = this->cache[*child];
 		if (!str.empty()) {
-			if (child != this->visitedchildren[node.index()].front()) dump << "\n";
+			if (child != it->second.front()) dump << "\n";
 			if (child->modinst->isBackground()) dump << "%";
 			if (child->modinst->isHighlight()) dump << "#";
 			dump << str;
-			empty = false;
 		}
 	}
-	if (!empty) dump << "\n";
+	dump << "\n";
 }
 
 /*!

--- a/src/nodedumper.cc
+++ b/src/nodedumper.cc
@@ -61,13 +61,11 @@ void NodeDumper::dumpChildren(const AbstractNode &node, std::stringstream &dump)
 		assert(isCached(*child));
 		const auto &str = this->cache[*child];
 		if (!str.empty()) {
-			if (child != it->second.front()) dump << "\n";
 			if (child->modinst->isBackground()) dump << "%";
 			if (child->modinst->isHighlight()) dump << "#";
-			dump << str;
+			dump << str << "\n";
 		}
 	}
-	dump << "\n";
 }
 
 /*!

--- a/src/nodedumper.cc
+++ b/src/nodedumper.cc
@@ -39,24 +39,20 @@ void NodeDumper::handleIndent(const State &state)
 	including braces and indentation.
 	All children are assumed to be cached already.
  */
-std::string NodeDumper::dumpChildBlock(const AbstractNode &node)
+void NodeDumper::dumpChildBlock(const AbstractNode &node, std::stringstream &dump)
 {
-	std::stringstream dump;
 	if (!this->visitedchildren[node.index()].empty()) {
 		dump << " {\n";
-		const auto &chstr = dumpChildren(node);
-		if (!chstr.empty()) dump << chstr << "\n";
+		dumpChildren(node, dump);
 		dump << this->currindent << "}";
 	}
 	else {
 		dump << ";";
 	}
-	return dump.str();
 }
 
-std::string NodeDumper::dumpChildren(const AbstractNode &node)
+void NodeDumper::dumpChildren(const AbstractNode &node, std::stringstream &dump)
 {
-	std::stringstream dump;
 	for (auto child : this->visitedchildren[node.index()]) {
 		assert(isCached(*child));
 		const auto &str = this->cache[*child];
@@ -67,7 +63,6 @@ std::string NodeDumper::dumpChildren(const AbstractNode &node)
 			dump << str;
 		}
 	}
-	return dump.str();
 }
 
 /*!
@@ -84,7 +79,7 @@ Response NodeDumper::visit(State &state, const AbstractNode &node)
 		dump << this->currindent;
 		if (this->idprefix) dump << "n" << node.index() << ":";
 		dump << node;
-		dump << dumpChildBlock(node);
+		dumpChildBlock(node, dump);
 		this->cache.insert(node, dump.str());
 	}
 
@@ -101,7 +96,7 @@ Response NodeDumper::visit(State &state, const RootNode &node)
 
 	if (state.isPostfix()) {
 		std::stringstream dump;
-		dump << dumpChildren(node);
+		dumpChildren(node, dump);
 		this->cache.insert(node, dump.str());
 	}
 

--- a/src/nodedumper.cc
+++ b/src/nodedumper.cc
@@ -53,6 +53,7 @@ void NodeDumper::dumpChildBlock(const AbstractNode &node, std::stringstream &dum
 
 void NodeDumper::dumpChildren(const AbstractNode &node, std::stringstream &dump)
 {
+	bool empty = true;
 	for (auto child : this->visitedchildren[node.index()]) {
 		assert(isCached(*child));
 		const auto &str = this->cache[*child];
@@ -61,8 +62,10 @@ void NodeDumper::dumpChildren(const AbstractNode &node, std::stringstream &dump)
 			if (child->modinst->isBackground()) dump << "%";
 			if (child->modinst->isHighlight()) dump << "#";
 			dump << str;
+			empty = false;
 		}
 	}
+	if (!empty) dump << "\n";
 }
 
 /*!

--- a/src/nodedumper.h
+++ b/src/nodedumper.h
@@ -23,8 +23,8 @@ private:
         void handleVisitedChildren(const State &state, const AbstractNode &node);
         bool isCached(const AbstractNode &node) const;
         void handleIndent(const State &state);
-        void dumpChildBlock(const AbstractNode &node, std::stringstream &dump);
-        void dumpChildren(const AbstractNode &node, std::stringstream &dump);
+        void dumpChildBlock(const AbstractNode &node, std::stringstream &dump) const;
+        void dumpChildren(const AbstractNode &node, std::stringstream &dump) const;
 
         NodeCache &cache;
         bool idprefix;

--- a/src/nodedumper.h
+++ b/src/nodedumper.h
@@ -23,8 +23,8 @@ private:
         void handleVisitedChildren(const State &state, const AbstractNode &node);
         bool isCached(const AbstractNode &node) const;
         void handleIndent(const State &state);
-        std::string dumpChildBlock(const AbstractNode &node);
-        std::string dumpChildren(const AbstractNode &node);
+        void dumpChildBlock(const AbstractNode &node, std::stringstream &dump);
+        void dumpChildren(const AbstractNode &node, std::stringstream &dump);
 
         NodeCache &cache;
         bool idprefix;


### PR DESCRIPTION
doesn't use any less memory, but runs recur(1000) in 4s instead of 8s
