### PR TITLE
Bring back double click to center 

### DIFF
--- a/src/QGLView.cc
+++ b/src/QGLView.cc
@@ -67,6 +67,10 @@ static bool running_under_wine = false;
 
 void QGLView::init()
 {
+  QSurfaceFormat format;
+  format.setDepthBufferSize(24);
+  format.setSamples(0);
+  QSurfaceFormat::setDefaultFormat(format);
   resetView();
 
   this->mouse_drag_active = false;
@@ -179,7 +183,7 @@ void QGLView::paintGL()
   GLView::paintGL();
 
 #ifdef USE_QOPENGLWIDGET
-  if (mouseDoubleClicked != nullptr) {
+  if (mouseDoubleClicked) {
     centerCameraOnMouse(mouseDoubleClicked);
     mouseDoubleClicked = nullptr;
   }

--- a/src/QGLView.cc
+++ b/src/QGLView.cc
@@ -67,10 +67,12 @@ static bool running_under_wine = false;
 
 void QGLView::init()
 {
+#ifdef USE_QOPENGLWIDGET
   QSurfaceFormat format;
   format.setDepthBufferSize(24);
   format.setSamples(0);
   QSurfaceFormat::setDefaultFormat(format);
+#endif
   resetView();
 
   this->mouse_drag_active = false;

--- a/src/QGLView.cc
+++ b/src/QGLView.cc
@@ -177,7 +177,7 @@ void QGLView::resizeGL(int w, int h)
 void QGLView::paintGL()
 {
   GLView::paintGL();
-  if (mouseDoubleClicked) {
+  if (mouseDoubleClicked != nullptr) {
     centerCameraOnMouse(mouseDoubleClicked);
     mouseDoubleClicked = nullptr;
   }

--- a/src/QGLView.cc
+++ b/src/QGLView.cc
@@ -177,10 +177,13 @@ void QGLView::resizeGL(int w, int h)
 void QGLView::paintGL()
 {
   GLView::paintGL();
+
+#ifdef USE_QOPENGLWIDGET
   if (mouseDoubleClicked != nullptr) {
     centerCameraOnMouse(mouseDoubleClicked);
     mouseDoubleClicked = nullptr;
   }
+#endif
 
   if (statusLabel) {
     Camera nc(cam);

--- a/src/QGLView.h
+++ b/src/QGLView.h
@@ -90,7 +90,9 @@ private:
 	void paintGL() override;
 	void normalizeAngle(GLdouble& angle);
 
-	QMouseEvent *mouseDoubleClicked;
+#ifdef USE_QOPENGLWIDGET
+    QMouseEvent *mouseDoubleClicked = nullptr;
+#endif
 	void centerCameraOnMouse(QMouseEvent *event);
 #ifdef ENABLE_OPENCSG
 	void display_opencsg_warning() override;

--- a/src/QGLView.h
+++ b/src/QGLView.h
@@ -90,6 +90,8 @@ private:
 	void paintGL() override;
 	void normalizeAngle(GLdouble& angle);
 
+	QMouseEvent *mouseDoubleClicked;
+	void centerCameraOnMouse(QMouseEvent *event);
 #ifdef ENABLE_OPENCSG
 	void display_opencsg_warning() override;
 private slots:


### PR DESCRIPTION
After paintGL return, the Qt flushes all offscreen framebuffers, so we need to read pixel during paintGL.
Fixes #1787