### PR TITLE
Translation context

### DIFF
--- a/doc/translation.txt
+++ b/doc/translation.txt
@@ -47,7 +47,7 @@ _("text"). In .ui files, #include "qtgettext.h" first in the .h file
 (see MainWindow.h). Then clean and rebuild to recreate the ui_xxxx.h 
 files.
 
-   $ make clean && qmake && make
+   $ make clean && qmake CONFIG+=experimental && make
 
 Then run the script to scan the source files, and regenerate .pot & .po files.
 You'll need itstool (http://itstool.org/) installed.

--- a/locale/cs.po
+++ b/locale/cs.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: OpenSCAD 2013.02.24\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2018-08-15 13:13+0200\n"
+"POT-Creation-Date: 2018-08-15 15:07+0200\n"
 "PO-Revision-Date: 2015-03-06 10:27+0100\n"
 "Last-Translator: Miro Hrončok <miro@hroncok.cz>\n"
 "Language-Team: Czech <miro@hroncok.cz>\n"
@@ -826,7 +826,9 @@ msgstr "Předvolby"
 msgid "3D View"
 msgstr "3D zobrazení"
 
-#: objects/ui_Preferences.h:1096 examples/examples.json:19
+#: objects/ui_Preferences.h:1096
+#, fuzzy
+msgctxt "preferences"
 msgid "Advanced"
 msgstr "Pokročilé"
 
@@ -1368,6 +1370,10 @@ msgstr "Základy"
 #: examples/examples.json:13
 msgid "Functions"
 msgstr "Funkce"
+
+#: examples/examples.json:19
+msgid "Advanced"
+msgstr "Pokročilé"
 
 #: examples/examples.json:28
 msgid "Parametric"

--- a/locale/cs.po
+++ b/locale/cs.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: OpenSCAD 2013.02.24\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2018-03-01 07:52+0100\n"
+"POT-Creation-Date: 2018-08-15 13:13+0200\n"
 "PO-Revision-Date: 2015-03-06 10:27+0100\n"
 "Last-Translator: Miro Hrončok <miro@hroncok.cz>\n"
 "Language-Team: Czech <miro@hroncok.cz>\n"
@@ -750,287 +750,363 @@ msgstr "Zobrazit tuto zprávu znovu"
 msgid "Close"
 msgstr "Zavřít"
 
-#: objects/ui_Preferences.h:1080
+#: objects/ui_ParameterEntryWidget.h:339 objects/ui_ParameterWidget.h:150
+msgid "Form"
+msgstr ""
+
+#: objects/ui_ParameterEntryWidget.h:341
+msgid "Parameter"
+msgstr ""
+
+#: objects/ui_ParameterEntryWidget.h:342 objects/ui_ParameterEntryWidget.h:343
+msgid "Description"
+msgstr ""
+
+#: objects/ui_ParameterWidget.h:151
+msgid "save preset"
+msgstr ""
+
+#: objects/ui_ParameterWidget.h:153
+msgid "delete current preset"
+msgstr ""
+
+#: objects/ui_ParameterWidget.h:155
+msgid "-"
+msgstr ""
+
+#: objects/ui_ParameterWidget.h:157
+msgid "preset selection"
+msgstr ""
+
+#: objects/ui_ParameterWidget.h:160 src/parameter/ParameterWidget.cc:154
+msgid "add new preset"
+msgstr ""
+
+#: objects/ui_ParameterWidget.h:162
+msgid "+"
+msgstr ""
+
+#: objects/ui_ParameterWidget.h:163
+#, fuzzy
+msgid "Automatic Preview"
+msgstr "&Automaticky načítat a zobrazovat"
+
+#: objects/ui_ParameterWidget.h:166
+#, fuzzy
+msgid "Show Details"
+msgstr "Zobrazit osy"
+
+#: objects/ui_ParameterWidget.h:167
+msgid "Inline Details"
+msgstr ""
+
+#: objects/ui_ParameterWidget.h:168
+#, fuzzy
+msgid "Hide Details"
+msgstr "Skrýt nástrojové lišty"
+
+#: objects/ui_ParameterWidget.h:169
+msgid "Description Only"
+msgstr ""
+
+#: objects/ui_ParameterWidget.h:172
+msgid "reset the parameters to the selected preset"
+msgstr ""
+
+#: objects/ui_ParameterWidget.h:174
+#, fuzzy
+msgid "Reset"
+msgstr "Výchozí pohled"
+
+#: objects/ui_Preferences.h:1094
 msgid "Preferences"
 msgstr "Předvolby"
 
-#: objects/ui_Preferences.h:1081
+#: objects/ui_Preferences.h:1095
 msgid "3D View"
 msgstr "3D zobrazení"
 
-#: objects/ui_Preferences.h:1082 examples/examples.json:19
+#: objects/ui_Preferences.h:1096 examples/examples.json:19
 msgid "Advanced"
 msgstr "Pokročilé"
 
-#: objects/ui_Preferences.h:1083 src/mainwin.cc:2518
+#: objects/ui_Preferences.h:1097 src/mainwin.cc:2532
 msgid "Editor"
 msgstr "Editor"
 
-#: objects/ui_Preferences.h:1084
+#: objects/ui_Preferences.h:1098
 msgid "Update"
 msgstr "Aktualizace"
 
-#: objects/ui_Preferences.h:1085 objects/ui_Preferences.h:1168
+#: objects/ui_Preferences.h:1099 objects/ui_Preferences.h:1182
 msgid "Features"
 msgstr "Funkce"
 
-#: objects/ui_Preferences.h:1087
+#: objects/ui_Preferences.h:1101
 msgid "Enable/Disable experimental features"
 msgstr "Povolit/Zakázat experimentální funkce"
 
-#: objects/ui_Preferences.h:1089
+#: objects/ui_Preferences.h:1103
 msgid "Color scheme:"
 msgstr "Barevné téma:"
 
-#: objects/ui_Preferences.h:1090
+#: objects/ui_Preferences.h:1104
 msgid "Show Warnings and Errors in 3D View"
 msgstr "Zobrazovat varování a chyby v 3D okně"
 
-#: objects/ui_Preferences.h:1091
+#: objects/ui_Preferences.h:1105
 msgid "Editor Type"
 msgstr "Varianta editoru"
 
-#: objects/ui_Preferences.h:1094
+#: objects/ui_Preferences.h:1108
 msgid "Simple Editor"
 msgstr "Jednoduchý editor"
 
-#: objects/ui_Preferences.h:1095
+#: objects/ui_Preferences.h:1109
 msgid "QScintilla Editor"
 msgstr "Editor QScintilla"
 
-#: objects/ui_Preferences.h:1097
+#: objects/ui_Preferences.h:1111
 msgid "(requires restart)"
 msgstr "(vyžaduje restart aplikace)"
 
-#: objects/ui_Preferences.h:1098
+#: objects/ui_Preferences.h:1112
 msgid "Font"
 msgstr "Písmo"
 
-#: objects/ui_Preferences.h:1099
+#: objects/ui_Preferences.h:1113
 msgid "Color syntax highlighting"
 msgstr "Barva zvýrazňování syntaxe"
 
-#: objects/ui_Preferences.h:1100
+#: objects/ui_Preferences.h:1114
 msgid "Ctrl/Cmd-Mouse-wheel zooms text"
 msgstr "Ctrl/Cmd a kolečko myši mění velikost písma"
 
-#: objects/ui_Preferences.h:1101
+#: objects/ui_Preferences.h:1115
 msgid "Indentation"
 msgstr "Odsazování"
 
-#: objects/ui_Preferences.h:1102
+#: objects/ui_Preferences.h:1116
 msgid "Auto Indent"
 msgstr "Automatické odsazování"
 
-#: objects/ui_Preferences.h:1103
+#: objects/ui_Preferences.h:1117
 msgid "Backspace unindents"
 msgstr ""
 
-#: objects/ui_Preferences.h:1104
+#: objects/ui_Preferences.h:1118
 msgid "Indent using"
 msgstr "Odsazovat pomocí"
 
-#: objects/ui_Preferences.h:1107 src/settings.cc:141
+#: objects/ui_Preferences.h:1121 src/settings.cc:141
 msgid "Spaces"
 msgstr "mezer"
 
-#: objects/ui_Preferences.h:1108 src/settings.cc:141
+#: objects/ui_Preferences.h:1122 src/settings.cc:141
 msgid "Tabs"
 msgstr "tabulátorů"
 
-#: objects/ui_Preferences.h:1110
+#: objects/ui_Preferences.h:1124
 msgid "Indentation width"
 msgstr "Velikost odsazení"
 
-#: objects/ui_Preferences.h:1111
+#: objects/ui_Preferences.h:1125
 msgid "Tab width"
 msgstr "Šířka tabulátoru"
 
-#: objects/ui_Preferences.h:1112
+#: objects/ui_Preferences.h:1126
 msgid "Tab key function"
 msgstr "Funkce klávesy tabulátor"
 
-#: objects/ui_Preferences.h:1115 objects/ui_Preferences.h:1146
+#: objects/ui_Preferences.h:1129 objects/ui_Preferences.h:1160
 #: src/settings.cc:142
 msgid "Indent"
 msgstr "odsadí"
 
-#: objects/ui_Preferences.h:1116 src/settings.cc:142
+#: objects/ui_Preferences.h:1130 src/settings.cc:142
 msgid "Insert Tab"
 msgstr "vloží znak tabulátoru"
 
-#: objects/ui_Preferences.h:1118
+#: objects/ui_Preferences.h:1132
 msgid "Show whitespace"
 msgstr "Zobrazovat mazery"
 
-#: objects/ui_Preferences.h:1121 src/settings.cc:137
+#: objects/ui_Preferences.h:1135 src/settings.cc:137
 msgid "Never"
 msgstr "nikdy"
 
-#: objects/ui_Preferences.h:1122 src/settings.cc:137
+#: objects/ui_Preferences.h:1136 src/settings.cc:137
 msgid "Always"
 msgstr "vždy"
 
-#: objects/ui_Preferences.h:1123
+#: objects/ui_Preferences.h:1137
 msgid "Only after indentation"
 msgstr "pouze za odsazením"
 
-#: objects/ui_Preferences.h:1125
+#: objects/ui_Preferences.h:1139
 msgid "Size"
 msgstr "Velikost"
 
-#: objects/ui_Preferences.h:1126
+#: objects/ui_Preferences.h:1140
 msgid "Display"
 msgstr "Vzhled"
 
-#: objects/ui_Preferences.h:1127
+#: objects/ui_Preferences.h:1141
 msgid "Enable brace matching"
 msgstr "Zvýrazňovat párové závorky"
 
-#: objects/ui_Preferences.h:1128
+#: objects/ui_Preferences.h:1142
 msgid "Highlight current line"
 msgstr "Zvýrazňovat aktuální řádek"
 
-#: objects/ui_Preferences.h:1129
+#: objects/ui_Preferences.h:1143
 msgid "Display Line Numbers"
 msgstr ""
 
-#: objects/ui_Preferences.h:1130 objects/ui_Preferences.h:1163
+#: objects/ui_Preferences.h:1144 objects/ui_Preferences.h:1177
 msgid "Line wrap"
 msgstr "Zalamování řádek"
 
-#: objects/ui_Preferences.h:1133 objects/ui_Preferences.h:1150
-#: objects/ui_Preferences.h:1158 src/settings.cc:132 src/settings.cc:135
+#: objects/ui_Preferences.h:1147 objects/ui_Preferences.h:1164
+#: objects/ui_Preferences.h:1172 src/settings.cc:132 src/settings.cc:135
 #: src/settings.cc:136
 msgid "None"
 msgstr "vypnout"
 
-#: objects/ui_Preferences.h:1134 src/settings.cc:132
+#: objects/ui_Preferences.h:1148 src/settings.cc:132
 msgid "Wrap at character boundaries"
 msgstr "zalamovat na úrovni znaků"
 
-#: objects/ui_Preferences.h:1135 src/settings.cc:132
+#: objects/ui_Preferences.h:1149 src/settings.cc:132
 msgid "Wrap at word boundaries"
 msgstr "zalamovat na úrovni slov"
 
-#: objects/ui_Preferences.h:1137
+#: objects/ui_Preferences.h:1151
 msgid "Line wrap indentation"
 msgstr "Odsazení zalomených řádek"
 
-#: objects/ui_Preferences.h:1138
+#: objects/ui_Preferences.h:1152
 msgid "Line wrap visualization"
 msgstr "Pozice symbolu zalomení"
 
-#: objects/ui_Preferences.h:1139
+#: objects/ui_Preferences.h:1153
 msgid "Style"
 msgstr "Styl"
 
-#: objects/ui_Preferences.h:1142 src/settings.cc:133
+#: objects/ui_Preferences.h:1156 src/settings.cc:133
 msgid "Fixed"
 msgstr "vždy stejný"
 
-#: objects/ui_Preferences.h:1143 src/settings.cc:133
+#: objects/ui_Preferences.h:1157 src/settings.cc:133
 msgid "Same"
 msgstr "jako počátek"
 
-#: objects/ui_Preferences.h:1144 src/settings.cc:133
+#: objects/ui_Preferences.h:1158 src/settings.cc:133
 msgid "Indented"
 msgstr "odsazený"
 
-#: objects/ui_Preferences.h:1147
+#: objects/ui_Preferences.h:1161
 msgid "Start"
 msgstr "Začátek"
 
-#: objects/ui_Preferences.h:1151 objects/ui_Preferences.h:1159
+#: objects/ui_Preferences.h:1165 objects/ui_Preferences.h:1173
 #: src/settings.cc:135 src/settings.cc:136
 msgid "Text"
 msgstr "za textem"
 
-#: objects/ui_Preferences.h:1152 objects/ui_Preferences.h:1160
+#: objects/ui_Preferences.h:1166 objects/ui_Preferences.h:1174
 #: src/settings.cc:135 src/settings.cc:136
 msgid "Border"
 msgstr "konec řádky"
 
-#: objects/ui_Preferences.h:1153 objects/ui_Preferences.h:1161
+#: objects/ui_Preferences.h:1167 objects/ui_Preferences.h:1175
 #: src/settings.cc:135 src/settings.cc:136
 msgid "Margin"
 msgstr "levý okraj"
 
-#: objects/ui_Preferences.h:1155
+#: objects/ui_Preferences.h:1169
 msgid "End"
 msgstr "Konec"
 
-#: objects/ui_Preferences.h:1164
+#: objects/ui_Preferences.h:1178
 msgid "Automatically check for updates"
 msgstr "Automaticky vyhledávat aktualizace"
 
-#: objects/ui_Preferences.h:1165
+#: objects/ui_Preferences.h:1179
 msgid "Include development snapshots"
 msgstr "Včetně nestabilních verzí"
 
-#: objects/ui_Preferences.h:1166
+#: objects/ui_Preferences.h:1180
 msgid "Check Now"
 msgstr "Zkontrolovat nyní"
 
-#: objects/ui_Preferences.h:1167
+#: objects/ui_Preferences.h:1181
 msgid "Last checked: "
 msgstr "Poslední kontrola:"
 
-#: objects/ui_Preferences.h:1169
+#: objects/ui_Preferences.h:1183
 msgid "OpenCSG"
 msgstr "OpenCSG"
 
-#: objects/ui_Preferences.h:1170
+#: objects/ui_Preferences.h:1184
 msgid "Show capability warning"
 msgstr "Zobrazovat varování o vlastnostech"
 
-#: objects/ui_Preferences.h:1171
+#: objects/ui_Preferences.h:1185
 msgid "Enable for OpenGL 1.x"
 msgstr "Povolit pro OpenGL 1.x"
 
-#: objects/ui_Preferences.h:1172
+#: objects/ui_Preferences.h:1186
 msgid "Turn off rendering at "
 msgstr "Vypnout renderování při"
 
-#: objects/ui_Preferences.h:1173
+#: objects/ui_Preferences.h:1187
 msgid "elements"
 msgstr "prvcích"
 
-#: objects/ui_Preferences.h:1174
+#: objects/ui_Preferences.h:1188
 msgid "Force Goldfeather"
 msgstr "Vynutit zobrazení Goldfeather"
 
-#: objects/ui_Preferences.h:1175
+#: objects/ui_Preferences.h:1189
 msgid "CGAL Cache size"
 msgstr "Velikost CGAL cache"
 
-#: objects/ui_Preferences.h:1176 objects/ui_Preferences.h:1178
+#: objects/ui_Preferences.h:1190 objects/ui_Preferences.h:1192
 msgid "bytes"
 msgstr "bytů"
 
-#: objects/ui_Preferences.h:1177
+#: objects/ui_Preferences.h:1191
 msgid "PolySet Cache size"
 msgstr "Velikost PolySet cache"
 
-#: objects/ui_Preferences.h:1179
+#: objects/ui_Preferences.h:1193
 msgid "Allow opening multiple documents"
 msgstr "Povolit současné otevření více dokumentů"
 
-#: objects/ui_Preferences.h:1180
+#: objects/ui_Preferences.h:1194
 msgid "Enable docking of Editor and Console in different places"
 msgstr "Povolit zaparkování editoru a konzole na různá místa"
 
-#: objects/ui_Preferences.h:1181
+#: objects/ui_Preferences.h:1195
 msgid "Enable undocking of Editor and Console to separate windows"
 msgstr "Povolit plovoucí editor a konzoli"
 
-#: objects/ui_Preferences.h:1182
+#: objects/ui_Preferences.h:1196
 msgid "Show Welcome Screen"
 msgstr "Zobrazovat uvítací obrazovku"
 
-#: objects/ui_Preferences.h:1183
+#: objects/ui_Preferences.h:1197
 msgid "Enable user interface localization (requires restart of OpenSCAD)"
 msgstr "Povolit lokalizaci rozhraní OpenSCADu (vyžaduje restart aplikace)"
+
+#: objects/ui_Preferences.h:1198
+msgid "Bring window to front after automatic reload"
+msgstr ""
+
+#: objects/ui_Preferences.h:1199
+msgid "Play sound notification on render complete"
+msgstr ""
 
 #: objects/ui_ProgressWidget.h:72
 msgid "%v / %m"
@@ -1055,52 +1131,52 @@ msgstr ""
 msgid "ERROR: \"%s\" write error. (Disk full?)"
 msgstr ""
 
-#: src/mainwin.cc:788 src/mainwin.cc:1438
+#: src/mainwin.cc:789 src/mainwin.cc:1443
 msgid "Untitled.scad"
 msgstr "Bezejmenný.scad"
 
-#: src/mainwin.cc:1027
+#: src/mainwin.cc:1032
 msgid "Compile error."
 msgstr "Chyba kompilace."
 
-#: src/mainwin.cc:1030
+#: src/mainwin.cc:1035
 msgid "Error while compiling '%1'."
 msgstr "Chyba při kompilaci '%1'."
 
-#: src/mainwin.cc:1034
+#: src/mainwin.cc:1039
 msgid "Compilation generated %1 warning."
 msgid_plural "Compilation generated %1 warnings."
 msgstr[0] "Kompilace vyvolala %1 varování."
 msgstr[1] "Kompilace vyvolala %1 varování."
 msgstr[2] "Kompilace vyvolala %1 varování."
 
-#: src/mainwin.cc:1044
+#: src/mainwin.cc:1049
 msgid " For details see <a href=\"#console\">console window</a>."
 msgstr " Pro podrobnosti nahlédněte do <a href=\"#console\">konzole</a>."
 
-#: src/mainwin.cc:1416
+#: src/mainwin.cc:1421
 #, fuzzy
 msgid "Failed to open file for writing"
 msgstr "Nepodařilo se otevřít soubor %s: %s"
 
-#: src/mainwin.cc:1426
+#: src/mainwin.cc:1431
 #, fuzzy, c-format
 msgid "Saved design '%s'."
 msgstr "Načten design '%s'."
 
-#: src/mainwin.cc:1429
+#: src/mainwin.cc:1434
 msgid "Error saving design"
 msgstr ""
 
-#: src/mainwin.cc:1437
+#: src/mainwin.cc:1442
 msgid "Save File"
 msgstr "Uložit soubor"
 
-#: src/mainwin.cc:1439
+#: src/mainwin.cc:1444
 msgid "OpenSCAD Designs (*.scad)"
 msgstr "OpenSCAD designy(*.scad)"
 
-#: src/mainwin.cc:1449
+#: src/mainwin.cc:1454
 msgid ""
 "%1 already exists.\n"
 "Do you want to replace it?"
@@ -1108,11 +1184,11 @@ msgstr ""
 "%1 již existuje.\n"
 "Chcete jej nahradit?"
 
-#: src/mainwin.cc:1796
+#: src/mainwin.cc:1805
 msgid "Application"
 msgstr "Aplikace"
 
-#: src/mainwin.cc:1797
+#: src/mainwin.cc:1806
 msgid ""
 "The document has been modified.\n"
 "Do you really want to reload the file?"
@@ -1120,56 +1196,56 @@ msgstr ""
 "Dokument byl pozměněn.\n"
 "Opravdu jej chcete znovu načíst?"
 
-#: src/mainwin.cc:2171
+#: src/mainwin.cc:2185
 msgid "Export %1 File"
 msgstr "Exportovat %s soubor(ů)"
 
-#: src/mainwin.cc:2172
+#: src/mainwin.cc:2186
 msgid "%1 Files (*%2)"
 msgstr "%1 Soubor(ů) (*%2)"
 
-#: src/mainwin.cc:2173
+#: src/mainwin.cc:2187
 msgid "Untitled"
 msgstr "Bezejmenný"
 
-#: src/mainwin.cc:2225
+#: src/mainwin.cc:2239
 msgid "Export CSG File"
 msgstr "Exportovat CSG soubor"
 
-#: src/mainwin.cc:2226
+#: src/mainwin.cc:2240
 msgid "Untitled.csg"
 msgstr "Bezejmenný.csg"
 
-#: src/mainwin.cc:2227
+#: src/mainwin.cc:2241
 msgid "CSG Files (*.csg)"
 msgstr "CSG soubory (*.csg)"
 
-#: src/mainwin.cc:2253
+#: src/mainwin.cc:2267
 #, fuzzy
 msgid "Untitled.png"
 msgstr "Bezejmenný.csg"
 
-#: src/mainwin.cc:2255
+#: src/mainwin.cc:2269
 msgid "Export Image"
 msgstr "Exportovat obrázek"
 
-#: src/mainwin.cc:2255
+#: src/mainwin.cc:2269
 msgid "PNG Files (*.png)"
 msgstr "PNG Soubory (*.png)"
 
-#: src/mainwin.cc:2523
+#: src/mainwin.cc:2537
 msgid "Console"
 msgstr "Konzole"
 
-#: src/mainwin.cc:2528
+#: src/mainwin.cc:2542
 msgid "Customizer"
 msgstr ""
 
-#: src/mainwin.cc:2672
+#: src/mainwin.cc:2686
 msgid "The document has been modified."
 msgstr "Dokument byl pozměněn."
 
-#: src/mainwin.cc:2673
+#: src/mainwin.cc:2687
 msgid "Do you want to save your changes?"
 msgstr "Chcete uložit změny?"
 
@@ -1236,105 +1312,53 @@ msgstr ""
 msgid "After indentation"
 msgstr "za odsazením"
 
-#: objects/ui_ParameterEntryWidget.h:343 objects/ui_ParameterWidget.h:150
-msgid "Form"
+#: src/parameter/ParameterWidget.cc:74 src/parameter/ParameterWidget.cc:218
+msgid "changes on current preset not saved"
 msgstr ""
 
-#: objects/ui_ParameterEntryWidget.h:345
-msgid "Parameter"
+#: src/parameter/ParameterWidget.cc:76
+msgid ""
+"The changes on the current preset %1 are not saved yet. Do you really want "
+"to reset this preset and lose your changes?"
 msgstr ""
 
-#: objects/ui_ParameterEntryWidget.h:346 objects/ui_ParameterEntryWidget.h:347
-msgid "Description"
-msgstr ""
-
-#: objects/ui_ParameterWidget.h:151
-msgid "save preset"
-msgstr ""
-
-#: objects/ui_ParameterWidget.h:153
-msgid "delete current preset"
-msgstr ""
-
-#: objects/ui_ParameterWidget.h:155
-msgid "-"
-msgstr ""
-
-#: objects/ui_ParameterWidget.h:157
-msgid "preset selection"
-msgstr ""
-
-#: objects/ui_ParameterWidget.h:160 src/parameter/ParameterWidget.cc:132
-msgid "add new preset"
-msgstr ""
-
-#: objects/ui_ParameterWidget.h:162
-msgid "+"
-msgstr ""
-
-#: objects/ui_ParameterWidget.h:163
-#, fuzzy
-msgid "Automatic Preview"
-msgstr "&Automaticky načítat a zobrazovat"
-
-#: objects/ui_ParameterWidget.h:166
-#, fuzzy
-msgid "Show Details"
-msgstr "Zobrazit osy"
-
-#: objects/ui_ParameterWidget.h:167
-msgid "Inline Details"
-msgstr ""
-
-#: objects/ui_ParameterWidget.h:168
-#, fuzzy
-msgid "Hide Details"
-msgstr "Skrýt nástrojové lišty"
-
-#: objects/ui_ParameterWidget.h:169
-msgid "Description Only"
-msgstr ""
-
-#: objects/ui_ParameterWidget.h:172
-msgid "reset the parameters to the selected preset"
-msgstr ""
-
-#: objects/ui_ParameterWidget.h:174
-#, fuzzy
-msgid "Reset"
-msgstr "Výchozí pohled"
-
-#: src/parameter/ParameterWidget.cc:134
+#: src/parameter/ParameterWidget.cc:156
 msgid "remove current preset"
 msgstr ""
 
