### PR TITLE
hardwarning debug

### DIFF
--- a/src/mainwin.cc
+++ b/src/mainwin.cc
@@ -3128,7 +3128,7 @@ void MainWindow::consoleOutput(const QString &msg)
 	c.movePosition(QTextCursor::End);
 	this->console->setTextCursor(c);
 
-	if (msg.startsWith("WARNING:") || msg.startsWith("DEPRECATED:")) {
+	if (msg.startsWith("WARNING:") || msg.startsWith("PARSER-WARNING:") || msg.startsWith("DEPRECATED:")) {
 		this->compileWarnings++;
 		this->console->appendHtml("<span style=\"color: black; background-color: #ffffb0;\">" + QT_HTML_ESCAPE(QString(msg)) + "</span>");
 	} else if (msg.startsWith("UI-WARNING:") || msg.startsWith("FONT-WARNING:") || msg.startsWith("EXPORT-WARNING:") || msg.startsWith("CSG-WARNING:")) {
@@ -3136,7 +3136,7 @@ void MainWindow::consoleOutput(const QString &msg)
 	} else if (msg.startsWith("ERROR:")) {
 		this->compileErrors++;
 		this->console->appendHtml("<span style=\"color: black; background-color: #ffb0b0;\">" + QT_HTML_ESCAPE(QString(msg)) + "</span>");
-	} else if (msg.startsWith("EXPORT-ERROR:") || msg.startsWith("UI-ERROR:")) {
+	} else if (msg.startsWith("EXPORT-ERROR:") || msg.startsWith("UI-ERROR:") || msg.startsWith("PARSER-ERROR:")) {
 		this->console->appendHtml("<span style=\"color: black; background-color: #ffb0b0;\">" + QT_HTML_ESCAPE(QString(msg)) + "</span>");
 	} else {
 		QString qmsg = msg;

--- a/src/parser.y
+++ b/src/parser.y
@@ -222,7 +222,7 @@ assignment:
                             //assigments via commandline
                         }else if(prevFile==mainFile && currFile == mainFile){
                             //both assigments in the mainFile
-                            PRINTB("WARNING: %s was assigned on line %i but was overwritten on line %i",
+                            PRINTB("PARSER-WARNING: %s was assigned on line %i but was overwritten on line %i",
                                     assignment.name%
                                     assignment.location().firstLine()%
                                     LOC(@$).firstLine());
@@ -230,7 +230,7 @@ assignment:
                             //assigment overwritten within the same file
                             //the line number beeing equal happens, when a file is included multiple times
                             if(assignment.location().firstLine() != LOC(@$).firstLine()){
-                                PRINTB("WARNING: %s was assigned on line %i of %s but was overwritten on line %i",
+                                PRINTB("PARSER-WARNING: %s was assigned on line %i of %s but was overwritten on line %i",
                                         assignment.name%
                                         assignment.location().firstLine()%
                                         uncPathPrev%
@@ -238,7 +238,7 @@ assignment:
                             }
                         }else if(prevFile==mainFile && currFile != mainFile){
                             //assigment from the mainFile overwritten by an include
-                            PRINTB("WARNING: %s was assigned on line %i of %s but was overwritten on line %i of %s",
+                            PRINTB("PARSER-WARNING: %s was assigned on line %i of %s but was overwritten on line %i of %s",
                                     assignment.name%
                                     assignment.location().firstLine()%
                                     uncPathPrev%
@@ -668,7 +668,7 @@ int parserlex(void)
 void yyerror (char const *s)
 {
   // FIXME: We leak memory on parser errors...
-  PRINTB("ERROR: Parser error in file %s, line %d: %s\n",
+  PRINTB("PARSER-ERROR: Parser error in file %s, line %d: %s\n",
          (*sourcefile()) % lexerget_lineno() % s);
 }
 

--- a/src/printutils.cc
+++ b/src/printutils.cc
@@ -56,7 +56,6 @@ void PRINT(const std::string &msg)
 
 void PRINT_NOCACHE(const std::string &msg)
 {
-	bool stop{false};
 	if (msg.empty()) return;
 
 	if (boost::starts_with(msg, "WARNING") || boost::starts_with(msg, "ERROR") || boost::starts_with(msg, "TRACE")) {

--- a/src/printutils.cc
+++ b/src/printutils.cc
@@ -59,14 +59,13 @@ void PRINT_NOCACHE(const std::string &msg)
 	bool stop{false};
 	if (msg.empty()) return;
 
-	if (boost::starts_with(msg, "WARNING") || boost::starts_with(msg, "ERROR")) {
+	if (boost::starts_with(msg, "WARNING") || boost::starts_with(msg, "ERROR") || boost::starts_with(msg, "TRACE")) {
 		size_t i;
 		for (i=0;i<lastmessages.size();i++) {
 			if (lastmessages[i] != msg) break;
 		}
 		if (i == 5) return; // Suppress output after 5 equal ERROR or WARNING outputs.
 		else lastmessages.push_back(msg);
-		stop=true;
 	}
 
 	if (!OpenSCAD::quiet || boost::starts_with(msg, "ERROR")) {
@@ -76,7 +75,7 @@ void PRINT_NOCACHE(const std::string &msg)
 			outputhandler(msg, outputhandler_data);
 		}
 	}
-	if(stop && OpenSCAD::hardwarnings){
+	if(boost::starts_with(msg, "WARNING") && OpenSCAD::hardwarnings){
 		throw HardWarningException(msg);
 	}
 }

--- a/tests/regression/echotest/include-overwrite-main-expected.echo
+++ b/tests/regression/echotest/include-overwrite-main-expected.echo
@@ -1,6 +1,6 @@
-WARNING: overwritten was assigned on line 12 but was overwritten on line 16
-WARNING: after was assigned on line 15 of "include-overwrite-main.scad" but was overwritten on line 2 of "include-overwrite-after.scad"
-WARNING: overwriteInuse was assigned on line 1 of "include-overwrite-use.scad" but was overwritten on line 2
+PARSER-WARNING: overwritten was assigned on line 12 but was overwritten on line 16
+PARSER-WARNING: after was assigned on line 15 of "include-overwrite-main.scad" but was overwritten on line 2 of "include-overwrite-after.scad"
+PARSER-WARNING: overwriteInuse was assigned on line 1 of "include-overwrite-use.scad" but was overwritten on line 2
 ECHO: "Can a variable be used when it assigned later? true"
 ECHO: "Does an include before the assigment take priority? false"
 ECHO: "Does an include after the assigment take priority? true"

--- a/tests/regression/echotest/scope-assignment-tests-expected.echo
+++ b/tests/regression/echotest/scope-assignment-tests-expected.echo
@@ -1,7 +1,7 @@
-WARNING: e was assigned on line 49 but was overwritten on line 52
-WARNING: f was assigned on line 58 but was overwritten on line 61
-WARNING: g was assigned on line 67 but was overwritten on line 69
-WARNING: h was assigned on line 73 but was overwritten on line 75
+PARSER-WARNING: e was assigned on line 49 but was overwritten on line 52
+PARSER-WARNING: f was assigned on line 58 but was overwritten on line 61
+PARSER-WARNING: g was assigned on line 67 but was overwritten on line 69
+PARSER-WARNING: h was assigned on line 73 but was overwritten on line 75
 WARNING: Ignoring unknown variable 'h', in file scope-assignment-tests.scad, line 75.
 ECHO: "union scope"
 ECHO: "local a (5):", 5

--- a/tests/regression/echotest/search-tests-expected.echo
+++ b/tests/regression/echotest/search-tests-expected.echo
@@ -1,4 +1,4 @@
-WARNING: vTable1 was assigned on line 29 but was overwritten on line 32
+PARSER-WARNING: vTable1 was assigned on line 29 but was overwritten on line 32
 ECHO: "Characters in string ("a"): [0]"
 ECHO: "Characters in string ("adeq"): [[0, 5], [3, 8], [4], []]"
 ECHO: "Default string search ("abe"): [0, 1, 8]"

--- a/tests/regression/echotest/value-reassignment-tests-expected.echo
+++ b/tests/regression/echotest/value-reassignment-tests-expected.echo
@@ -1,3 +1,3 @@
-WARNING: myval was assigned on line 5 but was overwritten on line 7
+PARSER-WARNING: myval was assigned on line 5 but was overwritten on line 7
 WARNING: Ignoring unknown variable 'i', in file value-reassignment-tests.scad, line 7.
 ECHO: undef, 2

--- a/tests/regression/echotest/value-reassignment-tests2-expected.echo
+++ b/tests/regression/echotest/value-reassignment-tests2-expected.echo
@@ -1,2 +1,2 @@
-WARNING: myval was assigned on line 5 but was overwritten on line 7
+PARSER-WARNING: myval was assigned on line 5 but was overwritten on line 7
 ECHO: 3, 3


### PR DESCRIPTION
hardwarning does not work within the parser, causing openscad to be unable to properly reparse the scad text even after fixing the error.