### PR TITLE
add line number to "Ignoring unknown variable" Warning

### DIFF
--- a/src/AST.cc
+++ b/src/AST.cc
@@ -3,6 +3,10 @@
 
 const Location Location::NONE(0, 0, 0, 0, nullptr);
 
+bool Location::isNone() const{
+	return (firstLine()==0 && firstColumn()==0 && lastLine()==0 && lastColumn()==0 && filePath()==nullptr);
+}
+
 std::ostream &operator<<(std::ostream &stream, const ASTNode &ast)
 {
 	ast.print(stream, "");

--- a/src/AST.h
+++ b/src/AST.h
@@ -22,7 +22,7 @@ public:
 	int firstColumn() const { return first_col; }
 	int lastLine() const { return last_line; }
 	int lastColumn() const { return last_col; }
-
+	bool isNone() const;
 
 	static const Location NONE;
 private:

--- a/src/context.cc
+++ b/src/context.cc
@@ -122,7 +122,7 @@ void Context::apply_variables(const Context &other)
 	}
 }
 
-ValuePtr Context::lookup_variable(const std::string &name, bool silent) const
+ValuePtr Context::lookup_variable(const std::string &name, bool silent, const Location &loc) const
 {
 	if (!this->ctx_stack) {
 		PRINT("ERROR: Context had null stack in lookup_variable()!!");
@@ -144,24 +144,30 @@ ValuePtr Context::lookup_variable(const std::string &name, bool silent) const
 		return this->variables.find(name)->second;
 	}
 	if (this->parent) {
-		return this->parent->lookup_variable(name, silent);
+		return this->parent->lookup_variable(name, silent, loc);
 	}
 	if (!silent) {
-		PRINTB("WARNING: Ignoring unknown variable '%s'.", name);
+		
+		if(loc.isNone()){
+			PRINTB("WARNING: Ignoring unknown variable '%s'.", name);
+		}else{
+			PRINTB("WARNING: Ignoring unknown variable '%s'.", name);
+			//output line number
+		}
 	}
 	return ValuePtr::undefined;
 }
 
 
-double Context::lookup_variable_with_default(const std::string &variable, const double &def) const
+double Context::lookup_variable_with_default(const std::string &variable, const double &def, const Location &loc) const
 {
-	ValuePtr v = this->lookup_variable(variable, true);
+	ValuePtr v = this->lookup_variable(variable, true, loc);
 	return (v->type() == Value::ValueType::NUMBER) ? v->toDouble() : def;
 }
 
-std::string Context::lookup_variable_with_default(const std::string &variable, const std::string &def) const
+std::string Context::lookup_variable_with_default(const std::string &variable, const std::string &def, const Location &loc) const
 {
-	ValuePtr v = this->lookup_variable(variable, true);
+	ValuePtr v = this->lookup_variable(variable, true, loc);
 	return (v->type() == Value::ValueType::STRING) ? v->toString() : def;
 }
 

--- a/src/context.cc
+++ b/src/context.cc
@@ -151,8 +151,7 @@ ValuePtr Context::lookup_variable(const std::string &name, bool silent, const Lo
 		if(loc.isNone()){
 			PRINTB("WARNING: Ignoring unknown variable '%s'.", name);
 		}else{
-			PRINTB("WARNING: Ignoring unknown variable '%s'.", name);
-			//output line number
+			PRINTB("WARNING: Ignoring unknown variable '%s', line %d.", name% loc.firstLine());
 		}
 	}
 	return ValuePtr::undefined;

--- a/src/context.h
+++ b/src/context.h
@@ -28,9 +28,9 @@ public:
 	void set_constant(const std::string &name, const Value &value);
 
 	void apply_variables(const Context &other);
-	ValuePtr lookup_variable(const std::string &name, bool silent = false) const;
-	double lookup_variable_with_default(const std::string &variable, const double &def) const;
-  std::string lookup_variable_with_default(const std::string &variable, const std::string &def) const;
+	ValuePtr lookup_variable(const std::string &name, bool silent = false, const Location &loc=Location::NONE) const;
+	double lookup_variable_with_default(const std::string &variable, const double &def, const Location &loc=Location::NONE) const;
+	std::string lookup_variable_with_default(const std::string &variable, const std::string &def, const Location &loc=Location::NONE) const;
 
 	bool has_local_variable(const std::string &name) const;
 

