### PR TITLE
[WIP] Use more automated config for cross-building with mxe (née mingw-cross-env)

### DIFF
--- a/cgal.pri
+++ b/cgal.pri
@@ -10,18 +10,10 @@ cgal {
     message("CGAL location: $$CGAL_DIR")
   }
 
-  CONFIG(mingw-cross-env)|CONFIG(mingw-cross-env-shared) {
-    LIBS += -lgmp -lmpfr -lCGAL
-    QMAKE_CXXFLAGS += -frounding-math 
-  } else {
-    win* {
-      *-g++* { 
-        QMAKE_CXXFLAGS += -frounding-math 
-      }
-    } else {
-      QMAKE_CXXFLAGS += -frounding-math 
-    }
     LIBS += -lCGAL -lmpfr -lgmp
+
+  *g++* {
+    QMAKE_CXXFLAGS += -frounding-math
   }
 
   *clang* {

--- a/common.pri
+++ b/common.pri
@@ -26,6 +26,7 @@ macx:isEmpty(OPENSCAD_LIBDIR) {
 }
 
 
+isEmpty(PKG_CONFIG):PKG_CONFIG = pkg-config
 include(qt.pri)
 include(win.pri)
 include(flex.pri)

--- a/eigen.pri
+++ b/eigen.pri
@@ -34,7 +34,7 @@ isEmpty(EIGEN_INCLUDEPATH) {
 }
 
 !exists($$EIGEN_INCLUDEPATH/Eigen/Core) {
-  EIGEN_CFLAGS = $$system("pkg-config --cflags eigen3")
+  EIGEN_CFLAGS = $$system("$$PKG_CONFIG --cflags eigen3")
   EIGEN_INCLUDEPATH = $$replace(EIGEN_CFLAGS,"-I","")
 }
 

--- a/fontconfig.pri
+++ b/fontconfig.pri
@@ -22,13 +22,13 @@ FONTCONFIG_DIR = $$(FONTCONFIGDIR)
 }
 
 isEmpty(FONTCONFIG_INCLUDEPATH) {
-  FONTCONFIG_CFLAGS = $$system("pkg-config --cflags fontconfig")
+  FONTCONFIG_CFLAGS = $$system("$$PKG_CONFIG --cflags fontconfig")
 } else {
   FONTCONFIG_CFLAGS = -I$$FONTCONFIG_INCLUDEPATH
 }
 
 isEmpty(FONTCONFIG_LIBPATH) {
-  FONTCONFIG_LIBS = $$system("pkg-config --libs fontconfig")
+  FONTCONFIG_LIBS = $$system("$$PKG_CONFIG --libs fontconfig")
 } else {
   FONTCONFIG_LIBS = -L$$FONTCONFIG_LIBPATH -lfontconfig
 }

--- a/freetype.pri
+++ b/freetype.pri
@@ -22,13 +22,13 @@ FREETYPE_DIR = $$(FREETYPEDIR)
 }
 
 isEmpty(FREETYPE_INCLUDEPATH) {
-  FREETYPE_CFLAGS = $$system("pkg-config --cflags freetype2")
+  FREETYPE_CFLAGS = $$system("$$PKG_CONFIG --cflags freetype2")
 } else {
   FREETYPE_CFLAGS = -I$$FREETYPE_INCLUDEPATH
 }
 
 isEmpty(FREETYPE_LIBPATH) {
-  FREETYPE_LIBS = $$system("pkg-config --libs freetype2")
+  FREETYPE_LIBS = $$system("$$PKG_CONFIG --libs freetype2")
 } else {
   FREETYPE_LIBS = -L$$FREETYPE_LIBPATH -lfreetype
 }

--- a/glew.pri
+++ b/glew.pri
@@ -9,9 +9,10 @@ glew {
   }
 
   unix:LIBS += -lGLEW
