### PR TITLE
hardwarning debug

### DIFF
--- a/src/printutils.cc
+++ b/src/printutils.cc
@@ -74,7 +74,7 @@ void PRINT_NOCACHE(const std::string &msg)
 			outputhandler(msg, outputhandler_data);
 		}
 	}
-	if(boost::starts_with(msg, "WARNING") && OpenSCAD::hardwarnings){
+	if(OpenSCAD::hardwarnings && !std::current_exception() && boost::starts_with(msg, "WARNING")){
 		throw HardWarningException(msg);
 	}
 }


### PR DESCRIPTION
Only throw HardWarningException, if currently no other exception is handled.

Currently, we `CGAL::set_error_behaviour(CGAL::THROW_EXCEPTION);`, catch that exception and then print a `WARNING:`. As this is an exception during an exception,  terminate is called.

This fix offcourse does cut into hardwarnings functionality.

This was discovered while working on  #2667, where an invalid nef3 file first caused CGAL to call terminate, then after setting CGAL to throw an exception, throwing an exception during the exception caused a terminate.