### PR TITLE
Flipped face triangulation on linear_extrude with twist (possibly fixes #901)

### DIFF
--- a/src/GeometryEvaluator.cc
+++ b/src/GeometryEvaluator.cc
@@ -642,7 +642,7 @@ static void add_slice(PolySet *ps, const Polygon2d &poly,
 	Eigen::Affine2d trans1(Eigen::Scaling(scale1) * Eigen::Rotation2D<double>(-rot1*M_PI/180));
 	Eigen::Affine2d trans2(Eigen::Scaling(scale2) * Eigen::Rotation2D<double>(-rot2*M_PI/180));
 	
-	bool splitfirst = sin((rot1 - rot2)*M_PI/180) > 0.0;
+	bool splitfirst = sin((rot2 - rot1)*M_PI/180) > 0.0;
 	for(const auto &o : poly.outlines()) {
 		Vector2d prev1 = trans1 * o.vertices[0];
 		Vector2d prev2 = trans2 * o.vertices[0];


### PR DESCRIPTION
#784 fixed specific twist angles triangulating differently during a linear_extrude but appears to now consistently triangulate the quadrilaterals with the split along the long axis, creating quite unsightly geometry (see #901 for examples).

This pull request attempts to flip the edge, similar to "Rotate Selected Edge" in Blender.

I am unable to build this to test it however, as I am currently on metered internet and do not have the remaining usage to download a Linux image or Visual Studio.