### PR TITLE
No longer clears the console.

### DIFF
--- a/src/MainWindow.h
+++ b/src/MainWindow.h
@@ -107,7 +107,7 @@ private:
 	void compileTopLevelDocument(bool rebuildParameterWidget);
 		void updateCompileResult();
 	void compile(bool reload, bool forcedone = false, bool rebuildParameterWidget=true);
-	void compileCSG(bool procevents);
+	void compileCSG();
 	bool maybeSave();
 		void saveError(const QIODevice &file, const std::string &msg);
 	bool checkEditorModified();

--- a/src/MainWindow.ui
+++ b/src/MainWindow.ui
@@ -585,7 +585,7 @@
       <number>0</number>
      </property>
      <item>
-      <widget class="QTextEdit" name="console">
+      <widget class="QPlainTextEdit" name="console">
        <property name="minimumSize">
         <size>
          <width>10</width>

--- a/src/mainwin.cc
+++ b/src/mainwin.cc
@@ -432,7 +432,7 @@ MainWindow::MainWindow(const QString &filename)
 
 	setCurrentOutput();
 
-	std::string helptitle = "OpenSCAD " + openscad_versionnumber +  "\nhttp://www.openscad.org\n\n";
+	std::string helptitle = "OpenSCAD " + openscad_versionnumber +  "\nhttp://www.openscad.org\n";
 	PRINT(helptitle);
 	PRINT(copyrighttext);
 	PRINT("");
@@ -1048,7 +1048,7 @@ void MainWindow::compile(bool reload, bool forcedone, bool rebuildParameterWidge
 		auto mtime = this->root_module->handleDependencies();
 		if (mtime > this->deps_mtime) {
 			this->deps_mtime = mtime;
-			PRINTB("Module cache size: %d modules", ModuleCache::instance()->size());
+			PRINTB("Used file cache size: %d modules", ModuleCache::instance()->size());
 			didcompile = true;
 		}
 	}

--- a/src/mainwin.cc
+++ b/src/mainwin.cc
@@ -2873,7 +2873,7 @@ void MainWindow::consoleOutput(const QString &msg)
 	}
 	else {
 		qmsg = msg;
-        qmsg.replace("\n","<br>");
+		qmsg.replace("\n","<br>");
 	}
 	auto c = this->console->textCursor();
 	c.movePosition(QTextCursor::End);

--- a/src/mainwin.cc
+++ b/src/mainwin.cc
@@ -1048,7 +1048,7 @@ void MainWindow::compile(bool reload, bool forcedone, bool rebuildParameterWidge
 		auto mtime = this->root_module->handleDependencies();
 		if (mtime > this->deps_mtime) {
 			this->deps_mtime = mtime;
-			PRINTB("Used file cache size: %d modules", ModuleCache::instance()->size());
+			PRINTB("Used file cache size: %d files", ModuleCache::instance()->size());
 			didcompile = true;
 		}
 	}

--- a/src/mainwin.cc
+++ b/src/mainwin.cc
@@ -1038,7 +1038,6 @@ void MainWindow::compile(bool reload, bool forcedone, bool rebuildParameterWidge
 	}
 
 	if (shouldcompiletoplevel) {
-		console->clear();
 		if (editor->isContentModified()) saveBackup();
 		compileTopLevelDocument(rebuildParameterWidget);
 		didcompile = true;
@@ -1326,7 +1325,7 @@ void MainWindow::compileCSG(bool procevents)
 																														this->background_products);
 	PRINT("Compile and preview finished.");
 	int s = this->renderingTime.elapsed() / 1000;
-	PRINTB("Total rendering time: %d hours, %d minutes, %d seconds", (s / (60*60)) % ((s / 60) % 60) % (s % 60));
+	PRINTB("Total rendering time: %d hours, %d minutes, %d seconds\n", (s / (60*60)) % ((s / 60) % 60) % (s % 60));
 	this->processEvents();
 }
 
@@ -2070,7 +2069,7 @@ void MainWindow::actionRenderDone(shared_ptr<const Geometry> root_geom)
 				assert(false && "Unknown geometry type");
 			}
 		}
-		PRINT("Rendering finished.");
+		PRINT("Rendering finished.\n");
 
 		this->root_geom = root_geom;
 		this->cgalRenderer = new CGALRenderer(root_geom);