-#: src/parameter/ParameterWidget.cc:136
+#: src/parameter/ParameterWidget.cc:158
 msgid "save current preset"
 msgstr ""
 
-#: src/parameter/ParameterWidget.cc:138 src/parameter/ParameterWidget.cc:139
-#: src/parameter/ParameterWidget.cc:140
+#: src/parameter/ParameterWidget.cc:160 src/parameter/ParameterWidget.cc:161
+#: src/parameter/ParameterWidget.cc:162
 msgid "JSON file read only"
 msgstr ""
 
-#: src/parameter/ParameterWidget.cc:165
+#: src/parameter/ParameterWidget.cc:202
 msgid "no preset selected"
 msgstr ""
 
-#: src/parameter/ParameterWidget.cc:380
+#: src/parameter/ParameterWidget.cc:220
+msgid ""
+"The current preset %1 contains changes, but is not saved yet. Do you really "
+"want to change the preset and lose your changes?"
+msgstr ""
+
+#: src/parameter/ParameterWidget.cc:449
 msgid "Create new set of parameter"
 msgstr ""
 
-#: src/parameter/ParameterWidget.cc:380
+#: src/parameter/ParameterWidget.cc:449
 msgid "Enter name of the parameter set"
 msgstr ""
 
-#: src/parameter/ParameterWidget.cc:407
+#: src/parameter/ParameterWidget.cc:485
 msgid "Saving presets"
 msgstr ""
 
-#: src/parameter/ParameterWidget.cc:408
-msgid "%1 was found, but was unreadble. Do you want to overwrite %1?"
+#: src/parameter/ParameterWidget.cc:486
+msgid "%1 was found, but was unreadable. Do you want to overwrite %1?"
 msgstr ""
 
 #: examples/examples.json:2
@@ -1354,12 +1378,12 @@ msgid "Old"
 msgstr "Staré"
 
 #. (itstool) path: component/summary
-#: openscad.appdata.xml.in:7
+#: openscad.appdata.xml.in:6
 msgid "The Programmers Solid 3D CAD Modeller"
 msgstr ""
 
 #. (itstool) path: description/p
-#: openscad.appdata.xml.in:9
+#: openscad.appdata.xml.in:19
 msgid ""
 "OpenSCAD is a software for creating solid 3D CAD models. Unlike most free "
 "software for creating 3D models (such as Blender) it does not focus on the "
@@ -1370,7 +1394,7 @@ msgid ""
 msgstr ""
 
 #. (itstool) path: description/p
-#: openscad.appdata.xml.in:10
+#: openscad.appdata.xml.in:20
 msgid ""
 "OpenSCAD is not an interactive modeller. Instead it is something like a 3D-"
 "compiler that reads in a script file that describes the object and renders "
@@ -1381,15 +1405,35 @@ msgid ""
 msgstr ""
 
 #. (itstool) path: description/p
-#: openscad.appdata.xml.in:11
+#: openscad.appdata.xml.in:21
 msgid ""
 "OpenSCAD provides two main modelling techniques: First there is constructive "
 "solid geometry (aka CSG) and second there is extrusion of 2D outlines. As "
-"data exchange format format for this 2D outlines Autocad DXF files are used. "
-"In addition to 2D paths for extrusion it is also possible to read design "
+"data exchange format for this 2D outlines Autocad DXF files are used. In "
+"addition to 2D paths for extrusion it is also possible to read design "
 "parameters from DXF files. Besides DXF files OpenSCAD can read and create 3D "
 "models in the STL and OFF file formats."
 msgstr ""
+
+#, fuzzy
+#~ msgid "Reset Trim"
+#~ msgstr "Výchozí pohled"
+
+#, fuzzy
+#~ msgid "Rotation"
+#~ msgstr "&Dokumentace"
+
+#, fuzzy
+#~ msgid "Zoom"
+#~ msgstr "Přiblížit"
+
+#, fuzzy
+#~ msgid "ViewPort rel.<br/>Translation"
+#~ msgstr "Vložit posun pohl&edu"
+
+#, fuzzy
+#~ msgid "SpaceNav"
+#~ msgstr "mezer"
 
 #~ msgid "<"
 #~ msgstr "<"

--- a/locale/de.po
+++ b/locale/de.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: OpenSCAD 2014.01.05\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2018-03-01 07:52+0100\n"
+"POT-Creation-Date: 2018-08-15 13:13+0200\n"
 "PO-Revision-Date: 2018-03-01 07:41+0100\n"
 "Last-Translator: Torsten Paul <Torsten.Paul@gmx.de>\n"
 "Language-Team: German\n"
@@ -769,291 +769,366 @@ msgstr "Diesen Dialog wieder anzeigen"
 msgid "Close"
 msgstr "Schließen"
 
-#: objects/ui_Preferences.h:1080
+#: objects/ui_ParameterEntryWidget.h:339 objects/ui_ParameterWidget.h:150
+msgid "Form"
+msgstr "Form"
+
+#: objects/ui_ParameterEntryWidget.h:341
+msgid "Parameter"
+msgstr ""
+
+#: objects/ui_ParameterEntryWidget.h:342 objects/ui_ParameterEntryWidget.h:343
+msgid "Description"
+msgstr ""
+
+#: objects/ui_ParameterWidget.h:151
+#, fuzzy
+msgid "save preset"
+msgstr "aktuelle Voreinstellung speichern"
+
+#: objects/ui_ParameterWidget.h:153
+#, fuzzy
+msgid "delete current preset"
+msgstr "aktuelle Voreinstellung löschen"
+
+#: objects/ui_ParameterWidget.h:155
+msgid "-"
+msgstr ""
+
+#: objects/ui_ParameterWidget.h:157
+#, fuzzy
+msgid "preset selection"
+msgstr "keine Voreinstellung ausgewählt"
+
+#: objects/ui_ParameterWidget.h:160 src/parameter/ParameterWidget.cc:154
+msgid "add new preset"
+msgstr "neue Voreinstellung hinzufügen"
+
+#: objects/ui_ParameterWidget.h:162
+msgid "+"
+msgstr ""
+
+#: objects/ui_ParameterWidget.h:163
+#, fuzzy
+msgid "Automatic Preview"
+msgstr "&Automatisch neu Laden und Vorschau"
+
+#: objects/ui_ParameterWidget.h:166
+#, fuzzy
+msgid "Show Details"
+msgstr "Koordinaten&achsen anzeigen"
+
+#: objects/ui_ParameterWidget.h:167
+msgid "Inline Details"
+msgstr ""
+
+#: objects/ui_ParameterWidget.h:168
+#, fuzzy
+msgid "Hide Details"
+msgstr "Symbolleisten verstecken"
+
+#: objects/ui_ParameterWidget.h:169
+msgid "Description Only"
+msgstr ""
+
+#: objects/ui_ParameterWidget.h:172
+msgid "reset the parameters to the selected preset"
+msgstr ""
+
+#: objects/ui_ParameterWidget.h:174
+#, fuzzy
+msgid "Reset"
+msgstr "Ans&icht zurücksetzen"
+
+#: objects/ui_Preferences.h:1094
 msgid "Preferences"
 msgstr "Einstellungen"
 
-#: objects/ui_Preferences.h:1081
+#: objects/ui_Preferences.h:1095
 msgid "3D View"
 msgstr "3D Ansicht"
 
-#: objects/ui_Preferences.h:1082 examples/examples.json:19
+#: objects/ui_Preferences.h:1096 examples/examples.json:19
 msgid "Advanced"
 msgstr "Erweitert"
 
-#: objects/ui_Preferences.h:1083 src/mainwin.cc:2518
+#: objects/ui_Preferences.h:1097 src/mainwin.cc:2532
 msgid "Editor"
 msgstr "Editor"
 
-#: objects/ui_Preferences.h:1084
+#: objects/ui_Preferences.h:1098
 msgid "Update"
 msgstr "Aktualisieren"
 
-#: objects/ui_Preferences.h:1085 objects/ui_Preferences.h:1168
+#: objects/ui_Preferences.h:1099 objects/ui_Preferences.h:1182
 msgid "Features"
 msgstr "Funktionen"
 
-#: objects/ui_Preferences.h:1087
+#: objects/ui_Preferences.h:1101
 msgid "Enable/Disable experimental features"
 msgstr "Experimentelle Erweiterungen ein-/ausschalten"
 
-#: objects/ui_Preferences.h:1089
+#: objects/ui_Preferences.h:1103
 msgid "Color scheme:"
 msgstr "Farbschema:"
 
-#: objects/ui_Preferences.h:1090
+#: objects/ui_Preferences.h:1104
 msgid "Show Warnings and Errors in 3D View"
 msgstr "Fehler und Warnungen in der 3D Ansicht anzeigen"
 
-#: objects/ui_Preferences.h:1091
+#: objects/ui_Preferences.h:1105
 msgid "Editor Type"
 msgstr "Editor"
 
-#: objects/ui_Preferences.h:1094
+#: objects/ui_Preferences.h:1108
 msgid "Simple Editor"
 msgstr "Einfacher Editor"
 
-#: objects/ui_Preferences.h:1095
+#: objects/ui_Preferences.h:1109
 msgid "QScintilla Editor"
 msgstr "QScintilla Editor"
 
-#: objects/ui_Preferences.h:1097
+#: objects/ui_Preferences.h:1111
 msgid "(requires restart)"
 msgstr "(Neustart erforderlich)"
 
-#: objects/ui_Preferences.h:1098
+#: objects/ui_Preferences.h:1112
 msgid "Font"
 msgstr "Font"
 
-#: objects/ui_Preferences.h:1099
+#: objects/ui_Preferences.h:1113
 msgid "Color syntax highlighting"
 msgstr "Syntaxhervorhebung"
 
-#: objects/ui_Preferences.h:1100
+#: objects/ui_Preferences.h:1114
 msgid "Ctrl/Cmd-Mouse-wheel zooms text"
 msgstr "Ctrl/Cmd+Mausrad zum Vergrößern des Textes benutzen"
 
-#: objects/ui_Preferences.h:1101
+#: objects/ui_Preferences.h:1115
 msgid "Indentation"
 msgstr "Einrückung"
 
-#: objects/ui_Preferences.h:1102
+#: objects/ui_Preferences.h:1116
 msgid "Auto Indent"
 msgstr "Automatisch einrücken"
 
-#: objects/ui_Preferences.h:1103
+#: objects/ui_Preferences.h:1117
 msgid "Backspace unindents"
 msgstr ""
 
-#: objects/ui_Preferences.h:1104
+#: objects/ui_Preferences.h:1118
 msgid "Indent using"
 msgstr "Einrücken mit"
 
-#: objects/ui_Preferences.h:1107 src/settings.cc:141
+#: objects/ui_Preferences.h:1121 src/settings.cc:141
 msgid "Spaces"
 msgstr "Leerzeichen"
 
-#: objects/ui_Preferences.h:1108 src/settings.cc:141
+#: objects/ui_Preferences.h:1122 src/settings.cc:141
 msgid "Tabs"
 msgstr "Tabs"
 
-#: objects/ui_Preferences.h:1110
+#: objects/ui_Preferences.h:1124
 msgid "Indentation width"
 msgstr "Einrückungstiefe"
 
-#: objects/ui_Preferences.h:1111
+#: objects/ui_Preferences.h:1125
 msgid "Tab width"
 msgstr "Tabulatorschrittweite"
 
-#: objects/ui_Preferences.h:1112
+#: objects/ui_Preferences.h:1126
 msgid "Tab key function"
 msgstr "Funktion der Tab-Taste"
 
-#: objects/ui_Preferences.h:1115 objects/ui_Preferences.h:1146
+#: objects/ui_Preferences.h:1129 objects/ui_Preferences.h:1160
 #: src/settings.cc:142
 msgid "Indent"
 msgstr "Einrücken"
 
-#: objects/ui_Preferences.h:1116 src/settings.cc:142
+#: objects/ui_Preferences.h:1130 src/settings.cc:142
 msgid "Insert Tab"
 msgstr "Tab einfügen"
 
-#: objects/ui_Preferences.h:1118
+#: objects/ui_Preferences.h:1132
 msgid "Show whitespace"
 msgstr "Formatierungsymbole anzeigen"
 
-#: objects/ui_Preferences.h:1121 src/settings.cc:137
+#: objects/ui_Preferences.h:1135 src/settings.cc:137
 msgid "Never"
 msgstr "nie"
 
-#: objects/ui_Preferences.h:1122 src/settings.cc:137
+#: objects/ui_Preferences.h:1136 src/settings.cc:137
 msgid "Always"
 msgstr "immer"
 
-#: objects/ui_Preferences.h:1123
+#: objects/ui_Preferences.h:1137
 msgid "Only after indentation"
 msgstr "nur nach Einrückung"
 
-#: objects/ui_Preferences.h:1125
+#: objects/ui_Preferences.h:1139
 msgid "Size"
 msgstr "Größe"
 
-#: objects/ui_Preferences.h:1126
+#: objects/ui_Preferences.h:1140
 msgid "Display"
 msgstr "Anzeige"
 
-#: objects/ui_Preferences.h:1127
+#: objects/ui_Preferences.h:1141
 msgid "Enable brace matching"
 msgstr "zusammengehörige Klammern hervorheben"
 
-#: objects/ui_Preferences.h:1128
+#: objects/ui_Preferences.h:1142
 msgid "Highlight current line"
 msgstr "Aktuelle Zeile hervorheben"
 
-#: objects/ui_Preferences.h:1129
+#: objects/ui_Preferences.h:1143
 msgid "Display Line Numbers"
 msgstr "Zeilennummern anzeigen"
 
-#: objects/ui_Preferences.h:1130 objects/ui_Preferences.h:1163
+#: objects/ui_Preferences.h:1144 objects/ui_Preferences.h:1177
 msgid "Line wrap"
 msgstr "Zeilenumbruch"
 
-#: objects/ui_Preferences.h:1133 objects/ui_Preferences.h:1150
-#: objects/ui_Preferences.h:1158 src/settings.cc:132 src/settings.cc:135
+#: objects/ui_Preferences.h:1147 objects/ui_Preferences.h:1164
+#: objects/ui_Preferences.h:1172 src/settings.cc:132 src/settings.cc:135
 #: src/settings.cc:136
 msgid "None"
 msgstr "nie"
 
-#: objects/ui_Preferences.h:1134 src/settings.cc:132
+#: objects/ui_Preferences.h:1148 src/settings.cc:132
 msgid "Wrap at character boundaries"
 msgstr "an jedem Zeichen"
 
-#: objects/ui_Preferences.h:1135 src/settings.cc:132
+#: objects/ui_Preferences.h:1149 src/settings.cc:132
 msgid "Wrap at word boundaries"
 msgstr "an Wörtern"
 
-#: objects/ui_Preferences.h:1137
+#: objects/ui_Preferences.h:1151
 msgid "Line wrap indentation"
 msgstr "Einrückung nach Zeilenumbruch"
 
-#: objects/ui_Preferences.h:1138
+#: objects/ui_Preferences.h:1152
 msgid "Line wrap visualization"
 msgstr "Zeilenumbruch anzeigen"
 
-#: objects/ui_Preferences.h:1139
+#: objects/ui_Preferences.h:1153
 msgid "Style"
 msgstr "Stil"
 
-#: objects/ui_Preferences.h:1142 src/settings.cc:133
+#: objects/ui_Preferences.h:1156 src/settings.cc:133
 msgid "Fixed"
 msgstr "Fest"
 
-#: objects/ui_Preferences.h:1143 src/settings.cc:133
+#: objects/ui_Preferences.h:1157 src/settings.cc:133
 msgid "Same"
 msgstr "Wie vorherige Zeile"
 
-#: objects/ui_Preferences.h:1144 src/settings.cc:133
+#: objects/ui_Preferences.h:1158 src/settings.cc:133
 msgid "Indented"
 msgstr "Eingerückt"
 
-#: objects/ui_Preferences.h:1147
+#: objects/ui_Preferences.h:1161
 msgid "Start"
 msgstr "Anfang"
 
-#: objects/ui_Preferences.h:1151 objects/ui_Preferences.h:1159
+#: objects/ui_Preferences.h:1165 objects/ui_Preferences.h:1173
 #: src/settings.cc:135 src/settings.cc:136
 msgid "Text"
 msgstr "Text"
 
-#: objects/ui_Preferences.h:1152 objects/ui_Preferences.h:1160
+#: objects/ui_Preferences.h:1166 objects/ui_Preferences.h:1174
 #: src/settings.cc:135 src/settings.cc:136
 msgid "Border"
 msgstr "Rand"
 
-#: objects/ui_Preferences.h:1153 objects/ui_Preferences.h:1161
+#: objects/ui_Preferences.h:1167 objects/ui_Preferences.h:1175
 #: src/settings.cc:135 src/settings.cc:136
 msgid "Margin"
 msgstr "Seitenrand"
 
-#: objects/ui_Preferences.h:1155
+#: objects/ui_Preferences.h:1169
 msgid "End"
 msgstr "Ende"
 
-#: objects/ui_Preferences.h:1164
+#: objects/ui_Preferences.h:1178
 msgid "Automatically check for updates"
 msgstr "Automatisch nach Aktualisierungen suchen"
 
-#: objects/ui_Preferences.h:1165
+#: objects/ui_Preferences.h:1179
 msgid "Include development snapshots"
 msgstr "Entwickler-Versionen einschließen"
 
-#: objects/ui_Preferences.h:1166
+#: objects/ui_Preferences.h:1180
 msgid "Check Now"
 msgstr "Jetzt suchen"
 
-#: objects/ui_Preferences.h:1167
+#: objects/ui_Preferences.h:1181
 msgid "Last checked: "
 msgstr "Zuletzt gesucht: "
 
-#: objects/ui_Preferences.h:1169
+#: objects/ui_Preferences.h:1183
 msgid "OpenCSG"
 msgstr "OpenCSG"
 
-#: objects/ui_Preferences.h:1170
+#: objects/ui_Preferences.h:1184
 msgid "Show capability warning"
 msgstr "Kompatibilitätswarnung anzeigen"
 
-#: objects/ui_Preferences.h:1171
+#: objects/ui_Preferences.h:1185
 msgid "Enable for OpenGL 1.x"
 msgstr "Aktivieren bei OpenGL 1.x"
 
-#: objects/ui_Preferences.h:1172
+#: objects/ui_Preferences.h:1186
 msgid "Turn off rendering at "
 msgstr "Rendern abbrechen ab "
 
-#: objects/ui_Preferences.h:1173
+#: objects/ui_Preferences.h:1187
 msgid "elements"
 msgstr "Elementen"
 
-#: objects/ui_Preferences.h:1174
+#: objects/ui_Preferences.h:1188
 msgid "Force Goldfeather"
 msgstr "Goldfeather Algorithmus erzwingen"
 
-#: objects/ui_Preferences.h:1175
+#: objects/ui_Preferences.h:1189
 msgid "CGAL Cache size"
 msgstr "CGAL Cache Größe"
 
-#: objects/ui_Preferences.h:1176 objects/ui_Preferences.h:1178
+#: objects/ui_Preferences.h:1190 objects/ui_Preferences.h:1192
 msgid "bytes"
 msgstr "Byte"
 
-#: objects/ui_Preferences.h:1177
+#: objects/ui_Preferences.h:1191
 msgid "PolySet Cache size"
 msgstr "PolySet Cache Größe"
 
-#: objects/ui_Preferences.h:1179
+#: objects/ui_Preferences.h:1193
 msgid "Allow opening multiple documents"
 msgstr "Öffnen von mehreren Dokumenten erlauben"
 
-#: objects/ui_Preferences.h:1180
+#: objects/ui_Preferences.h:1194
 msgid "Enable docking of Editor and Console in different places"
 msgstr "Verschieben des Editor und Konsolen-Fensters erlauben"
 
-#: objects/ui_Preferences.h:1181
+#: objects/ui_Preferences.h:1195
 msgid "Enable undocking of Editor and Console to separate windows"
 msgstr "Separate Editor und Konsolen-Fenster erlauben"
 
-#: objects/ui_Preferences.h:1182
+#: objects/ui_Preferences.h:1196
 msgid "Show Welcome Screen"
 msgstr "Startbildschirm anzeigen"
 
-#: objects/ui_Preferences.h:1183
+#: objects/ui_Preferences.h:1197
 msgid "Enable user interface localization (requires restart of OpenSCAD)"
 msgstr "Lokalisierung der GUI einschalten (benötigt Neustart von OpenSCAD)"
 
-#: objects/ui_Preferences.h:1184
+#: objects/ui_Preferences.h:1198
 msgid "Bring window to front after automatic reload"
 msgstr "Fenster nach vorne bringen nach automatischem Neuladen"
+
+#: objects/ui_Preferences.h:1199
+msgid "Play sound notification on render complete"
+msgstr ""
 
 #: objects/ui_ProgressWidget.h:72
 msgid "%v / %m"
@@ -1078,52 +1153,52 @@ msgstr "Can't open file \"%s\" for export"
 msgid "ERROR: \"%s\" write error. (Disk full?)"
 msgstr "FEHLER:  \"%s\" Schreibfehler. (Speichervoll?)"
 
-#: src/mainwin.cc:788 src/mainwin.cc:1438
+#: src/mainwin.cc:789 src/mainwin.cc:1443
 msgid "Untitled.scad"
 msgstr "Unbenannt.scad"
 
-#: src/mainwin.cc:1027
+#: src/mainwin.cc:1032
 msgid "Compile error."
 msgstr "Fehler"
 
-#: src/mainwin.cc:1030
+#: src/mainwin.cc:1035
 msgid "Error while compiling '%1'."
 msgstr "Fehler beim Kompilieren von '%1'."
 
-#: src/mainwin.cc:1034
+#: src/mainwin.cc:1039
 msgid "Compilation generated %1 warning."
 msgid_plural "Compilation generated %1 warnings."
 msgstr[0] "%1 Warnung beim Kompilieren."
 msgstr[1] "%1 Warnungen beim Kompilieren."
 
-#: src/mainwin.cc:1044
+#: src/mainwin.cc:1049
 msgid " For details see <a href=\"#console\">console window</a>."
 msgstr " Für Details das <a href=\"#console\">Konsolen-Fenster</a> öffnen."
 
-#: src/mainwin.cc:1416
+#: src/mainwin.cc:1421
 #, fuzzy
 msgid "Failed to open file for writing"
 msgstr "Failed to open file for writing: %s (%s)"
 
-#: src/mainwin.cc:1426
+#: src/mainwin.cc:1431
 #, c-format
 msgid "Saved design '%s'."
 msgstr "Saved design '%s'."
 
-#: src/mainwin.cc:1429
+#: src/mainwin.cc:1434
 #, fuzzy
 msgid "Error saving design"
 msgstr "error writing deps"
 
-#: src/mainwin.cc:1437
+#: src/mainwin.cc:1442
 msgid "Save File"
 msgstr "Datei speichern"
 
-#: src/mainwin.cc:1439
+#: src/mainwin.cc:1444
 msgid "OpenSCAD Designs (*.scad)"
 msgstr "OpenSCAD Designs (*.scad)"
 
-#: src/mainwin.cc:1449
+#: src/mainwin.cc:1454
 msgid ""
 "%1 already exists.\n"
 "Do you want to replace it?"
@@ -1131,11 +1206,11 @@ msgstr ""
 "%1 existiert bereits.\n"
 "Mochten Sie die Datei ersetzen?"
 
-#: src/mainwin.cc:1796
+#: src/mainwin.cc:1805
 msgid "Application"
 msgstr "Application"
 
-#: src/mainwin.cc:1797
+#: src/mainwin.cc:1806
 msgid ""
 "The document has been modified.\n"
 "Do you really want to reload the file?"
@@ -1143,55 +1218,55 @@ msgstr ""
 "Das Dokument ist verändert.\n"
 "Möchten Sie die Datei wirklich neu laden?"
 
-#: src/mainwin.cc:2171
+#: src/mainwin.cc:2185
 msgid "Export %1 File"
 msgstr "%1 Datei exportieren"
 
-#: src/mainwin.cc:2172
+#: src/mainwin.cc:2186
 msgid "%1 Files (*%2)"
 msgstr "%1 Dateien (*%2)"
 
-#: src/mainwin.cc:2173
+#: src/mainwin.cc:2187
 msgid "Untitled"
 msgstr "Unbenannt"
 
-#: src/mainwin.cc:2225
+#: src/mainwin.cc:2239
 msgid "Export CSG File"
 msgstr "Export CSG File"
 
-#: src/mainwin.cc:2226
+#: src/mainwin.cc:2240
 msgid "Untitled.csg"
 msgstr "Unbenannt.csg"
 
-#: src/mainwin.cc:2227
+#: src/mainwin.cc:2241
 msgid "CSG Files (*.csg)"
 msgstr "CSG Dateien (*.csg)"
 
-#: src/mainwin.cc:2253
+#: src/mainwin.cc:2267
 msgid "Untitled.png"
 msgstr "Unbenannt.png"
 
-#: src/mainwin.cc:2255
+#: src/mainwin.cc:2269
 msgid "Export Image"
 msgstr "Image exportieren"
 
-#: src/mainwin.cc:2255
+#: src/mainwin.cc:2269
 msgid "PNG Files (*.png)"
 msgstr "PNG Dateien (*.png)"
 
-#: src/mainwin.cc:2523
+#: src/mainwin.cc:2537
 msgid "Console"
 msgstr "Konsole"
 
-#: src/mainwin.cc:2528
+#: src/mainwin.cc:2542
 msgid "Customizer"
 msgstr "Customizer"
 
-#: src/mainwin.cc:2672
+#: src/mainwin.cc:2686
 msgid "The document has been modified."
 msgstr "Das Dokument ist verändert."
 
