### PR TITLE
Remove cache setting

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -3,9 +3,6 @@ skip_branch_with_pr: true
 image:
   - Visual Studio 2017
 
-cache:
-  - C:\msys64 -> scripts/msys2-install-dependencies.sh
-
 # Uncomment to enable RDP login at init time, this will not block job execution.
 #init:
 #  - ps: iex ((new-object net.webclient).DownloadString('https://raw.githubusercontent.com/appveyor/ci/master/scripts/enable-rdp.ps1'))


### PR DESCRIPTION
There's too much stuff pre-installed in C:\msys64 so cache is not working or potentially even killing a good build due to timeout.
```
Updating build cache...
Cache 'C:\msys64' - Zipping...Unable to save cache - skipping
Compressed cache item cannot exceed 1,048,576,000 bytes.
```