-  CONFIG(mingw-cross-env): {
-    !CONFIG(mingw-cross-env-shared) {
-      DEFINES += GLEW_STATIC
+  mingw-cross-env*: {
+     {
+      CONFIG += link_pkgconfig
+      PKGCONFIG += glew
     }
   } else {
     win32:LIBS += -lglew32

--- a/glib-2.0.pri
+++ b/glib-2.0.pri
@@ -28,36 +28,16 @@ GLIB2_DIR = $$(GLIB2DIR)
 }
 
 isEmpty(GLIB2_INCLUDEPATH) {
-  GLIB2_CFLAGS = $$system("pkg-config --cflags glib-2.0")
+  GLIB2_CFLAGS = $$system("$$PKG_CONFIG --cflags glib-2.0")
 } else {
   GLIB2_CFLAGS = -I$$GLIB2_INCLUDEPATH
   GLIB2_CFLAGS += -I$$GLIB2_INCLUDEPATH_2
 }
 
 isEmpty(GLIB2_LIBPATH) {
-  GLIB2_LIBS = $$system("pkg-config --libs glib-2.0")
+  GLIB2_LIBS = $$system("$$PKG_CONFIG --libs glib-2.0")
 } else {
   GLIB2_LIBS = -L$$GLIB2_LIBPATH -lglib-2.0
-}
-
-CONFIG(mingw-cross-env)|CONFIG(mingw-cross-env-shared) {
-  #message("mingw")
-  isEmpty(GLIB2_INCLUDEPATH) {
-    MXE_TARGET_DIR=$$(MXETARGETDIR)
-    #message($$MXE_TARGET_DIR)
-    contains( MXE_TARGET_DIR, .*x86_64-w64-mingw32 ) {
-      GLIB2_CFLAGS = $$system("x86_64-w64-mingw32-pkg-config --cflags glib-2.0")
-      GLIB2_LIBS = $$system("x86_64-w64-mingw32-pkg-config --libs glib-2.0")
-    }
-    contains( MXE_TARGET_DIR, .*i686-w64-mingw32 ) {
-      GLIB2_CFLAGS = $$system("i686-w64-mingw32-pkg-config --cflags glib-2.0")
-      GLIB2_LIBS = $$system("i686-w64-mingw32-pkg-config --libs glib-2.0")
-    }
-    contains( MXE_TARGET_DIR, .*i686-pc-mingw32 ) {
-      GLIB2_CFLAGS = $$system("i686-pc-mingw32-pkg-config --cflags glib-2.0")
-      GLIB2_LIBS = $$system("i686-pc-mingw32-pkg-config --libs glib-2.0")
-    }
-  }
 }
 
 QMAKE_CXXFLAGS += $$GLIB2_CFLAGS

--- a/harfbuzz.pri
+++ b/harfbuzz.pri
@@ -22,13 +22,13 @@ HARFBUZZ_DIR = $$(HARFBUZZDIR)
 }
 
 isEmpty(HARFBUZZ_INCLUDEPATH) {
-  HARFBUZZ_CFLAGS = $$system("pkg-config --cflags harfbuzz")
+  HARFBUZZ_CFLAGS = $$system("$$PKG_CONFIG --cflags harfbuzz")
 } else {
   HARFBUZZ_CFLAGS = -I$$HARFBUZZ_INCLUDEPATH
 }
 
 isEmpty(HARFBUZZ_LIBPATH) {
-  HARFBUZZ_LIBS = $$system("pkg-config --libs harfbuzz")
+  HARFBUZZ_LIBS = $$system("$$PKG_CONFIG --libs harfbuzz")
 } else {
   HARFBUZZ_LIBS = -L$$HARFBUZZ_LIBPATH -lharfbuzz
 }

--- a/libxml2.pri
+++ b/libxml2.pri
@@ -21,22 +21,15 @@ LIBXML2_DIR = $$(LIBXML2DIR)
 }
 
 isEmpty(LIBXML2_INCLUDEPATH) {
-  LIBXML2_CFLAGS = $$system("pkg-config --cflags libxml-2.0")
+  LIBXML2_CFLAGS = $$system("$$PKG_CONFIG --cflags libxml-2.0")
 } else {
   LIBXML2_CFLAGS = -I$$LIBXML2_INCLUDEPATH
 }
 
 isEmpty(LIBXML2_LIBPATH) {
-  LIBXML2_LIBS = $$system("pkg-config --libs libxml-2.0")
+  LIBXML2_LIBS = $$system("$$PKG_CONFIG --libs libxml-2.0")
 } else {
   LIBXML2_LIBS = -L$$LIBXML2_LIBPATH -lxml2
-}
-
-CONFIG(mingw-cross-env): {
-  LIBXML2_LIBS += -llzma
-  !CONFIG(mingw-cross-env-shared) {
-    DEFINES += LIBXML_STATIC
-  }
 }
 
 QMAKE_CXXFLAGS += $$LIBXML2_CFLAGS

