### PR TITLE
costumizer: improved file handling

### DIFF
--- a/src/parameter/ParameterWidget.cc
+++ b/src/parameter/ParameterWidget.cc
@@ -115,17 +115,13 @@ void ParameterWidget::readFile(QString scadFile)
 	setFile(scadFile);
 	bool exists = boost::filesystem::exists(this->jsonFile);
 	bool writeable = false;
+	bool readable = false;
 
 	if(exists){
-		bool readable = readParameterSet(this->jsonFile);
+		readable = readParameterSet(this->jsonFile);
 
-		//check whether file is writeable
-		std::fstream file;
-		file.open(this->jsonFile, std::ios::app);
-		if (file.is_open()) {
-			file.close();
-			writeable = true;
-		}
+		//check whether file is writeable or not
+		if (std::fstream(this->jsonFile, std::ios::app)) writeable = true;
 	}
 
 	if(writeable || !exists){

--- a/src/parameter/ParameterWidget.cc
+++ b/src/parameter/ParameterWidget.cc
@@ -104,16 +104,26 @@ void ParameterWidget::onSetSaveButton()
 void ParameterWidget::readFile(QString scadFile)
 {
 	this->jsonFile = scadFile.replace(".scad", ".json").toStdString();
-	bool readable=readParameterSet(this->jsonFile);
-	if(readable){
+	bool writeable = false;
+
+	bool readable = readParameterSet(this->jsonFile);
+
+	//check whether file is writeable
+	std::fstream file;
+	file.open(filename, std::ios::app);
+	if (file.is_open()) {
+		file.close();
+		writeable = true;
+	}
+
+	if(writeable){
 		connect(this->addButton, SIGNAL(clicked()), this, SLOT(onSetAdd()));
 		this->addButton->setToolTip(_("add new preset"));
 		connect(this->deleteButton, SIGNAL(clicked()), this, SLOT(onSetDelete()));
 		this->deleteButton->setToolTip(_("remove current preset"));
 		connect(this->presetSaveButton, SIGNAL(clicked()), this, SLOT(onSetSaveButton()));
 		this->presetSaveButton->setToolTip(_("save current preset"));
-	}
-	else{
+	}else{
 		this->addButton->setDisabled(true);
 		this->addButton->setToolTip(_("JSON file read only"));
 		this->deleteButton->setDisabled(true);

--- a/src/parameter/ParameterWidget.cc
+++ b/src/parameter/ParameterWidget.cc
@@ -37,8 +37,12 @@
 #include "modcontext.h"
 #include "comment.h"
 
+#include <boost/filesystem.hpp>
 #include <boost/property_tree/ptree.hpp>
 #include <boost/property_tree/json_parser.hpp>
+
+#include <fstream>
+
 namespace pt = boost::property_tree;
 
 #include <QInputDialog>
@@ -104,19 +108,22 @@ void ParameterWidget::onSetSaveButton()
 void ParameterWidget::readFile(QString scadFile)
 {
 	this->jsonFile = scadFile.replace(".scad", ".json").toStdString();
+	bool exists = boost::filesystem::exists(this->jsonFile);
 	bool writeable = false;
 
-	bool readable = readParameterSet(this->jsonFile);
+	if(exists){
+		bool readable = readParameterSet(this->jsonFile);
 
-	//check whether file is writeable
-	std::fstream file;
-	file.open(filename, std::ios::app);
-	if (file.is_open()) {
-		file.close();
-		writeable = true;
+		//check whether file is writeable
+		std::fstream file;
+		file.open(this->jsonFile, std::ios::app);
+		if (file.is_open()) {
+			file.close();
+			writeable = true;
+		}
 	}
 
-	if(writeable){
+	if(writeable || !exists){
 		connect(this->addButton, SIGNAL(clicked()), this, SLOT(onSetAdd()));
 		this->addButton->setToolTip(_("add new preset"));
 		connect(this->deleteButton, SIGNAL(clicked()), this, SLOT(onSetDelete()));

--- a/src/parameter/ParameterWidget.cc
+++ b/src/parameter/ParameterWidget.cc
@@ -106,7 +106,8 @@ void ParameterWidget::onSetSaveButton()
 }
 
 void ParameterWidget::setFile(QString scadFile){
-	this->jsonFile = scadFile.replace(".scad", ".json").toStdString();
+	boost::filesystem::path p = scadFile.toStdString();
+	this->jsonFile = p.replace_extension(".json").string();
 }
 
 void ParameterWidget::readFile(QString scadFile)

--- a/src/parameter/ParameterWidget.cc
+++ b/src/parameter/ParameterWidget.cc
@@ -105,9 +105,13 @@ void ParameterWidget::onSetSaveButton()
 	updateParameterSet(comboBoxPreset->itemData(this->comboBoxPreset->currentIndex()).toString().toStdString());
 }
 
+void ParameterWidget::setFile(QString scadFile){
+	this->jsonFile = scadFile.replace(".scad", ".json").toStdString();
+}
+
 void ParameterWidget::readFile(QString scadFile)
 {
-	this->jsonFile = scadFile.replace(".scad", ".json").toStdString();
+	setFile(scadFile);
 	bool exists = boost::filesystem::exists(this->jsonFile);
 	bool writeable = false;
 
@@ -147,8 +151,9 @@ void ParameterWidget::readFile(QString scadFile)
 
 void ParameterWidget::writeFileIfNotEmpty(QString scadFile)
 {
+	setFile(scadFile);
 	if (!root.empty()){
-		writeParameterSet(scadFile.replace(".scad", ".json").toStdString());
+		writeParameterSet(this->jsonFile);
 	}
 }
 

--- a/src/parameter/ParameterWidget.h
+++ b/src/parameter/ParameterWidget.h
@@ -57,6 +57,8 @@ private:
 	ParameterVirtualWidget* CreateParameterWidget(std::string parameterName);
 	void setComboBoxPresetForSet();
 
+	void setFile(QString File);
+
 public:
 	ParameterWidget(QWidget *parent = nullptr);
 	~ParameterWidget();

--- a/src/parameter/parameterset.cpp
+++ b/src/parameter/parameterset.cpp
@@ -3,7 +3,6 @@
 #include "modcontext.h"
 #include "expression.h"
 #include "printutils.h"
-#include <fstream>
 #include <boost/property_tree/json_parser.hpp>
 
 std::string ParameterSet::parameterSetsKey("parameterSets");

--- a/src/parameter/parameterset.cpp
+++ b/src/parameter/parameterset.cpp
@@ -57,20 +57,13 @@ void ParameterSet::addParameterSet(const std::string setName, const pt::ptree & 
 }
 
 /*!
-	Returns true if the file is writable
+	Returns true if the file was succesfully read
 */
 bool ParameterSet::readParameterSet(const std::string &filename)
 {
 	try {
 		pt::read_json(filename, this->root);
-
-		//check whether file is read-only
-		std::fstream file;
-		file.open(filename, std::ios::app);
-		if (file.is_open()) {
-			file.close();
-			return true;
-		}
+		return true;
 	}
 	catch (const pt::json_parser_error &e) {
 		PRINTB("ERROR: Cannot open Parameter Set '%s': %s", filename % e.what());


### PR DESCRIPTION
* move the writeable check from "readParameterSet" to "readFile"
   * This also fixes an issue with empty (0 bytes) json files: Empty json files cause an exception, causing readParameterSet to return false, without actually checking if the file would be writable.
* checking if the file exists, before trying to check for readability or writeabilty
*central setFile function with replace_extension instead of replace (closes #2307)