### PR TITLE
Boost options_description now used to generate command line help.

### DIFF
--- a/src/openscad.cc
+++ b/src/openscad.cc
@@ -767,7 +767,7 @@ int main(int argc, char **argv)
 	int rc = 0;
 	StackCheck::inst()->init();
 #ifdef OPENSCAD_QTGUI
-    QCoreApplication *app = new QCoreApplication(argc, argv);
+	QCoreApplication *app = new QCoreApplication(argc, argv);
 	PlatformUtils::registerApplicationPath(app->applicationDirPath().toLocal8Bit().constData());
 	delete app;
 #else

--- a/src/openscad.cc
+++ b/src/openscad.cc
@@ -128,7 +128,7 @@ public:
 	}
 };
 
-static void help(const char *arg0, po::options_description &desc, bool failure = false)
+static void help(const char *arg0, const po::options_description &desc, bool failure = false)
 {
 	std::stringstream ss;
 	ss << desc;

--- a/src/openscad.cc
+++ b/src/openscad.cc
@@ -767,7 +767,7 @@ int main(int argc, char **argv)
 	int rc = 0;
 	StackCheck::inst()->init();
 #ifdef OPENSCAD_QTGUI
-	{
+	{   // Need a dummy app instance to get the application path but it needs to be destroyed before the GUI is launched.
 		QCoreApplication app(argc, argv);
 		PlatformUtils::registerApplicationPath(app.applicationDirPath().toLocal8Bit().constData());
 	}

--- a/src/openscad.cc
+++ b/src/openscad.cc
@@ -767,9 +767,10 @@ int main(int argc, char **argv)
 	int rc = 0;
 	StackCheck::inst()->init();
 #ifdef OPENSCAD_QTGUI
-	QCoreApplication *app = new QCoreApplication(argc, argv);
-	PlatformUtils::registerApplicationPath(app->applicationDirPath().toLocal8Bit().constData());
-	delete app;
+	{
+		QCoreApplication app(argc, argv);
+		PlatformUtils::registerApplicationPath(app.applicationDirPath().toLocal8Bit().constData());
+	}
 #else
 	PlatformUtils::registerApplicationPath(fs::absolute(boost::filesystem::path(argv[0]).parent_path()).generic_string());
 #endif

--- a/src/openscad.cc
+++ b/src/openscad.cc
@@ -767,11 +767,12 @@ int main(int argc, char **argv)
 	int rc = 0;
 	StackCheck::inst()->init();
 #ifdef OPENSCAD_QTGUI
-	const auto application_path = QCoreApplication::applicationDirPath().toLocal8Bit().constData();
+    QCoreApplication *app = new QCoreApplication(argc, argv);
+	PlatformUtils::registerApplicationPath(app->applicationDirPath().toLocal8Bit().constData());
+    delete app;
 #else
-	const auto application_path = fs::absolute(boost::filesystem::path(argv[0]).parent_path()).generic_string();
+	PlatformUtils::registerApplicationPath(fs::absolute(boost::filesystem::path(argv[0]).parent_path()).generic_string());
 #endif
-	PlatformUtils::registerApplicationPath(application_path);
 	
 #ifdef Q_OS_MAC
 	bool isGuiLaunched = getenv("GUI_LAUNCHED") != nullptr;

--- a/src/openscad.cc
+++ b/src/openscad.cc
@@ -769,7 +769,7 @@ int main(int argc, char **argv)
 #ifdef OPENSCAD_QTGUI
     QCoreApplication *app = new QCoreApplication(argc, argv);
 	PlatformUtils::registerApplicationPath(app->applicationDirPath().toLocal8Bit().constData());
-    delete app;
+	delete app;
 #else
 	PlatformUtils::registerApplicationPath(fs::absolute(boost::filesystem::path(argv[0]).parent_path()).generic_string());
 #endif

--- a/src/openscad.cc
+++ b/src/openscad.cc
@@ -767,9 +767,9 @@ int main(int argc, char **argv)
 	int rc = 0;
 	StackCheck::inst()->init();
 #ifdef OPENSCAD_QTGUI
-	const std::string application_path = QCoreApplication::applicationDirPath().toLocal8Bit().constData();
+	const auto application_path = QCoreApplication::applicationDirPath().toLocal8Bit().constData();
 #else
-	const std::string application_path = fs::absolute(boost::filesystem::path(argv[0]).parent_path()).generic_string();
+	const auto application_path = fs::absolute(boost::filesystem::path(argv[0]).parent_path()).generic_string();
 #endif
 	PlatformUtils::registerApplicationPath(application_path);
 	

--- a/src/openscad.cc
+++ b/src/openscad.cc
@@ -812,31 +812,31 @@ int main(int argc, char **argv)
         
 	po::options_description desc("Allowed options");
 	desc.add_options()
-		("o,o", po::value<string>(), "out_file -output a file instead of running the GUI, the file extension specifies the type: stl, off, amf, csg, dxf, svg, png, echo, ast, term, nef3, nefdbg")
+		("o,o", po::value<string>(), "output specified file instead of running the GUI, the file extension specifies the type: stl, off, amf, csg, dxf, svg, png, echo, ast, term, nef3, nefdbg\n")
 		("D,D", po::value<vector<string>>(), "var=val -pre-define variables")
+#ifdef ENABLE_EXPERIMENTAL
 		("p,p", po::value<string>(), "customizer parameter file")
 		("P,P", po::value<string>(), "customizer parameter set")
-#ifdef ENABLE_EXPERIMENTAL
 		("enable", po::value<vector<string>>(), ("enable experimental features: " + features + "\n").c_str())
 #endif
 		("help,h", "print this help message and exit")
 		("version,v", "print the version")
 		("info", "print information about the build process\n")
 
-		("camera", po::value<string>(), "camera parameters when exporting png: translate_x,y,z,rot_x,y,z,dist or eye_x,y,z,center_x,y,z")
-		("autocenter", "adjust camera to look at object center")
+		("camera", po::value<string>(), "camera parameters when exporting png: =translate_x,y,z,rot_x,y,z,dist or =eye_x,y,z,center_x,y,z")
+		("autocenter", "adjust camera to look at object's center")
 		("viewall", "adjust camera to fit object")
-		("imgsize", po::value<string>(), "=width,height for exporting png")
-		("render", po::value<string>()->implicit_value(""), "if exporting a png image, do a full geometry evaluation")
-		("preview", po::value<string>()->implicit_value(""), "if exporting a png image, do an OpenCSG(default) or ThrownTogether preview")
-		("projection", po::value<string>(), "(o)rtho or (p)erspective when exporting png")
-		("csglimit", po::value<unsigned int>(), "if exporting a png image, stop rendering at the given number of CSG elements")
-		("colorscheme", po::value<string>(), ("colorscheme: " + colorSchemeNames + "\n").c_str())
+		("imgsize", po::value<string>(), "=width,height of exported png")
+		("render", po::value<string>()->implicit_value(""), "for full geometry evaluation when exporting png")
+		("preview", po::value<string>()->implicit_value(""), "[=throwntogether] -for ThrownTogether preview png")
+		("projection", po::value<string>(), "=(o)rtho or (p)erspective when exporting png")
+		("csglimit", po::value<unsigned int>(), "=n -stop rendering at n CSG elements when exporting png")
+		("colorscheme", po::value<string>(), ("=colorscheme: " + colorSchemeNames + "\n").c_str())
 
 		("d,d", po::value<string>(), "deps_file -generate a dependency file for make")
 		("m,m", po::value<string>(), "make_cmd -runs make_cmd file if file is missing")
-		("debug", po::value<string>(), "special debug info")
 		("quiet,q", "quiet mode (don't print anything *except* errors)")
+		("debug", po::value<string>(), "special debug info")
 #ifdef Q_OS_MACX
 		("psn", po::value<string>(), "process serial number")
 #endif

--- a/src/openscad.cc
+++ b/src/openscad.cc
@@ -839,15 +839,15 @@ int main(int argc, char **argv)
 		("m,m", po::value<string>(), "make_cmd -runs make_cmd file if file is missing")
 		("quiet,q", "quiet mode (don't print anything *except* errors)")
 		("debug", po::value<string>(), "special debug info")
-#ifdef Q_OS_MACX
-		("psn", po::value<string>(), "process serial number")
-#endif
 		("s,s", po::value<string>(), "stl_file deprecated, use -o")
 		("x,x", po::value<string>(), "dxf_file deprecated, use -o")
 		;
 
 	po::options_description hidden("Hidden options");
 	hidden.add_options()
+#ifdef Q_OS_MACX
+		("psn", po::value<string>(), "process serial number")
+#endif
 		("input-file", po::value< vector<string>>(), "input file");
 
 	po::positional_options_description p;


### PR DESCRIPTION
The command line help message is now programmatically generated from the  boost::options_description. The descriptions have been tidied up and extended to show the experimental features available and the color schemes available with the default marked by a star.

Unrecognised options give an error again, reversing @kintel's commit https://github.com/openscad/openscad/commit/752f35eab6c7b20d188bc36836e622665c8eba42. This assumes #2107 makes it no longer necessary.

This is an example of the error handling:
```
$ ./release/openscad.exe -fred
unrecognised option '-fred'

Usage: openscad.exe [options] file.scad
  -o [ --o ] arg        output specified file instead of running the GUI, the
                        file extension specifies the type: stl, off, amf, csg,
                        dxf, svg, png, echo, ast, term, nef3, nefdbg

  -D [ --D ] arg        var=val -pre-define variables
  -p [ --p ] arg        customizer parameter file
  -P [ --P ] arg        customizer parameter set
  --enable arg          enable experimental features: assert | echo | lc-each |
                        lc-else | lc-for-c | amf-import | svg-import |
                        customizer

  -h [ --help ]         print this help message and exit
  -v [ --version ]      print the version
  --info                print information about the build process

  --camera arg          camera parameters when exporting png:
                        =translate_x,y,z,rot_x,y,z,dist or
                        =eye_x,y,z,center_x,y,z
  --autocenter          adjust camera to look at object's center
  --viewall             adjust camera to fit object
  --imgsize arg         =width,height of exported png
  --render arg          for full geometry evaluation when exporting png
  --preview arg         [=throwntogether] -for ThrownTogether preview png
  --projection arg      =(o)rtho or (p)erspective when exporting png
  --csglimit arg        =n -stop rendering at n CSG elements when exporting png
  --colorscheme arg     =colorscheme: *Cornfield | Metallic | Sunset |
                        Starnight | BeforeDawn | Nature | DeepOcean | Solarized
                        | Tomorrow | Tomorrow Night | Monotone

  -d [ --d ] arg        deps_file -generate a dependency file for make
  -m [ --m ] arg        make_cmd -runs make_cmd file if file is missing
  -q [ --quiet ]        quiet mode (don't print anything *except* errors)
  --debug arg           special debug info
  -s [ --s ] arg        stl_file deprecated, use -o
  -x [ --x ] arg        dxf_file deprecated, use -o
```
