### PR TITLE
Move PARALLEL_CTEST setting to travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,9 @@ matrix:
     - os: linux
       compiler: gcc
       dist: trusty
-      env: DIST="trusty"
+      env:
+        - DIST="trusty"
+        - PARALLEL_CTEST=-j1
       sudo: required
       cache:
         - apt
@@ -13,14 +15,18 @@ matrix:
     - os: linux
       compiler: gcc
       dist: xenial
-      env: DIST="xenial"
+      env:
+        - DIST="xenial"
+        - PARALLEL_CTEST=-j1
       sudo: required
       cache:
         - apt
         - ccache
     - os: osx
       compiler: clang
-      env: DIST="osx"
+      env:
+        - DIST="osx"
+        - PARALLEL_CTEST=-j4
       cache:
         - ccache
         - directories:

--- a/scripts/travis-ci.sh
+++ b/scripts/travis-ci.sh
@@ -21,11 +21,9 @@ travis_finish() {
 }
 
 PARALLEL=-j2
-if [[ "$DIST" == "trusty" ]]; then
-    PARALLEL_CTEST=-j1
-else
-    PARALLEL_CTEST=-j4
-fi
+
+# This should be set via .travis.yml depending on the OS/Distribution
+# PARALLEL_CTEST=-j1
 
 travis_start qmake "Building OpenSCAD using qmake"
 qmake CONFIG+=experimental CONFIG+=nogui && make $PARALLEL


### PR DESCRIPTION
Tests are failing again on `xenial` with
```
Unable to open a connection to the X server.
DISPLAY=:1063
Can't create OpenGL OffscreenView. Code: -1.
```
So I think we need to revert to `-j1` as we did for `trusty`. This does not seem to have much impact on runtime anyway. In this instance with one test failing with `-j4` on `xenial` the runtime was ~13min for both.

This also moves the setting to travis.yml so we don't have to switch again in the travis run script based on other env variables.