### PR TITLE
warn, when an assigment from the RootModule overwritten by an include

### DIFF
--- a/doc/testing.txt
+++ b/doc/testing.txt
@@ -78,11 +78,12 @@ Adding a new test:
 2) if the test is non-obvious, create a human readable description as comments in the test (or in another file in the same directory in case the file isn't human readable)
 3) if a new test app was written, this must be added to tests/CMakeLists.txt
 4) Add the tests to the test apps for which you want them to run (in tests/CMakeLists.txt)
-5) run the test with the environment variable TEST_GENERATE=1, e.g.:
+5) rebuild the test environment
+6) run the test with the environment variable TEST_GENERATE=1, e.g.:
    $ TEST_GENERATE=1 ctest -R mytest
    (this will generate a mytest-expected.txt file which is used for regression testing)
-6) manually verify that the output is correct (tests/regression/<testapp>/mytest-expected.<suffix>)
-7) run the test normally and verify that it passes:
+7) manually verify that the output is correct (tests/regression/<testapp>/mytest-expected.<suffix>)
+8) run the test normally and verify that it passes:
   $ ctest -R mytest
 
 Adding a new example:

--- a/src/FileModule.cc
+++ b/src/FileModule.cc
@@ -182,8 +182,8 @@ AbstractNode *FileModule::instantiateWithFileContext(FileContext *ctx, const Mod
 		node->children.insert(node->children.end(), instantiatednodes.begin(), instantiatednodes.end());
 	}
 	catch (AssertionFailedException &e) {
-		auto docPath = boost::filesystem::path(ctx->documentPath());
-		auto uncPath = boostfs_uncomplete(e.loc.filePath(), docPath);
+		const auto docPath = boost::filesystem::path(ctx->documentPath());
+		const auto uncPath = boostfs_uncomplete(e.loc.filePath(), docPath);
 
 		PRINTB("%s failed in file %s, line %d", e.what() % uncPath.generic_string() % e.loc.firstLine());
 	}

--- a/src/parser.y
+++ b/src/parser.y
@@ -223,10 +223,10 @@ assignment:
                                     LOC(@$).firstLine());
                         }else if(assignmentWarning && prevFile == RootFile && currFile != prevFile){
                             //assigment from the RootModule overwritten by an include
-                            auto docPath = boost::filesystem::path(RootFile).parent_path();
+                            const auto docPath = boost::filesystem::path(RootFile).parent_path();
 
-                            auto uncPathCurr = boostfs_uncomplete(currFile, docPath);
-                            auto uncPathPrev = boostfs_uncomplete(prevFile, docPath);
+                            const auto uncPathCurr = boostfs_uncomplete(currFile, docPath);
+                            const auto uncPathPrev = boostfs_uncomplete(prevFile, docPath);
 
                             PRINTB("WARNING: %s was assigned on line %i of %s but was overwritten on line %i  of %s",
                                     assignment.name%

--- a/src/parser.y
+++ b/src/parser.y
@@ -45,6 +45,7 @@
 #include "memory.h"
 #include <sstream>
 #include <boost/filesystem.hpp>
+#include "boost-utils.h"
 
 namespace fs = boost::filesystem;
 
@@ -222,12 +223,17 @@ assignment:
                                     LOC(@$).firstLine());
                         }else if(assignmentWarning && prevFile == RootFile && currFile != prevFile){
                             //assigment from the RootModule overwritten by an include
+                            auto docPath = boost::filesystem::path(RootFile).parent_path();
+
+                            auto uncPathCurr = boostfs_uncomplete(currFile, docPath);
+                            auto uncPathPrev = boostfs_uncomplete(prevFile, docPath);
+
                             PRINTB("WARNING: %s was assigned on line %i of %s but was overwritten on line %i  of %s",
                                     assignment.name%
                                     assignment.location().firstLine()%
-                                    assignment.location().fileName()%
+                                    uncPathPrev%
                                     LOC(@$).firstLine()%
-                                    LOC(@$).fileName());
+                                    uncPathCurr);
                         }
                         assignment.expr = shared_ptr<Expression>($3);
                         assignment.setLocation(LOC(@$));

