### PR TITLE
Changing to shield.io badges (in README.md).

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,8 @@
-[![Travis CI](https://api.travis-ci.org/openscad/openscad.png)](https://travis-ci.org/openscad/openscad)
-[![CircleCI](https://circleci.com/gh/openscad/openscad/tree/master.svg?style=svg)](https://circleci.com/gh/openscad/openscad/tree/master)
-[![AppVeyor](https://ci.appveyor.com/api/projects/status/github/openscad/openscad?branch=master&svg=false)](https://ci.appveyor.com/project/kintel/openscad)
-[![Coverity Status](https://scan.coverity.com/projects/2510/badge.svg)](https://scan.coverity.com/projects/2510)
+[![Travis (master)](https://img.shields.io/travis/openscad/openscad/master.svg?logo=travis&logoColor=black&colorA=f9d72c&style=plastic)](https://travis-ci.org/openscad/openscad/)
+[![AppVeyor (master)](https://img.shields.io/appveyor/ci/kintel/openscad/master.svg?logo=appveyor&logoColor=black&colorA=f9d72c&style=plastic)](https://ci.appveyor.com/project/kintel/openscad)
+[![CircleCI (master)](https://img.shields.io/circleci/project/github/openscad/openscad/master.svg?logo=circleci&logoColor=black&colorA=f9d72c&style=plastic)](https://circleci.com/gh/openscad/openscad/tree/master)
+[![Coverity Scan](https://img.shields.io/coverity/scan/2510.svg?colorA=f9d72c&logoColor=black&style=plastic)](https://scan.coverity.com/projects/2510)
+
 
 [![Visit our IRC channel](https://kiwiirc.com/buttons/irc.freenode.net/openscad.png)](https://kiwiirc.com/client/irc.freenode.net/#openscad)
 


### PR DESCRIPTION
Badges in OpenSCAD color scheme. Unfortunately the name color seems to be fixed to white.

Preview via branch: https://github.com/openscad/openscad/tree/shield-io-badges