### PR TITLE
parser simplified

### DIFF
--- a/src/comment_parser.y
+++ b/src/comment_parser.y
@@ -22,82 +22,122 @@
 
 
 %token<num> NUM
-
 %token<text> WORD
+
 %type <text> word
 %type <expr> expr
+%type <expr> num
+%type <expr> value
+%type <vec> values
+%type <expr> wordexpr
 %type <expr> params
-%type <vec> vector_expr
-%type <vec> labled_vector
+%type <vec> labeled_vectors
 
 %%
 
 
 params:
-          expr
-            {
-                $$ = $1;
-                params = shared_ptr<Expression>($$);
-            }
-            ;
-            
-expr: 
-         NUM 
-            {
-                $$ = new Literal(ValuePtr($1));
-                
-            }
-        | word
-            {
-                $$ = new Literal(ValuePtr(std::string($1)));
-                free($1);
-            }
-        | '[' optional_commas ']'
-            {
-                $$ = new Literal(ValuePtr(Value::VectorType()));
-            }
-        | '[' vector_expr optional_commas ']'
-            {
-                $$ = $2;
-            }            
-        | '[' expr ':' expr ']'
-            {
-                $$ = new Range($2, $4,Location::NONE);
-            }
-        | '[' expr ':' expr ':' expr ']'
-            {
-                $$ = new Range($2, $4, $6,Location::NONE);
-            }
-        | labled_vector { $$=$1;}
-        ;
-                
-labled_vector: 
-        expr ':' expr {
-            $$ = new Vector(Location::NONE);
-            $$->push_back($1);
-            $$->push_back($3);
+    expr
+        {
+            $$ = $1;
+            params = shared_ptr<Expression>($$);
         }
-		;
+    ;
 
-optional_commas:
-          ',' optional_commas
-        | /* empty */
-        ;
-       
-vector_expr:
-          expr
-            {
-                $$ = new Vector(Location::NONE);
-                $$->push_back($1);
-            }
-            | vector_expr ',' optional_commas expr
-            {
-                $$ = $1;
-                $$->push_back($4);
-            }
-            ;		
+expr: 
+    '[' values ']'
+    {
+        $$ = $2;
+    }
+    | num
+    {
+        $$ = $1;
+    }
+    | wordexpr
+    {
+        $$ = $1;
+    }
+    | '[' num ':' num ']'
+    {
+        $$ = new Range($2, $4, Location::NONE);
+    }
+    | '[' num ':' num ':' num ']'
+    {
+        $$ = new Range($2, $4, $6, Location::NONE);
+    }
+    ;
 
-word:   
+num:
+    NUM
+    {
+        $$ = new Literal(ValuePtr($1));
+    }
+    ;
+
+value:
+    labeled_vectors
+    {
+        $$ = $1;
+    }
+    |num
+    {
+        $$ = $1;
+    }
+    |wordexpr
+    {
+        $$ = $1;
+    }
+    ;
+
+values:
+    value
+    {
+        $$ = new Vector(Location::NONE);
+        $$->push_back($1);
+    }
+    |values ',' value
+    {
+        $$ = $1;
+        $$->push_back($3);
+    }
+    ;
+
+labeled_vectors: 
+    num ':' num
+    {
+        $$ = new Vector(Location::NONE);
+        $$->push_back($1);
+        $$->push_back($3);
+    }
+    |num ':' wordexpr
+    {
+        $$ = new Vector(Location::NONE);
+        $$->push_back($1);
+        $$->push_back($3);
+    }
+    |wordexpr ':' num
+    {
+        $$ = new Vector(Location::NONE);
+        $$->push_back($1);
+        $$->push_back($3);
+    }
+    |wordexpr ':' wordexpr
+    {
+        $$ = new Vector(Location::NONE);
+        $$->push_back($1);
+        $$->push_back($3);
+    }
+    ;
+
+wordexpr:
+    word
+    {
+        $$ = new Literal(ValuePtr(std::string($1)));
+        free($1);
+    }
+    ;
+
+word:
     WORD
     {
         $$=$1;    
@@ -124,7 +164,7 @@ word:
 
 int comment_parserlex(void)
 {
-  return comment_lexerlex();
+    return comment_lexerlex();
 }
 
 void yyerror(const char * /*msg*/) {


### PR DESCRIPTION
The current comment parser tries and manages to parse things, it really shouldn't:
```
a=2; // [[1,2,3],[4,5,6],[9,5,4,2,3,1]]
echo(a);
d=4; // [[1,2,3]:a,50:d]
echo(d);
```
Looking into the details, due to the recursive nature, I can imagine that internally, the parse can generate a lot of interesting data-structures (which also makes unclear to a human reading the parser, what the parser is actually supposed to do).

The restructured code should be easier to read.

The simplification should also prevents/fixes various bugs, as the UI is not expecting the complex the data structures the current parser can generate.
 
refactored based on #2191