-#: src/mainwin.cc:2673
+#: src/mainwin.cc:2687
 msgid "Do you want to save your changes?"
 msgstr "Möchten Sie die Änderungen speichern?"
 
@@ -1260,108 +1335,55 @@ msgstr ""
 msgid "After indentation"
 msgstr "nach Einrückung"
 
-#: objects/ui_ParameterEntryWidget.h:343 objects/ui_ParameterWidget.h:150
-msgid "Form"
-msgstr "Form"
-
-#: objects/ui_ParameterEntryWidget.h:345
-msgid "Parameter"
-msgstr ""
-
-#: objects/ui_ParameterEntryWidget.h:346 objects/ui_ParameterEntryWidget.h:347
-msgid "Description"
-msgstr ""
-
-#: objects/ui_ParameterWidget.h:151
+#: src/parameter/ParameterWidget.cc:74 src/parameter/ParameterWidget.cc:218
 #, fuzzy
-msgid "save preset"
+msgid "changes on current preset not saved"
 msgstr "aktuelle Voreinstellung speichern"
 
-#: objects/ui_ParameterWidget.h:153
-#, fuzzy
-msgid "delete current preset"
-msgstr "aktuelle Voreinstellung löschen"
-
-#: objects/ui_ParameterWidget.h:155
-msgid "-"
+#: src/parameter/ParameterWidget.cc:76
+msgid ""
+"The changes on the current preset %1 are not saved yet. Do you really want "
+"to reset this preset and lose your changes?"
 msgstr ""
 
-#: objects/ui_ParameterWidget.h:157
-#, fuzzy
-msgid "preset selection"
-msgstr "keine Voreinstellung ausgewählt"
-
-#: objects/ui_ParameterWidget.h:160 src/parameter/ParameterWidget.cc:132
-msgid "add new preset"
-msgstr "neue Voreinstellung hinzufügen"
-
-#: objects/ui_ParameterWidget.h:162
-msgid "+"
-msgstr ""
-
-#: objects/ui_ParameterWidget.h:163
-#, fuzzy
-msgid "Automatic Preview"
-msgstr "&Automatisch neu Laden und Vorschau"
-
-#: objects/ui_ParameterWidget.h:166
-#, fuzzy
-msgid "Show Details"
-msgstr "Koordinaten&achsen anzeigen"
-
-#: objects/ui_ParameterWidget.h:167
-msgid "Inline Details"
-msgstr ""
-
-#: objects/ui_ParameterWidget.h:168
-#, fuzzy
-msgid "Hide Details"
-msgstr "Symbolleisten verstecken"
-
-#: objects/ui_ParameterWidget.h:169
-msgid "Description Only"
-msgstr ""
-
-#: objects/ui_ParameterWidget.h:172
-msgid "reset the parameters to the selected preset"
-msgstr ""
-
-#: objects/ui_ParameterWidget.h:174
-#, fuzzy
-msgid "Reset"
-msgstr "Ans&icht zurücksetzen"
-
-#: src/parameter/ParameterWidget.cc:134
+#: src/parameter/ParameterWidget.cc:156
 msgid "remove current preset"
 msgstr "aktuelle Voreinstellung löschen"
 
-#: src/parameter/ParameterWidget.cc:136
+#: src/parameter/ParameterWidget.cc:158
 msgid "save current preset"
 msgstr "aktuelle Voreinstellung speichern"
 
-#: src/parameter/ParameterWidget.cc:138 src/parameter/ParameterWidget.cc:139
-#: src/parameter/ParameterWidget.cc:140
+#: src/parameter/ParameterWidget.cc:160 src/parameter/ParameterWidget.cc:161
+#: src/parameter/ParameterWidget.cc:162
 msgid "JSON file read only"
 msgstr "JSON file ist nicht schreibbar"
 
-#: src/parameter/ParameterWidget.cc:165
+#: src/parameter/ParameterWidget.cc:202
 msgid "no preset selected"
 msgstr "keine Voreinstellung ausgewählt"
 
-#: src/parameter/ParameterWidget.cc:380
+#: src/parameter/ParameterWidget.cc:220
+msgid ""
+"The current preset %1 contains changes, but is not saved yet. Do you really "
+"want to change the preset and lose your changes?"
+msgstr ""
+
+#: src/parameter/ParameterWidget.cc:449
 msgid "Create new set of parameter"
 msgstr "Einen neuen Satz Voreinstellung erzeugen"
 
-#: src/parameter/ParameterWidget.cc:380
+#: src/parameter/ParameterWidget.cc:449
 msgid "Enter name of the parameter set"
 msgstr "Bitte einen Namen für diese Voreinstellung eingeben"
 
-#: src/parameter/ParameterWidget.cc:407
+#: src/parameter/ParameterWidget.cc:485
 msgid "Saving presets"
 msgstr "Voreinstellung speichern"
 
-#: src/parameter/ParameterWidget.cc:408
-msgid "%1 was found, but was unreadble. Do you want to overwrite %1?"
+#: src/parameter/ParameterWidget.cc:486
+#, fuzzy
+msgid "%1 was found, but was unreadable. Do you want to overwrite %1?"
 msgstr ""
 "%1 wurde gefunden, konnte aber nicht gelesen werden. Möchten Sie %1 "
 "überschreiben?"
@@ -1383,12 +1405,12 @@ msgid "Old"
 msgstr "Frühere"
 
 #. (itstool) path: component/summary
-#: openscad.appdata.xml.in:7
+#: openscad.appdata.xml.in:6
 msgid "The Programmers Solid 3D CAD Modeller"
 msgstr ""
 
 #. (itstool) path: description/p
-#: openscad.appdata.xml.in:9
+#: openscad.appdata.xml.in:19
 msgid ""
 "OpenSCAD is a software for creating solid 3D CAD models. Unlike most free "
 "software for creating 3D models (such as Blender) it does not focus on the "
@@ -1399,7 +1421,7 @@ msgid ""
 msgstr ""
 
 #. (itstool) path: description/p
-#: openscad.appdata.xml.in:10
+#: openscad.appdata.xml.in:20
 msgid ""
 "OpenSCAD is not an interactive modeller. Instead it is something like a 3D-"
 "compiler that reads in a script file that describes the object and renders "
@@ -1410,15 +1432,35 @@ msgid ""
 msgstr ""
 
 #. (itstool) path: description/p
-#: openscad.appdata.xml.in:11
+#: openscad.appdata.xml.in:21
 msgid ""
 "OpenSCAD provides two main modelling techniques: First there is constructive "
 "solid geometry (aka CSG) and second there is extrusion of 2D outlines. As "
-"data exchange format format for this 2D outlines Autocad DXF files are used. "
-"In addition to 2D paths for extrusion it is also possible to read design "
+"data exchange format for this 2D outlines Autocad DXF files are used. In "
+"addition to 2D paths for extrusion it is also possible to read design "
 "parameters from DXF files. Besides DXF files OpenSCAD can read and create 3D "
 "models in the STL and OFF file formats."
 msgstr ""
+
+#, fuzzy
+#~ msgid "Reset Trim"
+#~ msgstr "Ans&icht zurücksetzen"
+
+#, fuzzy
+#~ msgid "Rotation"
+#~ msgstr "&Dokumentation"
+
+#, fuzzy
+#~ msgid "Zoom"
+#~ msgstr "Vergrößern"
+
+#, fuzzy
+#~ msgid "ViewPort rel.<br/>Translation"
+#~ msgstr "Aktuelle Versch&iebung einfügen"
+
+#, fuzzy
+#~ msgid "SpaceNav"
+#~ msgstr "Leerzeichen"
 
 #~ msgid "<"
 #~ msgstr "<"

--- a/locale/de.po
+++ b/locale/de.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: OpenSCAD 2014.01.05\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2018-08-15 13:13+0200\n"
+"POT-Creation-Date: 2018-08-15 15:07+0200\n"
 "PO-Revision-Date: 2018-03-01 07:41+0100\n"
 "Last-Translator: Torsten Paul <Torsten.Paul@gmx.de>\n"
 "Language-Team: German\n"
@@ -848,7 +848,9 @@ msgstr "Einstellungen"
 msgid "3D View"
 msgstr "3D Ansicht"
 
-#: objects/ui_Preferences.h:1096 examples/examples.json:19
+#: objects/ui_Preferences.h:1096
+#, fuzzy
+msgctxt "preferences"
 msgid "Advanced"
 msgstr "Erweitert"
 
@@ -1395,6 +1397,10 @@ msgstr "Grundlagen"
 #: examples/examples.json:13
 msgid "Functions"
 msgstr "Funktionen"
+
+#: examples/examples.json:19
+msgid "Advanced"
+msgstr "Erweitert"
 
 #: examples/examples.json:28
 msgid "Parametric"

--- a/locale/es.po
+++ b/locale/es.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: OpenSCAD 2015.03\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2018-03-01 07:52+0100\n"
+"POT-Creation-Date: 2018-08-15 13:13+0200\n"
 "PO-Revision-Date: 2016-04-13 01:56-0300\n"
 "Last-Translator: Javier del Álamo <javialamo+github@gmail.com>\n"
 "Language-Team: Español\n"
@@ -806,290 +806,367 @@ msgstr "Mostrar este mensaje nuevamente"
 msgid "Close"
 msgstr "Cerrar"
 
-#: objects/ui_Preferences.h:1080
+#: objects/ui_ParameterEntryWidget.h:339 objects/ui_ParameterWidget.h:150
+msgid "Form"
+msgstr "Formulario"
+
+#: objects/ui_ParameterEntryWidget.h:341
+#, fuzzy
+msgid "Parameter"
+msgstr "Ocultar parámetros"
+
+#: objects/ui_ParameterEntryWidget.h:342 objects/ui_ParameterEntryWidget.h:343
+msgid "Description"
+msgstr ""
+
+#: objects/ui_ParameterWidget.h:151
+msgid "save preset"
+msgstr ""
+
+#: objects/ui_ParameterWidget.h:153
+msgid "delete current preset"
+msgstr ""
+
+#: objects/ui_ParameterWidget.h:155
+msgid "-"
+msgstr ""
+
+#: objects/ui_ParameterWidget.h:157
+msgid "preset selection"
+msgstr ""
+
+#: objects/ui_ParameterWidget.h:160 src/parameter/ParameterWidget.cc:154
+msgid "add new preset"
+msgstr ""
+
+#: objects/ui_ParameterWidget.h:162
+msgid "+"
+msgstr ""
+
+#: objects/ui_ParameterWidget.h:163
+#, fuzzy
+msgid "Automatic Preview"
+msgstr "Recargar y previsualizar automáticamente"
+
+#: objects/ui_ParameterWidget.h:166
+#, fuzzy
+msgid "Show Details"
+msgstr "Mostrar ejes"
+
+#: objects/ui_ParameterWidget.h:167
+msgid "Inline Details"
+msgstr ""
+
+#: objects/ui_ParameterWidget.h:168
+#, fuzzy
+msgid "Hide Details"
+msgstr "Ocultar barra de herramientas"
+
+#: objects/ui_ParameterWidget.h:169
+msgid "Description Only"
+msgstr ""
+
+#: objects/ui_ParameterWidget.h:172
+msgid "reset the parameters to the selected preset"
+msgstr ""
+
+#: objects/ui_ParameterWidget.h:174
+#, fuzzy
+msgid "Reset"
+msgstr "Reiniciar vista"
+
+#: objects/ui_Preferences.h:1094
 msgid "Preferences"
 msgstr "Preferencias"
 
-#: objects/ui_Preferences.h:1081
+#: objects/ui_Preferences.h:1095
 msgid "3D View"
 msgstr "Vista 3D"
 
-#: objects/ui_Preferences.h:1082 examples/examples.json:19
+#: objects/ui_Preferences.h:1096 examples/examples.json:19
 msgid "Advanced"
 msgstr "Avanzado"
 
-#: objects/ui_Preferences.h:1083 src/mainwin.cc:2518
+#: objects/ui_Preferences.h:1097 src/mainwin.cc:2532
 msgid "Editor"
 msgstr "Editar"
 
-#: objects/ui_Preferences.h:1084
+#: objects/ui_Preferences.h:1098
 msgid "Update"
 msgstr "Actualizar"
 
-#: objects/ui_Preferences.h:1085 objects/ui_Preferences.h:1168
+#: objects/ui_Preferences.h:1099 objects/ui_Preferences.h:1182
 msgid "Features"
 msgstr "Características"
 
-#: objects/ui_Preferences.h:1087
+#: objects/ui_Preferences.h:1101
 msgid "Enable/Disable experimental features"
 msgstr "Activar/Desactivar características experimentales"
 
-#: objects/ui_Preferences.h:1089
+#: objects/ui_Preferences.h:1103
 msgid "Color scheme:"
 msgstr "Paleta de colores:"
 
-#: objects/ui_Preferences.h:1090
+#: objects/ui_Preferences.h:1104
 msgid "Show Warnings and Errors in 3D View"
 msgstr "Mostrar errores y advertencias en la vista 3D"
 
-#: objects/ui_Preferences.h:1091
+#: objects/ui_Preferences.h:1105
 msgid "Editor Type"
 msgstr "Editor de texto"
 
-#: objects/ui_Preferences.h:1094
+#: objects/ui_Preferences.h:1108
 msgid "Simple Editor"
 msgstr "Editor simple"
 
-#: objects/ui_Preferences.h:1095
+#: objects/ui_Preferences.h:1109
 msgid "QScintilla Editor"
 msgstr "Editor QScintilla"
 
-#: objects/ui_Preferences.h:1097
+#: objects/ui_Preferences.h:1111
 msgid "(requires restart)"
 msgstr "(necesita reiniciar)"
 
-#: objects/ui_Preferences.h:1098
+#: objects/ui_Preferences.h:1112
 msgid "Font"
 msgstr "Fuente"
 
-#: objects/ui_Preferences.h:1099
+#: objects/ui_Preferences.h:1113
 msgid "Color syntax highlighting"
 msgstr "Colorear sintaxis"
 
-#: objects/ui_Preferences.h:1100
+#: objects/ui_Preferences.h:1114
 msgid "Ctrl/Cmd-Mouse-wheel zooms text"
 msgstr "Ctrl/Cmd + la rueda del mouse para hacer zoom al texto"
 
-#: objects/ui_Preferences.h:1101
+#: objects/ui_Preferences.h:1115
 msgid "Indentation"
 msgstr "Indentación"
 
-#: objects/ui_Preferences.h:1102
+#: objects/ui_Preferences.h:1116
 msgid "Auto Indent"
 msgstr "Sangría automática"
 
-#: objects/ui_Preferences.h:1103
+#: objects/ui_Preferences.h:1117
 msgid "Backspace unindents"
 msgstr ""
 
-#: objects/ui_Preferences.h:1104
+#: objects/ui_Preferences.h:1118
 msgid "Indent using"
 msgstr "Indentar usando"
 
-#: objects/ui_Preferences.h:1107 src/settings.cc:141
+#: objects/ui_Preferences.h:1121 src/settings.cc:141
 msgid "Spaces"
 msgstr "Espacio"
 
-#: objects/ui_Preferences.h:1108 src/settings.cc:141
+#: objects/ui_Preferences.h:1122 src/settings.cc:141
 msgid "Tabs"
 msgstr "Pestañas"
 
-#: objects/ui_Preferences.h:1110
+#: objects/ui_Preferences.h:1124
 msgid "Indentation width"
 msgstr "Ancho de indentado"
 
-#: objects/ui_Preferences.h:1111
+#: objects/ui_Preferences.h:1125
 msgid "Tab width"
 msgstr "Ancho de la pestaña"
 
-#: objects/ui_Preferences.h:1112
+#: objects/ui_Preferences.h:1126
 msgid "Tab key function"
 msgstr "Atajo de pestaña"
 
-#: objects/ui_Preferences.h:1115 objects/ui_Preferences.h:1146
+#: objects/ui_Preferences.h:1129 objects/ui_Preferences.h:1160
 #: src/settings.cc:142
 msgid "Indent"
 msgstr "Indentar"
 
-#: objects/ui_Preferences.h:1116 src/settings.cc:142
+#: objects/ui_Preferences.h:1130 src/settings.cc:142
 msgid "Insert Tab"
 msgstr "Insertar pestaña"
 
-#: objects/ui_Preferences.h:1118
+#: objects/ui_Preferences.h:1132
 msgid "Show whitespace"
 msgstr "Mostrar espacios en blanco"
 
-#: objects/ui_Preferences.h:1121 src/settings.cc:137
+#: objects/ui_Preferences.h:1135 src/settings.cc:137
 msgid "Never"
 msgstr "Nunca"
 
-#: objects/ui_Preferences.h:1122 src/settings.cc:137
+#: objects/ui_Preferences.h:1136 src/settings.cc:137
 msgid "Always"
 msgstr "Siempre"
 
-#: objects/ui_Preferences.h:1123
+#: objects/ui_Preferences.h:1137
 msgid "Only after indentation"
 msgstr "Sólo después de la indentación"
 
-#: objects/ui_Preferences.h:1125
+#: objects/ui_Preferences.h:1139
 msgid "Size"
 msgstr "Tamaño"
 
-#: objects/ui_Preferences.h:1126
+#: objects/ui_Preferences.h:1140
 msgid "Display"
 msgstr "Mostrar"
 
-#: objects/ui_Preferences.h:1127
+#: objects/ui_Preferences.h:1141
 msgid "Enable brace matching"
 msgstr "Habilitar alineamiento forzado"
 
-#: objects/ui_Preferences.h:1128
+#: objects/ui_Preferences.h:1142
 msgid "Highlight current line"
 msgstr "Marcar línea actual"
 
-#: objects/ui_Preferences.h:1129
+#: objects/ui_Preferences.h:1143
 msgid "Display Line Numbers"
 msgstr ""
 
-#: objects/ui_Preferences.h:1130 objects/ui_Preferences.h:1163
+#: objects/ui_Preferences.h:1144 objects/ui_Preferences.h:1177
 msgid "Line wrap"
 msgstr "Ajuste de línea"
 
-#: objects/ui_Preferences.h:1133 objects/ui_Preferences.h:1150
-#: objects/ui_Preferences.h:1158 src/settings.cc:132 src/settings.cc:135
+#: objects/ui_Preferences.h:1147 objects/ui_Preferences.h:1164
+#: objects/ui_Preferences.h:1172 src/settings.cc:132 src/settings.cc:135
 #: src/settings.cc:136
 msgid "None"
 msgstr "Nada"
 
-#: objects/ui_Preferences.h:1134 src/settings.cc:132
+#: objects/ui_Preferences.h:1148 src/settings.cc:132
 msgid "Wrap at character boundaries"
 msgstr "Ajustar a los límites de caracteres"
 
-#: objects/ui_Preferences.h:1135 src/settings.cc:132
+#: objects/ui_Preferences.h:1149 src/settings.cc:132
 msgid "Wrap at word boundaries"
 msgstr "Ajustar a los límites de las palabras"
 
-#: objects/ui_Preferences.h:1137
+#: objects/ui_Preferences.h:1151
 msgid "Line wrap indentation"
 msgstr "Ajuste de línea en el sangrado"
 
-#: objects/ui_Preferences.h:1138
+#: objects/ui_Preferences.h:1152
 msgid "Line wrap visualization"
 msgstr "Visualización del ajuste de línea"
 
-#: objects/ui_Preferences.h:1139
+#: objects/ui_Preferences.h:1153
 msgid "Style"
 msgstr "Estilo"
 
-#: objects/ui_Preferences.h:1142 src/settings.cc:133
+#: objects/ui_Preferences.h:1156 src/settings.cc:133
 msgid "Fixed"
 msgstr "Ajustar"
 
-#: objects/ui_Preferences.h:1143 src/settings.cc:133
+#: objects/ui_Preferences.h:1157 src/settings.cc:133
 msgid "Same"
 msgstr "Mismo"
 
-#: objects/ui_Preferences.h:1144 src/settings.cc:133
+#: objects/ui_Preferences.h:1158 src/settings.cc:133
 msgid "Indented"
 msgstr "Sangrado"
 
-#: objects/ui_Preferences.h:1147
+#: objects/ui_Preferences.h:1161
 msgid "Start"
 msgstr "Inicio"
 
-#: objects/ui_Preferences.h:1151 objects/ui_Preferences.h:1159
+#: objects/ui_Preferences.h:1165 objects/ui_Preferences.h:1173
 #: src/settings.cc:135 src/settings.cc:136
 msgid "Text"
 msgstr "Texto"
 
-#: objects/ui_Preferences.h:1152 objects/ui_Preferences.h:1160
+#: objects/ui_Preferences.h:1166 objects/ui_Preferences.h:1174
 #: src/settings.cc:135 src/settings.cc:136
 msgid "Border"
 msgstr "Borde"
 
-#: objects/ui_Preferences.h:1153 objects/ui_Preferences.h:1161
+#: objects/ui_Preferences.h:1167 objects/ui_Preferences.h:1175
 #: src/settings.cc:135 src/settings.cc:136
 msgid "Margin"
 msgstr "Margen"
 
-#: objects/ui_Preferences.h:1155
+#: objects/ui_Preferences.h:1169
 msgid "End"
 msgstr "Final"
 
-#: objects/ui_Preferences.h:1164
+#: objects/ui_Preferences.h:1178
 msgid "Automatically check for updates"
 msgstr "Comprobar automáticamente actualizaciones"
 
-#: objects/ui_Preferences.h:1165
+#: objects/ui_Preferences.h:1179
 msgid "Include development snapshots"
 msgstr "Incluir las versiones en desarrollo"
 
-#: objects/ui_Preferences.h:1166
+#: objects/ui_Preferences.h:1180
 msgid "Check Now"
 msgstr "Comprobar ahora"
 
-#: objects/ui_Preferences.h:1167
+#: objects/ui_Preferences.h:1181
 msgid "Last checked: "
 msgstr "Última verificación:"
 
-#: objects/ui_Preferences.h:1169
+#: objects/ui_Preferences.h:1183
 msgid "OpenCSG"
 msgstr "OpenCSG"
 
-#: objects/ui_Preferences.h:1170
+#: objects/ui_Preferences.h:1184
 msgid "Show capability warning"
 msgstr "Mostrar advertencias de capacidad"
 
-#: objects/ui_Preferences.h:1171
+#: objects/ui_Preferences.h:1185
 msgid "Enable for OpenGL 1.x"
 msgstr "Activar OpenGL 1.x"
 
-#: objects/ui_Preferences.h:1172
+#: objects/ui_Preferences.h:1186
 msgid "Turn off rendering at "
 msgstr "Desactivar el render en "
 
-#: objects/ui_Preferences.h:1173
+#: objects/ui_Preferences.h:1187
 msgid "elements"
 msgstr "elementos"
 
-#: objects/ui_Preferences.h:1174
+#: objects/ui_Preferences.h:1188
 msgid "Force Goldfeather"
 msgstr "Forzar Goldfeather"
 
-#: objects/ui_Preferences.h:1175
+#: objects/ui_Preferences.h:1189
 msgid "CGAL Cache size"
 msgstr "Tamaño de caché de CGAL"
 
-#: objects/ui_Preferences.h:1176 objects/ui_Preferences.h:1178
+#: objects/ui_Preferences.h:1190 objects/ui_Preferences.h:1192
 msgid "bytes"
 msgstr "bytes"
 
-#: objects/ui_Preferences.h:1177
+#: objects/ui_Preferences.h:1191
 msgid "PolySet Cache size"
 msgstr "Tamaño de caché de PolySet"
 
-#: objects/ui_Preferences.h:1179
+#: objects/ui_Preferences.h:1193
 msgid "Allow opening multiple documents"
 msgstr "Permitir abrir varios documentos"
 
-#: objects/ui_Preferences.h:1180
+#: objects/ui_Preferences.h:1194
 msgid "Enable docking of Editor and Console in different places"
 msgstr "Habilitar soporte de editor y consola en diferentes lugares"
 
-#: objects/ui_Preferences.h:1181
+#: objects/ui_Preferences.h:1195
 msgid "Enable undocking of Editor and Console to separate windows"
 msgstr ""
 "Habilitar el desacoplamiento de editor y consola para separar las ventanas"
 
-#: objects/ui_Preferences.h:1182
+#: objects/ui_Preferences.h:1196
 msgid "Show Welcome Screen"
 msgstr "Mostrar pantalla de bienvenida"
 
-#: objects/ui_Preferences.h:1183
+#: objects/ui_Preferences.h:1197
 msgid "Enable user interface localization (requires restart of OpenSCAD)"
 msgstr ""
 "Habilitar adaptación local de la interfaz de usuario (necesita reiniciar "
 "OpenSCAD)"
+
+#: objects/ui_Preferences.h:1198
+msgid "Bring window to front after automatic reload"
+msgstr ""
+
+#: objects/ui_Preferences.h:1199
+msgid "Play sound notification on render complete"
+msgstr ""
 
 #: objects/ui_ProgressWidget.h:72
 msgid "%v / %m"
@@ -1114,52 +1191,52 @@ msgstr ""
 msgid "ERROR: \"%s\" write error. (Disk full?)"
 msgstr ""
 
-#: src/mainwin.cc:788 src/mainwin.cc:1438
+#: src/mainwin.cc:789 src/mainwin.cc:1443
 msgid "Untitled.scad"
 msgstr "Sintitulo.scad"
 
-#: src/mainwin.cc:1027
+#: src/mainwin.cc:1032
 msgid "Compile error."
 msgstr "Error de compilación"
 
-#: src/mainwin.cc:1030
+#: src/mainwin.cc:1035
 msgid "Error while compiling '%1'."
 msgstr "Error durante la compilación '%1'."
 
