### PR TITLE
do not warn for duplicate assigmentens in "used" files

### DIFF
--- a/src/ModuleCache.cc
+++ b/src/ModuleCache.cc
@@ -106,7 +106,7 @@ time_t ModuleCache::evaluate(const std::string &filename, FileModule *&module)
 		print_messages_push();
 		
 		delete cacheEntry.parsed_module;
-		lib_mod = parse(cacheEntry.parsed_module, textbuf.str().c_str(), filename, false) ? cacheEntry.parsed_module : nullptr;
+		lib_mod = parse(cacheEntry.parsed_module, textbuf.str().c_str(), filename, false, false) ? cacheEntry.parsed_module : nullptr;
 		PRINTDB("  compiled module: %p", lib_mod);
 		cacheEntry.module = lib_mod;
 		cacheEntry.cache_id = cache_id;

--- a/src/mainwin.cc
+++ b/src/mainwin.cc
@@ -1730,7 +1730,7 @@ void MainWindow::compileTopLevelDocument(bool rebuildParameterWidget)
 	auto fnameba = this->fileName.toLocal8Bit();
 	const char* fname = this->fileName.isEmpty() ? "" : fnameba;
 	delete this->parsed_module;
-	this->root_module = parse(this->parsed_module, fulltext.c_str(), fname, false) ? this->parsed_module : nullptr;
+	this->root_module = parse(this->parsed_module, fulltext.c_str(), fname, false, true) ? this->parsed_module : nullptr;
 
 	if (Feature::ExperimentalCustomizer.is_enabled()) {
 		if (this->root_module!=nullptr) {

--- a/src/openscad.cc
+++ b/src/openscad.cc
@@ -368,7 +368,7 @@ int cmdline(const char *deps_output_file, const std::string &filename, Camera &c
 	}
 	std::string text((std::istreambuf_iterator<char>(ifs)), std::istreambuf_iterator<char>());
 	text += "\n\x03\n" + commandline_commands;
-	if (!parse(root_module, text.c_str(), filename, false)) {
+	if (!parse(root_module, text.c_str(), filename, false,true)) {
 		delete root_module;  // parse failed
 		root_module = nullptr;
 	}

--- a/src/openscad.h
+++ b/src/openscad.h
@@ -28,7 +28,7 @@
 
 #include <boost/filesystem.hpp>
 
-extern bool parse(class FileModule *&module, const char *text, const std::string &filename, int debug);
+extern bool parse(class FileModule *&module, const char *text, const std::string &filename, int debug, bool mainModule);
 
 #include <string>
 extern std::string commandline_commands;

--- a/src/parser.y
+++ b/src/parser.y
@@ -64,6 +64,7 @@ int lexerlex(void);
 
 std::stack<LocalScope *> scope_stack;
 FileModule *rootmodule;
+bool bMainModule;
 
 extern void lexerdestroy();
 extern FILE *lexerin;
@@ -215,13 +216,13 @@ assignment:
                         auto prevFile = assignment.location().fileName();
                         auto currFile = LOC(@$).fileName();
                         
-                        if(assignmentWarning && prevFile==RootFile && currFile == RootFile){
+                        if(bMainModule && assignmentWarning && prevFile==RootFile && currFile == RootFile){
                             //both assigments in the RootModule
                             PRINTB("WARNING: %s was assigned on line %i but was overwritten on line %i",
                                     assignment.name%
                                     assignment.location().firstLine()%
                                     LOC(@$).firstLine());
-                        }else if(assignmentWarning && prevFile == RootFile && currFile != prevFile){
+                        }else if(bMainModule && assignmentWarning && prevFile == RootFile && currFile != prevFile){
                             //assigment from the RootModule overwritten by an include
                             const auto docPath = boost::filesystem::path(RootFile).parent_path();
 
@@ -661,9 +662,11 @@ void yyerror (char const *s)
          (*sourcefile()) % lexerget_lineno() % s);
 }
 
-bool parse(FileModule *&module, const char *text, const std::string &filename, int debug)
+bool parse(FileModule *&module, const char *text, const std::string &filename, int debug, bool mainModule)
 {
   fs::path path = fs::absolute(fs::path(filename));
+  
+  bMainModule = mainModule;
   
   lexerin = NULL;
   parser_error_pos = -1;

--- a/testdata/scad/misc/include-overwrite-main.scad
+++ b/testdata/scad/misc/include-overwrite-main.scad
@@ -6,6 +6,7 @@ echo(str("Does an include before the assigment take priority? ", before));
 
 echo(str("Does an include after the assigment take priority? ", after));
 
+use     <include-overwrite-use.scad>;
 include <include-overwrite-before.scad>;
 
 overwritten=false;

--- a/testdata/scad/misc/include-overwrite-use.scad
+++ b/testdata/scad/misc/include-overwrite-use.scad
@@ -1,0 +1,2 @@
+overwriteInuse=false;
+overwriteInuse=true;

--- a/tests/regression/echotest/include-overwrite-main-expected.echo
+++ b/tests/regression/echotest/include-overwrite-main-expected.echo
@@ -1,5 +1,5 @@
-WARNING: overwritten was assigned on line 11 but was overwritten on line 15
-WARNING: after was assigned on line 14 of "../../../../../testdata/scad/misc/include-overwrite-main.scad" but was overwritten on line 2  of "../../../../../testdata/scad/misc/include-overwrite-after.scad"
+WARNING: overwritten was assigned on line 12 but was overwritten on line 16
+WARNING: after was assigned on line 15 of "../../../../../testdata/scad/misc/include-overwrite-main.scad" but was overwritten on line 2  of "../../../../../testdata/scad/misc/include-overwrite-after.scad"
 ECHO: "Can a variable be used when it assigned later? true"
 ECHO: "Does an include before the assigment take priority? false"
 ECHO: "Does an include after the assigment take priority? true"

--- a/tests/tests-common.cc
+++ b/tests/tests-common.cc
@@ -30,7 +30,7 @@ FileModule *parsefile(const char *filename, const char *fakepath)
 		std::string pathname;
 		if (fakepath) pathname = fakepath;
 		else pathname = fs::path(filename).parent_path().generic_string();
-		if(!parse(root_module, text.c_str(), pathname.c_str(), false)) {
+		if(!parse(root_module, text.c_str(), pathname.c_str(), false, true)) {
 			delete root_module;             // parse failed
 			root_module = NULL;
 		}


### PR DESCRIPTION
change on the parser: distinguish between mainModule and included modules