### PR TITLE
Viewport paste operations now copy to clipboard.

### DIFF
--- a/src/MainWindow.h
+++ b/src/MainWindow.h
@@ -61,18 +61,18 @@ public:
 	QString last_compiled_doc;
 
 	QAction *actionRecentFile[UIUtils::maxRecentFiles];
-		QMap<QString, QString> knownFileExtensions;
+	QMap<QString, QString> knownFileExtensions;
 
-		QLabel *versionLabel;
-		QWidget *editorDockTitleWidget;
-		QWidget *consoleDockTitleWidget;
-		QWidget *parameterDockTitleWidget;
+	QLabel *versionLabel;
+	QWidget *editorDockTitleWidget;
+	QWidget *consoleDockTitleWidget;
+	QWidget *parameterDockTitleWidget;
 
 	QString editortype;	
 	bool useScintilla;
 
-		int compileErrors;
-		int compileWarnings;
+	int compileErrors;
+	int compileWarnings;
 
 	MainWindow(const QString &filename);
 	~MainWindow();
@@ -86,9 +86,9 @@ private slots:
 	void updatedAnimSteps();
 	void updatedAnimDump(bool checked);
 	void updateTVal();
-		void updateMdiMode(bool mdi);
-		void updateUndockMode(bool undockMode);
-		void updateReorderMode(bool reorderMode);
+	void updateMdiMode(bool mdi);
+	void updateUndockMode(bool undockMode);
+	void updateReorderMode(bool reorderMode);
 	void setFileName(const QString &filename);
 	void setFont(const QString &family, uint size);
 	void setColorScheme(const QString &cs);
@@ -98,18 +98,18 @@ private slots:
 	void updateActionUndoState();
 
 private:
-		void initActionIcon(QAction *action, const char *darkResource, const char *lightResource);
-		void handleFileDrop(const QString &filename);
+	void initActionIcon(QAction *action, const char *darkResource, const char *lightResource);
+	void handleFileDrop(const QString &filename);
 	void refreshDocument();
 	void updateCamera(const class FileContext &ctx);
 	void updateTemporalVariables();
 	bool fileChangedOnDisk();
 	void compileTopLevelDocument(bool rebuildParameterWidget);
-		void updateCompileResult();
+	void updateCompileResult();
 	void compile(bool reload, bool forcedone = false, bool rebuildParameterWidget=true);
 	void compileCSG();
 	bool maybeSave();
-		void saveError(const QIODevice &file, const std::string &msg);
+	void saveError(const QIODevice &file, const std::string &msg);
 	bool checkEditorModified();
 	QString dumpCSGTree(AbstractNode *root);
 	static void consoleOutput(const std::string &msg, void *userdata);
@@ -140,7 +140,7 @@ private slots:
 	void actionSaveAs();
 	void actionReload();
 	void actionShowLibraryFolder();
-		void convertTabsToSpaces();
+	void convertTabsToSpaces();
 
 	void instantiateRoot();
 	void compileDone(bool didchange);
@@ -148,8 +148,9 @@ private slots:
 	void changeParameterWidget();
 
 private slots:
-	void pasteViewportTranslation();
-	void pasteViewportRotation();
+	void copyViewportTranslation();
+	void copyViewportRotation();
+	void copyViewportDistance();
 	void preferences();
 	void hideToolbars();
 	void hideEditor();
@@ -207,14 +208,14 @@ public:
 	void clearCurrentOutput();
   bool isEmpty();
 
-        void onAxisChanged(InputEventAxisChanged *event) override;
-        void onButtonChanged(InputEventButtonChanged *event) override;
+	void onAxisChanged(InputEventAxisChanged *event) override;
+	void onButtonChanged(InputEventButtonChanged *event) override;
 
