### PR TITLE
adding a "design default values" parameter set

### DIFF
--- a/src/mainwin.cc
+++ b/src/mainwin.cc
@@ -909,7 +909,7 @@ void MainWindow::refreshDocument()
 			PRINTB("Loaded design '%s'.", this->fileName.toLocal8Bit().constData());
 			if (editor->toPlainText() != text) {
 				editor->setPlainText(text);
-				this->contentschanged = true;
+				setContentsChanged();
 			}
 		}
 	}
@@ -2813,6 +2813,7 @@ void MainWindow::openCSGSettingsChanged()
 void MainWindow::setContentsChanged()
 {
 	this->contentschanged = true;
+	this->parameterWidget->setEnabled(false);
 }
 
 void MainWindow::processEvents()

--- a/src/parameter/ParameterWidget.cc
+++ b/src/parameter/ParameterWidget.cc
@@ -67,6 +67,7 @@ ParameterWidget::ParameterWidget(QWidget *parent) : QWidget(parent)
 	this->valueChanged=false;
 }
 
+//resets all parameters to the currently parameter set
 void ParameterWidget::resetParameter()
 {
 	if(this->valueChanged){
@@ -88,6 +89,7 @@ void ParameterWidget::resetParameter()
 	removeChangeIndicator(currPreset);
 
 	const std::string v = comboBoxPreset->itemData(currPreset).toString().toUtf8().constData();
+	defaultParameter();
 	applyParameterSet(v);
 	emit previewRequested();
 }
@@ -414,7 +416,7 @@ ParameterVirtualWidget* ParameterWidget::CreateParameterWidget(std::string param
 	return entry;
 }
 
-//reset all parameters to the default value
+//reset all parameters to the default value of the design file
 void ParameterWidget::defaultParameter(){
 	for (const auto &entry : entries) {
 		entry.second->value=entry.second->defaultValue;

--- a/src/parameter/ParameterWidget.cc
+++ b/src/parameter/ParameterWidget.cc
@@ -67,7 +67,7 @@ ParameterWidget::ParameterWidget(QWidget *parent) : QWidget(parent)
 	this->valueChanged=false;
 }
 
-//resets all parameters to the currently parameter set
+//resets all parameters to the currently selected parameter set
 void ParameterWidget::resetParameter()
 {
 	if(this->valueChanged){
@@ -88,9 +88,11 @@ void ParameterWidget::resetParameter()
 
 	removeChangeIndicator(currPreset);
 
-	const std::string v = comboBoxPreset->itemData(currPreset).toString().toUtf8().constData();
 	defaultParameter();
-	applyParameterSet(v);
+	if(comboBoxPreset->currentIndex() != 0){ //0 is "design default values"
+		const std::string v = comboBoxPreset->itemData(currPreset).toString().toUtf8().constData();
+		applyParameterSet(v);
+	}
 	emit previewRequested();
 }
 

--- a/src/parameter/ParameterWidget.cc
+++ b/src/parameter/ParameterWidget.cc
@@ -199,7 +199,7 @@ void ParameterWidget::applyParameters(FileModule *fileModule)
 
 void ParameterWidget::setComboBoxPresetForSet()
 {
-	this->comboBoxPreset->addItem(_("no preset selected"), QVariant(QString::fromStdString("")));
+	this->comboBoxPreset->addItem(_("design default values"), QVariant(QString::fromStdString(_("design default values"))));
 	if (setMgr->isEmpty()) return;
 	for (const auto &name : setMgr->getParameterNames()) {
 		const QString n = QString::fromStdString(name);
@@ -231,10 +231,13 @@ void ParameterWidget::onSetChanged(int idx)
 	
 	removeChangeIndicator(lastComboboxIndex);
 
-	//apply the change
 	this->lastComboboxIndex = idx;
-	const std::string v = comboBoxPreset->itemData(idx).toString().toUtf8().constData();
-	applyParameterSet(v);
+	defaultParameter();
+	if(idx!=0){ //0 is "design default values"
+		//apply the change
+		const std::string v = comboBoxPreset->itemData(idx).toString().toUtf8().constData();
+		applyParameterSet(v);
+	}
 	emit previewRequested(false);
 }
 
@@ -409,6 +412,13 @@ ParameterVirtualWidget* ParameterWidget::CreateParameterWidget(std::string param
 		}
 	}
 	return entry;
+}
+
+//reset all parameters to the default value
+void ParameterWidget::defaultParameter(){
+	for (const auto &entry : entries) {
+		entry.second->value=entry.second->defaultValue;
+	}
 }
 
 void ParameterWidget::applyParameterSet(std::string setName)

--- a/src/parameter/ParameterWidget.h
+++ b/src/parameter/ParameterWidget.h
@@ -84,6 +84,7 @@ protected slots:
 	void onSetSaveButton();
 	void onSetDelete();
 	void resetParameter();
+	void defaultParameter();
 
 signals:
 	void previewRequested(bool rebuildParameterUI=true);

--- a/src/parameter/ParameterWidget.ui
+++ b/src/parameter/ParameterWidget.ui
@@ -168,7 +168,7 @@
      <item>
       <widget class="QPushButton" name="reset">
        <property name="toolTip">
-        <string>reset the parameters to the selected preset</string>
+        <string>reset all parameters to the currently selected preset</string>
        </property>
        <property name="text">
         <string>Reset</string>


### PR DESCRIPTION
   * adding a "design default values" parameter set. 
   * Always reset to the "design default values" before applying any preset.
      -> this should prevent various issues like variables from one parameter set being transferred to an other parameter set that those not have the specific parameter has not set.