### PR TITLE
warn, when a variable from the root module is overwriten in the root module

### DIFF
--- a/src/ModuleCache.cc
+++ b/src/ModuleCache.cc
@@ -101,7 +101,7 @@ time_t ModuleCache::evaluate(const std::string &filename, FileModule *&module)
 			}
 			textbuf << ifs.rdbuf();
 		}
-		textbuf << "\n" << commandline_commands;
+		textbuf << "\n\x03\n" << commandline_commands;
 		
 		print_messages_push();
 		

--- a/src/lexer.l
+++ b/src/lexer.l
@@ -104,7 +104,6 @@ std::vector<std::string> openfilenames;
 
 std::string filename;
 std::string filepath;
-
 %}
 
 %option yylineno
@@ -205,6 +204,8 @@ use[ \t\r\n]*"<"	{ BEGIN(cond_use); }
 	if (!YY_CURRENT_BUFFER)
 		yyterminate();
 }
+
+"\x03"		return TOK_EOT;
 
 "module"	return TOK_MODULE;
 "function"	return TOK_FUNCTION;

--- a/src/mainwin.cc
+++ b/src/mainwin.cc
@@ -1755,7 +1755,7 @@ void MainWindow::compileTopLevelDocument(bool rebuildParameterWidget)
 
 	auto fulltext =
 		std::string(this->last_compiled_doc.toUtf8().constData()) +
-		"\n" + commandline_commands;
+		"\n\x03\n" + commandline_commands;
 	
 	auto fnameba = this->fileName.toLocal8Bit();
 	const char* fname = this->fileName.isEmpty() ? "" : fnameba;

--- a/src/openscad.cc
+++ b/src/openscad.cc
@@ -399,7 +399,7 @@ int cmdline(const char *deps_output_file, const std::string &filename, Camera &c
 		return 1;
 	}
 	std::string text((std::istreambuf_iterator<char>(ifs)), std::istreambuf_iterator<char>());
-	text += "\n" + commandline_commands;
+	text += "\n\x03\n" + commandline_commands;
 	if (!parse(root_module, text.c_str(), filename, false)) {
 		delete root_module;  // parse failed
 		root_module = nullptr;

--- a/src/parser.y
+++ b/src/parser.y
@@ -202,6 +202,7 @@ assignment:
                 bool found = false;
                 for (auto &assignment : scope_stack.top()->assignments) {
                     if (assignment.name == $1) {
+                        PRINTB("WARNING: %s was assigend on line %i but was overwritten on line %i",assignment.name%assignment.location().firstLine()%LOC(@$).firstLine());
                         assignment.expr = shared_ptr<Expression>($3);
                         assignment.setLocation(LOC(@$));
                         found = true;

--- a/src/parser.y
+++ b/src/parser.y
@@ -70,6 +70,7 @@ extern const char *parser_input_buffer;
 const char *parser_input_buffer;
 std::shared_ptr<fs::path> parser_sourcefile;
 
+bool assignmentWarning=true;
 %}
 
 %union {
@@ -85,6 +86,8 @@ std::shared_ptr<fs::path> parser_sourcefile;
 }
 
 %token TOK_ERROR
+
+%token TOK_EOT
 
 %token TOK_MODULE
 %token TOK_FUNCTION
@@ -189,6 +192,10 @@ statement:
               delete $4;
             }
           ';'
+        | TOK_EOT
+            {
+                assignmentWarning=false;
+            }
         ;
 
 inner_input:
@@ -202,7 +209,7 @@ assignment:
                 bool found = false;
                 for (auto &assignment : scope_stack.top()->assignments) {
                     if (assignment.name == $1) {
-                        if(rootmodule->getFullpath()==LOC(@$).fileName()){
+                        if(assignmentWarning && rootmodule->getFullpath()==LOC(@$).fileName()){
                             PRINTB("WARNING: %s was assigned on line %i but was overwritten on line %i",
                                     assignment.name%
                                     assignment.location().firstLine()%

--- a/src/parser.y
+++ b/src/parser.y
@@ -202,7 +202,12 @@ assignment:
                 bool found = false;
                 for (auto &assignment : scope_stack.top()->assignments) {
                     if (assignment.name == $1) {
-                        PRINTB("WARNING: %s was assigend on line %i but was overwritten on line %i",assignment.name%assignment.location().firstLine()%LOC(@$).firstLine());
+                        if(rootmodule->getFullpath()==LOC(@$).fileName()){
+                            PRINTB("WARNING: %s was assigned on line %i but was overwritten on line %i",
+                                    assignment.name%
+                                    assignment.location().firstLine()%
+                                    LOC(@$).firstLine());
+                        }
                         assignment.expr = shared_ptr<Expression>($3);
                         assignment.setLocation(LOC(@$));
                         found = true;

--- a/tests/regression/echotest/scope-assignment-tests-expected.echo
+++ b/tests/regression/echotest/scope-assignment-tests-expected.echo
@@ -1,3 +1,7 @@
+WARNING: e was assigned on line 49 but was overwritten on line 52
+WARNING: f was assigned on line 58 but was overwritten on line 61
+WARNING: g was assigned on line 67 but was overwritten on line 69
+WARNING: h was assigned on line 73 but was overwritten on line 75
 WARNING: Ignoring unknown variable 'h'.
 ECHO: "union scope"
 ECHO: "local a (5):", 5

--- a/tests/regression/echotest/search-tests-expected.echo
+++ b/tests/regression/echotest/search-tests-expected.echo
@@ -1,3 +1,4 @@
+WARNING: vTable1 was assigned on line 29 but was overwritten on line 32
 ECHO: "Characters in string ("a"): [0]"
 ECHO: "Characters in string ("adeq"): [[0, 5], [3, 8], [4], []]"
 ECHO: "Default string search ("abe"): [0, 1, 8]"

--- a/tests/regression/echotest/value-reassignment-tests-expected.echo
+++ b/tests/regression/echotest/value-reassignment-tests-expected.echo
@@ -1,2 +1,3 @@
+WARNING: myval was assigned on line 5 but was overwritten on line 7
 WARNING: Ignoring unknown variable 'i'.
 ECHO: undef, 2

--- a/tests/regression/echotest/value-reassignment-tests2-expected.echo
+++ b/tests/regression/echotest/value-reassignment-tests2-expected.echo
@@ -1,1 +1,2 @@
+WARNING: myval was assigned on line 5 but was overwritten on line 7
 ECHO: 3, 3


### PR DESCRIPTION
addressing #2439 #1770.

This still allows the root module to overwrite variables from includes without warning (which is an indented feature) and includes to overwrite variables from the root module without warning (which we can discuss).
It also avoids warnings from issues within used and inlcuded files.

The command line option `-D ` is an issue with that approach.
In the ModulCache, the command line is simply appended to the rootmodule:
`		textbuf << "\n" << commandline_commands;`
making the patch fail `openscad-override_override`. I mean I could regenerate the test, but the warning is not really acceptable:
`+WARNING: a was assigned on line 2 but was overwritten on line 6` as the scad file has only 5 lines. the 6th line are the appended `commandline_commands`.