-#: src/mainwin.cc:1034
+#: src/mainwin.cc:1039
 #, fuzzy
 msgid "Compilation generated %1 warning."
 msgid_plural "Compilation generated %1 warnings."
 msgstr[0] "La compilación generó %1 advertencia"
 msgstr[1] "La compilación generó %1 advertencias"
 
-#: src/mainwin.cc:1044
+#: src/mainwin.cc:1049
 msgid " For details see <a href=\"#console\">console window</a>."
 msgstr ""
 " Para más detalles vea la <a href=\"#console\">ventana de la consola</a>."
 
-#: src/mainwin.cc:1416
+#: src/mainwin.cc:1421
 msgid "Failed to open file for writing"
 msgstr ""
 
-#: src/mainwin.cc:1426
+#: src/mainwin.cc:1431
 #, c-format
 msgid "Saved design '%s'."
 msgstr ""
 
-#: src/mainwin.cc:1429
+#: src/mainwin.cc:1434
 msgid "Error saving design"
 msgstr ""
 
-#: src/mainwin.cc:1437
+#: src/mainwin.cc:1442
 msgid "Save File"
 msgstr "Guardar archivo"
 
-#: src/mainwin.cc:1439
+#: src/mainwin.cc:1444
 msgid "OpenSCAD Designs (*.scad)"
 msgstr "Diseños OpenSCAD (*.scad)"
 
-#: src/mainwin.cc:1449
+#: src/mainwin.cc:1454
 msgid ""
 "%1 already exists.\n"
 "Do you want to replace it?"
@@ -1167,11 +1244,11 @@ msgstr ""
 "%1 ya existe.\n"
 "Desea reemplazarlo?"
 
-#: src/mainwin.cc:1796
+#: src/mainwin.cc:1805
 msgid "Application"
 msgstr "Aplicación"
 
-#: src/mainwin.cc:1797
+#: src/mainwin.cc:1806
 msgid ""
 "The document has been modified.\n"
 "Do you really want to reload the file?"
@@ -1179,56 +1256,56 @@ msgstr ""
 "El documento ha sido modificado.\n"
 "¿Realmente desea volver a cargar el archivo?"
 
-#: src/mainwin.cc:2171
+#: src/mainwin.cc:2185
 msgid "Export %1 File"
 msgstr "Exportar el archivo %1"
 
-#: src/mainwin.cc:2172
+#: src/mainwin.cc:2186
 msgid "%1 Files (*%2)"
 msgstr "%1 Archivos (*%2)"
 
-#: src/mainwin.cc:2173
+#: src/mainwin.cc:2187
 msgid "Untitled"
 msgstr "Sin título"
 
-#: src/mainwin.cc:2225
+#: src/mainwin.cc:2239
 msgid "Export CSG File"
 msgstr "Exportar archivo CSG"
 
-#: src/mainwin.cc:2226
+#: src/mainwin.cc:2240
 msgid "Untitled.csg"
 msgstr "Sintitulo.csg"
 
-#: src/mainwin.cc:2227
+#: src/mainwin.cc:2241
 msgid "CSG Files (*.csg)"
 msgstr "Archivos CSG (*.csg)"
 
-#: src/mainwin.cc:2253
+#: src/mainwin.cc:2267
 #, fuzzy
 msgid "Untitled.png"
 msgstr "Sintitulo.csg"
 
-#: src/mainwin.cc:2255
+#: src/mainwin.cc:2269
 msgid "Export Image"
 msgstr "Exportar una imagen"
 
-#: src/mainwin.cc:2255
+#: src/mainwin.cc:2269
 msgid "PNG Files (*.png)"
 msgstr "Archivos PNG (*.png)"
 
-#: src/mainwin.cc:2523
+#: src/mainwin.cc:2537
 msgid "Console"
 msgstr "Consola"
 
-#: src/mainwin.cc:2528
+#: src/mainwin.cc:2542
 msgid "Customizer"
 msgstr ""
 
-#: src/mainwin.cc:2672
+#: src/mainwin.cc:2686
 msgid "The document has been modified."
 msgstr "El documento ha sido modificado."
 
-#: src/mainwin.cc:2673
+#: src/mainwin.cc:2687
 msgid "Do you want to save your changes?"
 msgstr "¿Desea guardar los cambios?"
 
@@ -1297,106 +1374,53 @@ msgstr ""
 msgid "After indentation"
 msgstr "Antes del indentado"
 
-#: objects/ui_ParameterEntryWidget.h:343 objects/ui_ParameterWidget.h:150
-msgid "Form"
-msgstr "Formulario"
-
-#: objects/ui_ParameterEntryWidget.h:345
-#, fuzzy
-msgid "Parameter"
-msgstr "Ocultar parámetros"
-
-#: objects/ui_ParameterEntryWidget.h:346 objects/ui_ParameterEntryWidget.h:347
-msgid "Description"
+#: src/parameter/ParameterWidget.cc:74 src/parameter/ParameterWidget.cc:218
+msgid "changes on current preset not saved"
 msgstr ""
 
-#: objects/ui_ParameterWidget.h:151
-msgid "save preset"
+#: src/parameter/ParameterWidget.cc:76
+msgid ""
+"The changes on the current preset %1 are not saved yet. Do you really want "
+"to reset this preset and lose your changes?"
 msgstr ""
 
-#: objects/ui_ParameterWidget.h:153
-msgid "delete current preset"
-msgstr ""
-
-#: objects/ui_ParameterWidget.h:155
-msgid "-"
-msgstr ""
-
-#: objects/ui_ParameterWidget.h:157
-msgid "preset selection"
-msgstr ""
-
-#: objects/ui_ParameterWidget.h:160 src/parameter/ParameterWidget.cc:132
-msgid "add new preset"
-msgstr ""
-
-#: objects/ui_ParameterWidget.h:162
-msgid "+"
-msgstr ""
-
-#: objects/ui_ParameterWidget.h:163
-#, fuzzy
-msgid "Automatic Preview"
-msgstr "Recargar y previsualizar automáticamente"
-
-#: objects/ui_ParameterWidget.h:166
-#, fuzzy
-msgid "Show Details"
-msgstr "Mostrar ejes"
-
-#: objects/ui_ParameterWidget.h:167
-msgid "Inline Details"
-msgstr ""
-
-#: objects/ui_ParameterWidget.h:168
-#, fuzzy
-msgid "Hide Details"
-msgstr "Ocultar barra de herramientas"
-
-#: objects/ui_ParameterWidget.h:169
-msgid "Description Only"
-msgstr ""
-
-#: objects/ui_ParameterWidget.h:172
-msgid "reset the parameters to the selected preset"
-msgstr ""
-
-#: objects/ui_ParameterWidget.h:174
-#, fuzzy
-msgid "Reset"
-msgstr "Reiniciar vista"
-
-#: src/parameter/ParameterWidget.cc:134
+#: src/parameter/ParameterWidget.cc:156
 msgid "remove current preset"
 msgstr ""
 
-#: src/parameter/ParameterWidget.cc:136
+#: src/parameter/ParameterWidget.cc:158
 msgid "save current preset"
 msgstr ""
 
-#: src/parameter/ParameterWidget.cc:138 src/parameter/ParameterWidget.cc:139
-#: src/parameter/ParameterWidget.cc:140
+#: src/parameter/ParameterWidget.cc:160 src/parameter/ParameterWidget.cc:161
+#: src/parameter/ParameterWidget.cc:162
 msgid "JSON file read only"
 msgstr ""
 
-#: src/parameter/ParameterWidget.cc:165
+#: src/parameter/ParameterWidget.cc:202
 msgid "no preset selected"
 msgstr ""
 
-#: src/parameter/ParameterWidget.cc:380
+#: src/parameter/ParameterWidget.cc:220
+msgid ""
+"The current preset %1 contains changes, but is not saved yet. Do you really "
+"want to change the preset and lose your changes?"
+msgstr ""
+
+#: src/parameter/ParameterWidget.cc:449
 msgid "Create new set of parameter"
 msgstr ""
 
-#: src/parameter/ParameterWidget.cc:380
+#: src/parameter/ParameterWidget.cc:449
 msgid "Enter name of the parameter set"
 msgstr ""
 
-#: src/parameter/ParameterWidget.cc:407
+#: src/parameter/ParameterWidget.cc:485
 msgid "Saving presets"
 msgstr ""
 
-#: src/parameter/ParameterWidget.cc:408
-msgid "%1 was found, but was unreadble. Do you want to overwrite %1?"
+#: src/parameter/ParameterWidget.cc:486
+msgid "%1 was found, but was unreadable. Do you want to overwrite %1?"
 msgstr ""
 
 #: examples/examples.json:2
@@ -1416,12 +1440,12 @@ msgid "Old"
 msgstr "Viejo"
 
 #. (itstool) path: component/summary
-#: openscad.appdata.xml.in:7
+#: openscad.appdata.xml.in:6
 msgid "The Programmers Solid 3D CAD Modeller"
 msgstr ""
 
 #. (itstool) path: description/p
-#: openscad.appdata.xml.in:9
+#: openscad.appdata.xml.in:19
 msgid ""
 "OpenSCAD is a software for creating solid 3D CAD models. Unlike most free "
 "software for creating 3D models (such as Blender) it does not focus on the "
@@ -1432,7 +1456,7 @@ msgid ""
 msgstr ""
 
 #. (itstool) path: description/p
-#: openscad.appdata.xml.in:10
+#: openscad.appdata.xml.in:20
 msgid ""
 "OpenSCAD is not an interactive modeller. Instead it is something like a 3D-"
 "compiler that reads in a script file that describes the object and renders "
@@ -1443,15 +1467,35 @@ msgid ""
 msgstr ""
 
 #. (itstool) path: description/p
-#: openscad.appdata.xml.in:11
+#: openscad.appdata.xml.in:21
 msgid ""
 "OpenSCAD provides two main modelling techniques: First there is constructive "
 "solid geometry (aka CSG) and second there is extrusion of 2D outlines. As "
-"data exchange format format for this 2D outlines Autocad DXF files are used. "
-"In addition to 2D paths for extrusion it is also possible to read design "
+"data exchange format for this 2D outlines Autocad DXF files are used. In "
+"addition to 2D paths for extrusion it is also possible to read design "
 "parameters from DXF files. Besides DXF files OpenSCAD can read and create 3D "
 "models in the STL and OFF file formats."
 msgstr ""
+
+#, fuzzy
+#~ msgid "Reset Trim"
+#~ msgstr "Reiniciar vista"
+
+#, fuzzy
+#~ msgid "Rotation"
+#~ msgstr "Documentación"
+
+#, fuzzy
+#~ msgid "Zoom"
+#~ msgstr "Acercar"
+
+#, fuzzy
+#~ msgid "ViewPort rel.<br/>Translation"
+#~ msgstr "Peg&ar traslado de la ventana"
+
+#, fuzzy
+#~ msgid "SpaceNav"
+#~ msgstr "Espacio"
 
 #~ msgid "<"
 #~ msgstr "<"

--- a/locale/es.po
+++ b/locale/es.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: OpenSCAD 2015.03\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2018-08-15 13:13+0200\n"
+"POT-Creation-Date: 2018-08-15 15:07+0200\n"
 "PO-Revision-Date: 2016-04-13 01:56-0300\n"
 "Last-Translator: Javier del Álamo <javialamo+github@gmail.com>\n"
 "Language-Team: Español\n"
@@ -883,7 +883,9 @@ msgstr "Preferencias"
 msgid "3D View"
 msgstr "Vista 3D"
 
-#: objects/ui_Preferences.h:1096 examples/examples.json:19
+#: objects/ui_Preferences.h:1096
+#, fuzzy
+msgctxt "preferences"
 msgid "Advanced"
 msgstr "Avanzado"
 
@@ -1430,6 +1432,10 @@ msgstr "Puntos Básicos"
 #: examples/examples.json:13
 msgid "Functions"
 msgstr "Funciones"
+
+#: examples/examples.json:19
+msgid "Advanced"
+msgstr "Avanzado"
 
 #: examples/examples.json:28
 msgid "Parametric"

--- a/locale/fr.po
+++ b/locale/fr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: OpenSCAD 2013.02.07\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2018-03-01 07:52+0100\n"
+"POT-Creation-Date: 2018-08-15 13:13+0200\n"
 "PO-Revision-Date: 2015-03-05 17:28-0500\n"
 "Last-Translator: Keven Villeneuve <keven.villeneuve@gmail.com>\n"
 "Language-Team: French\n"
@@ -770,290 +770,366 @@ msgstr "Affiche ce message à nouveau"
 msgid "Close"
 msgstr "Fermer"
 
-#: objects/ui_Preferences.h:1080
+#: objects/ui_ParameterEntryWidget.h:339 objects/ui_ParameterWidget.h:150
+msgid "Form"
+msgstr "Formulaire"
+
+#: objects/ui_ParameterEntryWidget.h:341
+msgid "Parameter"
+msgstr ""
+
+#: objects/ui_ParameterEntryWidget.h:342 objects/ui_ParameterEntryWidget.h:343
+msgid "Description"
+msgstr ""
+
+#: objects/ui_ParameterWidget.h:151
+msgid "save preset"
+msgstr ""
+
+#: objects/ui_ParameterWidget.h:153
+msgid "delete current preset"
+msgstr ""
+
+#: objects/ui_ParameterWidget.h:155
+msgid "-"
+msgstr ""
+
+#: objects/ui_ParameterWidget.h:157
+msgid "preset selection"
+msgstr ""
+
+#: objects/ui_ParameterWidget.h:160 src/parameter/ParameterWidget.cc:154
+msgid "add new preset"
+msgstr ""
+
+#: objects/ui_ParameterWidget.h:162
+msgid "+"
+msgstr ""
+
+#: objects/ui_ParameterWidget.h:163
+#, fuzzy
+msgid "Automatic Preview"
+msgstr "Recharger et Aperçu &Automatique"
+
+#: objects/ui_ParameterWidget.h:166
+#, fuzzy
+msgid "Show Details"
+msgstr "Afficher les Axes"
+
+#: objects/ui_ParameterWidget.h:167
+msgid "Inline Details"
+msgstr ""
+
+#: objects/ui_ParameterWidget.h:168
+#, fuzzy
+msgid "Hide Details"
+msgstr "Cacher les boîtes à outils"
+
+#: objects/ui_ParameterWidget.h:169
+msgid "Description Only"
+msgstr ""
+
+#: objects/ui_ParameterWidget.h:172
+msgid "reset the parameters to the selected preset"
+msgstr ""
+
+#: objects/ui_ParameterWidget.h:174
+#, fuzzy
+msgid "Reset"
+msgstr "Réinitialiser la vue"
+
+#: objects/ui_Preferences.h:1094
 msgid "Preferences"
 msgstr "Préférences"
 
-#: objects/ui_Preferences.h:1081
+#: objects/ui_Preferences.h:1095
 msgid "3D View"
 msgstr "&Vue 3D"
 
-#: objects/ui_Preferences.h:1082 examples/examples.json:19
+#: objects/ui_Preferences.h:1096 examples/examples.json:19
 msgid "Advanced"
 msgstr "Avancé"
 
-#: objects/ui_Preferences.h:1083 src/mainwin.cc:2518
+#: objects/ui_Preferences.h:1097 src/mainwin.cc:2532
 msgid "Editor"
 msgstr "Éditeur"
 
-#: objects/ui_Preferences.h:1084
+#: objects/ui_Preferences.h:1098
 msgid "Update"
 msgstr "Mettre à jour"
 
-#: objects/ui_Preferences.h:1085 objects/ui_Preferences.h:1168
+#: objects/ui_Preferences.h:1099 objects/ui_Preferences.h:1182
 msgid "Features"
 msgstr "Fonctionnalités"
 
-#: objects/ui_Preferences.h:1087
+#: objects/ui_Preferences.h:1101
 msgid "Enable/Disable experimental features"
 msgstr "Activer/Désactiver les fonctionnalités expérimentales"
 
-#: objects/ui_Preferences.h:1089
+#: objects/ui_Preferences.h:1103
 msgid "Color scheme:"
 msgstr "Palette de couleurs:"
 
-#: objects/ui_Preferences.h:1090
+#: objects/ui_Preferences.h:1104
 msgid "Show Warnings and Errors in 3D View"
 msgstr "Afficher les Avertissements et les Erreurs dans la fenêtre de rendu"
 
-#: objects/ui_Preferences.h:1091
+#: objects/ui_Preferences.h:1105
 msgid "Editor Type"
 msgstr "Type d'éditeur"
 
-#: objects/ui_Preferences.h:1094
+#: objects/ui_Preferences.h:1108
 msgid "Simple Editor"
 msgstr "Éditeur Simple"
 
-#: objects/ui_Preferences.h:1095
+#: objects/ui_Preferences.h:1109
 msgid "QScintilla Editor"
 msgstr "Éditeur QScintilla"
 
-#: objects/ui_Preferences.h:1097
+#: objects/ui_Preferences.h:1111
 msgid "(requires restart)"
 msgstr "(nécessite un redémarrage)"
 
-#: objects/ui_Preferences.h:1098
+#: objects/ui_Preferences.h:1112
 msgid "Font"
 msgstr "Police"
 
-#: objects/ui_Preferences.h:1099
+#: objects/ui_Preferences.h:1113
 msgid "Color syntax highlighting"
 msgstr "Colorer la coloration syntaxique"
 
-#: objects/ui_Preferences.h:1100
+#: objects/ui_Preferences.h:1114
 msgid "Ctrl/Cmd-Mouse-wheel zooms text"
 msgstr "Ctrl/Cmd-Roulette-Souris agrandit le texte"
 
-#: objects/ui_Preferences.h:1101
+#: objects/ui_Preferences.h:1115
 msgid "Indentation"
 msgstr "Indentation"
 
-#: objects/ui_Preferences.h:1102
+#: objects/ui_Preferences.h:1116
 msgid "Auto Indent"
 msgstr "Indentation Auto"
 
-#: objects/ui_Preferences.h:1103
+#: objects/ui_Preferences.h:1117
 msgid "Backspace unindents"
 msgstr ""
 
-#: objects/ui_Preferences.h:1104
+#: objects/ui_Preferences.h:1118
 msgid "Indent using"
 msgstr "Indenter en utilisant"
 
-#: objects/ui_Preferences.h:1107 src/settings.cc:141
+#: objects/ui_Preferences.h:1121 src/settings.cc:141
 msgid "Spaces"
 msgstr "Espaces"
 
-#: objects/ui_Preferences.h:1108 src/settings.cc:141
+#: objects/ui_Preferences.h:1122 src/settings.cc:141
 msgid "Tabs"
 msgstr "Tabulations"
 
-#: objects/ui_Preferences.h:1110
+#: objects/ui_Preferences.h:1124
 msgid "Indentation width"
 msgstr "Largeur d'Indentation"
 
-#: objects/ui_Preferences.h:1111
+#: objects/ui_Preferences.h:1125
 msgid "Tab width"
 msgstr "Largeur des tabulations"
 
-#: objects/ui_Preferences.h:1112
+#: objects/ui_Preferences.h:1126
 msgid "Tab key function"
 msgstr "Fonction de la touche Tab"
 
-#: objects/ui_Preferences.h:1115 objects/ui_Preferences.h:1146
+#: objects/ui_Preferences.h:1129 objects/ui_Preferences.h:1160
 #: src/settings.cc:142
 msgid "Indent"
 msgstr "Indenter"
 
-#: objects/ui_Preferences.h:1116 src/settings.cc:142
+#: objects/ui_Preferences.h:1130 src/settings.cc:142
 msgid "Insert Tab"
 msgstr "Insérer une Tabulation"
 
-#: objects/ui_Preferences.h:1118
+#: objects/ui_Preferences.h:1132
 msgid "Show whitespace"
 msgstr "Afficher les espaces blancs"
 
-#: objects/ui_Preferences.h:1121 src/settings.cc:137
+#: objects/ui_Preferences.h:1135 src/settings.cc:137
 msgid "Never"
 msgstr "Jamais"
 
-#: objects/ui_Preferences.h:1122 src/settings.cc:137
+#: objects/ui_Preferences.h:1136 src/settings.cc:137
 msgid "Always"
 msgstr "Toujours"
 
-#: objects/ui_Preferences.h:1123
+#: objects/ui_Preferences.h:1137
 msgid "Only after indentation"
 msgstr "Seulement après indentation"
 
-#: objects/ui_Preferences.h:1125
+#: objects/ui_Preferences.h:1139
 msgid "Size"
 msgstr "Taille"
 
-#: objects/ui_Preferences.h:1126
+#: objects/ui_Preferences.h:1140
 msgid "Display"
 msgstr "Afficher"
 
-#: objects/ui_Preferences.h:1127
+#: objects/ui_Preferences.h:1141
 msgid "Enable brace matching"
 msgstr "Activer la correspondance d'accolades"
 
-#: objects/ui_Preferences.h:1128
+#: objects/ui_Preferences.h:1142
 msgid "Highlight current line"
 msgstr "Surligner la ligne courante"
 
-#: objects/ui_Preferences.h:1129
+#: objects/ui_Preferences.h:1143
 msgid "Display Line Numbers"
 msgstr ""
 
-#: objects/ui_Preferences.h:1130 objects/ui_Preferences.h:1163
+#: objects/ui_Preferences.h:1144 objects/ui_Preferences.h:1177
 msgid "Line wrap"
 msgstr "Retour à la ligne"
 
-#: objects/ui_Preferences.h:1133 objects/ui_Preferences.h:1150
-#: objects/ui_Preferences.h:1158 src/settings.cc:132 src/settings.cc:135
+#: objects/ui_Preferences.h:1147 objects/ui_Preferences.h:1164
+#: objects/ui_Preferences.h:1172 src/settings.cc:132 src/settings.cc:135
 #: src/settings.cc:136
 msgid "None"
 msgstr "Aucun"
 
-#: objects/ui_Preferences.h:1134 src/settings.cc:132
+#: objects/ui_Preferences.h:1148 src/settings.cc:132
 msgid "Wrap at character boundaries"
 msgstr "Enveloppez aux limites des caractères"
 
-#: objects/ui_Preferences.h:1135 src/settings.cc:132
+#: objects/ui_Preferences.h:1149 src/settings.cc:132
 msgid "Wrap at word boundaries"
 msgstr "Enveloppez aux limites des mots"
 
-#: objects/ui_Preferences.h:1137
+#: objects/ui_Preferences.h:1151
 msgid "Line wrap indentation"
 msgstr "Indentation des retours à la ligne"
 
-#: objects/ui_Preferences.h:1138
+#: objects/ui_Preferences.h:1152
 msgid "Line wrap visualization"
 msgstr "Visualisation des retours à la ligne"
 
-#: objects/ui_Preferences.h:1139
+#: objects/ui_Preferences.h:1153
 msgid "Style"
 msgstr "Style"
 
-#: objects/ui_Preferences.h:1142 src/settings.cc:133
+#: objects/ui_Preferences.h:1156 src/settings.cc:133
 msgid "Fixed"
 msgstr "Fixé"
 
-#: objects/ui_Preferences.h:1143 src/settings.cc:133
+#: objects/ui_Preferences.h:1157 src/settings.cc:133
 msgid "Same"
 msgstr "Identique"
 
-#: objects/ui_Preferences.h:1144 src/settings.cc:133
+#: objects/ui_Preferences.h:1158 src/settings.cc:133
 msgid "Indented"
 msgstr "Indenté"
 
-#: objects/ui_Preferences.h:1147
+#: objects/ui_Preferences.h:1161
 msgid "Start"
 msgstr "Début"
 
-#: objects/ui_Preferences.h:1151 objects/ui_Preferences.h:1159
+#: objects/ui_Preferences.h:1165 objects/ui_Preferences.h:1173
 #: src/settings.cc:135 src/settings.cc:136
 msgid "Text"
 msgstr "Texte"
 
-#: objects/ui_Preferences.h:1152 objects/ui_Preferences.h:1160
+#: objects/ui_Preferences.h:1166 objects/ui_Preferences.h:1174
 #: src/settings.cc:135 src/settings.cc:136
 msgid "Border"
 msgstr "Bordure"
 
-#: objects/ui_Preferences.h:1153 objects/ui_Preferences.h:1161
+#: objects/ui_Preferences.h:1167 objects/ui_Preferences.h:1175
 #: src/settings.cc:135 src/settings.cc:136
 msgid "Margin"
 msgstr "Marge"
 
-#: objects/ui_Preferences.h:1155
+#: objects/ui_Preferences.h:1169
 msgid "End"
 msgstr "Fin"
 
-#: objects/ui_Preferences.h:1164
+#: objects/ui_Preferences.h:1178
 msgid "Automatically check for updates"
 msgstr "Vérifier les mises à jour automatiquement"
 
-#: objects/ui_Preferences.h:1165
+#: objects/ui_Preferences.h:1179
 msgid "Include development snapshots"
 msgstr "Inclure les versions de développement"
 
-#: objects/ui_Preferences.h:1166
+#: objects/ui_Preferences.h:1180
 msgid "Check Now"
 msgstr "Vérifier Maintenant"
 
-#: objects/ui_Preferences.h:1167
+#: objects/ui_Preferences.h:1181
 msgid "Last checked: "
 msgstr "Dernière vérification:"
 
-#: objects/ui_Preferences.h:1169
+#: objects/ui_Preferences.h:1183
 msgid "OpenCSG"
 msgstr "OpenCSG"
 
-#: objects/ui_Preferences.h:1170
+#: objects/ui_Preferences.h:1184
 msgid "Show capability warning"
 msgstr "Afficher les avertissements de capacité"
 
-#: objects/ui_Preferences.h:1171
+#: objects/ui_Preferences.h:1185
 msgid "Enable for OpenGL 1.x"
 msgstr "Activer pour OpenGL 1.x"
 
