### PR TITLE
FileModule::getFullpath(): fixing issue under windows with backslash

### DIFF
--- a/src/FileModule.cc
+++ b/src/FileModule.cc
@@ -194,7 +194,7 @@ const std::string FileModule::getFullpath() const {
 	if(fs::path(this->filename).is_absolute()){
 		return this->filename;
 	}else if(!this->path.empty()){
-		return (this->path + "/" + this->filename);
+		return (fs::path(this->path) / fs::path(this->filename)).generic_string();
 	}else{
 		return "";
 	}

--- a/src/FileModule.cc
+++ b/src/FileModule.cc
@@ -194,7 +194,7 @@ const std::string FileModule::getFullpath() const {
 	if(fs::path(this->filename).is_absolute()){
 		return this->filename;
 	}else if(!this->path.empty()){
-		return (fs::path(this->path) / fs::path(this->filename)).string();
+		return (this->path + "/" + this->filename);
 	}else{
 		return "";
 	}


### PR DESCRIPTION
path / path under windows causes boost to use backslash.
The file paths within openscad are normalized to normal slash.

Issue was discovered by  MichaelAtOz  while trying to test a new build for #2185

this fix was tested under windows 10 using https://en.wikibooks.org/wiki/OpenSCAD_User_Manual/Building_on_Microsoft_Windows for build instructions.

see also #2322