### PR TITLE
Specify Python3 as 2 no longer works.

### DIFF
--- a/doc/testing.txt
+++ b/doc/testing.txt
@@ -5,7 +5,7 @@ Running regression tests:
 
 Install the prerequisite helper programs on your system:
 
-     cmake, python2 (not 3), ImageMagick 6.5.9.3 or newer, diff
+     cmake, python3 (not 2), ImageMagick 6.5.9.3 or newer, diff
 
 There are binary installer packages of these tools available for Mac, 
 Win, Linux, BSD, and other systems. (except maybe diff for Win)


### PR DESCRIPTION
The test scripts have been updated for Python3 and no longer work on Python2.