--- a/src/parser.y
+++ b/src/parser.y
@@ -209,11 +209,25 @@ assignment:
                 bool found = false;
                 for (auto &assignment : scope_stack.top()->assignments) {
                     if (assignment.name == $1) {
-                        if(assignmentWarning && rootmodule->getFullpath()==LOC(@$).fileName()){
+
+                        auto RootFile = rootmodule->getFullpath();
+                        auto prevFile = assignment.location().fileName();
+                        auto currFile = LOC(@$).fileName();
+                        
+                        if(assignmentWarning && prevFile==RootFile && currFile == RootFile){
+                            //both assigments in the RootModule
                             PRINTB("WARNING: %s was assigned on line %i but was overwritten on line %i",
                                     assignment.name%
                                     assignment.location().firstLine()%
                                     LOC(@$).firstLine());
+                        }else if(assignmentWarning && prevFile == RootFile && currFile != prevFile){
+                            //assigment from the RootModule overwritten by an include
+                            PRINTB("WARNING: %s was assigned on line %i of %s but was overwritten on line %i  of %s",
+                                    assignment.name%
+                                    assignment.location().firstLine()%
+                                    assignment.location().fileName()%
+                                    LOC(@$).firstLine()%
+                                    LOC(@$).fileName());
                         }
                         assignment.expr = shared_ptr<Expression>($3);
                         assignment.setLocation(LOC(@$));

--- a/src/parser.y
+++ b/src/parser.y
@@ -649,6 +649,7 @@ bool parse(FileModule *&module, const char *text, const std::string &filename, i
   parser_error_pos = -1;
   parser_input_buffer = text;
   parser_sourcefile = std::make_shared<fs::path>(path);
+  assignmentWarning=true;
 
   rootmodule = new FileModule(path.parent_path().generic_string(), path.filename().generic_string());
   scope_stack.push(&rootmodule->scope);

--- a/testdata/scad/misc/include-overwrite-after.scad
+++ b/testdata/scad/misc/include-overwrite-after.scad
@@ -1,0 +1,2 @@
+echo("after");
+after = true;

--- a/testdata/scad/misc/include-overwrite-before.scad
+++ b/testdata/scad/misc/include-overwrite-before.scad
@@ -1,0 +1,2 @@
+echo("before");
+before = true;

--- a/testdata/scad/misc/include-overwrite-main.scad
+++ b/testdata/scad/misc/include-overwrite-main.scad
@@ -1,0 +1,19 @@
+echo(str("Can a variable be used when it assigned later? ",later))
+
+echo(str("Is overwritting possible? ", overwritten));
+
+echo(str("Does an include before the assigment take priority? ", before));
+
+echo(str("Does an include after the assigment take priority? ", after));
+
+include <include-overwrite-before.scad>;
+
+overwritten=false;
+main = true;
+before=false;
+after=false;
+overwritten=true;
+
+include <include-overwrite-after.scad>;
+
+later=true;

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1158,6 +1158,7 @@ list(APPEND EXAMPLE_FILES ${EXAMPLE_3D_FILES} ${EXAMPLE_2D_FILES})
 
 list(APPEND MISC_FILES ${CMAKE_SOURCE_DIR}/../testdata/scad/misc/escape-test.scad
                        ${CMAKE_SOURCE_DIR}/../testdata/scad/misc/include-tests.scad
+                       ${CMAKE_SOURCE_DIR}/../testdata/scad/misc/include-overwrite-main.scad
                        ${CMAKE_SOURCE_DIR}/../testdata/scad/misc/use-tests.scad
                        ${CMAKE_SOURCE_DIR}/../testdata/scad/misc/assert-tests.scad
                        ${CMAKE_SOURCE_DIR}/../testdata/scad/misc/let-module-tests.scad
@@ -1211,6 +1212,7 @@ list(APPEND ECHO_FILES ${FUNCTION_FILES} ${MISC_FILES}
             ${CMAKE_SOURCE_DIR}/../testdata/scad/misc/nbsp-latin1-test.scad
             ${CMAKE_SOURCE_DIR}/../testdata/scad/misc/concat-tests.scad
             ${CMAKE_SOURCE_DIR}/../testdata/scad/misc/include-recursive-test.scad
+            
             ${CMAKE_SOURCE_DIR}/../testdata/scad/misc/operators-tests.scad
             ${CMAKE_SOURCE_DIR}/../testdata/scad/issues/issue1472.scad
             ${CMAKE_SOURCE_DIR}/../testdata/scad/bugs/empty-stl.scad

--- a/tests/regression/astdumptest/include-overwrite-main-expected.ast
+++ b/tests/regression/astdumptest/include-overwrite-main-expected.ast
@@ -1,0 +1,10 @@
+before = false;
+overwritten = true;
+main = true;
+after = true;
+later = true;
+echo(str("Can a variable be used when it assigned later? ", later)) echo(str("Is overwritting possible? ", overwritten));
+echo(str("Does an include before the assigment take priority? ", before));
+echo(str("Does an include after the assigment take priority? ", after));
+echo("before");
+echo("after");

--- a/tests/regression/dumptest/include-overwrite-main-expected.csg
+++ b/tests/regression/dumptest/include-overwrite-main-expected.csg
@@ -1,0 +1,6 @@
+group();
+group();
+group();
+group();
+group();
+

--- a/tests/regression/echotest/include-overwrite-main-expected.echo
+++ b/tests/regression/echotest/include-overwrite-main-expected.echo
@@ -1,0 +1,7 @@
+WARNING: overwritten was assigned on line 11 but was overwritten on line 15
+WARNING: after was assigned on line 14 of "../../../../../testdata/scad/misc/include-overwrite-main.scad" but was overwritten on line 2  of "../../../../../testdata/scad/misc/include-overwrite-after.scad"
+ECHO: "Can a variable be used when it assigned later? true"
+ECHO: "Does an include before the assigment take priority? false"
+ECHO: "Does an include after the assigment take priority? true"
+ECHO: "before"
+ECHO: "after"


### PR DESCRIPTION
![beforemainafter](https://user-images.githubusercontent.com/24962768/45919350-511b9700-be94-11e8-9588-190911238bfa.png)

I used the uncomplete code as used by assert, so I added an "assert(false);" into my test files.