### PR TITLE
Feature addition: Option to raise the window upon auto-reload

### DIFF
--- a/locale/de.po
+++ b/locale/de.po
@@ -1051,6 +1051,10 @@ msgstr "Startbildschirm anzeigen"
 msgid "Enable user interface localization (requires restart of OpenSCAD)"
 msgstr "Lokalisierung der GUI einschalten (benötigt Neustart von OpenSCAD)"
 
+#: objects/ui_Preferences.h:1184
+msgid "Bring window to front after automatic reload"
+msgstr "Fenster nach vorne bringen nach automatischem Neuladen"
+
 #: objects/ui_ProgressWidget.h:72
 msgid "%v / %m"
 msgstr "%v / %m"

--- a/locale/openscad.pot
+++ b/locale/openscad.pot
@@ -1028,6 +1028,10 @@ msgstr ""
 msgid "Enable user interface localization (requires restart of OpenSCAD)"
 msgstr ""
 
+#: objects/ui_Preferences.h:1184
+msgid "Bring window to front after automatic reload"
+msgstr ""
+
 #: objects/ui_ProgressWidget.h:72
 msgid "%v / %m"
 msgstr ""

--- a/scripts/docker-build.sh
+++ b/scripts/docker-build.sh
@@ -1,0 +1,46 @@
+#! /bin/bash
+#
+# openscad-docker-build.sh -- a simple script to compile openscad using a docker container.
+#
+# (C) 2018 jnweiger@gmail.com
+# Distribute under GPL-2.0 or ask.
+
+test -d openscad || git clone --depth=50 --branch=master https://github.com/openscad/openscad.git openscad
+(cd openscad; git submodule update --init --recursive)
+
+mkdir -p docker
+cat <<'EOF'> docker/Dockerfile
+# openscad build env.
+FROM ubuntu:16.04
+RUN apt-get update -y; apt-get install -y git gcc
+
+ENV CXX=g++
+ENV CC=gcc
+
+RUN $CC --version
+
+RUN apt-get install -qq sudo; echo >> /etc/sudoers 'ALL ALL=(ALL) NOPASSWD: ALL'
+EOF
+
+if [ "$(md5sum docker/Dockerfile)" != "$(cat docker/Dockerfile.md5 2>/dev/null)" ]; then
+  docker build -t openscad-build docker
+  md5sum docker/Dockerfile > docker/Dockerfile.md5
+fi
+
+# Continue docker build outside the Dockerfile.
+# This is needed, as docker build cannot have volumes and cannot react to changed github contents.
+RUN()
+{
+  rm -f docker/cid 
+  docker run --cidfile docker/cid -v $PWD/openscad:/github/openscad -v /etc/passwd:/etc/passwd:ro --user $(stat -c "%u:%g" openscad) --workdir /github/openscad openscad-build "$@"
+}
+commit() { docker commit $(cat docker/cid) openscad-build; }
+
+RUN sudo ./scripts/uni-get-dependencies.sh
+commit
+RUN bash -c ./scripts/check-dependencies.sh
+RUN qmake openscad.pro
+RUN make
+
+ls -la openscad/openscad	# should show the final binary...
+RUN sudo checkinstall -D make install

