### PR TITLE
Limit number of frames painted 

### DIFF
--- a/src/QGLView.cc
+++ b/src/QGLView.cc
@@ -187,7 +187,7 @@ void QGLView::paintGL()
   PRINTDB("Requested frame #%d", this->requestedFrame);
 }
 
-// do actual rendering, called from renderThread
+// do actual rendering, invoked by frameTimer
 void QGLView::renderFrame()
 {
 	if (this->requestedFrame > this->currentFrame) {

--- a/src/QGLView.cc
+++ b/src/QGLView.cc
@@ -176,6 +176,9 @@ void QGLView::resizeGL(int w, int h)
 
 void QGLView::paintGL()
 {
+  this->frameCount++;
+  PRINTDB("paintGL frame #%d", frameCount);
+
   GLView::paintGL();
 
   if (statusLabel) {

--- a/src/QGLView.h
+++ b/src/QGLView.h
@@ -43,10 +43,6 @@ private:
     QMutex renderMutex;
     bool exiting;
 
-signals:
-    void beginRender();
-    void endRender();
-
 };
 
 

--- a/src/QGLView.h
+++ b/src/QGLView.h
@@ -75,6 +75,7 @@ private:
 	void init();
 
 	bool mouse_drag_active;
+	uint frameCount = 0;
 	QPoint last_mouse;
 	QImage frame; // Used by grabFrame() and save()
 

--- a/src/QGLView.h
+++ b/src/QGLView.h
@@ -15,6 +15,8 @@
 #include "GLView.h"
 #include "renderer.h"
 
+#define MAX_FPS 60
+
 class QGLView :
 #ifdef USE_QOPENGLWIDGET
 		public QOpenGLWidget,
@@ -65,6 +67,7 @@ public slots:
 #ifdef USE_QOPENGLWIDGET
 	inline void updateGL() { update(); }
 #endif
+	void renderFrame();
 
 public:
 	QLabel *statusLabel;
@@ -75,9 +78,11 @@ private:
 	void init();
 
 	bool mouse_drag_active;
-	uint frameCount = 0;
+	uint requestedFrame = 0;
+	uint currentFrame = 0;
 	QPoint last_mouse;
 	QImage frame; // Used by grabFrame() and save()
+	QTimer *frameTimer;
 
 	void wheelEvent(QWheelEvent *event) override;
 	void mousePressEvent(QMouseEvent *event) override;

--- a/src/QGLView.h
+++ b/src/QGLView.h
@@ -15,8 +15,6 @@
 #include "GLView.h"
 #include "renderer.h"
 
-#define MAX_FPS 60
-
 class QGLView :
 #ifdef USE_QOPENGLWIDGET
 		public QOpenGLWidget,
@@ -67,7 +65,6 @@ public slots:
 #ifdef USE_QOPENGLWIDGET
 	inline void updateGL() { update(); }
 #endif
-	void renderFrame();
 
 public:
 	QLabel *statusLabel;
@@ -82,17 +79,15 @@ private:
 	uint currentFrame = 0;
 	QPoint last_mouse;
 	QImage frame; // Used by grabFrame() and save()
-	QTimer *frameTimer;
 
+	bool eventFilter(QObject *obj, QEvent *event) override;
 	void wheelEvent(QWheelEvent *event) override;
 	void mousePressEvent(QMouseEvent *event) override;
 	void mouseMoveEvent(QMouseEvent *event) override;
 	void mouseReleaseEvent(QMouseEvent *event) override;
 	void mouseDoubleClickEvent(QMouseEvent *event) override;
-
 	void initializeGL() override;
 	void resizeGL(int w, int h) override;
-
 	void paintGL() override;
 	void normalizeAngle(GLdouble& angle);
 


### PR DESCRIPTION
This change is intended to workaround redundant calls to `QGLView::paintGL()`.  There are many possible events and function that result in a paint call.  

Below is an example script for manually testing the responsiveness of orbiting the camera view (left click drag).  I get about 1fps with these settings on the nightly OBS build, and about 2fps with my build; feels 2x faster.
```
$fn = 100;
for(x=[1:10],y=[1:10],z=[1:10])
  translate((1+$t)*[x,y,z])
    sphere(d=1);
```

One issue I've noticed (why I've set "DO NOT MERGE" for now) is that these changes don't seem to play nicely with the animation toolbar.  For example setting FPS 100 ans steps 100, it flickers through a lot of frames that only show background.  This may only be a problem when Animation toolbar FPS is greater than the `MAX_FPS` define in `QGLView.h`.  Should the Animation toolbar FPS have an upper limit imposed?

And another side effect is that the using Alt-Up/Down arrow repeatedly on the value in this script seems to add about almost a second delay to the last frame: 
```
cube(1);
```

Besides these two regressions which I'm still trying to understand, I think overall that viewing complex geometries is about twice as fast.
 