### PR TITLE
testing and debugging the search warnings

### DIFF
--- a/src/func.cc
+++ b/src/func.cc
@@ -730,7 +730,7 @@ static Value::VectorType search(const str_utf8_wrapper &find, const Value::Vecto
 		for (size_t j = 0; j < searchTableSize; j++) {
 			const Value::VectorType &entryVec = table[j]->toVector();
 			if (entryVec.size() <= index_col_num) {
-				PRINTB("WARNING: Invalid entry in search vector at index %d, required number of values in the entry: %d. Invalid entry: %s, %s", j % (index_col_num + 1) % table[j] % loc.toRelativeString(ctx->documentPath()));
+				PRINTB("WARNING: Invalid entry in search vector at index %d, required number of values in the entry: %d. Invalid entry: %s, %s", j % (index_col_num + 1) % table[j]->toEchoString() % loc.toRelativeString(ctx->documentPath()));
 				return Value::VectorType();
 			}
 			const gchar *ptr_st = g_utf8_offset_to_pointer(entryVec[index_col_num]->toString().c_str(), 0);

--- a/testdata/scad/misc/search-tests.scad
+++ b/testdata/scad/misc/search-tests.scad
@@ -69,17 +69,25 @@ l5=search(lSearch5,lTable3,0,1);
 echo(str("Return all matches for mixed search; alternate columns (",lSearch5,"): ",l5));
 
 // causing warnings
-lTable6=[ ["a",1],123 ];
-echo(search("a", lTable6, num_returns_per_match=0)); 
+lTableW1=[ ["a",1],123 ];
+echo(search("a", lTableW1, num_returns_per_match=0)); 
 
-lTable7=[ ["a",1],"string" ];
-echo(search("a", lTable7, num_returns_per_match=0)); 
+lTableW2=[ ["a",1],"string" ];
+echo(search("a", lTableW2, num_returns_per_match=0)); 
 
-lTable8=[ ["b",1] ];
-echo(search("a", lTable8, num_returns_per_match=0)); 
+lTableW3=[ ["b",1] ];
+echo(search("a", lTableW3, num_returns_per_match=0)); 
 
-lTable9=[ ["a",1] ];
-echo(search("abcd", lTable9, num_returns_per_match=0)); 
+lTableW4=[ ["a",1] ];
+echo(search("abcd", lTableW4, num_returns_per_match=0)); 
+
+echo(search("abcd", "xyz", num_returns_per_match=0)); 
+
+lTableW5=[ ["a",1],undef,1/0,-1/0 ];
+echo(search("a", lTableW5, num_returns_per_match=0)); 
+
+lTableW6=[ ["a",1],-1/0];
+echo(search("a", lTableW6, num_returns_per_match=0)); 
 
 // for completeness
 cube(1.0);

--- a/testdata/scad/misc/search-tests.scad
+++ b/testdata/scad/misc/search-tests.scad
@@ -68,6 +68,18 @@ lSearch5=[1,"zz","dog",500,11];
 l5=search(lSearch5,lTable3,0,1);
 echo(str("Return all matches for mixed search; alternate columns (",lSearch5,"): ",l5));
 
+// causing warnings
+lTable6=[ ["a",1],123 ];
+echo(search("a", lTable6, num_returns_per_match=0)); 
+
+lTable7=[ ["a",1],"string" ];
+echo(search("a", lTable7, num_returns_per_match=0)); 
+
+lTable8=[ ["b",1] ];
+echo(search("a", lTable8, num_returns_per_match=0)); 
+
+lTable9=[ ["a",1] ];
+echo(search("abcd", lTable9, num_returns_per_match=0)); 
 
 // for completeness
 cube(1.0);

--- a/tests/regression/echotest/search-tests-expected.echo
+++ b/tests/regression/echotest/search-tests-expected.echo
@@ -16,3 +16,13 @@ ECHO: "Default list string search (["b", "zzz", "a", "c", "apple", "dog"]): [1, 
 ECHO: "Default list mixed search (["b", 4, "zzz", "c", "apple", 500, "a", ""]): [1, 3, [], 2, 9, [], 4, []]"
 ECHO: "Return all matches for mixed search (["b", 4, "zzz", "c", "apple", 500, "a", ""]): [[1, 5], [3], [], [2, 6], [9], [], [4, 10], []]"
 ECHO: "Return all matches for mixed search; alternate columns ([1, "zz", "dog", 500, 11]): [[0], [], [3], [], [10]]"
+WARNING: Invalid entry in search vector at index 1, required number of values in the entry: 1. Invalid entry: 123, in file search-tests.scad, line 73
+ECHO: []
+WARNING: Invalid entry in search vector at index 1, required number of values in the entry: 1. Invalid entry: "string", in file search-tests.scad, line 76
+ECHO: []
+  WARNING: search term not found: "a", in file search-tests.scad, line 79
+ECHO: [[]]
+  WARNING: search term not found: "b", in file search-tests.scad, line 82
+  WARNING: search term not found: "c", in file search-tests.scad, line 82
+  WARNING: search term not found: "d", in file search-tests.scad, line 82
+ECHO: [[0], [], [], []]

--- a/tests/regression/echotest/search-tests-expected.echo
+++ b/tests/regression/echotest/search-tests-expected.echo
@@ -26,3 +26,8 @@ ECHO: [[]]
   WARNING: search term not found: "c", in file search-tests.scad, line 82
   WARNING: search term not found: "d", in file search-tests.scad, line 82
 ECHO: [[0], [], [], []]
+ECHO: [[], [], [], []]
+WARNING: Invalid entry in search vector at index 1, required number of values in the entry: 1. Invalid entry: undef, in file search-tests.scad, line 87
+ECHO: []
+WARNING: Invalid entry in search vector at index 1, required number of values in the entry: 1. Invalid entry: -inf, in file search-tests.scad, line 90
+ECHO: []


### PR DESCRIPTION
One example why we need `->toEchoString()`:
```
data=[ ["a",1],123 ];

echo(search("a", data, num_returns_per_match=0)); 
```

```
Compiling design (CSG Tree generation)...
WARNING: Invalid entry in search vector at index 1, required number of values in the entry: 1. Invalid entry: 0x557571988eb0, line 3
ECHO: []
```
And off-course I added a test case to prevent regression.