--- a/libzip.pri
+++ b/libzip.pri
@@ -15,7 +15,7 @@ exists($$LIBZIP_INCLUDEPATH/zip.h) {
 }
 
 isEmpty(LIBZIP_INCLUDEPATH) {
-  LIBZIP_CFLAGS = $$system("pkg-config --cflags libzip")
+  LIBZIP_CFLAGS = $$system("$$PKG_CONFIG --cflags libzip")
   !isEmpty(LIBZIP_CFLAGS) {
     ENABLE_LIBZIP=yes
   }
@@ -24,7 +24,7 @@ isEmpty(LIBZIP_INCLUDEPATH) {
 }
 
 isEmpty(LIBZIP_LIBPATH) {
-  LIBZIP_LIBS = $$system("pkg-config --libs libzip")
+  LIBZIP_LIBS = $$system("$$PKG_CONFIG --libs libzip")
 } else {
   LIBZIP_LIBS = -L$$LIBZIP_LIBPATH -lzip
 }

--- a/mingw-cross-env.pri
+++ b/mingw-cross-env.pri
@@ -1,38 +1,8 @@
 # cross compilation unix->win32
 # To use static linking, pass CONFIG+=mingw-cross-env to qmake
 # To use shared linking, pass CONFIG+=mingw-cross-env-shared to qmake
-CONFIG(mingw-cross-env) {
-  LIBS += mingw-cross-env/lib/libglew32s.a 
-  LIBS += mingw-cross-env/lib/libglut.a 
-  LIBS += mingw-cross-env/lib/libopengl32.a 
-  LIBS += mingw-cross-env/lib/libGLEW.a 
-#  exists( mingw-cross-env/lib/libglaux.a ) {
-#    LIBS += mingw-cross-env/lib/libglaux.a
-#  }
-  LIBS += mingw-cross-env/lib/libglu32.a 
-  LIBS += mingw-cross-env/lib/libopencsg.a 
-  LIBS += mingw-cross-env/lib/libmpfr.a 
-  LIBS += mingw-cross-env/lib/libgmp.a 
-  LIBS += mingw-cross-env/lib/libCGAL.a
-  LIBS += mingw-cross-env/lib/libfontconfig.a
-  LIBS += mingw-cross-env/lib/libfreetype.a
-  LIBS += mingw-cross-env/lib/libharfbuzz.a
-  LIBS += mingw-cross-env/lib/libbz2.a
-  LIBS += mingw-cross-env/lib/libexpat.a
-  LIBS += mingw-cross-env/lib/libintl.a
-  LIBS += mingw-cross-env/lib/libiconv.a
-}
 
-CONFIG(mingw-cross-env-shared) {
-  # on MXE, the shared library .dll files are under 'bin' not 'lib'.
-  QMAKE_LFLAGS += -L./mingw-cross-env/bin
-  LIBS += -lglew32 -lglut -lopengl32 -lGLEW -lglu32
-  LIBS += -lopencsg -lmpfr -lgmp -lCGAL 
-  LIBS += -lfontconfig -lfreetype -lharfbuzz -lbz2 -lexpat -lintl -liconv
-}
-
-CONFIG(mingw-cross-env)|CONFIG(mingw-cross-env-shared) {
-  QMAKE_CXXFLAGS += -fpermissive
+mingw-cross-env* {
   QMAKE_DEL_FILE = rm -f
   QMAKE_CXXFLAGS_WARN_ON += -Wno-unused-local-typedefs #eigen3
 }

--- a/qscintilla2.prf
+++ b/qscintilla2.prf
@@ -10,6 +10,9 @@ INCLUDEPATH += $$[QT_INSTALL_HEADERS]
 
 LIBS += -L$$[QT_INSTALL_LIBS]
 
+mingw-cross-env* {
+    CONFIG += qscintilla2
+} else {
 QT5LIB=qt5scintilla2
 
 unix:linux* {
@@ -51,4 +54,5 @@ CONFIG(debug, debug|release) {
         }
       }
     }
+}
 }


### PR DESCRIPTION
Basically removes manually specified options and mxe-specific sections in favour of qmake/pkg-config to set up the build.