### PR TITLE
save hidden variables, but to not apply them (see #2450)

### DIFF
--- a/src/parameter/ParameterWidget.cc
+++ b/src/parameter/ParameterWidget.cc
@@ -459,11 +459,9 @@ void ParameterWidget::updateParameterSet(std::string setName)
 
 		pt::ptree iroot;
 		for (const auto &entry : entries) {
-			if (entry.second->groupName != "Hidden") {
-				const auto &VariableName = entry.first;
-				const auto &VariableValue = entry.second->value->toString();
-				iroot.put(VariableName, VariableValue);
-			}
+			const auto &VariableName = entry.first;
+			const auto &VariableValue = entry.second->value->toString();
+			iroot.put(VariableName, VariableValue);
 		}
 		setMgr->addParameterSet(setName, iroot);
 		const QString s(QString::fromStdString(setName));

--- a/src/parameter/parameterextractor.cpp
+++ b/src/parameter/parameterextractor.cpp
@@ -17,8 +17,10 @@ void ParameterExtractor::applyParameters(FileModule *fileModule, entry_map_t& en
   for (auto &assignment : fileModule->scope.assignments) {
     auto entry = entries.find(assignment.name);
     if (entry != entries.end()) {
-      entry->second->applyParameter(assignment);
-      entry->second->set = false;
+      if (entry->second->groupName != "Hidden") {
+        entry->second->applyParameter(assignment);
+        entry->second->set = false;
+      }
     }
   }
 }


### PR DESCRIPTION
there are for different possible implementation for hidden variables:

1. hidden variables are stored and retrieved from the json file
1. hidden variables **NOT stored** in json file, but are retrieved from the json file
1.  hidden variables are stored in the json file, but are **NOT retrieved** from the json file
1. hidden variables are **neither** stored and  nor retrieved from the json file

Originally, the OpenSCAD customizer has behaved as in 1.

Currently, the OpenSCAD customizer behaves as in 2. The customizer applying variables from the hidden group when found in a json file does not make sense.

Implementing 3 would be a reasonable compromise. Hidden variables are not applied, but still stored. Meaning: If a once hidden variable becomes visible, it also becomes applicable. This allows a designer to use the hidden section for reserved variables, that become customizable (and assigend with a different default) in a future version, without breaking existing preset. 

Implementing 4 would be consequent.

This is the implementation of 3.