### PR TITLE
make the comboBoxPreset editable

### DIFF
--- a/src/parameter/ParameterWidget.cc
+++ b/src/parameter/ParameterWidget.cc
@@ -90,7 +90,7 @@ void ParameterWidget::resetParameter()
 
 	int currPreset = this->comboBoxPreset->currentIndex();
 
-	removeChangeIndicator(currPreset);
+	removeChangeIndicator();
 
 	defaultParameter();
 	if(comboBoxPreset->currentIndex() != 0){ //0 is "design default values"
@@ -249,7 +249,7 @@ void ParameterWidget::onSetChanged(int idx)
 	}
 	this->valueChanged=false;
 	
-	removeChangeIndicator(lastComboboxIndex);
+	removeChangeIndicator();
 
 	this->lastComboboxIndex = idx;
 	defaultParameter();
@@ -280,7 +280,7 @@ void ParameterWidget::onSetNameChanged(){
 		msgBox.setWindowTitle(_("Do you want to delete the current preset?"));
 		msgBox.setText(
 			QString(_("Do you want to delete the current preset '%1'?"))
-			.arg(oldName);
+			.arg(oldName));
 		msgBox.setStandardButtons(QMessageBox::Ok | QMessageBox::Cancel);
 		msgBox.setDefaultButton(QMessageBox::Cancel);
 
@@ -569,7 +569,7 @@ void ParameterWidget::updateParameterSet(std::string setName, bool newSet)
 			this->comboBoxPreset->addItem(s, QVariant(s));
 			this->comboBoxPreset->setCurrentIndex(this->comboBoxPreset->findData(s));
 		}else{
-			removeChangeIndicator(idx);
+			removeChangeIndicator();
 		}
 		writeParameterSets();
 	}
@@ -592,7 +592,7 @@ void ParameterWidget::writeParameterSets()
 	this->valueChanged=false;
 }
 
-void ParameterWidget::removeChangeIndicator(int idx)
+void ParameterWidget::removeChangeIndicator()
 {
 	this->labelChangeIndicator->setText("");
 }

--- a/src/parameter/ParameterWidget.h
+++ b/src/parameter/ParameterWidget.h
@@ -58,7 +58,7 @@ private:
 	void rebuildGroupMap();
 	ParameterVirtualWidget* CreateParameterWidget(std::string parameterName);
 	void setComboBoxPresetForSet();
-	void removeChangeIndicator(int idx);
+	void removeChangeIndicator();
 
 	void setFile(QString File);
 

--- a/src/parameter/ParameterWidget.h
+++ b/src/parameter/ParameterWidget.h
@@ -82,6 +82,7 @@ protected slots:
 	void onPreviewTimerElapsed();
 	void onDescriptionLoDChanged();
 	void onSetChanged(int idx);
+	void onSetNameChanged();
 	void onSetAdd();
 	void onSetSaveButton();
 	void onSetDelete();

--- a/src/parameter/ParameterWidget.ui
+++ b/src/parameter/ParameterWidget.ui
@@ -31,7 +31,7 @@
    </property>
    <item row="8" column="0" colspan="3">
     <layout class="QGridLayout" name="gridLayout_2">
-     <item row="0" column="4">
+     <item row="0" column="5">
       <widget class="QPushButton" name="presetSaveButton">
        <property name="enabled">
         <bool>false</bool>
@@ -52,7 +52,7 @@
        </property>
       </widget>
      </item>
-     <item row="0" column="3">
+     <item row="0" column="4">
       <widget class="QPushButton" name="deleteButton">
        <property name="enabled">
         <bool>false</bool>
@@ -94,9 +94,12 @@
        <property name="toolTip">
         <string>preset selection</string>
        </property>
+       <property name="editable">
+        <bool>true</bool>
+       </property>
       </widget>
      </item>
-     <item row="0" column="2">
+     <item row="0" column="3">
       <widget class="QPushButton" name="addButton">
        <property name="enabled">
         <bool>false</bool>
@@ -124,6 +127,13 @@
        </property>
        <property name="text">
         <string>+</string>
+       </property>
+      </widget>
+     </item>
+     <item row="0" column="2">
+      <widget class="QLabel" name="labelChangeIndicator">
+       <property name="text">
+        <string/>
        </property>
       </widget>
      </item>


### PR DESCRIPTION
make the comboBoxPreset editable
* if the set name is changed to "" asks if the user want to delete the current preset
* if the set name is changed and  no  values are changed, rename the current preset
* if the set name is changed and some values are changed, create a new set

The ability to directly rename the parameter set is new.
Adding and removing sets is redundant to the + and - buttons.

As the name is now editable, I had to move the change indicator "*" into its very own label.

Interestingly, when the user enters a name of a preset that already exists, QT does automatically changes to it. That might need some testing and tweaking.