@@ -2079,7 +2078,7 @@ void MainWindow::actionRenderDone(shared_ptr<const Geometry> root_geom)
 		else viewModeSurface();
 	}
 	else {
-		PRINT("WARNING: No top level geometry to render");
+		PRINT("WARNING: No top level geometry to render\n");
 	}
 
 	updateStatusBar(nullptr);

--- a/src/mainwin.cc
+++ b/src/mainwin.cc
@@ -2877,7 +2877,7 @@ void MainWindow::consoleOutput(const QString &msg)
 	auto c = this->console->textCursor();
 	c.movePosition(QTextCursor::End);
 	this->console->setTextCursor(c);
-	if(qmsg.contains('\t'))
+	if(qmsg.contains('\t') && !qmsg.contains("<pre>", Qt::CaseInsensitive))
 		this->console->appendPlainText(qmsg);
 	else {
 		qmsg.replace("\n","<br>");

--- a/src/mainwin.cc
+++ b/src/mainwin.cc
@@ -2873,12 +2873,16 @@ void MainWindow::consoleOutput(const QString &msg)
 	}
 	else {
 		qmsg = msg;
-		qmsg.replace("\n","<br>");
 	}
 	auto c = this->console->textCursor();
 	c.movePosition(QTextCursor::End);
 	this->console->setTextCursor(c);
-	this->console->appendHtml(qmsg);
+	if(qmsg.contains('\t'))
+		this->console->appendPlainText(qmsg);
+	else {
+		qmsg.replace("\n","<br>");
+		this->console->appendHtml(qmsg);
+	}
 	this->processEvents();
 }
 

--- a/src/mainwin.cc
+++ b/src/mainwin.cc
@@ -140,12 +140,11 @@
 unsigned int GuiLocker::gui_locked = 0;
 
 static char copyrighttext[] =
-	"Copyright (C) 2009-2018 The OpenSCAD Developers\n"
-	"\n"
+	"Copyright (C) 2009-2018 The OpenSCAD Developers\n\n"
 	"This program is free software; you can redistribute it and/or modify "
 	"it under the terms of the GNU General Public License as published by "
 	"the Free Software Foundation; either version 2 of the License, or "
-	"(at your option) any later version.";
+	"(at your option) any later version.\n";
 bool MainWindow::mdiMode = false;
 bool MainWindow::undockMode = false;
 bool MainWindow::reorderMode = false;
@@ -597,6 +596,8 @@ MainWindow::MainWindow(const QString &filename)
 
 	setAcceptDrops(true);
 	clearCurrentOutput();
+
+	this->console->setMaximumBlockCount(500);
 }
 
 void MainWindow::initActionIcon(QAction *action, const char *darkResource, const char *lightResource)
@@ -1218,7 +1219,7 @@ void MainWindow::instantiateRoot()
 	Generates CSG tree for OpenCSG evaluation.
 	Assumes that the design has been parsed and evaluated (this->root_node is set)
 */
