### PR TITLE
add the line number to the bad range warning

### DIFF
--- a/src/control.cc
+++ b/src/control.cc
@@ -79,7 +79,7 @@ void ControlModule::for_eval(AbstractNode &node, const ModuleInstantiation &inst
 			RangeType range = it_values->toRange();
 			uint32_t steps = range.numValues();
 			if (steps >= 10000) {
-				PRINTB("WARNING: Bad range parameter in for statement: too many elements (%lu).", steps);
+				PRINTB("WARNING: Bad range parameter in for statement: too many elements (%lu), %s", steps % inst.location().toString());
 			} else {
 				for (RangeType::iterator it = range.begin();it != range.end();it++) {
 					c.set_variable(it_name, ValuePtr(*it));

--- a/src/expr.cc
+++ b/src/expr.cc
@@ -577,7 +577,7 @@ ValuePtr LcEach::evaluate(const Context *context) const
         RangeType range = v->toRange();
         uint32_t steps = range.numValues();
         if (steps >= 1000000) {
-            PRINTB("WARNING: Bad range parameter in for statement: too many elements (%lu).", steps);
+            PRINTB("WARNING: Bad range parameter in for statement: too many elements (%lu), %s", loc.toString());
         } else {
             for (RangeType::iterator it = range.begin();it != range.end();it++) {
                 vec.push_back(ValuePtr(*it));
@@ -631,7 +631,7 @@ ValuePtr LcFor::evaluate(const Context *context) const
         RangeType range = it_values->toRange();
         uint32_t steps = range.numValues();
         if (steps >= 1000000) {
-            PRINTB("WARNING: Bad range parameter in for statement: too many elements (%lu).", steps);
+            PRINTB("WARNING: Bad range parameter in for statement: too many elements (%lu), %s", steps % loc.toString());
         } else {
             for (RangeType::iterator it = range.begin();it != range.end();it++) {
                 c.set_variable(it_name, ValuePtr(*it));

--- a/tests/regression/echotest/for-tests-expected.echo
+++ b/tests/regression/echotest/for-tests-expected.echo
@@ -1,5 +1,5 @@
 DEPRECATED: Using ranges of the form [begin:end] with begin value greater than the end value is deprecated.
-WARNING: Bad range parameter in for statement: too many elements (4294967295).
+WARNING: Bad range parameter in for statement: too many elements (4294967295), line 35
 ECHO: "a"
 ECHO: "↑"
 ECHO: "b"
@@ -11,7 +11,15 @@ ECHO: "INF", 0
 ECHO: "-INF", 0
 ECHO: "INF", 0
 ECHO: "-INF", 1
-WARNING: Bad range parameter in for statement: too many elements (4294967295).
-WARNING: Bad range parameter in for statement: too many elements (4294967295).
-WARNING: Bad range parameter in for statement: too many elements (4294967295).
-WARNING: Bad range parameter in for statement: too many elements (4294967295).
+WARNING: Bad range parameter in for statement: too many elements (4294967295), line 72
+WARNING: Bad range parameter in for statement: too many elements (4294967295), line 73
+WARNING: Bad range parameter in for statement: too many elements (4294967295), line 74
+WARNING: Bad range parameter in for statement: too many elements (4294967295), line 75
+WARNING: Bad range parameter in for statement: too many elements (4294967295), line 77
+WARNING: Bad range parameter in for statement: too many elements (4294967295), line 78
+WARNING: Bad range parameter in for statement: too many elements (4294967295), line 79
+WARNING: Bad range parameter in for statement: too many elements (4294967295), line 80
+WARNING: Bad range parameter in for statement: too many elements (4294967295), line 81
+WARNING: Bad range parameter in for statement: too many elements (4294967295), line 82
+WARNING: Bad range parameter in for statement: too many elements (4294967295), line 83
+WARNING: Bad range parameter in for statement: too many elements (4294967295), line 84

--- a/tests/regression/echotest/range-tests-expected.echo
+++ b/tests/regression/echotest/range-tests-expected.echo
@@ -60,7 +60,7 @@ ECHO: "[b06] ", 1
 ECHO: "[b07] ----- [0:0:0]"
 ECHO: "[b08] ----- [1:0:1]"
 ECHO: "[b09] ----- [1:0:5]"
-WARNING: Bad range parameter in for statement: too many elements (4294967295).
+WARNING: Bad range parameter in for statement: too many elements (4294967295), line 18
 ECHO: "[b10] ----- [0:1:0]"
 ECHO: "[b10] ", 0
 ECHO: "[b11] ----- [3:-.5:-3]"

--- a/tests/regression/echotest/special-consts-expected.echo
+++ b/tests/regression/echotest/special-consts-expected.echo
@@ -39,4 +39,4 @@ ECHO: "-- comparing nan --"
 ECHO: "nan != nan"
 ECHO: "-- 3d objects --"
 ECHO: "-- for loops --"
-WARNING: Bad range parameter in for statement: too many elements (4294967295).
+WARNING: Bad range parameter in for statement: too many elements (4294967295), line 106


### PR DESCRIPTION
going back to #1843

This PR shows in the test case one of the side effecs of adding the line number and other context information: The warnings are now unique, so they are not considered repeats anymore.