### PR TITLE
Make editor type setting independent from translations.

### DIFF
--- a/src/Preferences.cc
+++ b/src/Preferences.cc
@@ -134,7 +134,7 @@ void Preferences::init() {
 	this->defaultmap["editor/fontfamily"] = found_family;
  	this->defaultmap["editor/fontsize"] = 12;
 	this->defaultmap["editor/syntaxhighlight"] = "For Light Background";
-	this->defaultmap["editor/editortype"] = "QScintilla Editor";
+	this->defaultmap[Preferences::PREF_EDITOR_TYPE] = Preferences::EDITOR_TYPE_QSCINTILLA;
 
 #if defined (Q_OS_MAC)
 	this->defaultmap["editor/ctrlmousewheelzoom"] = false;
@@ -346,10 +346,10 @@ void Preferences::on_fontSize_currentIndexChanged(const QString &size)
 	emit fontChanged(getValue("editor/fontfamily").toString(), intsize);
 }
 
-void Preferences::on_editorType_currentIndexChanged(const QString &type)
+void Preferences::on_editorType_currentIndexChanged(int idx)
 {
 	QSettingsCached settings;
-	settings.setValue("editor/editortype", type);
+	settings.setValue(Preferences::PREF_EDITOR_TYPE, idx == 0 ? Preferences::EDITOR_TYPE_SIMPLE : Preferences::EDITOR_TYPE_QSCINTILLA);
 }
 
 void Preferences::on_syntaxHighlight_activated(const QString &s)
@@ -665,9 +665,9 @@ void Preferences::updateGUI()
 	    }
 	}
 
-	QString editortypevar = getValue("editor/editortype").toString();
-	int edidx = this->editorType->findText(editortypevar);
-	if (edidx >=0) this->editorType->setCurrentIndex(edidx);
+	QString editortypevar = getValue(Preferences::PREF_EDITOR_TYPE).toString();
+	int edidx = editortypevar == Preferences::EDITOR_TYPE_SIMPLE ? 0 : 1;
+	this->editorType->setCurrentIndex(edidx);
 
 	this->mouseWheelZoomBox->setChecked(getValue("editor/ctrlmousewheelzoom").toBool());
 

--- a/src/Preferences.h
+++ b/src/Preferences.h
@@ -12,6 +12,11 @@ class Preferences : public QMainWindow, public Ui::Preferences
 	Q_OBJECT;
 
 public:
+	static constexpr const char* PREF_EDITOR_TYPE = "editor/editortype";
+
+	static constexpr const char* EDITOR_TYPE_SIMPLE = "Simple Editor";
+	static constexpr const char* EDITOR_TYPE_QSCINTILLA = "QScintilla Editor";
+
 	~Preferences();
 	
 	static void create(QStringList colorSchemes);
@@ -45,7 +50,7 @@ public slots:
 	void on_undockCheckBox_toggled(bool);
 	void on_checkNowButton_clicked();
 	void on_launcherBox_toggled(bool);
-	void on_editorType_currentIndexChanged(const QString &);
+	void on_editorType_currentIndexChanged(int);
 
 	void on_checkBoxShowWarningsIn3dView_toggled(bool);
   //

--- a/src/mainwin.cc
+++ b/src/mainwin.cc
@@ -169,8 +169,8 @@ MainWindow::MainWindow(const QString &filename)
 	updateStatusBar(nullptr);
 
 	QSettingsCached settings;
-	editortype = settings.value("editor/editortype").toString();
-	useScintilla = (editortype != "Simple Editor");
+	editortype = settings.value(Preferences::PREF_EDITOR_TYPE).toString();
+	useScintilla = (editortype != Preferences::EDITOR_TYPE_SIMPLE);
 
 #ifdef USE_SCINTILLA_EDITOR
 	if (useScintilla) {


### PR DESCRIPTION
This now uses the combo box index, so it needs to be in sync with the UI file.