### PR TITLE
Adds "record" data type

### DIFF
--- a/src/expression.h
+++ b/src/expression.h
@@ -4,6 +4,7 @@
 
 #include <string>
 #include <vector>
+#include <unordered_map>
 #include "value.h"
 #include "memory.h"
 #include "Assignment.h"
@@ -125,6 +126,18 @@ public:
 	bool isLiteral() const override;
 private:
 	std::vector<shared_ptr<Expression>> children;
+};
+
+class Record : public Expression
+{
+public:
+	Record(const Location &loc);
+	ValuePtr evaluate(const class Context *context) const override;
+	void print(std::ostream &stream, const std::string &indent) const override;
+	bool isLiteral() const override;
+	void add(const char *key, Expression *expr);
+private:
+	std::unordered_map<std::string, shared_ptr<Expression>> children;
 };
 
 class Lookup : public Expression

--- a/src/parser.y
+++ b/src/parser.y
@@ -78,6 +78,7 @@ std::shared_ptr<fs::path> parser_sourcefile;
   class Value *value;
   class Expression *expr;
   class Vector *vec;
+  class Record *rec;
   class ModuleInstantiation *inst;
   class IfElseModuleInstantiation *ifelse;
   class Assignment *arg;
@@ -129,6 +130,7 @@ std::shared_ptr<fs::path> parser_sourcefile;
 
 %type <expr> expr
 %type <vec> vector_expr
+%type <rec> record_expr
 %type <expr> list_comprehension_elements
 %type <expr> list_comprehension_elements_p
 %type <expr> list_comprehension_elements_or_expr
@@ -363,6 +365,14 @@ expr:
             {
               $$ = $2;
             }
+        | '{' optional_commas '}'
+            {
+              $$ = new Literal(ValuePtr(Value::RecordType()), LOC(@$));
+            }
+        | '{' record_expr optional_commas '}'
+            {
+              $$ = $2;
+            }
         | expr '*' expr
             {
               $$ = new BinaryOp($1, BinaryOp::Op::Multiply, $3, LOC(@$));
@@ -550,6 +560,20 @@ vector_expr:
               $$->push_back($4);
             }
         ;
+
+record_expr:
+           TOK_ID ':' expr
+            {
+              $$ = new Record(LOC(@$));
+              $$->add($1,$3);
+              free($1);
+            }
+        | record_expr ',' optional_commas TOK_ID ':' expr
+            {
+              $$ = $1;
+              $$->add($4,$6);
+              free($4);
+            }
 
 arguments_decl:
           /* empty */

--- a/src/value.h
+++ b/src/value.h
@@ -4,6 +4,7 @@
 #include <string>
 #include <algorithm>
 #include <limits>
+#include <unordered_map>
 
 // Workaround for https://bugreports.qt-project.org/browse/QTBUG-22829
 #ifndef Q_MOC_RUN
@@ -112,6 +113,7 @@ public:
   ValuePtr(const char v);
   ValuePtr(const class std::vector<ValuePtr> &v);
   ValuePtr(const class RangeType &v);
+  ValuePtr(const class std::unordered_map<std::string, ValuePtr> &v);
 
 	operator bool() const;
 
@@ -159,6 +161,7 @@ class Value
 {
 public:
 	typedef std::vector<ValuePtr> VectorType;
+	typedef std::unordered_map<std::string, ValuePtr> RecordType;
 
   enum class ValueType {
     UNDEFINED,
@@ -166,7 +169,8 @@ public:
     NUMBER,
     STRING,
     VECTOR,
-    RANGE
+    RANGE,
+    RECORD
   };
   static const Value undefined;
 
@@ -179,6 +183,7 @@ public:
   Value(const char v);
   Value(const VectorType &v);
   Value(const RangeType &v);
+  Value(const RecordType &v);
   ~Value() {}
 
   ValueType type() const;
@@ -194,6 +199,7 @@ public:
   std::string toEchoString() const;
   std::string chrString() const;
   const VectorType &toVector() const;
+  const RecordType &toRecord() const;
   bool getVec2(double &x, double &y, bool ignoreInfinite = false) const;
   bool getVec3(double &x, double &y, double &z, double defaultval = 0.0) const;
   RangeType toRange() const;
@@ -221,7 +227,7 @@ public:
     return stream;
   }
 
-  typedef boost::variant< boost::blank, bool, double, str_utf8_wrapper, VectorType, RangeType > Variant;
+  typedef boost::variant< boost::blank, bool, double, str_utf8_wrapper, VectorType, RangeType, RecordType > Variant;
 
 private:
   static Value multvecnum(const Value &vecval, const Value &numval);


### PR DESCRIPTION
I've added support for simple, untyped key-value stores. Currently, records are created like `{key: "value", e: [1,2,3,4], f: 5}`, and objects are accessed with dot syntax. Under the hood, I use std::unordered_map.

When coerced to a boolean, only the empty record returns false. The `+`, `-`, and `*` operators are overloaded to refer to set union, difference, and intersection respectively, with values taken from the second operand. Currently, there is no way to iterate over records, but it's worth looking into.

I plan to use this feature as a more readable and extensible alternative to long lists of kwargs. For example, take a module like this:
```
module example(args) {
    defaults = {
        radius: 5.0,
        height: 10.0,
        points: [[0,0], [1,0], [1,1], [0,1]]
    };
    settings = defaults + args;
    echo(settings.points);
}
example({radius: 8.0});
```
The record syntax also allows the use of more complicated expressions than function argument defaults.

Another obvious use is for basic data objects, beyond what makes sense to use arrays or xyz object access for:
```
connector = {h: 3.0, w: 8.0, l: 30.0};
flange = {h: 3.0, r: 30.0};
function volume(cube) = cube.h * cube.w * cube.l;
volume(connector);
```