### PR TITLE
Various fixes to the test scripts for Python3.

### DIFF
--- a/tests/export_import_pngtest.py
+++ b/tests/export_import_pngtest.py
@@ -38,12 +38,13 @@ def failquit(*args):
     sys.exit(1)
 
 def createImport(inputfile, scadfile):
+        inputfilename = os.path.split(inputfile)[1]
         print ('createImport: ' + inputfile + " " + scadfile)
         outputdir = os.path.dirname(scadfile)
         try:
                 if outputdir and not os.path.exists(outputdir): os.mkdir(outputdir)
                 f = open(scadfile,'w')
-                f.write('import("'+inputfile+'");'+os.linesep)
+                f.write('import("'+inputfilename+'");'+os.linesep)
                 f.close()
         except:
                 failquit('failure while opening/writing ' + scadfile + ': ' + str(sys.exc_info()))
@@ -118,7 +119,7 @@ if args.format != 'csg':
 create_png_cmd = [args.openscad, newscadfile, '-o', pngfile] + remaining_args
 print('Running OpenSCAD #2:', file=sys.stderr)
 print(' '.join(create_png_cmd), file=sys.stderr)
-fontdir =  os.path.join(os.path.dirname(__file__), "..", "testdata");
+fontdir =  os.path.join(os.path.dirname(__file__), "..", "testdata/ttf");
 fontenv = os.environ.copy();
 fontenv["OPENSCAD_FONT_PATH"] = fontdir;
 result = subprocess.call(create_png_cmd, env = fontenv);

--- a/tests/test_cmdline_tool.py
+++ b/tests/test_cmdline_tool.py
@@ -234,7 +234,7 @@ def run_test(testname, cmd, args):
         cmdline = [cmd] + args + [outputname]
         sys.stderr.flush()
         print('run_test() cmdline:',cmdline)
-        fontdir =  os.path.join(os.path.dirname(cmd), "testdata")
+        fontdir =  os.path.join(os.path.dirname(__file__), "..", "testdata/ttf");
         fontenv = os.environ.copy()
         fontenv["OPENSCAD_FONT_PATH"] = fontdir
         print('using font directory:', fontdir)

--- a/tests/test_cmdline_tool.py
+++ b/tests/test_cmdline_tool.py
@@ -232,6 +232,7 @@ def run_test(testname, cmd, args):
 
     try:
         cmdline = [cmd] + args + [outputname]
+        sys.stderr.flush()
         print('run_test() cmdline:',cmdline)
         fontdir =  os.path.join(os.path.dirname(cmd), "testdata")
         fontenv = os.environ.copy()

--- a/tests/test_pretty_print.py
+++ b/tests/test_pretty_print.py
@@ -210,7 +210,7 @@ def load_makefiles(builddir):
 
 def png_encode64(fname, width=512, data=None, alt=''):
     # en.wikipedia.org/wiki/Data_URI_scheme
-    data = data or tryread(fname) or ''
+    data = data or tryread(fname) or b''
     data_uri = base64.b64encode(data).decode('ascii')
     tag = '''<img src="data:image/png;base64,%s" width="%s" %s/>'''
     if alt=="": alt = 'alt="openscad_test_image:' + fname + '" '

--- a/tests/test_pretty_print.py
+++ b/tests/test_pretty_print.py
@@ -87,10 +87,10 @@ def ezsearch(pattern, str):
 def read_gitinfo():
     # won't work if run from outside of branch. 
     try:
-        data = subprocess.Popen(['git', 'remote', '-v'], stdout=subprocess.PIPE).stdout.read()
+        data = subprocess.Popen(['git', 'remote', '-v'], stdout=subprocess.PIPE).stdout.read().decode('utf-8')
         origin = ezsearch('^origin *?(.*?)\(fetch.*?$', data)
         upstream = ezsearch('^upstream *?(.*?)\(fetch.*?$', data)
-        data = subprocess.Popen(['git', 'branch'], stdout=subprocess.PIPE).stdout.read()
+        data = subprocess.Popen(['git', 'branch'], stdout=subprocess.PIPE).stdout.read().decode('utf-8')
         branch = ezsearch('^\*(.*?)$', data)
         out = 'Git branch: ' + branch + ' from origin ' + origin + '\n'
         out += 'Git upstream: ' + upstream + '\n'
@@ -233,6 +233,7 @@ def findlogfile(builddir):
 class Templates(object):
     html_template = '''<html>
     <head><title>Test run for {sysid}</title>
+    <meta charset="utf-8" />
     {style}
     </head>
     <body>


### PR DESCRIPTION
Also defined the charset as utf-8 in the generated HTML.
Added a flush to test_cmdline_tool sothat  output appears in the order it is printed.