-        void onTranslateEvent(InputEventTranslate *event) override;
-        void onRotateEvent(InputEventRotate *event) override;
-        void onRotate2Event(InputEventRotate2 *event) override;
-        void onActionEvent(InputEventAction *event) override;
-        void onZoomEvent(InputEventZoom *event) override;
+	void onTranslateEvent(InputEventTranslate *event) override;
+	void onRotateEvent(InputEventRotate *event) override;
+	void onRotate2Event(InputEventRotate2 *event) override;
+	void onActionEvent(InputEventAction *event) override;
+	void onZoomEvent(InputEventZoom *event) override;
 
 	QList<double> getTranslation() const;
 	QList<double> getRotation() const;
@@ -222,14 +223,14 @@ public:
 public slots:
 	void openFile(const QString &filename);
 	void actionReloadRenderPreview();
-		void on_editorDock_visibilityChanged(bool);
-		void on_consoleDock_visibilityChanged(bool);
-		void on_parameterDock_visibilityChanged(bool);
-		void on_toolButtonCompileResultClose_clicked();
-		void editorTopLevelChanged(bool);
-		void consoleTopLevelChanged(bool);
-		void parameterTopLevelChanged(bool);
-		void processEvents();
+	void on_editorDock_visibilityChanged(bool);
+	void on_consoleDock_visibilityChanged(bool);
+	void on_parameterDock_visibilityChanged(bool);
+	void on_toolButtonCompileResultClose_clicked();
+	void editorTopLevelChanged(bool);
+	void consoleTopLevelChanged(bool);
+	void parameterTopLevelChanged(bool);
+	void processEvents();
 
 #ifdef ENABLE_OPENCSG
 	void viewModePreview();
@@ -295,6 +296,9 @@ private:
 	bool contentschanged; // Set if the source code has changes since the last render (F6)
 	time_t includes_mtime;   // latest include mod time
 	time_t deps_mtime;	  // latest dependency mod time
+	std::unordered_map<std::string, QString> export_paths; // for each file type, where it was exported to last
+	void clearExportPaths(); // clear exports paths when main file is changed by open, new, etc.
+	QString exportPath(const char *suffix); // look up the last export path and generate one if not found
 
 signals:
 	void highlightError(int);

--- a/src/MainWindow.ui
+++ b/src/MainWindow.ui
@@ -330,16 +330,16 @@
     <addaction name="editActionCopy"/>
     <addaction name="editActionPaste"/>
     <addaction name="separator"/>
-    <addaction name="editActionCopyViewport"/>
-    <addaction name="separator"/>
     <addaction name="editActionIndent"/>
     <addaction name="editActionUnindent"/>
     <addaction name="editActionComment"/>
     <addaction name="editActionUncomment"/>
     <addaction name="editActionConvertTabsToSpaces"/>
     <addaction name="separator"/>
-    <addaction name="editActionPasteVPT"/>
-    <addaction name="editActionPasteVPR"/>
+    <addaction name="editActionCopyViewport"/>
+    <addaction name="editActionCopyVPT"/>
+    <addaction name="editActionCopyVPR"/>
+    <addaction name="editActionCopyVPD"/>
     <addaction name="separator"/>
     <addaction name="editActionFind"/>
     <addaction name="editActionFindAndReplace"/>
@@ -799,17 +799,30 @@
     <string>Ctrl+Shift+D</string>
    </property>
   </action>
-  <action name="editActionPasteVPT">
+  <action name="editActionCopyViewport">
    <property name="text">
-    <string>P&amp;aste viewport translation</string>
+    <string>Copy viewport ima&amp;ge</string>
+   </property>
+   <property name="shortcut">
+    <string>Ctrl+Shift+C</string>
+   </property>
+  </action>
+  <action name="editActionCopyVPT">
+   <property name="text">
+    <string>Copy viewport transl&amp;ation</string>
    </property>
    <property name="shortcut">
     <string>Ctrl+T</string>
    </property>
   </action>
-  <action name="editActionPasteVPR">
+  <action name="editActionCopyVPR">
    <property name="text">