-#: objects/ui_Preferences.h:1172
+#: objects/ui_Preferences.h:1186
 msgid "Turn off rendering at "
 msgstr "Désactiver le rendu à"
 
-#: objects/ui_Preferences.h:1173
+#: objects/ui_Preferences.h:1187
 msgid "elements"
 msgstr "éléments"
 
-#: objects/ui_Preferences.h:1174
+#: objects/ui_Preferences.h:1188
 msgid "Force Goldfeather"
 msgstr "Forcer Goldfeather"
 
-#: objects/ui_Preferences.h:1175
+#: objects/ui_Preferences.h:1189
 msgid "CGAL Cache size"
 msgstr "Taille du Cache de CGAL"
 
-#: objects/ui_Preferences.h:1176 objects/ui_Preferences.h:1178
+#: objects/ui_Preferences.h:1190 objects/ui_Preferences.h:1192
 msgid "bytes"
 msgstr "octets"
 
-#: objects/ui_Preferences.h:1177
+#: objects/ui_Preferences.h:1191
 msgid "PolySet Cache size"
 msgstr "Taille du Cache PolySet"
 
-#: objects/ui_Preferences.h:1179
+#: objects/ui_Preferences.h:1193
 msgid "Allow opening multiple documents"
 msgstr "Autoriser l'ouverture de plusieurs documents"
 
-#: objects/ui_Preferences.h:1180
+#: objects/ui_Preferences.h:1194
 msgid "Enable docking of Editor and Console in different places"
 msgstr "Activer l'ancrage de l'Éditeur et de la Console à différents endroits"
 
-#: objects/ui_Preferences.h:1181
+#: objects/ui_Preferences.h:1195
 msgid "Enable undocking of Editor and Console to separate windows"
 msgstr ""
 "Activer désancrage de l'Éditeur et de la Console dans des fenêtres séparés"
 
-#: objects/ui_Preferences.h:1182
+#: objects/ui_Preferences.h:1196
 msgid "Show Welcome Screen"
 msgstr "Affiche l'écran d'accueil"
 
-#: objects/ui_Preferences.h:1183
+#: objects/ui_Preferences.h:1197
 msgid "Enable user interface localization (requires restart of OpenSCAD)"
 msgstr ""
 "Activer la localisation de l'interface utilisateur (Nécessite un redémarrage "
 "d'OpenSCAD)"
+
+#: objects/ui_Preferences.h:1198
+msgid "Bring window to front after automatic reload"
+msgstr ""
+
+#: objects/ui_Preferences.h:1199
+msgid "Play sound notification on render complete"
+msgstr ""
 
 #: objects/ui_ProgressWidget.h:72
 msgid "%v / %m"
@@ -1078,50 +1154,50 @@ msgstr ""
 msgid "ERROR: \"%s\" write error. (Disk full?)"
 msgstr ""
 
-#: src/mainwin.cc:788 src/mainwin.cc:1438
+#: src/mainwin.cc:789 src/mainwin.cc:1443
 msgid "Untitled.scad"
 msgstr "Untitled.scad"
 
-#: src/mainwin.cc:1027
+#: src/mainwin.cc:1032
 msgid "Compile error."
 msgstr "Erreur de Compilation."
 
-#: src/mainwin.cc:1030
+#: src/mainwin.cc:1035
 msgid "Error while compiling '%1'."
 msgstr "Erreur lors de la compilation de '%1'."
 
-#: src/mainwin.cc:1034
+#: src/mainwin.cc:1039
 msgid "Compilation generated %1 warning."
 msgid_plural "Compilation generated %1 warnings."
 msgstr[0] "La compilation a généré %1 avertissement"
 msgstr[1] "La compilation a généré %1 avertissements"
 
-#: src/mainwin.cc:1044
+#: src/mainwin.cc:1049
 msgid " For details see <a href=\"#console\">console window</a>."
 msgstr " Pour détails voir <a href=\"#console\">Fenêtre de la Console</a>."
 
-#: src/mainwin.cc:1416
+#: src/mainwin.cc:1421
 msgid "Failed to open file for writing"
 msgstr ""
 
-#: src/mainwin.cc:1426
+#: src/mainwin.cc:1431
 #, c-format
 msgid "Saved design '%s'."
 msgstr ""
 
-#: src/mainwin.cc:1429
+#: src/mainwin.cc:1434
 msgid "Error saving design"
 msgstr ""
 
-#: src/mainwin.cc:1437
+#: src/mainwin.cc:1442
 msgid "Save File"
 msgstr "Enregistrer le Fichier"
 
-#: src/mainwin.cc:1439
+#: src/mainwin.cc:1444
 msgid "OpenSCAD Designs (*.scad)"
 msgstr "OpenSCAD Designs (*.scad)"
 
-#: src/mainwin.cc:1449
+#: src/mainwin.cc:1454
 msgid ""
 "%1 already exists.\n"
 "Do you want to replace it?"
@@ -1129,11 +1205,11 @@ msgstr ""
 "%1 existe déjà.\n"
 "Voulez-vous le remplacer?"
 
-#: src/mainwin.cc:1796
+#: src/mainwin.cc:1805
 msgid "Application"
 msgstr "Application"
 
-#: src/mainwin.cc:1797
+#: src/mainwin.cc:1806
 msgid ""
 "The document has been modified.\n"
 "Do you really want to reload the file?"
@@ -1141,56 +1217,56 @@ msgstr ""
 "Ce document a été modifié.\n"
 "Voulez-vous vraiment recharger le fichier?"
 
-#: src/mainwin.cc:2171
+#: src/mainwin.cc:2185
 msgid "Export %1 File"
 msgstr "Exporter %1 Fichier"
 
-#: src/mainwin.cc:2172
+#: src/mainwin.cc:2186
 msgid "%1 Files (*%2)"
 msgstr "%1 Fichiers (*%2)"
 
-#: src/mainwin.cc:2173
+#: src/mainwin.cc:2187
 msgid "Untitled"
 msgstr "Sans Titre"
 
-#: src/mainwin.cc:2225
+#: src/mainwin.cc:2239
 msgid "Export CSG File"
 msgstr "Exporter un fichier CSG"
 
-#: src/mainwin.cc:2226
+#: src/mainwin.cc:2240
 msgid "Untitled.csg"
 msgstr "SansTitre.csg"
 
-#: src/mainwin.cc:2227
+#: src/mainwin.cc:2241
 msgid "CSG Files (*.csg)"
 msgstr "Fichiers CSG (*.csg)"
 
-#: src/mainwin.cc:2253
+#: src/mainwin.cc:2267
 #, fuzzy
 msgid "Untitled.png"
 msgstr "SansTitre.csg"
 
-#: src/mainwin.cc:2255
+#: src/mainwin.cc:2269
 msgid "Export Image"
 msgstr "Exporter une Image"
 
-#: src/mainwin.cc:2255
+#: src/mainwin.cc:2269
 msgid "PNG Files (*.png)"
 msgstr "Fichiers PNG (*.png)"
 
-#: src/mainwin.cc:2523
+#: src/mainwin.cc:2537
 msgid "Console"
 msgstr "Console"
 
-#: src/mainwin.cc:2528
+#: src/mainwin.cc:2542
 msgid "Customizer"
 msgstr ""
 
-#: src/mainwin.cc:2672
+#: src/mainwin.cc:2686
 msgid "The document has been modified."
 msgstr "Ce document a été modifié"
 
-#: src/mainwin.cc:2673
+#: src/mainwin.cc:2687
 msgid "Do you want to save your changes?"
 msgstr "Voulez-vous enregistrer vos changements?"
 
@@ -1259,105 +1335,53 @@ msgstr ""
 msgid "After indentation"
 msgstr "Après indentation"
 
-#: objects/ui_ParameterEntryWidget.h:343 objects/ui_ParameterWidget.h:150
-msgid "Form"
-msgstr "Formulaire"
-
-#: objects/ui_ParameterEntryWidget.h:345
-msgid "Parameter"
+#: src/parameter/ParameterWidget.cc:74 src/parameter/ParameterWidget.cc:218
+msgid "changes on current preset not saved"
 msgstr ""
 
-#: objects/ui_ParameterEntryWidget.h:346 objects/ui_ParameterEntryWidget.h:347
-msgid "Description"
+#: src/parameter/ParameterWidget.cc:76
+msgid ""
+"The changes on the current preset %1 are not saved yet. Do you really want "
+"to reset this preset and lose your changes?"
 msgstr ""
 
-#: objects/ui_ParameterWidget.h:151
-msgid "save preset"
-msgstr ""
-
-#: objects/ui_ParameterWidget.h:153
-msgid "delete current preset"
-msgstr ""
-
-#: objects/ui_ParameterWidget.h:155
-msgid "-"
-msgstr ""
-
-#: objects/ui_ParameterWidget.h:157
-msgid "preset selection"
-msgstr ""
-
-#: objects/ui_ParameterWidget.h:160 src/parameter/ParameterWidget.cc:132
-msgid "add new preset"
-msgstr ""
-
-#: objects/ui_ParameterWidget.h:162
-msgid "+"
-msgstr ""
-
-#: objects/ui_ParameterWidget.h:163
-#, fuzzy
-msgid "Automatic Preview"
-msgstr "Recharger et Aperçu &Automatique"
-
-#: objects/ui_ParameterWidget.h:166
-#, fuzzy
-msgid "Show Details"
-msgstr "Afficher les Axes"
-
-#: objects/ui_ParameterWidget.h:167
-msgid "Inline Details"
-msgstr ""
-
-#: objects/ui_ParameterWidget.h:168
-#, fuzzy
-msgid "Hide Details"
-msgstr "Cacher les boîtes à outils"
-
-#: objects/ui_ParameterWidget.h:169
-msgid "Description Only"
-msgstr ""
-
-#: objects/ui_ParameterWidget.h:172
-msgid "reset the parameters to the selected preset"
-msgstr ""
-
-#: objects/ui_ParameterWidget.h:174
-#, fuzzy
-msgid "Reset"
-msgstr "Réinitialiser la vue"
-
-#: src/parameter/ParameterWidget.cc:134
+#: src/parameter/ParameterWidget.cc:156
 msgid "remove current preset"
 msgstr ""
 
-#: src/parameter/ParameterWidget.cc:136
+#: src/parameter/ParameterWidget.cc:158
 msgid "save current preset"
 msgstr ""
 
-#: src/parameter/ParameterWidget.cc:138 src/parameter/ParameterWidget.cc:139
-#: src/parameter/ParameterWidget.cc:140
+#: src/parameter/ParameterWidget.cc:160 src/parameter/ParameterWidget.cc:161
+#: src/parameter/ParameterWidget.cc:162
 msgid "JSON file read only"
 msgstr ""
 
-#: src/parameter/ParameterWidget.cc:165
+#: src/parameter/ParameterWidget.cc:202
 msgid "no preset selected"
 msgstr ""
 
-#: src/parameter/ParameterWidget.cc:380
+#: src/parameter/ParameterWidget.cc:220
+msgid ""
+"The current preset %1 contains changes, but is not saved yet. Do you really "
+"want to change the preset and lose your changes?"
+msgstr ""
+
+#: src/parameter/ParameterWidget.cc:449
 msgid "Create new set of parameter"
 msgstr ""
 
-#: src/parameter/ParameterWidget.cc:380
+#: src/parameter/ParameterWidget.cc:449
 msgid "Enter name of the parameter set"
 msgstr ""
 
-#: src/parameter/ParameterWidget.cc:407
+#: src/parameter/ParameterWidget.cc:485
 msgid "Saving presets"
 msgstr ""
 
-#: src/parameter/ParameterWidget.cc:408
-msgid "%1 was found, but was unreadble. Do you want to overwrite %1?"
+#: src/parameter/ParameterWidget.cc:486
+msgid "%1 was found, but was unreadable. Do you want to overwrite %1?"
 msgstr ""
 
 #: examples/examples.json:2
@@ -1377,12 +1401,12 @@ msgid "Old"
 msgstr "Ancien"
 
 #. (itstool) path: component/summary
-#: openscad.appdata.xml.in:7
+#: openscad.appdata.xml.in:6
 msgid "The Programmers Solid 3D CAD Modeller"
 msgstr ""
 
 #. (itstool) path: description/p
-#: openscad.appdata.xml.in:9
+#: openscad.appdata.xml.in:19
 msgid ""
 "OpenSCAD is a software for creating solid 3D CAD models. Unlike most free "
 "software for creating 3D models (such as Blender) it does not focus on the "
@@ -1393,7 +1417,7 @@ msgid ""
 msgstr ""
 
 #. (itstool) path: description/p
-#: openscad.appdata.xml.in:10
+#: openscad.appdata.xml.in:20
 msgid ""
 "OpenSCAD is not an interactive modeller. Instead it is something like a 3D-"
 "compiler that reads in a script file that describes the object and renders "
@@ -1404,15 +1428,35 @@ msgid ""
 msgstr ""
 
 #. (itstool) path: description/p
-#: openscad.appdata.xml.in:11
+#: openscad.appdata.xml.in:21
 msgid ""
 "OpenSCAD provides two main modelling techniques: First there is constructive "
 "solid geometry (aka CSG) and second there is extrusion of 2D outlines. As "
-"data exchange format format for this 2D outlines Autocad DXF files are used. "
-"In addition to 2D paths for extrusion it is also possible to read design "
+"data exchange format for this 2D outlines Autocad DXF files are used. In "
+"addition to 2D paths for extrusion it is also possible to read design "
 "parameters from DXF files. Besides DXF files OpenSCAD can read and create 3D "
 "models in the STL and OFF file formats."
 msgstr ""
+
+#, fuzzy
+#~ msgid "Reset Trim"
+#~ msgstr "Réinitialiser la vue"
+
+#, fuzzy
+#~ msgid "Rotation"
+#~ msgstr "&Documentation"
+
+#, fuzzy
+#~ msgid "Zoom"
+#~ msgstr "Zoom Avant"
+
+#, fuzzy
+#~ msgid "ViewPort rel.<br/>Translation"
+#~ msgstr "C&oller la translation de la fenêtre de rendu"
+
+#, fuzzy
+#~ msgid "SpaceNav"
+#~ msgstr "Espaces"
 
 #~ msgid "<"
 #~ msgstr "<"

--- a/locale/fr.po
+++ b/locale/fr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: OpenSCAD 2013.02.07\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2018-08-15 13:13+0200\n"
+"POT-Creation-Date: 2018-08-15 15:07+0200\n"
 "PO-Revision-Date: 2015-03-05 17:28-0500\n"
 "Last-Translator: Keven Villeneuve <keven.villeneuve@gmail.com>\n"
 "Language-Team: French\n"
@@ -846,7 +846,9 @@ msgstr "Préférences"
 msgid "3D View"
 msgstr "&Vue 3D"
 
-#: objects/ui_Preferences.h:1096 examples/examples.json:19
+#: objects/ui_Preferences.h:1096
+#, fuzzy
+msgctxt "preferences"
 msgid "Advanced"
 msgstr "Avancé"
 
@@ -1391,6 +1393,10 @@ msgstr "Bases"
 #: examples/examples.json:13
 msgid "Functions"
 msgstr "Fonctions"
+
+#: examples/examples.json:19
+msgid "Advanced"
+msgstr "Avancé"
 
 #: examples/examples.json:28
 msgid "Parametric"

--- a/locale/openscad.pot
+++ b/locale/openscad.pot
@@ -1,4 +1,4 @@
-# #-#-#-#-#  openscad-tmp.pot (OpenSCAD 2018.03.01)  #-#-#-#-#
+# #-#-#-#-#  openscad-tmp.pot (OpenSCAD 2018.08.15)  #-#-#-#-#
 # SOME DESCRIPTIVE TITLE.
 # Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
 # This file is distributed under the same license as the OpenSCAD package.
@@ -7,10 +7,10 @@
 #, fuzzy
 msgid ""
 msgstr ""
-"#-#-#-#-#  openscad-tmp.pot (OpenSCAD 2018.03.01)  #-#-#-#-#\n"
-"Project-Id-Version: OpenSCAD 2018.03.01\n"
+"#-#-#-#-#  openscad-tmp.pot (OpenSCAD 2018.08.15)  #-#-#-#-#\n"
+"Project-Id-Version: OpenSCAD 2018.08.15\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2018-03-01 07:52+0100\n"
+"POT-Creation-Date: 2018-08-15 13:13+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -21,7 +21,7 @@ msgstr ""
 "Plural-Forms: nplurals=INTEGER; plural=EXPRESSION;\n"
 "#-#-#-#-#  appdata-strings.pot (PACKAGE VERSION)  #-#-#-#-#\n"
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2018-03-01 07:52+0100\n"
+"POT-Creation-Date: 2018-08-15 13:13+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -746,290 +746,358 @@ msgstr ""
 msgid "Close"
 msgstr ""
 
-#: objects/ui_Preferences.h:1080
-msgid "Preferences"
+#: objects/ui_ParameterEntryWidget.h:339 objects/ui_ParameterWidget.h:150
+msgid "Form"
 msgstr ""
 
-#: objects/ui_Preferences.h:1081
-msgid "3D View"
+#: objects/ui_ParameterEntryWidget.h:341
+msgid "Parameter"
 msgstr ""
 
-#: objects/ui_Preferences.h:1082 examples/examples.json:19
-msgid "Advanced"
+#: objects/ui_ParameterEntryWidget.h:342 objects/ui_ParameterEntryWidget.h:343
+msgid "Description"
 msgstr ""
 
-#: objects/ui_Preferences.h:1083 src/mainwin.cc:2518
-msgid "Editor"
+#: objects/ui_ParameterWidget.h:151
+msgid "save preset"
 msgstr ""
 
-#: objects/ui_Preferences.h:1084
-msgid "Update"
+#: objects/ui_ParameterWidget.h:153
+msgid "delete current preset"
 msgstr ""
 
-#: objects/ui_Preferences.h:1085 objects/ui_Preferences.h:1168
-msgid "Features"
+#: objects/ui_ParameterWidget.h:155
+msgid "-"
 msgstr ""
 
-#: objects/ui_Preferences.h:1087
-msgid "Enable/Disable experimental features"
+#: objects/ui_ParameterWidget.h:157
+msgid "preset selection"
 msgstr ""
 
-#: objects/ui_Preferences.h:1089
-msgid "Color scheme:"
+#: objects/ui_ParameterWidget.h:160 src/parameter/ParameterWidget.cc:154
+msgid "add new preset"
 msgstr ""
 
-#: objects/ui_Preferences.h:1090
-msgid "Show Warnings and Errors in 3D View"
+#: objects/ui_ParameterWidget.h:162
+msgid "+"
 msgstr ""
 
-#: objects/ui_Preferences.h:1091
-msgid "Editor Type"
+#: objects/ui_ParameterWidget.h:163
+msgid "Automatic Preview"
+msgstr ""
+
+#: objects/ui_ParameterWidget.h:166
+msgid "Show Details"
+msgstr ""
+
+#: objects/ui_ParameterWidget.h:167
+msgid "Inline Details"
+msgstr ""
+
+#: objects/ui_ParameterWidget.h:168
+msgid "Hide Details"
+msgstr ""
+
+#: objects/ui_ParameterWidget.h:169
+msgid "Description Only"
+msgstr ""
+
+#: objects/ui_ParameterWidget.h:172
+msgid "reset the parameters to the selected preset"
+msgstr ""
+
+#: objects/ui_ParameterWidget.h:174
+msgid "Reset"
 msgstr ""
 
 #: objects/ui_Preferences.h:1094
-msgid "Simple Editor"
+msgid "Preferences"
 msgstr ""
 
 #: objects/ui_Preferences.h:1095
-msgid "QScintilla Editor"
+msgid "3D View"
 msgstr ""
 
-#: objects/ui_Preferences.h:1097
-msgid "(requires restart)"
+#: objects/ui_Preferences.h:1096 examples/examples.json:19
+msgid "Advanced"
+msgstr ""
+
+#: objects/ui_Preferences.h:1097 src/mainwin.cc:2532
+msgid "Editor"
 msgstr ""
 
 #: objects/ui_Preferences.h:1098
-msgid "Font"
+msgid "Update"
 msgstr ""
 
-#: objects/ui_Preferences.h:1099
-msgid "Color syntax highlighting"
-msgstr ""
-
-#: objects/ui_Preferences.h:1100
-msgid "Ctrl/Cmd-Mouse-wheel zooms text"
+#: objects/ui_Preferences.h:1099 objects/ui_Preferences.h:1182
+msgid "Features"
 msgstr ""
 
 #: objects/ui_Preferences.h:1101
-msgid "Indentation"
-msgstr ""
-
-#: objects/ui_Preferences.h:1102
-msgid "Auto Indent"
+msgid "Enable/Disable experimental features"
 msgstr ""
 
 #: objects/ui_Preferences.h:1103
-msgid "Backspace unindents"
+msgid "Color scheme:"
 msgstr ""
 
 #: objects/ui_Preferences.h:1104
-msgid "Indent using"
+msgid "Show Warnings and Errors in 3D View"
 msgstr ""
 
-#: objects/ui_Preferences.h:1107 src/settings.cc:141
-msgid "Spaces"
+#: objects/ui_Preferences.h:1105
+msgid "Editor Type"
 msgstr ""
 
-#: objects/ui_Preferences.h:1108 src/settings.cc:141
-msgid "Tabs"
+#: objects/ui_Preferences.h:1108
+msgid "Simple Editor"
 msgstr ""
 
-#: objects/ui_Preferences.h:1110
-msgid "Indentation width"
+#: objects/ui_Preferences.h:1109
+msgid "QScintilla Editor"
 msgstr ""
 
 #: objects/ui_Preferences.h:1111
-msgid "Tab width"
+msgid "(requires restart)"
 msgstr ""
 
 #: objects/ui_Preferences.h:1112
+msgid "Font"
+msgstr ""
+
+#: objects/ui_Preferences.h:1113
+msgid "Color syntax highlighting"
+msgstr ""
+
+#: objects/ui_Preferences.h:1114
+msgid "Ctrl/Cmd-Mouse-wheel zooms text"
+msgstr ""
+
+#: objects/ui_Preferences.h:1115
+msgid "Indentation"
+msgstr ""
+
+#: objects/ui_Preferences.h:1116
+msgid "Auto Indent"
+msgstr ""
+
+#: objects/ui_Preferences.h:1117
+msgid "Backspace unindents"
+msgstr ""
+
+#: objects/ui_Preferences.h:1118
+msgid "Indent using"
+msgstr ""
+
+#: objects/ui_Preferences.h:1121 src/settings.cc:141
+msgid "Spaces"
+msgstr ""
+
+#: objects/ui_Preferences.h:1122 src/settings.cc:141
+msgid "Tabs"
+msgstr ""
+
+#: objects/ui_Preferences.h:1124
+msgid "Indentation width"
+msgstr ""
+
+#: objects/ui_Preferences.h:1125
+msgid "Tab width"
+msgstr ""
+
+#: objects/ui_Preferences.h:1126
 msgid "Tab key function"
 msgstr ""
 
-#: objects/ui_Preferences.h:1115 objects/ui_Preferences.h:1146
+#: objects/ui_Preferences.h:1129 objects/ui_Preferences.h:1160
 #: src/settings.cc:142
 msgid "Indent"
 msgstr ""
 
-#: objects/ui_Preferences.h:1116 src/settings.cc:142
+#: objects/ui_Preferences.h:1130 src/settings.cc:142
 msgid "Insert Tab"
 msgstr ""
 
-#: objects/ui_Preferences.h:1118
+#: objects/ui_Preferences.h:1132
 msgid "Show whitespace"
 msgstr ""
 
-#: objects/ui_Preferences.h:1121 src/settings.cc:137
+#: objects/ui_Preferences.h:1135 src/settings.cc:137
 msgid "Never"
 msgstr ""
 
-#: objects/ui_Preferences.h:1122 src/settings.cc:137
+#: objects/ui_Preferences.h:1136 src/settings.cc:137
 msgid "Always"
 msgstr ""
 
-#: objects/ui_Preferences.h:1123
+#: objects/ui_Preferences.h:1137
 msgid "Only after indentation"
 msgstr ""
 
-#: objects/ui_Preferences.h:1125
+#: objects/ui_Preferences.h:1139
 msgid "Size"
 msgstr ""
 
-#: objects/ui_Preferences.h:1126
+#: objects/ui_Preferences.h:1140
 msgid "Display"
 msgstr ""
 
-#: objects/ui_Preferences.h:1127
+#: objects/ui_Preferences.h:1141
 msgid "Enable brace matching"
 msgstr ""
 
-#: objects/ui_Preferences.h:1128
+#: objects/ui_Preferences.h:1142
 msgid "Highlight current line"
 msgstr ""
 
-#: objects/ui_Preferences.h:1129
+#: objects/ui_Preferences.h:1143
 msgid "Display Line Numbers"
 msgstr ""
 
-#: objects/ui_Preferences.h:1130 objects/ui_Preferences.h:1163
+#: objects/ui_Preferences.h:1144 objects/ui_Preferences.h:1177
 msgid "Line wrap"
 msgstr ""
 
-#: objects/ui_Preferences.h:1133 objects/ui_Preferences.h:1150
-#: objects/ui_Preferences.h:1158 src/settings.cc:132 src/settings.cc:135
+#: objects/ui_Preferences.h:1147 objects/ui_Preferences.h:1164
+#: objects/ui_Preferences.h:1172 src/settings.cc:132 src/settings.cc:135
 #: src/settings.cc:136
 msgid "None"
 msgstr ""
 