--- a/src/Preferences.cc
+++ b/src/Preferences.cc
@@ -168,7 +168,7 @@ void Preferences::init() {
 	this->defaultmap["advanced/reorderWindows"] = true;
 	this->defaultmap["launcher/showOnStartup"] = true;
 	this->defaultmap["advanced/localization"] = true;
-	this->defaultmap["advanced/autoReloadRaise"] = true;
+	this->defaultmap["advanced/autoReloadRaise"] = false;
 
 	// Toolbar
 	QActionGroup *group = new QActionGroup(this);

--- a/src/Preferences.cc
+++ b/src/Preferences.cc
@@ -168,6 +168,7 @@ void Preferences::init() {
 	this->defaultmap["advanced/reorderWindows"] = true;
 	this->defaultmap["launcher/showOnStartup"] = true;
 	this->defaultmap["advanced/localization"] = true;
+	this->defaultmap["advanced/autoReloadRaise"] = true;
 
 	// Toolbar
 	QActionGroup *group = new QActionGroup(this);
@@ -463,6 +464,12 @@ void Preferences::on_localizationCheckBox_toggled(bool state)
 	settings.setValue("advanced/localization", state);
 }
 
+void Preferences::on_autoReloadRaiseCheckBox_toggled(bool state)
+{
+	QSettingsCached settings;
+	settings.setValue("advanced/autoReloadRaise", state);
+}
+
 void Preferences::on_forceGoldfeatherBox_toggled(bool state)
 {
 	QSettingsCached settings;
@@ -676,6 +683,7 @@ void Preferences::updateGUI()
 	this->polysetCacheSizeEdit->setText(getValue("advanced/polysetCacheSize").toString());
 	this->opencsgLimitEdit->setText(getValue("advanced/openCSGLimit").toString());
 	this->localizationCheckBox->setChecked(getValue("advanced/localization").toBool());
+	this->autoReloadRaiseCheckBox->setChecked(getValue("advanced/autoReloadRaise").toBool());
 	this->forceGoldfeatherBox->setChecked(getValue("advanced/forceGoldfeather").toBool());
 	this->mdiCheckBox->setChecked(getValue("advanced/mdi").toBool());
 	this->reorderCheckBox->setChecked(getValue("advanced/reorderWindows").toBool());

--- a/src/Preferences.h
+++ b/src/Preferences.h
@@ -37,6 +37,7 @@ public slots:
 	void on_forceGoldfeatherBox_toggled(bool);
 	void on_mouseWheelZoomBox_toggled(bool);
 	void on_localizationCheckBox_toggled(bool);
+	void on_autoReloadRaiseCheckBox_toggled(bool);
 	void on_updateCheckBox_toggled(bool);
 	void on_snapshotCheckBox_toggled(bool);
 	void on_mdiCheckBox_toggled(bool);

--- a/src/Preferences.ui
+++ b/src/Preferences.ui
@@ -1440,7 +1440,7 @@
                <string>Bring window to front after automatic reload</string>
               </property>
               <property name="checked">
-               <bool>true</bool>
+               <bool>false</bool>
               </property>
              </widget>
             </item>

--- a/src/Preferences.ui
+++ b/src/Preferences.ui
@@ -1435,6 +1435,16 @@
              </widget>
             </item>
             <item>
+             <widget class="QCheckBox" name="autoReloadRaiseCheckBox">
+              <property name="text">
+               <string>Bring window to front after automatic reload</string>
+              </property>
+              <property name="checked">
+               <bool>true</bool>
+              </property>
+             </widget>
+            </item>
+            <item>
              <spacer name="verticalSpacer">
               <property name="orientation">
                <enum>Qt::Vertical</enum>

--- a/src/mainwin.cc
+++ b/src/mainwin.cc
@@ -930,6 +930,10 @@ void MainWindow::compile(bool reload, bool forcedone, bool rebuildParameterWidge
 		if (fileChangedOnDisk() && checkEditorModified()) {
 			shouldcompiletoplevel = true;
 			refreshDocument();
+			if (Preferences::inst()->getValue("advanced/autoReloadRaise").toBool()) {
+				// reloading the 'same' document brings the 'old' one to front.
+				this->raise();
+			}
 		}
 		// If the file hasn't changed, we might still need to compile it
 		// if we haven't yet compiled the current text.


### PR DESCRIPTION
When auto reload happens, the main window is raise()d to the front.
This is very useful with generating the .scad file from another application that
would cover most of the screen space. I use openscad together with inkscape
and inkscape likes to be in front most of the time...
An option is added to the Preferences advanced page to disable that new feature. 
I suggest to enable by default.

Also added scripts/docker-build.sh -- a quick wrapper to build on linux
bringing all prerequisites into a docker container to not pollute the build host.
Read and adjust the script before use, some things are hardcoded there.
It works with a git checkout outside the container, so that all object files and
the binary are easily accessible.
It shortcuts to the next needed step, but is quite slow doing so.