-    <string>Past&amp;e viewport rotation</string>
+    <string>Cop&amp;y viewport rotation</string>
+   </property>
+  </action>
+  <action name="editActionCopyVPD">
+   <property name="text">
+    <string>Copy vie&amp;wport distance</string>
    </property>
   </action>
   <action name="editActionZoomTextIn">
@@ -1369,14 +1382,6 @@
   <action name="helpActionCheatSheet">
    <property name="text">
     <string>&amp;Cheat Sheet</string>
-   </property>
-  </action>
-  <action name="editActionCopyViewport">
-   <property name="text">
-    <string>Copy Viewport</string>
-   </property>
-   <property name="shortcut">
-    <string>Ctrl+Shift+C</string>
    </property>
   </action>
   <action name="viewActionHideParameters">

--- a/src/mainwin.cc
+++ b/src/mainwin.cc
@@ -341,8 +341,9 @@ MainWindow::MainWindow(const QString &filename)
 	connect(this->editActionComment, SIGNAL(triggered()), editor, SLOT(commentSelection()));
 	connect(this->editActionUncomment, SIGNAL(triggered()), editor, SLOT(uncommentSelection()));
 	connect(this->editActionConvertTabsToSpaces, SIGNAL(triggered()), this, SLOT(convertTabsToSpaces()));
-	connect(this->editActionPasteVPT, SIGNAL(triggered()), this, SLOT(pasteViewportTranslation()));
-	connect(this->editActionPasteVPR, SIGNAL(triggered()), this, SLOT(pasteViewportRotation()));
+	connect(this->editActionCopyVPT, SIGNAL(triggered()), this, SLOT(copyViewportTranslation()));
+	connect(this->editActionCopyVPR, SIGNAL(triggered()), this, SLOT(copyViewportRotation()));
+	connect(this->editActionCopyVPD, SIGNAL(triggered()), this, SLOT(copyViewportDistance()));
 	connect(this->editActionZoomTextIn, SIGNAL(triggered()), editor, SLOT(zoomIn()));
 	connect(this->editActionZoomTextOut, SIGNAL(triggered()), editor, SLOT(zoomOut()));
 	connect(this->editActionPreferences, SIGNAL(triggered()), this, SLOT(preferences()));
@@ -1588,20 +1589,27 @@ void MainWindow::actionReload()
 	}
 }
 
-void MainWindow::pasteViewportTranslation()
+void MainWindow::copyViewportTranslation()
 {
 	QString txt;
 	auto vpt = qglview->cam.getVpt();
 	txt.sprintf("[ %.2f, %.2f, %.2f ]", vpt.x(), vpt.y(), vpt.z());
-	this->editor->insert(txt);
+	QApplication::clipboard()->setText(txt);
 }
 
-void MainWindow::pasteViewportRotation()
+void MainWindow::copyViewportRotation()
 {
 	QString txt;
 	auto vpr = qglview->cam.getVpr();
 	txt.sprintf("[ %.2f, %.2f, %.2f ]", vpr.x(), vpr.y(), vpr.z());
-	this->editor->insert(txt);
+	QApplication::clipboard()->setText(txt);
+}
+
+void MainWindow::copyViewportDistance()
+{
+	QString txt;
+	txt.sprintf("%.2f", qglview->cam.zoomValue());
+	QApplication::clipboard()->setText(txt);
 }
 
 QList<double> MainWindow::getTranslation() const
@@ -2365,6 +2373,7 @@ void MainWindow::actionExportCSG()
 		fstream << this->tree.getString(*this->root_node, "\t") << "\n";
 		fstream.close();
 		PRINT("CSG export finished.");
+		this->export_paths[suffix] = csg_filename;
 	}
 
 	clearCurrentOutput();


### PR DESCRIPTION
Added copy viewport distance. Changed copy viewport to copy viewport image and grouped it with the others.

![image](https://user-images.githubusercontent.com/566149/50445653-09c7fb00-0908-11e9-953c-a1c2cce392c1.png)