-#: objects/ui_Preferences.h:1134 src/settings.cc:132
+#: objects/ui_Preferences.h:1148 src/settings.cc:132
 msgid "Wrap at character boundaries"
 msgstr ""
 
-#: objects/ui_Preferences.h:1135 src/settings.cc:132
+#: objects/ui_Preferences.h:1149 src/settings.cc:132
 msgid "Wrap at word boundaries"
 msgstr ""
 
-#: objects/ui_Preferences.h:1137
+#: objects/ui_Preferences.h:1151
 msgid "Line wrap indentation"
 msgstr ""
 
-#: objects/ui_Preferences.h:1138
+#: objects/ui_Preferences.h:1152
 msgid "Line wrap visualization"
 msgstr ""
 
-#: objects/ui_Preferences.h:1139
+#: objects/ui_Preferences.h:1153
 msgid "Style"
 msgstr ""
 
-#: objects/ui_Preferences.h:1142 src/settings.cc:133
+#: objects/ui_Preferences.h:1156 src/settings.cc:133
 msgid "Fixed"
 msgstr ""
 
-#: objects/ui_Preferences.h:1143 src/settings.cc:133
+#: objects/ui_Preferences.h:1157 src/settings.cc:133
 msgid "Same"
 msgstr ""
 
-#: objects/ui_Preferences.h:1144 src/settings.cc:133
+#: objects/ui_Preferences.h:1158 src/settings.cc:133
 msgid "Indented"
 msgstr ""
 
-#: objects/ui_Preferences.h:1147
+#: objects/ui_Preferences.h:1161
 msgid "Start"
 msgstr ""
 
-#: objects/ui_Preferences.h:1151 objects/ui_Preferences.h:1159
+#: objects/ui_Preferences.h:1165 objects/ui_Preferences.h:1173
 #: src/settings.cc:135 src/settings.cc:136
 msgid "Text"
 msgstr ""
 
-#: objects/ui_Preferences.h:1152 objects/ui_Preferences.h:1160
+#: objects/ui_Preferences.h:1166 objects/ui_Preferences.h:1174
 #: src/settings.cc:135 src/settings.cc:136
 msgid "Border"
 msgstr ""
 
-#: objects/ui_Preferences.h:1153 objects/ui_Preferences.h:1161
+#: objects/ui_Preferences.h:1167 objects/ui_Preferences.h:1175
 #: src/settings.cc:135 src/settings.cc:136
 msgid "Margin"
 msgstr ""
 
-#: objects/ui_Preferences.h:1155
+#: objects/ui_Preferences.h:1169
 msgid "End"
 msgstr ""
 
-#: objects/ui_Preferences.h:1164
+#: objects/ui_Preferences.h:1178
 msgid "Automatically check for updates"
 msgstr ""
 
-#: objects/ui_Preferences.h:1165
+#: objects/ui_Preferences.h:1179
 msgid "Include development snapshots"
 msgstr ""
 
-#: objects/ui_Preferences.h:1166
+#: objects/ui_Preferences.h:1180
 msgid "Check Now"
 msgstr ""
 
-#: objects/ui_Preferences.h:1167
+#: objects/ui_Preferences.h:1181
 msgid "Last checked: "
 msgstr ""
 
-#: objects/ui_Preferences.h:1169
+#: objects/ui_Preferences.h:1183
 msgid "OpenCSG"
 msgstr ""
 
-#: objects/ui_Preferences.h:1170
+#: objects/ui_Preferences.h:1184
 msgid "Show capability warning"
 msgstr ""
 
-#: objects/ui_Preferences.h:1171
+#: objects/ui_Preferences.h:1185
 msgid "Enable for OpenGL 1.x"
 msgstr ""
 
-#: objects/ui_Preferences.h:1172
+#: objects/ui_Preferences.h:1186
 msgid "Turn off rendering at "
 msgstr ""
 
-#: objects/ui_Preferences.h:1173
+#: objects/ui_Preferences.h:1187
 msgid "elements"
 msgstr ""
 
-#: objects/ui_Preferences.h:1174
+#: objects/ui_Preferences.h:1188
 msgid "Force Goldfeather"
 msgstr ""
 
-#: objects/ui_Preferences.h:1175
+#: objects/ui_Preferences.h:1189
 msgid "CGAL Cache size"
 msgstr ""
 
-#: objects/ui_Preferences.h:1176 objects/ui_Preferences.h:1178
+#: objects/ui_Preferences.h:1190 objects/ui_Preferences.h:1192
 msgid "bytes"
 msgstr ""
 
-#: objects/ui_Preferences.h:1177
+#: objects/ui_Preferences.h:1191
 msgid "PolySet Cache size"
 msgstr ""
 
-#: objects/ui_Preferences.h:1179
+#: objects/ui_Preferences.h:1193
 msgid "Allow opening multiple documents"
 msgstr ""
 
-#: objects/ui_Preferences.h:1180
+#: objects/ui_Preferences.h:1194
 msgid "Enable docking of Editor and Console in different places"
 msgstr ""
 
-#: objects/ui_Preferences.h:1181
+#: objects/ui_Preferences.h:1195
 msgid "Enable undocking of Editor and Console to separate windows"
 msgstr ""
 
-#: objects/ui_Preferences.h:1182
+#: objects/ui_Preferences.h:1196
 msgid "Show Welcome Screen"
 msgstr ""
 
-#: objects/ui_Preferences.h:1183
+#: objects/ui_Preferences.h:1197
 msgid "Enable user interface localization (requires restart of OpenSCAD)"
 msgstr ""
 
-#: objects/ui_Preferences.h:1184
+#: objects/ui_Preferences.h:1198
 msgid "Bring window to front after automatic reload"
+msgstr ""
+
+#: objects/ui_Preferences.h:1199
+msgid "Play sound notification on render complete"
 msgstr ""
 
 #: objects/ui_ProgressWidget.h:72
@@ -1053,114 +1121,114 @@ msgstr ""
 msgid "ERROR: \"%s\" write error. (Disk full?)"
 msgstr ""
 
-#: src/mainwin.cc:788 src/mainwin.cc:1438
+#: src/mainwin.cc:789 src/mainwin.cc:1443
 msgid "Untitled.scad"
 msgstr ""
 
-#: src/mainwin.cc:1027
+#: src/mainwin.cc:1032
 msgid "Compile error."
 msgstr ""
 
-#: src/mainwin.cc:1030
+#: src/mainwin.cc:1035
 msgid "Error while compiling '%1'."
 msgstr ""
 
-#: src/mainwin.cc:1034
+#: src/mainwin.cc:1039
 msgid "Compilation generated %1 warning."
 msgid_plural "Compilation generated %1 warnings."
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/mainwin.cc:1044
+#: src/mainwin.cc:1049
 msgid " For details see <a href=\"#console\">console window</a>."
 msgstr ""
 
-#: src/mainwin.cc:1416
+#: src/mainwin.cc:1421
 msgid "Failed to open file for writing"
 msgstr ""
 
-#: src/mainwin.cc:1426
+#: src/mainwin.cc:1431
 #, c-format
 msgid "Saved design '%s'."
 msgstr ""
 
-#: src/mainwin.cc:1429
+#: src/mainwin.cc:1434
 msgid "Error saving design"
 msgstr ""
 
-#: src/mainwin.cc:1437
+#: src/mainwin.cc:1442
 msgid "Save File"
 msgstr ""
 
-#: src/mainwin.cc:1439
+#: src/mainwin.cc:1444
 msgid "OpenSCAD Designs (*.scad)"
 msgstr ""
 
-#: src/mainwin.cc:1449
+#: src/mainwin.cc:1454
 msgid ""
 "%1 already exists.\n"
 "Do you want to replace it?"
 msgstr ""
 
-#: src/mainwin.cc:1796
+#: src/mainwin.cc:1805
 msgid "Application"
 msgstr ""
 
-#: src/mainwin.cc:1797
+#: src/mainwin.cc:1806
 msgid ""
 "The document has been modified.\n"
 "Do you really want to reload the file?"
 msgstr ""
 
-#: src/mainwin.cc:2171
+#: src/mainwin.cc:2185
 msgid "Export %1 File"
 msgstr ""
 
-#: src/mainwin.cc:2172
+#: src/mainwin.cc:2186
 msgid "%1 Files (*%2)"
 msgstr ""
 
-#: src/mainwin.cc:2173
+#: src/mainwin.cc:2187
 msgid "Untitled"
 msgstr ""
 
-#: src/mainwin.cc:2225
+#: src/mainwin.cc:2239
 msgid "Export CSG File"
 msgstr ""
 
-#: src/mainwin.cc:2226
+#: src/mainwin.cc:2240
 msgid "Untitled.csg"
 msgstr ""
 
-#: src/mainwin.cc:2227
+#: src/mainwin.cc:2241
 msgid "CSG Files (*.csg)"
 msgstr ""
 
-#: src/mainwin.cc:2253
+#: src/mainwin.cc:2267
 msgid "Untitled.png"
 msgstr ""
 
-#: src/mainwin.cc:2255
+#: src/mainwin.cc:2269
 msgid "Export Image"
 msgstr ""
 
-#: src/mainwin.cc:2255
+#: src/mainwin.cc:2269
 msgid "PNG Files (*.png)"
 msgstr ""
 
-#: src/mainwin.cc:2523
+#: src/mainwin.cc:2537
 msgid "Console"
 msgstr ""
 
-#: src/mainwin.cc:2528
+#: src/mainwin.cc:2542
 msgid "Customizer"
 msgstr ""
 
-#: src/mainwin.cc:2672
+#: src/mainwin.cc:2686
 msgid "The document has been modified."
 msgstr ""
 
-#: src/mainwin.cc:2673
+#: src/mainwin.cc:2687
 msgid "Do you want to save your changes?"
 msgstr ""
 
@@ -1215,101 +1283,53 @@ msgstr ""
 msgid "After indentation"
 msgstr ""
 
-#: objects/ui_ParameterEntryWidget.h:343 objects/ui_ParameterWidget.h:150
-msgid "Form"
+#: src/parameter/ParameterWidget.cc:74 src/parameter/ParameterWidget.cc:218
+msgid "changes on current preset not saved"
 msgstr ""
 
-#: objects/ui_ParameterEntryWidget.h:345
-msgid "Parameter"
+#: src/parameter/ParameterWidget.cc:76
+msgid ""
+"The changes on the current preset %1 are not saved yet. Do you really want "
+"to reset this preset and lose your changes?"
 msgstr ""
 
-#: objects/ui_ParameterEntryWidget.h:346 objects/ui_ParameterEntryWidget.h:347
-msgid "Description"
-msgstr ""
-
-#: objects/ui_ParameterWidget.h:151
-msgid "save preset"
-msgstr ""
-
-#: objects/ui_ParameterWidget.h:153
-msgid "delete current preset"
-msgstr ""
-
-#: objects/ui_ParameterWidget.h:155
-msgid "-"
-msgstr ""
-
-#: objects/ui_ParameterWidget.h:157
-msgid "preset selection"
-msgstr ""
-
-#: objects/ui_ParameterWidget.h:160 src/parameter/ParameterWidget.cc:132
-msgid "add new preset"
-msgstr ""
-
-#: objects/ui_ParameterWidget.h:162
-msgid "+"
-msgstr ""
-
-#: objects/ui_ParameterWidget.h:163
-msgid "Automatic Preview"
-msgstr ""
-
-#: objects/ui_ParameterWidget.h:166
-msgid "Show Details"
-msgstr ""
-
-#: objects/ui_ParameterWidget.h:167
-msgid "Inline Details"
-msgstr ""
-
-#: objects/ui_ParameterWidget.h:168
-msgid "Hide Details"
-msgstr ""
-
-#: objects/ui_ParameterWidget.h:169
-msgid "Description Only"
-msgstr ""
-
-#: objects/ui_ParameterWidget.h:172
-msgid "reset the parameters to the selected preset"
-msgstr ""
-
-#: objects/ui_ParameterWidget.h:174
-msgid "Reset"
-msgstr ""
-
-#: src/parameter/ParameterWidget.cc:134
+#: src/parameter/ParameterWidget.cc:156
 msgid "remove current preset"
 msgstr ""
 
-#: src/parameter/ParameterWidget.cc:136
+#: src/parameter/ParameterWidget.cc:158
 msgid "save current preset"
 msgstr ""
 
-#: src/parameter/ParameterWidget.cc:138 src/parameter/ParameterWidget.cc:139
-#: src/parameter/ParameterWidget.cc:140
+#: src/parameter/ParameterWidget.cc:160 src/parameter/ParameterWidget.cc:161
+#: src/parameter/ParameterWidget.cc:162
 msgid "JSON file read only"
 msgstr ""
 
-#: src/parameter/ParameterWidget.cc:165
+#: src/parameter/ParameterWidget.cc:202
 msgid "no preset selected"
 msgstr ""
 
-#: src/parameter/ParameterWidget.cc:380
+#: src/parameter/ParameterWidget.cc:220
+msgid ""
+"The current preset %1 contains changes, but is not saved yet. Do you really "
+"want to change the preset and lose your changes?"
+msgstr ""
+
+#: src/parameter/ParameterWidget.cc:449
 msgid "Create new set of parameter"
 msgstr ""
 
-#: src/parameter/ParameterWidget.cc:380
+#: src/parameter/ParameterWidget.cc:449
 msgid "Enter name of the parameter set"
 msgstr ""
 
-#: src/parameter/ParameterWidget.cc:407
+#: src/parameter/ParameterWidget.cc:485
 msgid "Saving presets"
 msgstr ""
 
-#: src/parameter/ParameterWidget.cc:408
-msgid "%1 was found, but was unreadble. Do you want to overwrite %1?"
+#: src/parameter/ParameterWidget.cc:486
+msgid "%1 was found, but was unreadable. Do you want to overwrite %1?"
 msgstr ""
 
 #: examples/examples.json:2
@@ -1329,12 +1349,12 @@ msgid "Old"
 msgstr ""
 
 #. (itstool) path: component/summary
-#: openscad.appdata.xml.in:7
+#: openscad.appdata.xml.in:6
 msgid "The Programmers Solid 3D CAD Modeller"
 msgstr ""
 
 #. (itstool) path: description/p
-#: openscad.appdata.xml.in:9
+#: openscad.appdata.xml.in:19
 msgid ""
 "OpenSCAD is a software for creating solid 3D CAD models. Unlike most free "
 "software for creating 3D models (such as Blender) it does not focus on the "
@@ -1345,7 +1365,7 @@ msgid ""
 msgstr ""
 
 #. (itstool) path: description/p
-#: openscad.appdata.xml.in:10
+#: openscad.appdata.xml.in:20
 msgid ""
 "OpenSCAD is not an interactive modeller. Instead it is something like a 3D-"
 "compiler that reads in a script file that describes the object and renders "
@@ -1356,12 +1376,12 @@ msgid ""
 msgstr ""
 
 #. (itstool) path: description/p
-#: openscad.appdata.xml.in:11
+#: openscad.appdata.xml.in:21
 msgid ""
 "OpenSCAD provides two main modelling techniques: First there is constructive "
 "solid geometry (aka CSG) and second there is extrusion of 2D outlines. As "
-"data exchange format format for this 2D outlines Autocad DXF files are used. "
-"In addition to 2D paths for extrusion it is also possible to read design "
+"data exchange format for this 2D outlines Autocad DXF files are used. In "
+"addition to 2D paths for extrusion it is also possible to read design "
 "parameters from DXF files. Besides DXF files OpenSCAD can read and create 3D "
 "models in the STL and OFF file formats."
 msgstr ""

--- a/locale/openscad.pot
+++ b/locale/openscad.pot
@@ -10,7 +10,7 @@ msgstr ""
 "#-#-#-#-#  openscad-tmp.pot (OpenSCAD 2018.08.15)  #-#-#-#-#\n"
 "Project-Id-Version: OpenSCAD 2018.08.15\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2018-08-15 13:13+0200\n"
+"POT-Creation-Date: 2018-08-15 15:07+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -21,7 +21,7 @@ msgstr ""
 "Plural-Forms: nplurals=INTEGER; plural=EXPRESSION;\n"
 "#-#-#-#-#  appdata-strings.pot (PACKAGE VERSION)  #-#-#-#-#\n"
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2018-08-15 13:13+0200\n"
+"POT-Creation-Date: 2018-08-15 15:07+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -818,7 +818,8 @@ msgstr ""
 msgid "3D View"
 msgstr ""
 
-#: objects/ui_Preferences.h:1096 examples/examples.json:19
+#: objects/ui_Preferences.h:1096
+msgctxt "preferences"
 msgid "Advanced"
 msgstr ""
 
@@ -1338,6 +1339,10 @@ msgstr ""
 
 #: examples/examples.json:13
 msgid "Functions"
+msgstr ""
+
+#: examples/examples.json:19
+msgid "Advanced"
 msgstr ""
 
 #: examples/examples.json:28

--- a/locale/pl.po
+++ b/locale/pl.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: OpenSCAD 2015.03.05\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2018-08-15 13:13+0200\n"
+"POT-Creation-Date: 2018-08-15 15:07+0200\n"
 "PO-Revision-Date: 2016-09-13 23:33+0200\n"
 "Last-Translator: Marek Pikuła <marek.pikula@sent.tech>\n"
 "Language-Team: \n"
@@ -842,7 +842,9 @@ msgstr "Preferencje"
 msgid "3D View"
 msgstr "Widok 3D"
 
-#: objects/ui_Preferences.h:1096 examples/examples.json:19
+#: objects/ui_Preferences.h:1096
+#, fuzzy
+msgctxt "preferences"
 msgid "Advanced"
 msgstr "Zaawansowane"
 
@@ -1386,6 +1388,10 @@ msgstr "Podstawy"
 #: examples/examples.json:13
 msgid "Functions"
 msgstr "Funkcje"
+
+#: examples/examples.json:19
+msgid "Advanced"
+msgstr "Zaawansowane"
 
 #: examples/examples.json:28
 msgid "Parametric"

--- a/locale/pl.po
+++ b/locale/pl.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: OpenSCAD 2015.03.05\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2018-03-01 07:52+0100\n"
+"POT-Creation-Date: 2018-08-15 13:13+0200\n"
 "PO-Revision-Date: 2016-09-13 23:33+0200\n"
 "Last-Translator: Marek Pikuła <marek.pikula@sent.tech>\n"
 "Language-Team: \n"
@@ -766,289 +766,365 @@ msgstr "Pokazuj tą wiadomość ponownie"
 msgid "Close"
 msgstr "Zamknij"
 
-#: objects/ui_Preferences.h:1080
+#: objects/ui_ParameterEntryWidget.h:339 objects/ui_ParameterWidget.h:150
+msgid "Form"
+msgstr ""
+
+#: objects/ui_ParameterEntryWidget.h:341
+msgid "Parameter"
+msgstr ""
+
+#: objects/ui_ParameterEntryWidget.h:342 objects/ui_ParameterEntryWidget.h:343
+msgid "Description"
+msgstr ""
+
+#: objects/ui_ParameterWidget.h:151
+msgid "save preset"
+msgstr ""
+
+#: objects/ui_ParameterWidget.h:153
+msgid "delete current preset"
+msgstr ""
+
+#: objects/ui_ParameterWidget.h:155
+msgid "-"
+msgstr ""
+
+#: objects/ui_ParameterWidget.h:157
+msgid "preset selection"
+msgstr ""
+
+#: objects/ui_ParameterWidget.h:160 src/parameter/ParameterWidget.cc:154
+msgid "add new preset"
+msgstr ""
+
+#: objects/ui_ParameterWidget.h:162
+msgid "+"
+msgstr ""
+
+#: objects/ui_ParameterWidget.h:163
+#, fuzzy
+msgid "Automatic Preview"
+msgstr "&Automatycznie przeładuj i pokaż podgląd"
+
+#: objects/ui_ParameterWidget.h:166
+#, fuzzy
+msgid "Show Details"
+msgstr "Pokaż osie"
+
+#: objects/ui_ParameterWidget.h:167
+msgid "Inline Details"
+msgstr ""
+
+#: objects/ui_ParameterWidget.h:168
+#, fuzzy
+msgid "Hide Details"
+msgstr "Ukryj paski narzędzi"
+
+#: objects/ui_ParameterWidget.h:169
+msgid "Description Only"
+msgstr ""
+
+#: objects/ui_ParameterWidget.h:172
+msgid "reset the parameters to the selected preset"
+msgstr ""
+
+#: objects/ui_ParameterWidget.h:174
+#, fuzzy
+msgid "Reset"
+msgstr "Resetuj widok"
+
+#: objects/ui_Preferences.h:1094
 msgid "Preferences"
 msgstr "Preferencje"
 
-#: objects/ui_Preferences.h:1081
+#: objects/ui_Preferences.h:1095
 msgid "3D View"
 msgstr "Widok 3D"
 
-#: objects/ui_Preferences.h:1082 examples/examples.json:19
+#: objects/ui_Preferences.h:1096 examples/examples.json:19
 msgid "Advanced"
 msgstr "Zaawansowane"
 
-#: objects/ui_Preferences.h:1083 src/mainwin.cc:2518
+#: objects/ui_Preferences.h:1097 src/mainwin.cc:2532
 msgid "Editor"
 msgstr "Edytor"
 
-#: objects/ui_Preferences.h:1084
+#: objects/ui_Preferences.h:1098
 msgid "Update"
 msgstr "Aktualizuj"
 
-#: objects/ui_Preferences.h:1085 objects/ui_Preferences.h:1168
+#: objects/ui_Preferences.h:1099 objects/ui_Preferences.h:1182
 msgid "Features"
 msgstr "Funkcje"
 
-#: objects/ui_Preferences.h:1087
+#: objects/ui_Preferences.h:1101
 msgid "Enable/Disable experimental features"
 msgstr "Włącz/wyłącz eksperymentalne funkcje"
 
-#: objects/ui_Preferences.h:1089
+#: objects/ui_Preferences.h:1103
 msgid "Color scheme:"
 msgstr "Schemat kolorów:"
 
-#: objects/ui_Preferences.h:1090
+#: objects/ui_Preferences.h:1104
 msgid "Show Warnings and Errors in 3D View"
 msgstr "Pokazuj ostrzeżenia i błędy w widoku 3D"
 
-#: objects/ui_Preferences.h:1091
+#: objects/ui_Preferences.h:1105
 msgid "Editor Type"
 msgstr "Rodzaj edytora"
 
-#: objects/ui_Preferences.h:1094
+#: objects/ui_Preferences.h:1108
 msgid "Simple Editor"
 msgstr "Prosty edytor"
 
-#: objects/ui_Preferences.h:1095
+#: objects/ui_Preferences.h:1109
 msgid "QScintilla Editor"
 msgstr "Edytor QScintilla"
 
-#: objects/ui_Preferences.h:1097
+#: objects/ui_Preferences.h:1111
 msgid "(requires restart)"
 msgstr "(wymaga ponownego uruchomienia)"
 
-#: objects/ui_Preferences.h:1098
+#: objects/ui_Preferences.h:1112
 msgid "Font"
 msgstr "Font"
 
-#: objects/ui_Preferences.h:1099
+#: objects/ui_Preferences.h:1113
 msgid "Color syntax highlighting"
 msgstr "Podkreślanie składni kolorem"
 
-#: objects/ui_Preferences.h:1100
+#: objects/ui_Preferences.h:1114
 msgid "Ctrl/Cmd-Mouse-wheel zooms text"
 msgstr "Ctrl/Cmd-kółko-myszy przybliża tekst"
 
-#: objects/ui_Preferences.h:1101
+#: objects/ui_Preferences.h:1115
 msgid "Indentation"
 msgstr "Wcięcia"
 
-#: objects/ui_Preferences.h:1102
+#: objects/ui_Preferences.h:1116
 msgid "Auto Indent"
 msgstr "Automatyczne wcięcia"
 
-#: objects/ui_Preferences.h:1103
+#: objects/ui_Preferences.h:1117
 msgid "Backspace unindents"
 msgstr "Backspace usuwa wcięcie"
 
-#: objects/ui_Preferences.h:1104
+#: objects/ui_Preferences.h:1118
 msgid "Indent using"
 msgstr "Do wcięć używaj"
 
-#: objects/ui_Preferences.h:1107 src/settings.cc:141
+#: objects/ui_Preferences.h:1121 src/settings.cc:141
 msgid "Spaces"
 msgstr "Spacji"
 
-#: objects/ui_Preferences.h:1108 src/settings.cc:141
+#: objects/ui_Preferences.h:1122 src/settings.cc:141
 msgid "Tabs"
 msgstr "Tabulacji"
 
-#: objects/ui_Preferences.h:1110
+#: objects/ui_Preferences.h:1124
 msgid "Indentation width"
 msgstr "Szerokość wcięć"
 
-#: objects/ui_Preferences.h:1111
+#: objects/ui_Preferences.h:1125
 msgid "Tab width"
 msgstr "Szerokość tabulacji"
 
-#: objects/ui_Preferences.h:1112
+#: objects/ui_Preferences.h:1126
 msgid "Tab key function"
 msgstr "Funkcja klawisza Tab"
 
-#: objects/ui_Preferences.h:1115 objects/ui_Preferences.h:1146
+#: objects/ui_Preferences.h:1129 objects/ui_Preferences.h:1160
 #: src/settings.cc:142
 msgid "Indent"
 msgstr "Wcięcie"
 
-#: objects/ui_Preferences.h:1116 src/settings.cc:142
+#: objects/ui_Preferences.h:1130 src/settings.cc:142
 msgid "Insert Tab"
 msgstr "Wstaw Tab"
 
-#: objects/ui_Preferences.h:1118
+#: objects/ui_Preferences.h:1132
 msgid "Show whitespace"
 msgstr "Pokazuj znaki niedrukowalne"
 
