### PR TITLE
Fixed Info.plist to allow http request for update check

### DIFF
--- a/Info.plist
+++ b/Info.plist
@@ -20,8 +20,8 @@
 	<string>@SHORT_VERSION@</string>
 	<key>LSEnvironment</key>
 	<dict>
-	  <key>GUI_LAUNCHED</key>
-	  <string></string>
+		<key>GUI_LAUNCHED</key>
+		<string></string>
 	</dict>
 	<key>CFBundleDocumentTypes</key>
 	<array>
@@ -114,13 +114,18 @@
 	<string>dsa_pub.pem</string>
 	<key>SUFeedURL</key>
 	<string>http://files.openscad.org/appcast.xml</string>
-        <key>NSExceptionDomains</key>  
-        <dict>  
-          <key>files.openscad.org</key>
-          <dict>  
-            <key>NSExceptionAllowsInsecureHTTPLoads</key><true/>  
-            <key>NSExceptionRequiresForwardSecrecy</key><false/>  
-          </dict>  
-        </dict>
+	<key>NSAppTransportSecurity</key>
+	<dict>
+		<key>NSAllowsArbitraryLoads</key>
+		<false/>
+		<key>NSExceptionDomains</key>
+		<dict>
+			<key>files.openscad.org</key>
+			<dict>
+				<key>NSExceptionAllowsInsecureHTTPLoads</key><true/>
+				<key>NSExceptionRequiresForwardSecrecy</key><false/>
+			</dict>
+		</dict>
+	</dict>
 </dict>
 </plist>

--- a/Info.plist.in
+++ b/Info.plist.in
@@ -20,8 +20,8 @@
 	<string>${MACOSX_BUNDLE_SHORT_VERSION_STRING}</string>
 	<key>LSEnvironment</key>
 	<dict>
-	  <key>GUI_LAUNCHED</key>
-	  <string></string>
+		<key>GUI_LAUNCHED</key>
+		<string></string>
 	</dict>
 	<key>CFBundleDocumentTypes</key>
 	<array>
@@ -104,13 +104,18 @@
 	<string>dsa_pub.pem</string>
 	<key>SUFeedURL</key>
 	<string>http://files.openscad.org/appcast.xml</string>
-        <key>NSExceptionDomains</key>  
-        <dict>  
-          <key>files.openscad.org</key>
-          <dict>  
-            <key>NSExceptionAllowsInsecureHTTPLoads</key><true/>  
-            <key>NSExceptionRequiresForwardSecrecy</key><false/>  
-          </dict>  
-        </dict>
+	<key>NSAppTransportSecurity</key>
+	<dict>
+		<key>NSAllowsArbitraryLoads</key>
+		<false/>
+		<key>NSExceptionDomains</key>
+		<dict>
+			<key>files.openscad.org</key>
+			<dict>
+				<key>NSExceptionAllowsInsecureHTTPLoads</key><true/>
+				<key>NSExceptionRequiresForwardSecrecy</key><false/>
+			</dict>
+		</dict>
+	</dict>
 </dict>
 </plist>


### PR DESCRIPTION
This should fix #2277. In the existing code, an attempt was made to allow insecure access, however some tags were missing.

This is the reference I used: https://stackoverflow.com/questions/31254725/transport-security-has-blocked-a-cleartext-http/32560433#32560433

I wasn't able to test it since I'm not able to successfully set up the build environment on macOS 10.14.2. Manually copying the new Info.plist into the App bundle leads to a successful http request, though.

Finally - as noted in the stackoverflow thread - this should be a short-term fix and long-term enabling https would be preferred.