### PR TITLE
osx high Sierra  fixes

### DIFF
--- a/scripts/macosx-build-dependencies.sh
+++ b/scripts/macosx-build-dependencies.sh
@@ -302,7 +302,7 @@ build_mpfr()
   cd $BASEDIR/src
   rm -rf mpfr-$version
   if [ ! -f mpfr-$version.tar.bz2 ]; then
-    curl -O http://www.mpfr.org/mpfr-$version/mpfr-$version.tar.bz2
+    curl -L -O http://www.mpfr.org/mpfr-$version/mpfr-$version.tar.bz2
   fi
   tar xjf mpfr-$version.tar.bz2
   cd mpfr-$version

--- a/scripts/macosx-build-dependencies.sh
+++ b/scripts/macosx-build-dependencies.sh
@@ -604,7 +604,7 @@ build_fontconfig()
   cd "$BASEDIR"/src
   rm -rf "fontconfig-$version"
   if [ ! -f "fontconfig-$version.tar.gz" ]; then
-    curl --insecure -LO "http://www.freedesktop.org/software/fontconfig/release/fontconfig-$version.tar.gz"
+    curl -LO "http://www.freedesktop.org/software/fontconfig/release/fontconfig-$version.tar.gz"
   fi
   tar xzf "fontconfig-$version.tar.gz"
   cd "fontconfig-$version"
@@ -762,8 +762,12 @@ done
 OPTION_PACKAGES="${@:$OPTIND}"
 
 OSX_VERSION=`sw_vers -productVersion | cut -d. -f2`
-if (( $OSX_VERSION >= 13 )); then
+if (( $OSX_VERSION >= 14 )); then
+  echo "Detected Mojave (10.14) or later"
+elif (( $OSX_VERSION >= 13 )); then
   echo "Detected High Sierra (10.13) or later"
+elif (( $OSX_VERSION >= 12 )); then
+  echo "Detected Sierra (10.12) or later"
 elif (( $OSX_VERSION >= 11 )); then
   echo "Detected El Capitan (10.11) or later"
 elif (( $OSX_VERSION >= 10 )); then

--- a/scripts/macosx-build-dependencies.sh
+++ b/scripts/macosx-build-dependencies.sh
@@ -212,11 +212,11 @@ build_qt5()
   echo "Building Qt" $version "..."
   cd $BASEDIR/src
   v=(${version//./ }) # Split into array
-  #rm -rf qt-opensource-src-$version
+  rm -rf qt-opensource-src-$version
   if [ ! -f qt-everywhere-src-$version.tar.xz ]; then
       curl -O -L http://download.qt.io/official_releases/qt/${v[0]}.${v[1]}/$version/single/qt-everywhere-src-$version.tar.xz
   fi
-  #tar xzf qt-everywhere-src-$version.tar.xz
+  tar xzf qt-everywhere-src-$version.tar.xz
   cd qt-everywhere-src-$version
   if ! $USING_CXX11; then
     QT_EXTRA_FLAGS="-no-c++11"

--- a/scripts/macosx-build-dependencies.sh
+++ b/scripts/macosx-build-dependencies.sh
@@ -31,6 +31,7 @@ OPTION_LLVM=false
 OPTION_CLANG=false
 OPTION_DEPLOY=false
 OPTION_FORCE=0
+OPTION_FORCE_BREW=0
 OPTION_CXX11=true
 
 PACKAGES=(
@@ -773,7 +774,7 @@ if [ ! -f $OPENSCADDIR/openscad.pro ]; then
 fi
 OPENSCAD_SCRIPTDIR=$PWD/scripts
 
-while getopts '3lcdfv' c
+while getopts '3lcdfvb' c
 do
   case $c in
     3) USING_CXX11=false;;
@@ -781,6 +782,7 @@ do
     c) OPTION_CLANG=true;;
     d) OPTION_DEPLOY=true;;
     f) OPTION_FORCE=1;;
+    b) OPTION_FORCE_BREW=1;;
     v) echo verbose on;;
     *) printUsage;exit 1;;
   esac
@@ -830,6 +832,16 @@ if $USING_CXX11; then
 else
   export CXXSTDFLAGS="-std=c++03 -stdlib=libstdc++"
   export LDSTDFLAGS="-stdlib=libstdc++"
+fi
+
+if [ "`command -v brew`" ]; then
+  if $OPTION_FORCE_BREW; then
+    echo overriding homebrew interlock
+  else
+    echo homebrew is installed, do you really want to build without it??
+    echo rerun this with -b to override this homebrew interlock
+    exit 1
+  fi
 fi
 
 echo "Building for $MAC_OSX_VERSION_MIN or later"

--- a/scripts/macosx-build-dependencies.sh
+++ b/scripts/macosx-build-dependencies.sh
@@ -604,7 +604,7 @@ build_fontconfig()
   cd "$BASEDIR"/src
   rm -rf "fontconfig-$version"
   if [ ! -f "fontconfig-$version.tar.gz" ]; then
-    curl -LO "http://www.freedesktop.org/software/fontconfig/release/fontconfig-$version.tar.gz"
+    curl -LO "https://www.freedesktop.org/software/fontconfig/release/fontconfig-$version.tar.gz"
   fi
   tar xzf "fontconfig-$version.tar.gz"
   cd "fontconfig-$version"
@@ -730,7 +730,7 @@ build_harfbuzz()
   cd "$BASEDIR"/src
   rm -rf "harfbuzz-$version"
   if [ ! -f "harfbuzz-$version.tar.gz" ]; then
-    curl --insecure -LO "https://www.freedesktop.org/software/harfbuzz/release/harfbuzz-$version.tar.bz2"
+    curl -LO "https://www.freedesktop.org/software/harfbuzz/release/harfbuzz-$version.tar.bz2"
   fi
   tar xzf "harfbuzz-$version.tar.bz2"
   cd "harfbuzz-$version"


### PR DESCRIPTION
a few tweaks so high Sierra build works, but untested on Sierra / el capitan

qt 5.11.1 is required because of a lot of new C++ stuff... maybe there is a way to force build with different C++ standard but it seemed easier to just bump version a few notches

the other thing I'm not sure about is the HarfBuzz... when building with autogen it required ragel and pkg-config which I did not want to install, so I tried instead to download the release version of HarfBuzz, which comes with 'configure' script already built... and I ran that while disabling gtk-doc-html and it seemed to work, but I'm not sure if that will work for other OSX