-#: objects/ui_Preferences.h:1121 src/settings.cc:137
+#: objects/ui_Preferences.h:1135 src/settings.cc:137
 msgid "Never"
 msgstr "Nigdy"
 
-#: objects/ui_Preferences.h:1122 src/settings.cc:137
+#: objects/ui_Preferences.h:1136 src/settings.cc:137
 msgid "Always"
 msgstr "Zawsze"
 
-#: objects/ui_Preferences.h:1123
+#: objects/ui_Preferences.h:1137
 msgid "Only after indentation"
 msgstr "Tylko po wcięciu"
 
-#: objects/ui_Preferences.h:1125
+#: objects/ui_Preferences.h:1139
 msgid "Size"
 msgstr "Rozmiar"
 
-#: objects/ui_Preferences.h:1126
+#: objects/ui_Preferences.h:1140
 msgid "Display"
 msgstr "Wygląd"
 
-#: objects/ui_Preferences.h:1127
+#: objects/ui_Preferences.h:1141
 msgid "Enable brace matching"
 msgstr "Włącz dopasowywanie nawiasów"
 
-#: objects/ui_Preferences.h:1128
+#: objects/ui_Preferences.h:1142
 msgid "Highlight current line"
 msgstr "Zakreśl aktywną linijkę"
 
-#: objects/ui_Preferences.h:1129
+#: objects/ui_Preferences.h:1143
 msgid "Display Line Numbers"
 msgstr "Numeruj linijki"
 
-#: objects/ui_Preferences.h:1130 objects/ui_Preferences.h:1163
+#: objects/ui_Preferences.h:1144 objects/ui_Preferences.h:1177
 msgid "Line wrap"
 msgstr "Zawijanie wierszy"
 
-#: objects/ui_Preferences.h:1133 objects/ui_Preferences.h:1150
-#: objects/ui_Preferences.h:1158 src/settings.cc:132 src/settings.cc:135
+#: objects/ui_Preferences.h:1147 objects/ui_Preferences.h:1164
+#: objects/ui_Preferences.h:1172 src/settings.cc:132 src/settings.cc:135
 #: src/settings.cc:136
 msgid "None"
 msgstr "Brak"
 
-#: objects/ui_Preferences.h:1134 src/settings.cc:132
+#: objects/ui_Preferences.h:1148 src/settings.cc:132
 msgid "Wrap at character boundaries"
 msgstr "Zawijaj na znakach"
 
-#: objects/ui_Preferences.h:1135 src/settings.cc:132
+#: objects/ui_Preferences.h:1149 src/settings.cc:132
 msgid "Wrap at word boundaries"
 msgstr "Zawijaj na słowach"
 
-#: objects/ui_Preferences.h:1137
+#: objects/ui_Preferences.h:1151
 msgid "Line wrap indentation"
 msgstr "Wcięcie zawiniętych linijek"
 
-#: objects/ui_Preferences.h:1138
+#: objects/ui_Preferences.h:1152
 msgid "Line wrap visualization"
 msgstr "Wizualizacja zawiniętych linijek"
 
-#: objects/ui_Preferences.h:1139
+#: objects/ui_Preferences.h:1153
 msgid "Style"
 msgstr "Styl"
 
-#: objects/ui_Preferences.h:1142 src/settings.cc:133
+#: objects/ui_Preferences.h:1156 src/settings.cc:133
 msgid "Fixed"
 msgstr "Na sztywno"
 
-#: objects/ui_Preferences.h:1143 src/settings.cc:133
+#: objects/ui_Preferences.h:1157 src/settings.cc:133
 msgid "Same"
 msgstr "Takie samo"
 
-#: objects/ui_Preferences.h:1144 src/settings.cc:133
+#: objects/ui_Preferences.h:1158 src/settings.cc:133
 msgid "Indented"
 msgstr "Wcięte"
 
-#: objects/ui_Preferences.h:1147
+#: objects/ui_Preferences.h:1161
 msgid "Start"
 msgstr "Początek"
 
-#: objects/ui_Preferences.h:1151 objects/ui_Preferences.h:1159
+#: objects/ui_Preferences.h:1165 objects/ui_Preferences.h:1173
 #: src/settings.cc:135 src/settings.cc:136
 msgid "Text"
 msgstr "Tekst"
 
-#: objects/ui_Preferences.h:1152 objects/ui_Preferences.h:1160
+#: objects/ui_Preferences.h:1166 objects/ui_Preferences.h:1174
 #: src/settings.cc:135 src/settings.cc:136
 msgid "Border"
 msgstr "Krawędź"
 
-#: objects/ui_Preferences.h:1153 objects/ui_Preferences.h:1161
+#: objects/ui_Preferences.h:1167 objects/ui_Preferences.h:1175
 #: src/settings.cc:135 src/settings.cc:136
 msgid "Margin"
 msgstr "Margines"
 
-#: objects/ui_Preferences.h:1155
+#: objects/ui_Preferences.h:1169
 msgid "End"
 msgstr "Koniec"
 
-#: objects/ui_Preferences.h:1164
+#: objects/ui_Preferences.h:1178
 msgid "Automatically check for updates"
 msgstr "Automatycznie sprawdzaj aktualizacje"
 
-#: objects/ui_Preferences.h:1165
+#: objects/ui_Preferences.h:1179
 msgid "Include development snapshots"
 msgstr "Bierz pod uwagę wersje rozwojowe"
 
-#: objects/ui_Preferences.h:1166
+#: objects/ui_Preferences.h:1180
 msgid "Check Now"
 msgstr "Sprawdź teraz"
 
-#: objects/ui_Preferences.h:1167
+#: objects/ui_Preferences.h:1181
 msgid "Last checked: "
 msgstr "Ostatnio sprawdzono:"
 
-#: objects/ui_Preferences.h:1169
+#: objects/ui_Preferences.h:1183
 msgid "OpenCSG"
 msgstr "OpenCSG"
 
-#: objects/ui_Preferences.h:1170
+#: objects/ui_Preferences.h:1184
 msgid "Show capability warning"
 msgstr "Pokazuj ostrzeżenia o rozszerzeniach"
 
-#: objects/ui_Preferences.h:1171
+#: objects/ui_Preferences.h:1185
 msgid "Enable for OpenGL 1.x"
 msgstr "Włącz dla OpenGL 1.x"
 
-#: objects/ui_Preferences.h:1172
+#: objects/ui_Preferences.h:1186
 msgid "Turn off rendering at "
 msgstr "Wyłącz renderowanie przy"
 
-#: objects/ui_Preferences.h:1173
+#: objects/ui_Preferences.h:1187
 msgid "elements"
 msgstr "elementach"
 
-#: objects/ui_Preferences.h:1174
+#: objects/ui_Preferences.h:1188
 msgid "Force Goldfeather"
 msgstr "Wymuś Goldfeather"
 
-#: objects/ui_Preferences.h:1175
+#: objects/ui_Preferences.h:1189
 msgid "CGAL Cache size"
 msgstr "Rozmiar cache CGAL"
 
-#: objects/ui_Preferences.h:1176 objects/ui_Preferences.h:1178
+#: objects/ui_Preferences.h:1190 objects/ui_Preferences.h:1192
 msgid "bytes"
 msgstr "bajtów"
 
-#: objects/ui_Preferences.h:1177
+#: objects/ui_Preferences.h:1191
 msgid "PolySet Cache size"
 msgstr "Rozmiar pamięci podręcznej PolySetów"
 
-#: objects/ui_Preferences.h:1179
+#: objects/ui_Preferences.h:1193
 msgid "Allow opening multiple documents"
 msgstr "Pozwalaj na otwieranie wielu dokumentów"
 
-#: objects/ui_Preferences.h:1180
+#: objects/ui_Preferences.h:1194
 msgid "Enable docking of Editor and Console in different places"
 msgstr "Włącz dokowanie edytora i konsoli w różnych miejscach"
 
-#: objects/ui_Preferences.h:1181
+#: objects/ui_Preferences.h:1195
 msgid "Enable undocking of Editor and Console to separate windows"
 msgstr "Włącz przenoszenie edytora i konsoli do osobnych okien"
 
-#: objects/ui_Preferences.h:1182
+#: objects/ui_Preferences.h:1196
 msgid "Show Welcome Screen"
 msgstr "Pokaż ekran powitalny"
 
-#: objects/ui_Preferences.h:1183
+#: objects/ui_Preferences.h:1197
 msgid "Enable user interface localization (requires restart of OpenSCAD)"
 msgstr ""
 "Włącz tłumaczenie interfejsu użytkownika (wymaga uruchomienia ponownie "
 "programu)"
+
+#: objects/ui_Preferences.h:1198
+msgid "Bring window to front after automatic reload"
+msgstr ""
+
+#: objects/ui_Preferences.h:1199
+msgid "Play sound notification on render complete"
+msgstr ""
 
 #: objects/ui_ProgressWidget.h:72
 msgid "%v / %m"
@@ -1073,51 +1149,51 @@ msgstr "Nie można otworzyć pliku \"%s\" do eksportu"
 msgid "ERROR: \"%s\" write error. (Disk full?)"
 msgstr "Błąd: \"%s\" – błąd zapisu. (Pełny dysk?)"
 
-#: src/mainwin.cc:788 src/mainwin.cc:1438
+#: src/mainwin.cc:789 src/mainwin.cc:1443
 msgid "Untitled.scad"
 msgstr "Bez tytułu.scad"
 
-#: src/mainwin.cc:1027
+#: src/mainwin.cc:1032
 msgid "Compile error."
 msgstr "Błąd kompilacji."
 
-#: src/mainwin.cc:1030
+#: src/mainwin.cc:1035
 msgid "Error while compiling '%1'."
 msgstr "Błąd podczas kompilowania '%1'."
 
-#: src/mainwin.cc:1034
+#: src/mainwin.cc:1039
 msgid "Compilation generated %1 warning."
 msgid_plural "Compilation generated %1 warnings."
 msgstr[0] "Podczas kompilacji wygenerowano %1 ostrzeżenie."
 msgstr[1] "Podczas kompilacji wygenerowano %1 ostrzeżenia."
 msgstr[2] "Podczas kompilacji wygenerowano %1 ostrzeżeń."
 
-#: src/mainwin.cc:1044
+#: src/mainwin.cc:1049
 msgid " For details see <a href=\"#console\">console window</a>."
 msgstr "Szczegóły w <a href=\"#console\">oknie konsoli</a>."
 
-#: src/mainwin.cc:1416
+#: src/mainwin.cc:1421
 msgid "Failed to open file for writing"
 msgstr "Nie udało się zapisać do pliku"
 
-#: src/mainwin.cc:1426
+#: src/mainwin.cc:1431
 #, c-format
 msgid "Saved design '%s'."
 msgstr "Zapisano projekt „%s”."
 
-#: src/mainwin.cc:1429
+#: src/mainwin.cc:1434
 msgid "Error saving design"
 msgstr "Błąd przy zapisie projektu"
 
-#: src/mainwin.cc:1437
+#: src/mainwin.cc:1442
 msgid "Save File"
 msgstr "Zapisz plik"
 
-#: src/mainwin.cc:1439
+#: src/mainwin.cc:1444
 msgid "OpenSCAD Designs (*.scad)"
 msgstr "Projekty OpenSCAD (*.scad)"
 
-#: src/mainwin.cc:1449
+#: src/mainwin.cc:1454
 msgid ""
 "%1 already exists.\n"
 "Do you want to replace it?"
@@ -1125,11 +1201,11 @@ msgstr ""
 "%1 już istnieje.\n"
 "Czy chcesz zamienić?"
 
-#: src/mainwin.cc:1796
+#: src/mainwin.cc:1805
 msgid "Application"
 msgstr "Aplikacja"
 
-#: src/mainwin.cc:1797
+#: src/mainwin.cc:1806
 msgid ""
 "The document has been modified.\n"
 "Do you really want to reload the file?"
@@ -1137,55 +1213,55 @@ msgstr ""
 "Dokument został zmodyfikowany.\n"
 "Czy na pewno chcesz go przeładować?"
 
-#: src/mainwin.cc:2171
+#: src/mainwin.cc:2185
 msgid "Export %1 File"
 msgstr "Eksportuj plik %1"
 
-#: src/mainwin.cc:2172
+#: src/mainwin.cc:2186
 msgid "%1 Files (*%2)"
 msgstr "Pliki %1 (*%2)"
 
-#: src/mainwin.cc:2173
+#: src/mainwin.cc:2187
 msgid "Untitled"
 msgstr "Bez tytułu"
 
-#: src/mainwin.cc:2225
+#: src/mainwin.cc:2239
 msgid "Export CSG File"
 msgstr "Eksportuj plik CSG"
 
-#: src/mainwin.cc:2226
+#: src/mainwin.cc:2240
 msgid "Untitled.csg"
 msgstr "Bez tytułu.csg"
 
-#: src/mainwin.cc:2227
+#: src/mainwin.cc:2241
 msgid "CSG Files (*.csg)"
 msgstr "Pliki CSG (*.csg)"
 
-#: src/mainwin.cc:2253
+#: src/mainwin.cc:2267
 msgid "Untitled.png"
 msgstr "Bez tytułu.png"
 
-#: src/mainwin.cc:2255
+#: src/mainwin.cc:2269
 msgid "Export Image"
 msgstr "Eksportuj obrazek"
 
-#: src/mainwin.cc:2255
+#: src/mainwin.cc:2269
 msgid "PNG Files (*.png)"
 msgstr "Pliki PBG (*.png)"
 
-#: src/mainwin.cc:2523
+#: src/mainwin.cc:2537
 msgid "Console"
 msgstr "Konsola"
 
-#: src/mainwin.cc:2528
+#: src/mainwin.cc:2542
 msgid "Customizer"
 msgstr ""
 
-#: src/mainwin.cc:2672
+#: src/mainwin.cc:2686
 msgid "The document has been modified."
 msgstr "Dokument został zmodyfikowany."
 
-#: src/mainwin.cc:2673
+#: src/mainwin.cc:2687
 msgid "Do you want to save your changes?"
 msgstr "Czy chcesz zapisać zmiany?"
 
@@ -1254,105 +1330,53 @@ msgstr ""
 msgid "After indentation"
 msgstr "Po wcięciu"
 
-#: objects/ui_ParameterEntryWidget.h:343 objects/ui_ParameterWidget.h:150
-msgid "Form"
+#: src/parameter/ParameterWidget.cc:74 src/parameter/ParameterWidget.cc:218
+msgid "changes on current preset not saved"
 msgstr ""
 
-#: objects/ui_ParameterEntryWidget.h:345
-msgid "Parameter"
+#: src/parameter/ParameterWidget.cc:76
+msgid ""
+"The changes on the current preset %1 are not saved yet. Do you really want "
+"to reset this preset and lose your changes?"
 msgstr ""
 
-#: objects/ui_ParameterEntryWidget.h:346 objects/ui_ParameterEntryWidget.h:347
-msgid "Description"
-msgstr ""
-
-#: objects/ui_ParameterWidget.h:151
-msgid "save preset"
-msgstr ""
-
-#: objects/ui_ParameterWidget.h:153
-msgid "delete current preset"
-msgstr ""
-
-#: objects/ui_ParameterWidget.h:155
-msgid "-"
-msgstr ""
-
-#: objects/ui_ParameterWidget.h:157
-msgid "preset selection"
-msgstr ""
-
-#: objects/ui_ParameterWidget.h:160 src/parameter/ParameterWidget.cc:132
-msgid "add new preset"
-msgstr ""
-
-#: objects/ui_ParameterWidget.h:162
-msgid "+"
-msgstr ""
-
-#: objects/ui_ParameterWidget.h:163
-#, fuzzy
-msgid "Automatic Preview"
-msgstr "&Automatycznie przeładuj i pokaż podgląd"
-
-#: objects/ui_ParameterWidget.h:166
-#, fuzzy
-msgid "Show Details"
-msgstr "Pokaż osie"
-
-#: objects/ui_ParameterWidget.h:167
-msgid "Inline Details"
-msgstr ""
-
-#: objects/ui_ParameterWidget.h:168
-#, fuzzy
-msgid "Hide Details"
-msgstr "Ukryj paski narzędzi"
-
-#: objects/ui_ParameterWidget.h:169
-msgid "Description Only"
-msgstr ""
-
-#: objects/ui_ParameterWidget.h:172
-msgid "reset the parameters to the selected preset"
-msgstr ""
-
-#: objects/ui_ParameterWidget.h:174
-#, fuzzy
-msgid "Reset"
-msgstr "Resetuj widok"
-
-#: src/parameter/ParameterWidget.cc:134
+#: src/parameter/ParameterWidget.cc:156
 msgid "remove current preset"
 msgstr ""
 
-#: src/parameter/ParameterWidget.cc:136
+#: src/parameter/ParameterWidget.cc:158
 msgid "save current preset"
 msgstr ""
 
-#: src/parameter/ParameterWidget.cc:138 src/parameter/ParameterWidget.cc:139
-#: src/parameter/ParameterWidget.cc:140
+#: src/parameter/ParameterWidget.cc:160 src/parameter/ParameterWidget.cc:161
+#: src/parameter/ParameterWidget.cc:162
 msgid "JSON file read only"
 msgstr ""
 
-#: src/parameter/ParameterWidget.cc:165
+#: src/parameter/ParameterWidget.cc:202
 msgid "no preset selected"
 msgstr ""
 
-#: src/parameter/ParameterWidget.cc:380
+#: src/parameter/ParameterWidget.cc:220
+msgid ""
+"The current preset %1 contains changes, but is not saved yet. Do you really "
+"want to change the preset and lose your changes?"
+msgstr ""
+
+#: src/parameter/ParameterWidget.cc:449
 msgid "Create new set of parameter"
 msgstr ""
 
-#: src/parameter/ParameterWidget.cc:380
+#: src/parameter/ParameterWidget.cc:449
 msgid "Enter name of the parameter set"
 msgstr ""
 
-#: src/parameter/ParameterWidget.cc:407
+#: src/parameter/ParameterWidget.cc:485
 msgid "Saving presets"
 msgstr ""
 
-#: src/parameter/ParameterWidget.cc:408
-msgid "%1 was found, but was unreadble. Do you want to overwrite %1?"
+#: src/parameter/ParameterWidget.cc:486
+msgid "%1 was found, but was unreadable. Do you want to overwrite %1?"
 msgstr ""
 
 #: examples/examples.json:2
@@ -1372,12 +1396,12 @@ msgid "Old"
 msgstr "Stare"
 
 #. (itstool) path: component/summary
-#: openscad.appdata.xml.in:7
+#: openscad.appdata.xml.in:6
 msgid "The Programmers Solid 3D CAD Modeller"
 msgstr "Program CAD do bryłowego modelownia 3D"
 
 #. (itstool) path: description/p
-#: openscad.appdata.xml.in:9
+#: openscad.appdata.xml.in:19
 msgid ""
 "OpenSCAD is a software for creating solid 3D CAD models. Unlike most free "
 "software for creating 3D models (such as Blender) it does not focus on the "
@@ -1394,7 +1418,7 @@ msgstr ""
 "jesteś zainteresowany w tworzeniu filmów animowanych komputerowo."
 
 #. (itstool) path: description/p
-#: openscad.appdata.xml.in:10
+#: openscad.appdata.xml.in:20
 msgid ""
 "OpenSCAD is not an interactive modeller. Instead it is something like a 3D-"
 "compiler that reads in a script file that describes the object and renders "
@@ -1411,12 +1435,13 @@ msgstr ""
 "konfigurowalnych parametrów."
 
 #. (itstool) path: description/p
-#: openscad.appdata.xml.in:11
+#: openscad.appdata.xml.in:21
+#, fuzzy
 msgid ""
 "OpenSCAD provides two main modelling techniques: First there is constructive "
 "solid geometry (aka CSG) and second there is extrusion of 2D outlines. As "
-"data exchange format format for this 2D outlines Autocad DXF files are used. "
-"In addition to 2D paths for extrusion it is also possible to read design "
+"data exchange format for this 2D outlines Autocad DXF files are used. In "
+"addition to 2D paths for extrusion it is also possible to read design "
 "parameters from DXF files. Besides DXF files OpenSCAD can read and create 3D "
 "models in the STL and OFF file formats."
 msgstr ""
@@ -1425,6 +1450,26 @@ msgstr ""
 "użyć plików w formacie Autocad DXF. Oprócz ścieżek 2D można z tych plików "
 "wczytywać parametry projektu. Dodatkowo OpenSCAD może wczytywać i tworzyć "
 "modele 3D w formacie STL i OFF."
+
+#, fuzzy
+#~ msgid "Reset Trim"
+#~ msgstr "Resetuj widok"
+
+#, fuzzy
+#~ msgid "Rotation"
+#~ msgstr "&Dokumentacja"
+
+#, fuzzy
+#~ msgid "Zoom"
+#~ msgstr "Przybliż"
+
+#, fuzzy
+#~ msgid "ViewPort rel.<br/>Translation"
+#~ msgstr "Wklej przesunięcie podglądu (&translate)"
+
+#, fuzzy
+#~ msgid "SpaceNav"
+#~ msgstr "Spacji"
 
 #~ msgid "<"
 #~ msgstr "<"

--- a/locale/ru.po
+++ b/locale/ru.po
@@ -5,7 +5,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: OpenSCAD 2015.03\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2018-03-01 07:52+0100\n"
+"POT-Creation-Date: 2018-08-15 13:13+0200\n"
 "PO-Revision-Date: 2015-03-11 10:03+0300\n"
 "Last-Translator: Alexandre Prokoudine <alexandre.prokoudine@gmail.com>\n"
 "Language-Team: Russian\n"
@@ -768,287 +768,363 @@ msgstr "Показывать снова"
 msgid "Close"
 msgstr "Закрыть"
 
-#: objects/ui_Preferences.h:1080
+#: objects/ui_ParameterEntryWidget.h:339 objects/ui_ParameterWidget.h:150
+msgid "Form"
+msgstr ""
+
+#: objects/ui_ParameterEntryWidget.h:341
+msgid "Parameter"
+msgstr ""
+
+#: objects/ui_ParameterEntryWidget.h:342 objects/ui_ParameterEntryWidget.h:343
+msgid "Description"
+msgstr ""
+
+#: objects/ui_ParameterWidget.h:151
+msgid "save preset"
+msgstr ""
+
+#: objects/ui_ParameterWidget.h:153
+msgid "delete current preset"
+msgstr ""
+
+#: objects/ui_ParameterWidget.h:155
+msgid "-"
+msgstr ""
+
+#: objects/ui_ParameterWidget.h:157
+msgid "preset selection"
+msgstr ""
+
+#: objects/ui_ParameterWidget.h:160 src/parameter/ParameterWidget.cc:154
+msgid "add new preset"
+msgstr ""
+
+#: objects/ui_ParameterWidget.h:162
+msgid "+"
+msgstr ""
+
+#: objects/ui_ParameterWidget.h:163
+#, fuzzy
+msgid "Automatic Preview"
+msgstr "&Автоматически обновлять и выполнять предпросмотр"
+
+#: objects/ui_ParameterWidget.h:166
+#, fuzzy
+msgid "Show Details"
+msgstr "Показывать оси"
+
+#: objects/ui_ParameterWidget.h:167
+msgid "Inline Details"
+msgstr ""
+
+#: objects/ui_ParameterWidget.h:168
+#, fuzzy
+msgid "Hide Details"
+msgstr "Скрыть панели"
+
+#: objects/ui_ParameterWidget.h:169
+msgid "Description Only"
+msgstr ""
+
+#: objects/ui_ParameterWidget.h:172
+msgid "reset the parameters to the selected preset"
+msgstr ""
+
+#: objects/ui_ParameterWidget.h:174
+#, fuzzy
+msgid "Reset"
+msgstr "Сбросить вид"
+
+#: objects/ui_Preferences.h:1094
 msgid "Preferences"
 msgstr "Параметры OpenSCAD"
 
-#: objects/ui_Preferences.h:1081
+#: objects/ui_Preferences.h:1095
 msgid "3D View"
 msgstr "Просмотр 3D"
 
-#: objects/ui_Preferences.h:1082 examples/examples.json:19
+#: objects/ui_Preferences.h:1096 examples/examples.json:19
 msgid "Advanced"
 msgstr "Дополнительные"
 
-#: objects/ui_Preferences.h:1083 src/mainwin.cc:2518
+#: objects/ui_Preferences.h:1097 src/mainwin.cc:2532
 msgid "Editor"
 msgstr "Редактор"
 
-#: objects/ui_Preferences.h:1084
+#: objects/ui_Preferences.h:1098
 msgid "Update"
 msgstr "Обновления"
 
-#: objects/ui_Preferences.h:1085 objects/ui_Preferences.h:1168
+#: objects/ui_Preferences.h:1099 objects/ui_Preferences.h:1182
 msgid "Features"
 msgstr "Функции"
 
-#: objects/ui_Preferences.h:1087
+#: objects/ui_Preferences.h:1101
 msgid "Enable/Disable experimental features"
 msgstr "Включить/Выключить экспериментальные возможности"
 
-#: objects/ui_Preferences.h:1089
+#: objects/ui_Preferences.h:1103
 msgid "Color scheme:"
 msgstr "Цветовая схема:"
 
-#: objects/ui_Preferences.h:1090
+#: objects/ui_Preferences.h:1104
 msgid "Show Warnings and Errors in 3D View"
 msgstr "Показывать ошибки и предупреждения в 3D виде"
 
-#: objects/ui_Preferences.h:1091
+#: objects/ui_Preferences.h:1105
 msgid "Editor Type"
 msgstr "Редактор"
 
-#: objects/ui_Preferences.h:1094
+#: objects/ui_Preferences.h:1108
 msgid "Simple Editor"
 msgstr "Простой редактор"
 
