### PR TITLE
customizer: add support for text max. length

### DIFF
--- a/src/parameter/parameterobject.cpp
+++ b/src/parameter/parameterobject.cpp
@@ -34,7 +34,7 @@ int ParameterObject::setValue(const class ValuePtr defaultValue, const class Val
     target = checkVectorWidget();
   } else if ((vt == Value::ValueType::RANGE || makerBotMax) && (dvt == Value::ValueType::NUMBER)) {
     target = SLIDER;
-  } else if ((vt == Value::ValueType::RANGE || makerBotMax) && (dvt == Value::ValueType::STRING)){
+  } else if ((makerBotMax) && (dvt == Value::ValueType::STRING)){
     target = TEXT;
   } else if ((vt == Value::ValueType::VECTOR) && ((dvt == Value::ValueType::NUMBER) || (dvt == Value::ValueType::STRING))) {
     target = COMBOBOX;

--- a/src/parameter/parameterobject.cpp
+++ b/src/parameter/parameterobject.cpp
@@ -34,6 +34,8 @@ int ParameterObject::setValue(const class ValuePtr defaultValue, const class Val
     target = checkVectorWidget();
   } else if ((vt == Value::ValueType::RANGE || makerBotMax) && (dvt == Value::ValueType::NUMBER)) {
     target = SLIDER;
+  } else if ((vt == Value::ValueType::RANGE || makerBotMax) && (dvt == Value::ValueType::STRING)){
+    target = TEXT;
   } else if ((vt == Value::ValueType::VECTOR) && ((dvt == Value::ValueType::NUMBER) || (dvt == Value::ValueType::STRING))) {
     target = COMBOBOX;
   } else if (dvt == Value::ValueType::NUMBER) {

--- a/src/parameter/parametertext.cpp
+++ b/src/parameter/parametertext.cpp
@@ -7,6 +7,15 @@ ParameterText::ParameterText(ParameterObject *parameterobject, int showDescripti
 	object = parameterobject;
 	setName(QString::fromStdString(object->name));
 	setValue();
+
+	double max=0;
+	if(object->values->type() == Value::ValueType::RANGE ){ // [min:max] and [min:step:max] format;
+		max = object->values->toRange().end_value();
+	}else{ // [max] format from makerbot customizer
+		max = std::stoi(object->values->toVector()[0]->toString(),nullptr,0);
+	}
+	lineEdit->setMaxLength(max);
+
 	connect(lineEdit, SIGNAL(textChanged(QString)), this, SLOT(onChanged(QString)));
 	if (showDescription == 0 || showDescription == 3) {
 		setDescription(object->description);

--- a/src/parameter/parametertext.cpp
+++ b/src/parameter/parametertext.cpp
@@ -9,9 +9,7 @@ ParameterText::ParameterText(ParameterObject *parameterobject, int showDescripti
 	setValue();
 
 	double max=32767;
-	if(object->values->type() == Value::ValueType::RANGE ){ // [min:max] and [min:step:max] format;
-		max = object->values->toRange().end_value();
-	}else if(object->values->toVector().size() == 1){ // [max] format from makerbot customizer
+	if(object->values->toVector().size() == 1){ // [max] format from makerbot customizer
 		max = std::stoi(object->values->toVector()[0]->toString(),nullptr,0);
 	}
 	lineEdit->setMaxLength(max);

--- a/src/parameter/parametertext.cpp
+++ b/src/parameter/parametertext.cpp
@@ -8,18 +8,13 @@ ParameterText::ParameterText(ParameterObject *parameterobject, int showDescripti
 	setName(QString::fromStdString(object->name));
 	setValue();
 
-	double max=0;
+	double max=32767;
 	if(object->values->type() == Value::ValueType::RANGE ){ // [min:max] and [min:step:max] format;
 		max = object->values->toRange().end_value();
 	}else if(object->values->toVector().size() == 1){ // [max] format from makerbot customizer
-		
 		max = std::stoi(object->values->toVector()[0]->toString(),nullptr,0);
 	}
-	if(max > 0){
-		lineEdit->setMaxLength(max);
-	}else{
-		lineEdit->setMaxLength(32767);
-	}
+	lineEdit->setMaxLength(max);
 
 	connect(lineEdit, SIGNAL(textChanged(QString)), this, SLOT(onChanged(QString)));
 	if (showDescription == 0 || showDescription == 3) {

--- a/src/parameter/parametertext.cpp
+++ b/src/parameter/parametertext.cpp
@@ -11,10 +11,15 @@ ParameterText::ParameterText(ParameterObject *parameterobject, int showDescripti
 	double max=0;
 	if(object->values->type() == Value::ValueType::RANGE ){ // [min:max] and [min:step:max] format;
 		max = object->values->toRange().end_value();
-	}else{ // [max] format from makerbot customizer
+	}else if(object->values->toVector().size() == 1){ // [max] format from makerbot customizer
+		
 		max = std::stoi(object->values->toVector()[0]->toString(),nullptr,0);
 	}
-	lineEdit->setMaxLength(max);
+	if(max > 0){
+		lineEdit->setMaxLength(max);
+	}else{
+		lineEdit->setMaxLength(32767);
+	}
 
 	connect(lineEdit, SIGNAL(textChanged(QString)), this, SLOT(onChanged(QString)));
 	if (showDescription == 0 || showDescription == 3) {


### PR DESCRIPTION
It would make sense tobe able to limit the string length, so I implemented just that:

test1 = "123"; //[3]
~~test2 = "1234"; //[0:4]~~
~~test3 = "12345"; //[0:1:5]~~
