### PR TITLE
remove the unused boostfs_relative_path function

### DIFF
--- a/src/boost-utils.cc
+++ b/src/boost-utils.cc
@@ -4,45 +4,6 @@
 #include <iostream>
 
 namespace fs=boost::filesystem;
-// If the given (absolute) path is relative to the relative_to path, return a new
-// relative path. Will normalize the given path first
-fs::path boostfs_relative_path(const fs::path &path, const fs::path &relative_to)
-{
-	// create absolute paths
-	auto p = fs::absolute(boostfs_normalize(path));
-	auto r = fs::absolute(relative_to);
-	
-	// if root paths are different, return absolute path
-	if (p.root_path() != r.root_path()) return p;
-	
-	// initialize relative path
-	fs::path result;
-	
-	// find out where the two paths diverge
-	auto itr_path = p.begin();
-	auto itr_relative_to = r.begin();
-	while (*itr_path == *itr_relative_to && itr_path != p.end() && itr_relative_to != r.end()) {
-		++itr_path;
-		++itr_relative_to;
-	}
-	
-	// add "../" for each remaining token in relative_to
-	if (itr_relative_to != r.end()) {
-		++itr_relative_to;
-		while (itr_relative_to != r.end()) {
-			result /= "..";
-			++itr_relative_to;
-		}
-	}
-	
-	// add remaining path
-	while (itr_path != p.end()) {
-		result /= *itr_path;
-		++itr_path;
-	}
-	
-	return result;
-}
 
 // Will normalize the given path, i.e. remove any redundant ".." path elements.
 fs::path boostfs_normalize(const fs::path &path)

--- a/src/boost-utils.h
+++ b/src/boost-utils.h
@@ -3,9 +3,6 @@
 #include <boost/filesystem.hpp>
 namespace fs = boost::filesystem;
 
-// FIXME: boostfs_relative_path() has been replaced by 
-// boostfs_uncomplete(), but kept around for now.
-fs::path boostfs_relative_path(const fs::path &path, const fs::path &relative_to);
 fs::path boostfs_normalize(const fs::path &path);
 fs::path boostfs_uncomplete(fs::path const p, fs::path const base);
 


### PR DESCRIPTION
The function is unused for years. Mid therm, we will use/maintain `boostfs_uncomplete` until we can replace that with c++17 or boost 1.60.0 `lexically_relative`.