-void MainWindow::compileCSG(bool procevents)
+void MainWindow::compileCSG()
 {
 	assert(this->root_node);
 	PRINT("Compiling design (CSG Products generation)...");
@@ -1911,7 +1912,7 @@ void MainWindow::actionReloadRenderPreview()
 
 void MainWindow::csgReloadRender()
 {
-	if (this->root_node) compileCSG(true);
+	if (this->root_node) compileCSG();
 
 	// Go to non-CGAL view mode
 	if (viewActionThrownTogether->isChecked()) {
@@ -1954,7 +1955,7 @@ void MainWindow::actionRenderPreview(bool rebuildParameterWidget)
 
 void MainWindow::csgRender()
 {
-	if (this->root_node) compileCSG(!viewActionAnimate->isChecked());
+	if (this->root_node) compileCSG();
 
 	// Go to non-CGAL view mode
 	if (viewActionThrownTogether->isChecked()) {
@@ -2872,11 +2873,12 @@ void MainWindow::consoleOutput(const QString &msg)
 	}
 	else {
 		qmsg = msg;
+        qmsg.replace("\n","<br>");
 	}
 	auto c = this->console->textCursor();
 	c.movePosition(QTextCursor::End);
 	this->console->setTextCursor(c);
-	this->console->append(qmsg);
+	this->console->appendHtml(qmsg);
 	this->processEvents();
 }
 

--- a/src/mainwin.cc
+++ b/src/mainwin.cc
@@ -2866,10 +2866,10 @@ void MainWindow::consoleOutput(const QString &msg)
 	QString qmsg;
 	if (msg.startsWith("WARNING:") || msg.startsWith("DEPRECATED:")) {
 		this->compileWarnings++;
-		qmsg = "<html><span style=\"color: black; background-color: #ffffb0;\">" + QT_HTML_ESCAPE(QString(msg)) + "</span></html>\n";
+		qmsg = "<html><span style=\"color: black; background-color: #ffffb0;\">" + QT_HTML_ESCAPE(QString(msg)) + "</span></html>";
 	} else if (msg.startsWith("ERROR:")) {
 		this->compileErrors++;
-		qmsg = "<html><span style=\"color: black; background-color: #ffb0b0;\">" + QT_HTML_ESCAPE(QString(msg)) + "</span></html>\n";
+		qmsg = "<html><span style=\"color: black; background-color: #ffb0b0;\">" + QT_HTML_ESCAPE(QString(msg)) + "</span></html>";
 	}
 	else {
 		qmsg = msg;

--- a/src/mainwin.cc
+++ b/src/mainwin.cc
@@ -2863,25 +2863,25 @@ void MainWindow::consoleOutput(const std::string &msg, void *userdata)
 
 void MainWindow::consoleOutput(const QString &msg)
 {
-	QString qmsg;
-	if (msg.startsWith("WARNING:") || msg.startsWith("DEPRECATED:")) {
-		this->compileWarnings++;
-		qmsg = "<html><span style=\"color: black; background-color: #ffffb0;\">" + QT_HTML_ESCAPE(QString(msg)) + "</span></html>";
-	} else if (msg.startsWith("ERROR:")) {
-		this->compileErrors++;
-		qmsg = "<html><span style=\"color: black; background-color: #ffb0b0;\">" + QT_HTML_ESCAPE(QString(msg)) + "</span></html>";
-	}
-	else {
-		qmsg = msg;
-	}
 	auto c = this->console->textCursor();
 	c.movePosition(QTextCursor::End);
 	this->console->setTextCursor(c);
-	if(qmsg.contains('\t') && !qmsg.contains("<pre>", Qt::CaseInsensitive))
-		this->console->appendPlainText(qmsg);
+
+	if (msg.startsWith("WARNING:") || msg.startsWith("DEPRECATED:")) {
+		this->compileWarnings++;
+		this->console->appendHtml("<span style=\"color: black; background-color: #ffffb0;\">" + QT_HTML_ESCAPE(QString(msg)) + "</span>");
+	} else if (msg.startsWith("ERROR:")) {
+		this->compileErrors++;
+		this->console->appendHtml("<span style=\"color: black; background-color: #ffb0b0;\">" + QT_HTML_ESCAPE(QString(msg)) + "</span>");
+	}
 	else {
-		qmsg.replace("\n","<br>");
-		this->console->appendHtml(qmsg);
+		QString qmsg = msg;
+		if(qmsg.contains('\t') && !qmsg.contains("<pre>", Qt::CaseInsensitive))
+			this->console->appendPlainText(qmsg);
+		else {
+			qmsg.replace("\n","<br>");
+			this->console->appendHtml(qmsg);
+		}
 	}
 	this->processEvents();
 }

--- a/src/mainwin.cc
+++ b/src/mainwin.cc
@@ -435,7 +435,6 @@ MainWindow::MainWindow(const QString &filename)
 	std::string helptitle = "OpenSCAD " + openscad_versionnumber +  "\nhttp://www.openscad.org\n";
 	PRINT(helptitle);
 	PRINT(copyrighttext);
-	PRINT("");
 
 	if (!filename.isEmpty()) {
 		openFile(filename);
@@ -1211,6 +1210,7 @@ void MainWindow::instantiateRoot()
 		} else {
 			PRINT("ERROR: Compilation failed!");
 		}
+		PRINT(" ");
 		this->processEvents();
 	}
 }
@@ -2079,7 +2079,8 @@ void MainWindow::actionRenderDone(shared_ptr<const Geometry> root_geom)
 		else viewModeSurface();
 	}
 	else {
-		PRINT("WARNING: No top level geometry to render\n");
+		PRINT("WARNING: No top level geometry to render");
+		PRINT(" ");
 	}
 
 	updateStatusBar(nullptr);


### PR DESCRIPTION
A blank line is printed instead to separate each compilation.

The console clearing was not consistent because it depended on whether the main file changed or just its dependencies. It also cleared duplicate assignment warnings and the start up messages prematurely.