--- a/src/expr.cc
+++ b/src/expr.cc
@@ -384,7 +384,7 @@ Lookup::Lookup(const std::string &name, const Location &loc) : Expression(loc), 
 
 ValuePtr Lookup::evaluate(const Context *context) const
 {
-	return context->lookup_variable(this->name);
+	return context->lookup_variable(this->name,false,loc);
 }
 
 void Lookup::print(std::ostream &stream, const std::string &) const

--- a/tests/regression/echotest/rands-expected.echo
+++ b/tests/regression/echotest/rands-expected.echo
@@ -1,4 +1,4 @@
-WARNING: Ignoring unknown variable 'v'.
+WARNING: Ignoring unknown variable 'v', line 28.
 ECHO: "i hope rands() did not crash"
 ECHO: [1, 1, 1, 1]
 ECHO: [1.4486, 1.96977, 1.8777]

--- a/tests/regression/echotest/scope-assignment-tests-expected.echo
+++ b/tests/regression/echotest/scope-assignment-tests-expected.echo
@@ -2,7 +2,7 @@ WARNING: e was assigned on line 49 but was overwritten on line 52
 WARNING: f was assigned on line 58 but was overwritten on line 61
 WARNING: g was assigned on line 67 but was overwritten on line 69
 WARNING: h was assigned on line 73 but was overwritten on line 75
-WARNING: Ignoring unknown variable 'h'.
+WARNING: Ignoring unknown variable 'h', line 75.
 ECHO: "union scope"
 ECHO: "local a (5):", 5
 ECHO: "global a (4):", 4

--- a/tests/regression/echotest/special-consts-expected.echo
+++ b/tests/regression/echotest/special-consts-expected.echo
@@ -3,17 +3,17 @@ ECHO: "undef is undef"
 ECHO: "a is undef"
 ECHO: "undef is a"
 ECHO: "a is b"
-WARNING: Ignoring unknown variable 'c'.
+WARNING: Ignoring unknown variable 'c', line 21.
 ECHO: "c is undef"
-WARNING: Ignoring unknown variable 'c'.
+WARNING: Ignoring unknown variable 'c', line 25.
 ECHO: "undef is c"
 ECHO: "-- comparing undef --"
 ECHO: "undef evaluates false"
-WARNING: Ignoring unknown variable 'c'.
+WARNING: Ignoring unknown variable 'c', line 36.
 ECHO: "undef evaluates false"
 ECHO: "-- echo undef --"
 ECHO: undef
-WARNING: Ignoring unknown variable 'c'.
+WARNING: Ignoring unknown variable 'c', line 40.
 ECHO: undef
 ECHO: "-- calculating with undef --"
 ECHO: undef

--- a/tests/regression/echotest/use-tests-expected.echo
+++ b/tests/regression/echotest/use-tests-expected.echo
@@ -4,4 +4,4 @@ WARNING: Can't open library 'test/'.
 WARNING: Can't open library '/'.
 WARNING: Ignoring unknown module 'test3'.
 WARNING: Ignoring unknown module 'test4'.
-WARNING: Ignoring unknown variable 'test2_variable'.
+WARNING: Ignoring unknown variable 'test2_variable', line 49.

--- a/tests/regression/echotest/value-reassignment-tests-expected.echo
+++ b/tests/regression/echotest/value-reassignment-tests-expected.echo
@@ -1,3 +1,3 @@
 WARNING: myval was assigned on line 5 but was overwritten on line 7
-WARNING: Ignoring unknown variable 'i'.
+WARNING: Ignoring unknown variable 'i', line 7.
 ECHO: undef, 2

--- a/tests/regression/echotest/variable-scope-tests-expected.echo
+++ b/tests/regression/echotest/variable-scope-tests-expected.echo
@@ -1,6 +1,6 @@
 ECHO: "special variable inheritance"
 ECHO: 23, 5
-WARNING: Ignoring unknown variable 'a'.
+WARNING: Ignoring unknown variable 'a', line 8.
 ECHO: undef
 ECHO: 23, 5
 ECHO: "$children scope"
@@ -19,7 +19,7 @@ ECHO: 7
 ECHO: 7
 ECHO: "assign only visible in children's scope"
 DEPRECATED: The assign() module will be removed in future releases. Use a regular assignment instead.
-WARNING: Ignoring unknown variable 'c'.
+WARNING: Ignoring unknown variable 'c', line 65.
 ECHO: undef
 ECHO: 5
 ECHO: "undeclared variable can still be passed and used"


### PR DESCRIPTION
this partially addressees  #1843

I would be trival to output the filename, however: The filename is not very use full on its own.
Outputting the path breakes the tests. Uncompleting the path requires the path of the main file - the patch required for that is partially in #2520, so I would postpone outputting the filename until #2520 is merged.