### PR TITLE
Scad modules: load project-specific libraries recursively in nodejs-like way

### DIFF
--- a/src/parsersettings.cc
+++ b/src/parsersettings.cc
@@ -97,7 +97,7 @@ void parser_init()
 		std::string sep = PlatformUtils::pathSeparatorChar();
 		typedef boost::split_iterator<std::string::iterator> string_split_iterator;
 		for (string_split_iterator it = boost::make_split_iterator(paths, boost::first_finder(sep, boost::is_iequal())); it != string_split_iterator(); ++it) {
-			add_librarydir(fs::absolute(fs::path(boost::copy_range<std::string>(*it))).string());
+			add_librarydir(fs::path(boost::copy_range<std::string>(*it)).string());
 		}
 	}
 

--- a/src/parsersettings.cc
+++ b/src/parsersettings.cc
@@ -132,4 +132,6 @@ void parser_init()
 	add_librarydir(PlatformUtils::userLibraryPath());
 
 	add_librarydir(fs::absolute(PlatformUtils::resourcePath("libraries")).string());
+	
+	add_librarydir("scad_modules");
 }

--- a/src/parsersettings.h
+++ b/src/parsersettings.h
@@ -12,7 +12,7 @@ extern int parser_error_pos;
  */
 void parser_init();
 
-fs::path search_libs(const fs::path &localpath);
+fs::path search_libs(const fs::path &localpath, const fs::path &sourcepath);
 fs::path find_valid_path(const fs::path &sourcepath, 
                          const fs::path &localpath, 
                          const std::vector<std::string> *openfilenames = nullptr);


### PR DESCRIPTION
Create pull-request from this ticket:
https://github.com/openscad/openscad/issues/2377

1. Allow relative library paths in OPENSCADPATH
2. Search for included library file recursively starting from source .scad file dir+libdir to fs root+libdir when library dir is set as relative path
3. Add 'scad_modules' relative lib dir path to libraries paths for project-specific libraries by default


In a project like
project1/model.scad
project1/modules/lib1/lib1.scad
project1/modules/lib2/lib2.scad

one will be able to import lib1 and lib2 like:

~~~openscad
use <lib1/lib1.scad>
use <lib2/lib2.scad>
~~~

if OPENSCADPATH is set to 'modules' (or contains it among multiple values)
~~~
OPENSCADPATH=modules
~~~

A bit more complex usecase:

Imagine, we still have project
project1/model.scad
project1/modules/lib1/lib1.scad
project1/modules/lib2/lib2.scad

model.scad references lib1.scad like above
~~~openscad
use <lib1/lib1.scad>
~~~

and lib1.scad, in turn, references lib2.scad also in a similar way:
~~~openscad
use <lib2/lib2.scad>
~~~

This is common case if we use nodejs-like modules which depend on each other and refer to each other while being loaded to the same plain 'modules' dir.

But with current OpenSCAD library load strategy this will NOT work, because while being included from lib1.scad, lib2.scad should be located in the same dir as lib1.scad or in a subdir or somewhere in system libraries.

https://en.wikibooks.org/wiki/OpenSCAD_User_Manual/Libraries
> In the case of a library file itself having use <...> or include <...> the directory of the library .scad file is the 'calling' file, i.e. when looking for libraries within a library, it does not check the directory of the top level .scad file.

Now change library search strategy:

once lib2.scad is included from lib1.scad like:
~~~openscad
use <lib2/lib2.scad>
~~~

first, try to search in relatively to lib1.scad dir in:
/home/user/project1/modules/lib1/modules/lib2/lib2.scad (NO)
if not found, then do the same for parent dir:
/home/user/project1/modules/modules/lib2/lib2.scad (NO)
and recursively until we reach root or find library:
/home/user/project1/modules/lib2/lib2.scad (YES)

in case, we did not find it above:
/home/user/modules/lib2/lib2.scad (NO)
/home//modules/lib2/lib2.scad (NO)
/modules/lib2/lib2.scad (NO)
no parent here -> library not found at all

In this case lib2.scad would be finally found in
project1/modules/lib2/lib2.scad

on the same level with lib1. This means, that different modules can be loaded in the same dir as main project dependencies and reference each other mostly by name.

This patch should not affect library dirs with absolute path in any way (so should not break any old setups), and libs with relative paths did not work anyway.

Also, add 'scad_modules' relative path to bult-in library dirs by default, so it could be used for openscad nodejs-style project-related modules (like "node_modules" in NodeJS), and the user will not have to add it OPENSCADPATH each time.

So, projects like:
project1/model.scad
project1/scad_modules/lib1/lib1.scad
project1/scad_modules/lib2/lib2.scad

will not have to set OPENSCADPATH to 'scad_modules' by default.