-#: objects/ui_Preferences.h:1095
+#: objects/ui_Preferences.h:1109
 msgid "QScintilla Editor"
 msgstr "Редактор QScintilla"
 
-#: objects/ui_Preferences.h:1097
+#: objects/ui_Preferences.h:1111
 msgid "(requires restart)"
 msgstr "(требуется перезапуск)"
 
-#: objects/ui_Preferences.h:1098
+#: objects/ui_Preferences.h:1112
 msgid "Font"
 msgstr "Шрифт"
 
-#: objects/ui_Preferences.h:1099
+#: objects/ui_Preferences.h:1113
 msgid "Color syntax highlighting"
 msgstr "Подсветка синтаксиса"
 
-#: objects/ui_Preferences.h:1100
+#: objects/ui_Preferences.h:1114
 msgid "Ctrl/Cmd-Mouse-wheel zooms text"
 msgstr "Ctrl/Cmd-Колесико-мыши увеличивает текст"
 
-#: objects/ui_Preferences.h:1101
+#: objects/ui_Preferences.h:1115
 msgid "Indentation"
 msgstr "Отступы"
 
-#: objects/ui_Preferences.h:1102
+#: objects/ui_Preferences.h:1116
 msgid "Auto Indent"
 msgstr "Автоотступы"
 
-#: objects/ui_Preferences.h:1103
+#: objects/ui_Preferences.h:1117
 msgid "Backspace unindents"
 msgstr ""
 
-#: objects/ui_Preferences.h:1104
+#: objects/ui_Preferences.h:1118
 msgid "Indent using"
 msgstr "Делать отступы"
 
-#: objects/ui_Preferences.h:1107 src/settings.cc:141
+#: objects/ui_Preferences.h:1121 src/settings.cc:141
 msgid "Spaces"
 msgstr "Пробелами"
 
-#: objects/ui_Preferences.h:1108 src/settings.cc:141
+#: objects/ui_Preferences.h:1122 src/settings.cc:141
 msgid "Tabs"
 msgstr "Табуляцией"
 
-#: objects/ui_Preferences.h:1110
+#: objects/ui_Preferences.h:1124
 msgid "Indentation width"
 msgstr "Ширина отступа"
 
-#: objects/ui_Preferences.h:1111
+#: objects/ui_Preferences.h:1125
 msgid "Tab width"
 msgstr "Ширина табуляции"
 
-#: objects/ui_Preferences.h:1112
+#: objects/ui_Preferences.h:1126
 msgid "Tab key function"
 msgstr "Функция клавиши Tab"
 
-#: objects/ui_Preferences.h:1115 objects/ui_Preferences.h:1146
+#: objects/ui_Preferences.h:1129 objects/ui_Preferences.h:1160
 #: src/settings.cc:142
 msgid "Indent"
 msgstr "Отступов"
 
-#: objects/ui_Preferences.h:1116 src/settings.cc:142
+#: objects/ui_Preferences.h:1130 src/settings.cc:142
 msgid "Insert Tab"
 msgstr "Вставить Tab"
 
-#: objects/ui_Preferences.h:1118
+#: objects/ui_Preferences.h:1132
 msgid "Show whitespace"
 msgstr "Показывать пробел"
 
-#: objects/ui_Preferences.h:1121 src/settings.cc:137
+#: objects/ui_Preferences.h:1135 src/settings.cc:137
 msgid "Never"
 msgstr "Никогда"
 
-#: objects/ui_Preferences.h:1122 src/settings.cc:137
+#: objects/ui_Preferences.h:1136 src/settings.cc:137
 msgid "Always"
 msgstr "Всегда"
 
-#: objects/ui_Preferences.h:1123
+#: objects/ui_Preferences.h:1137
 msgid "Only after indentation"
 msgstr "Только после отступа"
 
-#: objects/ui_Preferences.h:1125
+#: objects/ui_Preferences.h:1139
 msgid "Size"
 msgstr "Размер"
 
-#: objects/ui_Preferences.h:1126
+#: objects/ui_Preferences.h:1140
 msgid "Display"
 msgstr "Вид"
 
-#: objects/ui_Preferences.h:1127
+#: objects/ui_Preferences.h:1141
 msgid "Enable brace matching"
 msgstr "Подсвечивать парные скобки"
 
-#: objects/ui_Preferences.h:1128
+#: objects/ui_Preferences.h:1142
 msgid "Highlight current line"
 msgstr "Выделять текущую строку"
 
-#: objects/ui_Preferences.h:1129
+#: objects/ui_Preferences.h:1143
 msgid "Display Line Numbers"
 msgstr ""
 
-#: objects/ui_Preferences.h:1130 objects/ui_Preferences.h:1163
+#: objects/ui_Preferences.h:1144 objects/ui_Preferences.h:1177
 msgid "Line wrap"
 msgstr "Перенос строк"
 
-#: objects/ui_Preferences.h:1133 objects/ui_Preferences.h:1150
-#: objects/ui_Preferences.h:1158 src/settings.cc:132 src/settings.cc:135
+#: objects/ui_Preferences.h:1147 objects/ui_Preferences.h:1164
+#: objects/ui_Preferences.h:1172 src/settings.cc:132 src/settings.cc:135
 #: src/settings.cc:136
 msgid "None"
 msgstr "Нет"
 
-#: objects/ui_Preferences.h:1134 src/settings.cc:132
+#: objects/ui_Preferences.h:1148 src/settings.cc:132
 msgid "Wrap at character boundaries"
 msgstr "Перенос с границы символа"
 
-#: objects/ui_Preferences.h:1135 src/settings.cc:132
+#: objects/ui_Preferences.h:1149 src/settings.cc:132
 msgid "Wrap at word boundaries"
 msgstr "Перенос с границы слова"
 
-#: objects/ui_Preferences.h:1137
+#: objects/ui_Preferences.h:1151
 msgid "Line wrap indentation"
 msgstr "Отступы в переносах:"
 
-#: objects/ui_Preferences.h:1138
+#: objects/ui_Preferences.h:1152
 msgid "Line wrap visualization"
 msgstr "Вид переносов строк:"
 
-#: objects/ui_Preferences.h:1139
+#: objects/ui_Preferences.h:1153
 msgid "Style"
 msgstr "Стиль"
 
-#: objects/ui_Preferences.h:1142 src/settings.cc:133
+#: objects/ui_Preferences.h:1156 src/settings.cc:133
 msgid "Fixed"
 msgstr "Фиксированный"
 
-#: objects/ui_Preferences.h:1143 src/settings.cc:133
+#: objects/ui_Preferences.h:1157 src/settings.cc:133
 msgid "Same"
 msgstr "Такой же"
 
-#: objects/ui_Preferences.h:1144 src/settings.cc:133
+#: objects/ui_Preferences.h:1158 src/settings.cc:133
 msgid "Indented"
 msgstr "С отступами"
 
-#: objects/ui_Preferences.h:1147
+#: objects/ui_Preferences.h:1161
 msgid "Start"
 msgstr "Начало"
 
-#: objects/ui_Preferences.h:1151 objects/ui_Preferences.h:1159
+#: objects/ui_Preferences.h:1165 objects/ui_Preferences.h:1173
 #: src/settings.cc:135 src/settings.cc:136
 msgid "Text"
 msgstr "Текст"
 
-#: objects/ui_Preferences.h:1152 objects/ui_Preferences.h:1160
+#: objects/ui_Preferences.h:1166 objects/ui_Preferences.h:1174
 #: src/settings.cc:135 src/settings.cc:136
 msgid "Border"
 msgstr "Граница"
 
-#: objects/ui_Preferences.h:1153 objects/ui_Preferences.h:1161
+#: objects/ui_Preferences.h:1167 objects/ui_Preferences.h:1175
 #: src/settings.cc:135 src/settings.cc:136
 msgid "Margin"
 msgstr "Поле"
 
-#: objects/ui_Preferences.h:1155
+#: objects/ui_Preferences.h:1169
 msgid "End"
 msgstr "Конец"
 
-#: objects/ui_Preferences.h:1164
+#: objects/ui_Preferences.h:1178
 msgid "Automatically check for updates"
 msgstr "Автоматически проверять обновления"
 
-#: objects/ui_Preferences.h:1165
+#: objects/ui_Preferences.h:1179
 msgid "Include development snapshots"
 msgstr "Включая рабочие сборки"
 
-#: objects/ui_Preferences.h:1166
+#: objects/ui_Preferences.h:1180
 msgid "Check Now"
 msgstr "Проверить сейчас"
 
-#: objects/ui_Preferences.h:1167
+#: objects/ui_Preferences.h:1181
 msgid "Last checked: "
 msgstr "Последняя проверка: "
 
-#: objects/ui_Preferences.h:1169
+#: objects/ui_Preferences.h:1183
 msgid "OpenCSG"
 msgstr "OpenCSG"
 
-#: objects/ui_Preferences.h:1170
+#: objects/ui_Preferences.h:1184
 msgid "Show capability warning"
 msgstr "Показывать предупреждение о возможностях"
 
-#: objects/ui_Preferences.h:1171
+#: objects/ui_Preferences.h:1185
 msgid "Enable for OpenGL 1.x"
 msgstr "Включить для OpenGL 1.x"
 
-#: objects/ui_Preferences.h:1172
+#: objects/ui_Preferences.h:1186
 msgid "Turn off rendering at "
 msgstr "Отключать отрисовку на "
 
-#: objects/ui_Preferences.h:1173
+#: objects/ui_Preferences.h:1187
 msgid "elements"
 msgstr "элементах"
 
-#: objects/ui_Preferences.h:1174
+#: objects/ui_Preferences.h:1188
 msgid "Force Goldfeather"
 msgstr "Принудительно использовать Goldfeather"
 
-#: objects/ui_Preferences.h:1175
+#: objects/ui_Preferences.h:1189
 msgid "CGAL Cache size"
 msgstr "Размер кэша CGAL"
 
-#: objects/ui_Preferences.h:1176 objects/ui_Preferences.h:1178
+#: objects/ui_Preferences.h:1190 objects/ui_Preferences.h:1192
 msgid "bytes"
 msgstr "байт"
 
-#: objects/ui_Preferences.h:1177
+#: objects/ui_Preferences.h:1191
 msgid "PolySet Cache size"
 msgstr "Размер кэша PolySet"
 
-#: objects/ui_Preferences.h:1179
+#: objects/ui_Preferences.h:1193
 msgid "Allow opening multiple documents"
 msgstr "Разрешить открытие нескольких документов"
 
-#: objects/ui_Preferences.h:1180
+#: objects/ui_Preferences.h:1194
 msgid "Enable docking of Editor and Console in different places"
 msgstr "Включить прилипание Редактора и Консоли в разных местах"
 
-#: objects/ui_Preferences.h:1181
+#: objects/ui_Preferences.h:1195
 msgid "Enable undocking of Editor and Console to separate windows"
 msgstr "Включить перетаскивание Редактора и Консоли в разные окна"
 
-#: objects/ui_Preferences.h:1182
+#: objects/ui_Preferences.h:1196
 msgid "Show Welcome Screen"
 msgstr "Показать экран приветствия"
 
-#: objects/ui_Preferences.h:1183
+#: objects/ui_Preferences.h:1197
 msgid "Enable user interface localization (requires restart of OpenSCAD)"
 msgstr "Включить локализацию интерфейса (необходимо перезапустить OpenSCAD)"
+
+#: objects/ui_Preferences.h:1198
+msgid "Bring window to front after automatic reload"
+msgstr ""
+
+#: objects/ui_Preferences.h:1199
+msgid "Play sound notification on render complete"
+msgstr ""
 
 #: objects/ui_ProgressWidget.h:72
 msgid "%v / %m"
@@ -1073,51 +1149,51 @@ msgstr ""
 msgid "ERROR: \"%s\" write error. (Disk full?)"
 msgstr ""
 
-#: src/mainwin.cc:788 src/mainwin.cc:1438
+#: src/mainwin.cc:789 src/mainwin.cc:1443
 msgid "Untitled.scad"
 msgstr "Безымянный.scad"
 
-#: src/mainwin.cc:1027
+#: src/mainwin.cc:1032
 msgid "Compile error."
 msgstr "Ошибка при сборке"
 
-#: src/mainwin.cc:1030
+#: src/mainwin.cc:1035
 msgid "Error while compiling '%1'."
 msgstr "Ошибка при сборке '%1'."
 
-#: src/mainwin.cc:1034
+#: src/mainwin.cc:1039
 msgid "Compilation generated %1 warning."
 msgid_plural "Compilation generated %1 warnings."
 msgstr[0] "При сборке выведено %1 предупреждение"
 msgstr[1] "При сборке выведено %1 предупреждения"
 msgstr[2] "При сборке выведено %1 предупреждений"
 
-#: src/mainwin.cc:1044
+#: src/mainwin.cc:1049
 msgid " For details see <a href=\"#console\">console window</a>."
 msgstr "Для подробностей смотреть <a href=\"#console\">окно консоли</a>."
 
-#: src/mainwin.cc:1416
+#: src/mainwin.cc:1421
 msgid "Failed to open file for writing"
 msgstr ""
 
-#: src/mainwin.cc:1426
+#: src/mainwin.cc:1431
 #, c-format
 msgid "Saved design '%s'."
 msgstr ""
 
-#: src/mainwin.cc:1429
+#: src/mainwin.cc:1434
 msgid "Error saving design"
 msgstr ""
 
-#: src/mainwin.cc:1437
+#: src/mainwin.cc:1442
 msgid "Save File"
 msgstr "Сохранить файл"
 
-#: src/mainwin.cc:1439
+#: src/mainwin.cc:1444
 msgid "OpenSCAD Designs (*.scad)"
 msgstr "Модели OpenSCAD (*.scad)"
 
-#: src/mainwin.cc:1449
+#: src/mainwin.cc:1454
 msgid ""
 "%1 already exists.\n"
 "Do you want to replace it?"
@@ -1125,11 +1201,11 @@ msgstr ""
 "%1 уже существует.\n"
 "Перезаписать?"
 
-#: src/mainwin.cc:1796
+#: src/mainwin.cc:1805
 msgid "Application"
 msgstr "Приложение"
 
-#: src/mainwin.cc:1797
+#: src/mainwin.cc:1806
 msgid ""
 "The document has been modified.\n"
 "Do you really want to reload the file?"
@@ -1137,56 +1213,56 @@ msgstr ""
 "Документ был изменен.\n"
 "Хотите перезагрузить документ?"
 
-#: src/mainwin.cc:2171
+#: src/mainwin.cc:2185
 msgid "Export %1 File"
 msgstr "Экспортировать в файл формата %1"
 
-#: src/mainwin.cc:2172
+#: src/mainwin.cc:2186
 msgid "%1 Files (*%2)"
 msgstr "Файлы %1 (*%2)"
 
-#: src/mainwin.cc:2173
+#: src/mainwin.cc:2187
 msgid "Untitled"
 msgstr "Безымянный.scad"
 
-#: src/mainwin.cc:2225
+#: src/mainwin.cc:2239
 msgid "Export CSG File"
 msgstr "Экспортировать файл CSG"
 
-#: src/mainwin.cc:2226
+#: src/mainwin.cc:2240
 msgid "Untitled.csg"
 msgstr "Безымянный.csg"
 
-#: src/mainwin.cc:2227
+#: src/mainwin.cc:2241
 msgid "CSG Files (*.csg)"
 msgstr "Файлы CSG (*.csg)"
 
-#: src/mainwin.cc:2253
+#: src/mainwin.cc:2267
 #, fuzzy
 msgid "Untitled.png"
 msgstr "Безымянный.csg"
 
-#: src/mainwin.cc:2255
+#: src/mainwin.cc:2269
 msgid "Export Image"
 msgstr "Экспортировать изображение"
 
-#: src/mainwin.cc:2255
+#: src/mainwin.cc:2269
 msgid "PNG Files (*.png)"
 msgstr "Файлы PNG (*.png)"
 
-#: src/mainwin.cc:2523
+#: src/mainwin.cc:2537
 msgid "Console"
 msgstr "Консоль"
 
-#: src/mainwin.cc:2528
+#: src/mainwin.cc:2542
 msgid "Customizer"
 msgstr ""
 
-#: src/mainwin.cc:2672
+#: src/mainwin.cc:2686
 msgid "The document has been modified."
 msgstr "Документ был изменен."
 
-#: src/mainwin.cc:2673
+#: src/mainwin.cc:2687
 msgid "Do you want to save your changes?"
 msgstr "Сохранить изменения?"
 
@@ -1255,105 +1331,53 @@ msgstr ""
 msgid "After indentation"
 msgstr "После отступа"
 
-#: objects/ui_ParameterEntryWidget.h:343 objects/ui_ParameterWidget.h:150
-msgid "Form"
+#: src/parameter/ParameterWidget.cc:74 src/parameter/ParameterWidget.cc:218
+msgid "changes on current preset not saved"
 msgstr ""
 
-#: objects/ui_ParameterEntryWidget.h:345
-msgid "Parameter"
+#: src/parameter/ParameterWidget.cc:76
+msgid ""
+"The changes on the current preset %1 are not saved yet. Do you really want "
+"to reset this preset and lose your changes?"
 msgstr ""
 
-#: objects/ui_ParameterEntryWidget.h:346 objects/ui_ParameterEntryWidget.h:347
-msgid "Description"
-msgstr ""
-
-#: objects/ui_ParameterWidget.h:151
-msgid "save preset"
-msgstr ""
-
-#: objects/ui_ParameterWidget.h:153
-msgid "delete current preset"
-msgstr ""
-
-#: objects/ui_ParameterWidget.h:155
-msgid "-"
-msgstr ""
-
-#: objects/ui_ParameterWidget.h:157
-msgid "preset selection"
-msgstr ""
-
-#: objects/ui_ParameterWidget.h:160 src/parameter/ParameterWidget.cc:132
-msgid "add new preset"
-msgstr ""
-
-#: objects/ui_ParameterWidget.h:162
-msgid "+"
-msgstr ""
-
-#: objects/ui_ParameterWidget.h:163
-#, fuzzy
-msgid "Automatic Preview"
-msgstr "&Автоматически обновлять и выполнять предпросмотр"
-
-#: objects/ui_ParameterWidget.h:166
-#, fuzzy
-msgid "Show Details"
-msgstr "Показывать оси"
-
-#: objects/ui_ParameterWidget.h:167
-msgid "Inline Details"
-msgstr ""
-
-#: objects/ui_ParameterWidget.h:168
-#, fuzzy
-msgid "Hide Details"
-msgstr "Скрыть панели"
-
-#: objects/ui_ParameterWidget.h:169
-msgid "Description Only"
-msgstr ""
-
-#: objects/ui_ParameterWidget.h:172
-msgid "reset the parameters to the selected preset"
-msgstr ""
-
-#: objects/ui_ParameterWidget.h:174
-#, fuzzy
-msgid "Reset"
-msgstr "Сбросить вид"
-
-#: src/parameter/ParameterWidget.cc:134
+#: src/parameter/ParameterWidget.cc:156
 msgid "remove current preset"
 msgstr ""
 
-#: src/parameter/ParameterWidget.cc:136
+#: src/parameter/ParameterWidget.cc:158
 msgid "save current preset"
 msgstr ""
 
-#: src/parameter/ParameterWidget.cc:138 src/parameter/ParameterWidget.cc:139
-#: src/parameter/ParameterWidget.cc:140
+#: src/parameter/ParameterWidget.cc:160 src/parameter/ParameterWidget.cc:161
+#: src/parameter/ParameterWidget.cc:162
 msgid "JSON file read only"
 msgstr ""
 
-#: src/parameter/ParameterWidget.cc:165
+#: src/parameter/ParameterWidget.cc:202
 msgid "no preset selected"
 msgstr ""
 
-#: src/parameter/ParameterWidget.cc:380
+#: src/parameter/ParameterWidget.cc:220
+msgid ""
+"The current preset %1 contains changes, but is not saved yet. Do you really "
+"want to change the preset and lose your changes?"
+msgstr ""
+
+#: src/parameter/ParameterWidget.cc:449
 msgid "Create new set of parameter"
 msgstr ""
 
-#: src/parameter/ParameterWidget.cc:380
+#: src/parameter/ParameterWidget.cc:449
 msgid "Enter name of the parameter set"
 msgstr ""
 
-#: src/parameter/ParameterWidget.cc:407
+#: src/parameter/ParameterWidget.cc:485
 msgid "Saving presets"
 msgstr ""
 
-#: src/parameter/ParameterWidget.cc:408
-msgid "%1 was found, but was unreadble. Do you want to overwrite %1?"
+#: src/parameter/ParameterWidget.cc:486
+msgid "%1 was found, but was unreadable. Do you want to overwrite %1?"
 msgstr ""
 
 #: examples/examples.json:2
@@ -1373,12 +1397,12 @@ msgid "Old"
 msgstr "Старый"
 
 #. (itstool) path: component/summary
-#: openscad.appdata.xml.in:7
+#: openscad.appdata.xml.in:6
 msgid "The Programmers Solid 3D CAD Modeller"
 msgstr ""
 
 #. (itstool) path: description/p
-#: openscad.appdata.xml.in:9
+#: openscad.appdata.xml.in:19
 msgid ""
 "OpenSCAD is a software for creating solid 3D CAD models. Unlike most free "
 "software for creating 3D models (such as Blender) it does not focus on the "
@@ -1389,7 +1413,7 @@ msgid ""
 msgstr ""
 
 #. (itstool) path: description/p
-#: openscad.appdata.xml.in:10
+#: openscad.appdata.xml.in:20
 msgid ""
 "OpenSCAD is not an interactive modeller. Instead it is something like a 3D-"
 "compiler that reads in a script file that describes the object and renders "
@@ -1400,15 +1424,35 @@ msgid ""
 msgstr ""
 
 #. (itstool) path: description/p
-#: openscad.appdata.xml.in:11
+#: openscad.appdata.xml.in:21
 msgid ""
 "OpenSCAD provides two main modelling techniques: First there is constructive "
 "solid geometry (aka CSG) and second there is extrusion of 2D outlines. As "
-"data exchange format format for this 2D outlines Autocad DXF files are used. "
-"In addition to 2D paths for extrusion it is also possible to read design "
+"data exchange format for this 2D outlines Autocad DXF files are used. In "
+"addition to 2D paths for extrusion it is also possible to read design "
 "parameters from DXF files. Besides DXF files OpenSCAD can read and create 3D "
 "models in the STL and OFF file formats."
 msgstr ""
+
+#, fuzzy
+#~ msgid "Reset Trim"
+#~ msgstr "Сбросить вид"
+
+#, fuzzy
+#~ msgid "Rotation"
+#~ msgstr "&Документация"
+
+#, fuzzy
+#~ msgid "Zoom"
+#~ msgstr "Увеличить масштаб"
+
+#, fuzzy
+#~ msgid "ViewPort rel.<br/>Translation"
+#~ msgstr "Вст&авить смещение точки обзора"
+
+#, fuzzy
+#~ msgid "SpaceNav"
+#~ msgstr "Пробелами"
 
 #~ msgid "<"
 #~ msgstr "<"

--- a/locale/ru.po
+++ b/locale/ru.po
@@ -5,7 +5,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: OpenSCAD 2015.03\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2018-08-15 13:13+0200\n"
+"POT-Creation-Date: 2018-08-15 15:07+0200\n"
 "PO-Revision-Date: 2015-03-11 10:03+0300\n"
 "Last-Translator: Alexandre Prokoudine <alexandre.prokoudine@gmail.com>\n"
 "Language-Team: Russian\n"
@@ -844,7 +844,9 @@ msgstr "Параметры OpenSCAD"
 msgid "3D View"
 msgstr "Просмотр 3D"
 
-#: objects/ui_Preferences.h:1096 examples/examples.json:19
+#: objects/ui_Preferences.h:1096
+#, fuzzy
+msgctxt "preferences"
 msgid "Advanced"
 msgstr "Дополнительные"
 
@@ -1387,6 +1389,10 @@ msgstr "Примитивы"
 #: examples/examples.json:13
 msgid "Functions"
 msgstr "Функции"
+
+#: examples/examples.json:19
+msgid "Advanced"
+msgstr "Дополнительные"
 
 #: examples/examples.json:28
 msgid "Parametric"

--- a/scripts/translation-update.sh
+++ b/scripts/translation-update.sh
@@ -34,7 +34,8 @@ updatepot()
  OPTS=$OPTS' --package-version='$VER
  OPTS=$OPTS' --default-domain=openscad'
  OPTS=$OPTS' --keyword=_'
- OPTS=$OPTS' --keyword=N_'
+ OPTS=$OPTS' --keyword=N_,'
+ OPTS=$OPTS' --keyword=_:1,2c'
  OPTS=$OPTS' --files-from=./locale/POTFILES'
  cmd="${GETTEXT_PATH}xgettext "$OPTS' -o ./locale/openscad-tmp.pot'
  echo $cmd

--- a/src/Preferences.ui
+++ b/src/Preferences.ui
@@ -1529,7 +1529,7 @@
      <normaloff>:/icons/prefsAdvanced.png</normaloff>:/icons/prefsAdvanced.png</iconset>
    </property>
    <property name="text">
-    <string>Advanced</string>
+    <string comment="preferences">Advanced</string>
    </property>
   </action>
   <action name="prefsActionEditor">


### PR DESCRIPTION
for issue  #2431 

side notes:
   * clarify, that CONFIG+=experimental should be used when updating the translation files (relates to #2316)
   * update the translation
   * adding translation context
     * adding `-keyword=_:1,2c` to `xgettext` `OPTS`
     * `<string comment="preferences">Advanced</string>`
