### PR TITLE
Better error message for Recursion Exception

### DIFF
--- a/src/FileModule.cc
+++ b/src/FileModule.cc
@@ -181,6 +181,12 @@ AbstractNode *FileModule::instantiateWithFileContext(FileContext *ctx, const Mod
 		auto instantiatednodes = this->scope.instantiateChildren(ctx);
 		node->children.insert(node->children.end(), instantiatednodes.begin(), instantiatednodes.end());
 	}
+	catch (RecursionException &e) {
+		const auto docPath = boost::filesystem::path(ctx->documentPath());
+		const auto uncPath = boostfs_uncomplete(e.loc.filePath(), docPath);
+
+		PRINTB("%s in file %s, line %d", e.what() % uncPath.generic_string() % e.loc.firstLine());
+	}
 	catch (AssertionFailedException &e) {
 		const auto docPath = boost::filesystem::path(ctx->documentPath());
 		const auto uncPath = boostfs_uncomplete(e.loc.filePath(), docPath);

--- a/src/UserModule.cc
+++ b/src/UserModule.cc
@@ -40,7 +40,7 @@ std::deque<std::string> UserModule::module_stack;
 AbstractNode *UserModule::instantiate(const Context *ctx, const ModuleInstantiation *inst, EvalContext *evalctx) const
 {
 	if (StackCheck::inst()->check()) {
-		throw RecursionException::create("module", inst->name());
+		throw RecursionException::create("module", inst->name(),loc);
 		return nullptr;
 	}
 

--- a/src/boost-utils.cc
+++ b/src/boost-utils.cc
@@ -101,7 +101,7 @@ boostfs_uncomplete(fs::path const p, fs::path const base)
 
 	// create absolute paths
 	fs::path abs_p = fs::absolute(boostfs_normalize(p));
-	fs::path abs_base = fs::absolute(base);
+	fs::path abs_base = fs::absolute(boostfs_normalize(base));
 
 	fs::path from_path, from_base, output;
 

--- a/src/exceptions.h
+++ b/src/exceptions.h
@@ -21,13 +21,16 @@ public:
 
 class RecursionException: public EvaluationException {
 public:
-	static RecursionException create(const char *recursiontype, const std::string &name) {
+	static RecursionException create(const char *recursiontype, const std::string &name, const Location &loc) {
 		std::stringstream out;
 		out << "ERROR: Recursion detected calling " << recursiontype << " '" << name << "'";
-		return RecursionException(out.str());
+		return RecursionException(out.str(), loc);
 	}
 	~RecursionException() throw() {}
 
+public:
+	Location loc;
+
 private:
-	RecursionException(const std::string &what_arg) : EvaluationException(what_arg) {}
+	RecursionException(const std::string &what_arg, const Location &loc) : EvaluationException(what_arg), loc(loc) {}
 };

--- a/src/expr.cc
+++ b/src/expr.cc
@@ -427,7 +427,7 @@ FunctionCall::FunctionCall(const std::string &name,
 ValuePtr FunctionCall::evaluate(const Context *context) const
 {
 	if (StackCheck::inst()->check()) {
-		throw RecursionException::create("function", this->name);
+		throw RecursionException::create("function", this->name,loc);
 	}
     
 	EvalContext c(context, this->arguments);
@@ -678,7 +678,7 @@ ValuePtr LcForC::evaluate(const Context *context) const
     while (this->cond->evaluate(&c)) {
         vec.push_back(this->expr->evaluate(&c));
 
-		if (counter++ == 1000000) throw RecursionException::create("for loop", "");
+		if (counter++ == 1000000) throw RecursionException::create("for loop", "", loc);
 
         Context tmp(&c);
         evaluate_sequential_assignment(this->incr_arguments, &tmp);

--- a/src/function.cc
+++ b/src/function.cc
@@ -95,7 +95,7 @@ public:
 			tmp.setVariables(definition_arguments, &ec);
 			c.apply_variables(tmp);
 			
-			if (counter++ == 1000000) throw RecursionException::create("function", this->name);
+			if (counter++ == 1000000) throw RecursionException::create("function", this->name,loc);
 		}
 		
 		ValuePtr result = endexpr->evaluate(&c);

--- a/testdata/scad/misc/recursion-test-function3.scad
+++ b/testdata/scad/misc/recursion-test-function3.scad
@@ -1,17 +1,11 @@
 //Example without tail-recursion
 //https://en.wikibooks.org/w/index.php?title=OpenSCAD_User_Manual/User-Defined_Functions_and_Modules&oldid=3379916#Recursive_functions
-function add_up_to_tail(n, sum=0) =
-    n==0 ?
-        sum :
-        add_up_to_tail(n-1, sum+n);
 
 function add_up_to(n) = (
     n==0 ? 0 : n + add_up_to(n-1)
     );
 
-//demonstration that tail recursion has a higher limit
-a=10000;
-echo(sum=add_up_to_tail(a));
-echo(sum=add_up_to(a));
+echo(sum10=add_up_to(10));
+echo(sum=add_up_to(-1));
 
-assert(false && "Did you intentionally change the recursion limit?");
+

--- a/testdata/scad/misc/recursion-test-function3.scad
+++ b/testdata/scad/misc/recursion-test-function3.scad
@@ -1,0 +1,8 @@
+//Example without tail-recursion
+//https://en.wikibooks.org/w/index.php?title=OpenSCAD_User_Manual/User-Defined_Functions_and_Modules&oldid=3379916#Recursive_functions
+
+function add_up_to(n) = (
+    n==0 ? 0 : n + add_up_to(n-1)
+    );
+
+echo(sum=add_up_to(-1));

--- a/testdata/scad/misc/recursion-test-function3.scad
+++ b/testdata/scad/misc/recursion-test-function3.scad
@@ -1,8 +1,17 @@
 //Example without tail-recursion
 //https://en.wikibooks.org/w/index.php?title=OpenSCAD_User_Manual/User-Defined_Functions_and_Modules&oldid=3379916#Recursive_functions
+function add_up_to_tail(n, sum=0) =
+    n==0 ?
+        sum :
+        add_up_to_tail(n-1, sum+n);
 
 function add_up_to(n) = (
     n==0 ? 0 : n + add_up_to(n-1)
     );
 
-echo(sum=add_up_to(-1));
+//demonstration that tail recursion has a higher limit
+a=10000;
+echo(sum=add_up_to_tail(a));
+echo(sum=add_up_to(a));
+
+assert(false && "Did you intentionally change the recursion limit?");

--- a/testdata/scad/misc/recursion-test-function4.scad
+++ b/testdata/scad/misc/recursion-test-function4.scad
@@ -1,0 +1,4 @@
+//recursion detected calling an in built function
+function recurse(x) = max(x, recurse(x));
+
+x = recurse(1);

--- a/testdata/scad/misc/recursion-test-function4.scad
+++ b/testdata/scad/misc/recursion-test-function4.scad
@@ -1,4 +1,0 @@
-//recursion detected calling an in built function
-function recurse(x) = max(x, recurse(x));
-
-x = recurse(1);

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1196,7 +1196,6 @@ list(APPEND ECHO_FILES ${FUNCTION_FILES} ${MISC_FILES}
             ${CMAKE_SOURCE_DIR}/../testdata/scad/misc/recursion-test-function.scad
             ${CMAKE_SOURCE_DIR}/../testdata/scad/misc/recursion-test-function2.scad
             ${CMAKE_SOURCE_DIR}/../testdata/scad/misc/recursion-test-function3.scad
-            ${CMAKE_SOURCE_DIR}/../testdata/scad/misc/recursion-test-function4.scad
             ${CMAKE_SOURCE_DIR}/../testdata/scad/misc/recursion-test-module.scad
             ${CMAKE_SOURCE_DIR}/../testdata/scad/misc/recursion-test-vector.scad
             ${CMAKE_SOURCE_DIR}/../testdata/scad/misc/tail-recursion-tests.scad

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1196,6 +1196,7 @@ list(APPEND ECHO_FILES ${FUNCTION_FILES} ${MISC_FILES}
             ${CMAKE_SOURCE_DIR}/../testdata/scad/misc/recursion-test-function.scad
             ${CMAKE_SOURCE_DIR}/../testdata/scad/misc/recursion-test-function2.scad
             ${CMAKE_SOURCE_DIR}/../testdata/scad/misc/recursion-test-function3.scad
+            ${CMAKE_SOURCE_DIR}/../testdata/scad/misc/recursion-test-function4.scad
             ${CMAKE_SOURCE_DIR}/../testdata/scad/misc/recursion-test-module.scad
             ${CMAKE_SOURCE_DIR}/../testdata/scad/misc/recursion-test-vector.scad
             ${CMAKE_SOURCE_DIR}/../testdata/scad/misc/tail-recursion-tests.scad

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1195,6 +1195,7 @@ list(APPEND ECHO_FILES ${FUNCTION_FILES} ${MISC_FILES}
             ${CMAKE_SOURCE_DIR}/../testdata/scad/misc/search-tests-unicode.scad
             ${CMAKE_SOURCE_DIR}/../testdata/scad/misc/recursion-test-function.scad
             ${CMAKE_SOURCE_DIR}/../testdata/scad/misc/recursion-test-function2.scad
+            ${CMAKE_SOURCE_DIR}/../testdata/scad/misc/recursion-test-function3.scad
             ${CMAKE_SOURCE_DIR}/../testdata/scad/misc/recursion-test-module.scad
             ${CMAKE_SOURCE_DIR}/../testdata/scad/misc/recursion-test-vector.scad
             ${CMAKE_SOURCE_DIR}/../testdata/scad/misc/tail-recursion-tests.scad

--- a/tests/regression/echotest/assert-expression-fail1-test-expected.echo
+++ b/tests/regression/echotest/assert-expression-fail1-test-expected.echo
@@ -1,1 +1,1 @@
-ERROR: Assertion 'false' failed in file ../../../../../testdata/scad/functions/assert-expression-fail1-test.scad, line 1
+ERROR: Assertion 'false' failed in file assert-expression-fail1-test.scad, line 1

--- a/tests/regression/echotest/assert-expression-fail2-test-expected.echo
+++ b/tests/regression/echotest/assert-expression-fail2-test-expected.echo
@@ -1,1 +1,1 @@
-ERROR: Assertion '((a < 20) && (b < 20))': "Test! <html>&</html>" failed in file ../../../../../testdata/scad/functions/assert-expression-fail2-test.scad, line 3
+ERROR: Assertion '((a < 20) && (b < 20))': "Test! <html>&</html>" failed in file assert-expression-fail2-test.scad, line 3

--- a/tests/regression/echotest/assert-expression-fail3-test-expected.echo
+++ b/tests/regression/echotest/assert-expression-fail3-test-expected.echo
@@ -1,1 +1,1 @@
-ERROR: Assertion '(f(angle) > 0)' failed in file ../../../../../testdata/scad/functions/assert-expression-fail3-test.scad, line 4
+ERROR: Assertion '(f(angle) > 0)' failed in file assert-expression-fail3-test.scad, line 4

--- a/tests/regression/echotest/assert-fail1-test-expected.echo
+++ b/tests/regression/echotest/assert-fail1-test-expected.echo
@@ -1,1 +1,1 @@
-ERROR: Assertion 'false' failed in file ../../../../../testdata/scad/misc/assert-fail1-test.scad, line 1
+ERROR: Assertion 'false' failed in file assert-fail1-test.scad, line 1

--- a/tests/regression/echotest/assert-fail2-test-expected.echo
+++ b/tests/regression/echotest/assert-fail2-test-expected.echo
@@ -1,1 +1,1 @@
-ERROR: Assertion '((a < 20) && (b < 20))': "Test! <html>&</html>" failed in file ../../../../../testdata/scad/misc/assert-fail2-test.scad, line 3
+ERROR: Assertion '((a < 20) && (b < 20))': "Test! <html>&</html>" failed in file assert-fail2-test.scad, line 3

--- a/tests/regression/echotest/assert-fail3-test-expected.echo
+++ b/tests/regression/echotest/assert-fail3-test-expected.echo
@@ -1,1 +1,1 @@
-ERROR: Assertion '(f(angle) > 0)' failed in file ../../../../../testdata/scad/misc/assert-fail3-test.scad, line 4
+ERROR: Assertion '(f(angle) > 0)' failed in file assert-fail3-test.scad, line 4

--- a/tests/regression/echotest/include-overwrite-main-expected.echo
+++ b/tests/regression/echotest/include-overwrite-main-expected.echo
@@ -1,5 +1,5 @@
 WARNING: overwritten was assigned on line 11 but was overwritten on line 15
-WARNING: after was assigned on line 14 of "../../../../../testdata/scad/misc/include-overwrite-main.scad" but was overwritten on line 2  of "../../../../../testdata/scad/misc/include-overwrite-after.scad"
+WARNING: after was assigned on line 14 of "include-overwrite-main.scad" but was overwritten on line 2  of "include-overwrite-after.scad"
 ECHO: "Can a variable be used when it assigned later? true"
 ECHO: "Does an include before the assigment take priority? false"
 ECHO: "Does an include after the assigment take priority? true"

--- a/tests/regression/echotest/recursion-test-function-expected.echo
+++ b/tests/regression/echotest/recursion-test-function-expected.echo
@@ -1,1 +1,1 @@
-ERROR: Recursion detected calling function 'crash'
+ERROR: Recursion detected calling function 'crash' in file ../../../../../testdata/scad/misc/recursion-test-function.scad, line 1

--- a/tests/regression/echotest/recursion-test-function-expected.echo
+++ b/tests/regression/echotest/recursion-test-function-expected.echo
@@ -1,1 +1,1 @@
-ERROR: Recursion detected calling function 'crash' in file ../../../../../testdata/scad/misc/recursion-test-function.scad, line 1
+ERROR: Recursion detected calling function 'crash' in file recursion-test-function.scad, line 1

--- a/tests/regression/echotest/recursion-test-function2-expected.echo
+++ b/tests/regression/echotest/recursion-test-function2-expected.echo
@@ -1,1 +1,1 @@
-ERROR: Recursion detected calling function 'crash'
+ERROR: Recursion detected calling function 'crash' in file ../../../../../testdata/scad/misc/recursion-test-function2.scad, line 2

--- a/tests/regression/echotest/recursion-test-function2-expected.echo
+++ b/tests/regression/echotest/recursion-test-function2-expected.echo
@@ -1,1 +1,1 @@
-ERROR: Recursion detected calling function 'crash' in file ../../../../../testdata/scad/misc/recursion-test-function2.scad, line 2
+ERROR: Recursion detected calling function 'crash' in file recursion-test-function2.scad, line 2

--- a/tests/regression/echotest/recursion-test-function3-expected.echo
+++ b/tests/regression/echotest/recursion-test-function3-expected.echo
@@ -1,2 +1,2 @@
 ECHO: sum10 = 55
-ERROR: Recursion detected calling function 'add_up_to' in file ../../../../../testdata/scad/misc/recursion-test-function3.scad, line 5
+ERROR: Recursion detected calling function 'add_up_to' in file recursion-test-function3.scad, line 5

--- a/tests/regression/echotest/recursion-test-function3-expected.echo
+++ b/tests/regression/echotest/recursion-test-function3-expected.echo
@@ -1,1 +1,2 @@
-ERROR: Recursion detected calling function 'add_up_to' in file ../../../../../testdata/scad/misc/recursion-test-function3.scad, line 5
+ECHO: sum = 5.0005e+07
+ERROR: Recursion detected calling function 'add_up_to' in file ../../../../../testdata/scad/misc/recursion-test-function3.scad, line 9

--- a/tests/regression/echotest/recursion-test-function3-expected.echo
+++ b/tests/regression/echotest/recursion-test-function3-expected.echo
@@ -1,2 +1,2 @@
-ECHO: sum = 5.0005e+07
-ERROR: Recursion detected calling function 'add_up_to' in file ../../../../../testdata/scad/misc/recursion-test-function3.scad, line 9
+ECHO: sum10 = 55
+ERROR: Recursion detected calling function 'add_up_to' in file ../../../../../testdata/scad/misc/recursion-test-function3.scad, line 5

--- a/tests/regression/echotest/recursion-test-function3-expected.echo
+++ b/tests/regression/echotest/recursion-test-function3-expected.echo
@@ -1,0 +1,1 @@
+ERROR: Recursion detected calling function 'add_up_to' in file ../../../../../testdata/scad/misc/recursion-test-function3.scad, line 5

--- a/tests/regression/echotest/recursion-test-function4-expected.echo
+++ b/tests/regression/echotest/recursion-test-function4-expected.echo
@@ -1,0 +1,1 @@
+ERROR: Recursion detected calling function 'max' in file ../../../../../testdata/scad/misc/recursion-test-function4.scad, line 2

--- a/tests/regression/echotest/recursion-test-function4-expected.echo
+++ b/tests/regression/echotest/recursion-test-function4-expected.echo
@@ -1,1 +1,0 @@
-ERROR: Recursion detected calling function 'max' in file ../../../../../testdata/scad/misc/recursion-test-function4.scad, line 2

--- a/tests/regression/echotest/recursion-test-module-expected.echo
+++ b/tests/regression/echotest/recursion-test-module-expected.echo
@@ -1,1 +1,1 @@
-ERROR: Recursion detected calling module 'crash' in file ../../../../../testdata/scad/misc/recursion-test-module.scad, line 2
+ERROR: Recursion detected calling module 'crash' in file recursion-test-module.scad, line 2

--- a/tests/regression/echotest/recursion-test-module-expected.echo
+++ b/tests/regression/echotest/recursion-test-module-expected.echo
@@ -1,1 +1,1 @@
-ERROR: Recursion detected calling module 'crash'
+ERROR: Recursion detected calling module 'crash' in file ../../../../../testdata/scad/misc/recursion-test-module.scad, line 2

--- a/tests/regression/echotest/recursion-test-vector-expected.echo
+++ b/tests/regression/echotest/recursion-test-vector-expected.echo
@@ -1,1 +1,1 @@
-ERROR: Recursion detected calling module 'rec'
+ERROR: Recursion detected calling module 'rec' in file ../../../../../testdata/scad/misc/recursion-test-vector.scad, line 6

--- a/tests/regression/echotest/recursion-test-vector-expected.echo
+++ b/tests/regression/echotest/recursion-test-vector-expected.echo
@@ -1,1 +1,1 @@
-ERROR: Recursion detected calling module 'rec' in file ../../../../../testdata/scad/misc/recursion-test-vector.scad, line 6
+ERROR: Recursion detected calling module 'rec' in file recursion-test-vector.scad, line 6


### PR DESCRIPTION
For tracing a recursion, a call stack would be best, but this is (currently) out of reach.

So, let us see if something lower hanging could be potentially be useful.