### PR TITLE
customizer: check if a parameter set name already exists and ask before overwritting 

### DIFF
--- a/src/parameter/ParameterWidget.cc
+++ b/src/parameter/ParameterWidget.cc
@@ -454,6 +454,20 @@ void ParameterWidget::updateParameterSet(std::string setName)
 		}
 	}
 
+	//check for duplicates
+	if(setMgr->setNameExists(setName)){
+		QMessageBox msgBox;
+		msgBox.setWindowTitle(QString(_("Set Name %1 allready exists")).arg(QString::fromStdString(setName)));
+		msgBox.setText(QString(_("The set name  %1 allready exists. Do you want overwrite it?")).arg(QString::fromStdString(setName)));
+		msgBox.setStandardButtons(QMessageBox::Yes);
+		msgBox.addButton(QMessageBox::No);
+		msgBox.setDefaultButton(QMessageBox::No);
+
+		if (msgBox.exec() != QMessageBox::Yes) {
+			setName = "";
+		}
+	}
+
 	if (!setName.empty()) {
 		this->valueChanged=false;
 

--- a/src/parameter/ParameterWidget.cc
+++ b/src/parameter/ParameterWidget.cc
@@ -117,7 +117,7 @@ void ParameterWidget::onSetAdd()
 		pt::ptree setRoot;
 		setMgr->addChild(ParameterSet::parameterSetsKey, setRoot);
 	}
-	updateParameterSet("");
+	updateParameterSet("",true);
 }
 
 void ParameterWidget::onSetSaveButton()
@@ -439,9 +439,9 @@ void ParameterWidget::applyParameterSet(std::string setName)
 	}
 }
 
-void ParameterWidget::updateParameterSet(std::string setName)
+void ParameterWidget::updateParameterSet(std::string setName, bool newSet)
 {
-	if (setName == "") {
+	if (newSet && setName == "") {
 		QInputDialog *setDialog = new QInputDialog();
 
 		bool ok = true;
@@ -455,7 +455,7 @@ void ParameterWidget::updateParameterSet(std::string setName)
 	}
 
 	//check for duplicates
-	if(setMgr->setNameExists(setName)){
+	if(newSet && setMgr->setNameExists(setName)){
 		QMessageBox msgBox;
 		msgBox.setWindowTitle(QString(_("Set Name %1 allready exists")).arg(QString::fromStdString(setName)));
 		msgBox.setText(QString(_("The set name  %1 allready exists. Do you want overwrite it?")).arg(QString::fromStdString(setName)));

--- a/src/parameter/ParameterWidget.cc
+++ b/src/parameter/ParameterWidget.cc
@@ -463,7 +463,15 @@ void ParameterWidget::updateParameterSet(std::string setName)
 		msgBox.addButton(QMessageBox::No);
 		msgBox.setDefaultButton(QMessageBox::No);
 
-		if (msgBox.exec() != QMessageBox::Yes) {
+		if (msgBox.exec() == QMessageBox::Yes) {
+			//delete the preexisting preset to avoid side efects
+			boost::optional<pt::ptree &> sets = setMgr->parameterSets();
+			if (sets.is_initialized()) {
+				sets.get().erase(pt::ptree::key_type(setName));
+			}
+			
+			this->comboBoxPreset->removeItem(this->comboBoxPreset->findData(QString::fromStdString(setName)));
+		}else{
 			setName = "";
 		}
 	}

--- a/src/parameter/ParameterWidget.h
+++ b/src/parameter/ParameterWidget.h
@@ -90,7 +90,7 @@ signals:
 
 protected:
 	void applyParameterSet(std::string setName);
-	void updateParameterSet(std::string setName);
+	void updateParameterSet(std::string setName, bool newSet=false);
 	void writeParameterSets();
 };
 

--- a/src/parameter/parameterset.cpp
+++ b/src/parameter/parameterset.cpp
@@ -27,6 +27,16 @@ std::vector<std::string> ParameterSet::getParameterNames()
 	return names;
 }
 
+bool ParameterSet::setNameExists(const std::string &setName){
+	boost::optional<pt::ptree &> sets = parameterSets();
+	if (sets.is_initialized()) {
+		for (const auto &v : sets.get()) {
+			if(v.first == setName) return true;
+		}
+	}
+	return false;
+}
+
 boost::optional<pt::ptree &> ParameterSet::getParameterSet(const std::string &setName)
 {
 	boost::optional<pt::ptree &> sets = parameterSets();

--- a/src/parameter/parameterset.h
+++ b/src/parameter/parameterset.h
@@ -20,6 +20,7 @@ public:
 	~ParameterSet() {}
 	boost::optional<pt::ptree &> parameterSets();
 	std::vector<std::string> getParameterNames();
+	bool setNameExists(const std::string &setName);
 	boost::optional<pt::ptree &> getParameterSet(const std::string &setName);
 	void addParameterSet(const std::string setName, const pt::ptree & set);
 	bool readParameterSet(const std::string &filename);


### PR DESCRIPTION
This handles the case, where a "new" parameter set has the same name as an existing one.