### PR TITLE
Green refactor: Introduced STR() macro

### DIFF
--- a/src/AST.cc
+++ b/src/AST.cc
@@ -35,7 +35,7 @@ std::ostream &operator<<(std::ostream &stream, const ASTNode &ast)
 
 std::string ASTNode::dump(const std::string &indent) const
 {
-	std::stringstream stream;
+	std::ostringstream stream;
 	print(stream, indent);
 	return stream.str();
 }

--- a/src/CSGTreeEvaluator.cc
+++ b/src/CSGTreeEvaluator.cc
@@ -16,8 +16,6 @@
 #include <string>
 #include <map>
 #include <list>
-#include <sstream>
-#include <iostream>
 #include <assert.h>
 #include <cstddef>
 
@@ -161,9 +159,6 @@ shared_ptr<CSGNode> CSGTreeEvaluator::evaluateCSGNodeFromGeometry(
 	State &state, const shared_ptr<const Geometry> &geom,
 	const ModuleInstantiation *modinst, const AbstractNode &node)
 {
-	std::stringstream stream;
-	stream << node.name() << node.index();
-
 	// We cannot render Polygon2d directly, so we preprocess (tessellate) it here
 	auto g = geom;
 	if (!g->isEmpty()) {
@@ -187,7 +182,7 @@ shared_ptr<CSGNode> CSGTreeEvaluator::evaluateCSGNodeFromGeometry(
 		}
 	}
 
-	shared_ptr<CSGNode> t(new CSGLeaf(g, state.matrix(), state.color(), stream.str()));
+	shared_ptr<CSGNode> t(new CSGLeaf(g, state.matrix(), state.color(), STR(node.name() << node.index())));
 	if (modinst->isHighlight()) t->setHighlight(true);
 	else if (modinst->isBackground()) t->setBackground(true);
 	return t;

--- a/src/GLView.cc
+++ b/src/GLView.cc
@@ -18,8 +18,6 @@
 #include <opencsg.h>
 #endif
 
-#include <boost/lexical_cast.hpp>
-
 GLView::GLView()
 {
   aspectratio = 1;
@@ -560,10 +558,7 @@ void GLView::showScalemarkers(const Color4f &col)
 
 void GLView::decodeMarkerValue(double i, double l, int size_div_sm)
 {
-	// convert the axis position to a string
-	std::ostringstream oss;
-	oss << i;
-	const auto unsigned_digit = oss.str();
+	const auto unsigned_digit = std::to_string(i);
 
 	// setup how far above the axis (or tick TBD) to draw the number
 	double dig_buf = (l/size_div_sm)/4;

--- a/src/GLView.cc
+++ b/src/GLView.cc
@@ -558,7 +558,7 @@ void GLView::showScalemarkers(const Color4f &col)
 
 void GLView::decodeMarkerValue(double i, double l, int size_div_sm)
 {
-	const auto unsigned_digit = std::to_string(i);
+	const auto unsigned_digit = STR(i);
 
 	// setup how far above the axis (or tick TBD) to draw the number
 	double dig_buf = (l/size_div_sm)/4;

--- a/src/LibraryInfo.cc
+++ b/src/LibraryInfo.cc
@@ -40,7 +40,7 @@ extern const char * LODEPNG_VERSION_STRING;
 
 std::string LibraryInfo::info()
 {
-	std::stringstream s;
+	std::ostringstream s;
 
 #if defined(__x86_64__) || defined(_M_X64)
 	std::string bits(" 64bit");

--- a/src/ModuleCache.cc
+++ b/src/ModuleCache.cc
@@ -8,7 +8,6 @@
 
 #include <stdio.h>
 #include <fstream>
-#include <sstream>
 #include <sys/stat.h>
 #include <algorithm>
 
@@ -93,15 +92,12 @@ std::time_t ModuleCache::evaluate(const std::string &mainFile,const std::string 
 
 		std::string text;
 		{
-			std::stringstream textbuf;
 			std::ifstream ifs(filename.c_str());
 			if (!ifs.is_open()) {
 				PRINTB("WARNING: Can't open library file '%s'\n", filename);
 				return 0;
 			}
-			textbuf << ifs.rdbuf();
-			textbuf << "\n\x03\n" << commandline_commands;
-			text = textbuf.str();
+			text = STR(ifs.rdbuf() << "\n\x03\n" << commandline_commands);
 		}
 		
 		print_messages_push();

--- a/src/OffscreenContextCGL.mm
+++ b/src/OffscreenContextCGL.mm
@@ -23,8 +23,6 @@ struct OffscreenContext
 
 std::string offscreen_context_getinfo(OffscreenContext *)
 {
-  std::stringstream out;
-
   struct utsname name;
   uname(&name);
 
@@ -38,6 +36,7 @@ std::string offscreen_context_getinfo(OffscreenContext *)
   if (sizeof(int*) == 4) arch = "32-bit";
   else if (sizeof(int*) == 8) arch = "64-bit";
 
+  std::ostringstream out;
   out << "GL context creator: Cocoa / CGL\n"
       << "PNG generator: Core Foundation\n"
       << "OS info: Mac OS X " << majorVersion << "." << minorVersion << "." << bugFixVersion << " (" << name.machine << " kernel)\n"

--- a/src/OffscreenContextGLX.cc
+++ b/src/OffscreenContextGLX.cc
@@ -77,7 +77,7 @@ std::string get_os_info()
 		return STR("OS info: " << u.sysname << " " << u.release << " " << u.version << "\n" <<
 							 "Machine: " << u.machine);
 	}
-	return ""
+	return "";
 }
 
 std::string offscreen_context_getinfo(OffscreenContext *ctx)

--- a/src/OffscreenContextGLX.cc
+++ b/src/OffscreenContextGLX.cc
@@ -69,19 +69,15 @@ struct OffscreenContext
 std::string get_os_info()
 {
 	struct utsname u;
-	std::stringstream out;
 
 	if (uname(&u) < 0) {
-		out << "OS info: unknown, uname() error\n";
+		return STR("OS info: unknown, uname() error\n");
 	}
 	else {
-		out << "OS info: "
-		    << u.sysname << " "
-		    << u.release << " "
-		    << u.version << "\n";
-		out << "Machine: " << u.machine;
+		return STR("OS info: " << u.sysname << " " << u.release << " " << u.version << "\n" <<
+							 "Machine: " << u.machine);
 	}
-	return out.str();
+	return ""
 }
 
 std::string offscreen_context_getinfo(OffscreenContext *ctx)
@@ -95,13 +91,10 @@ std::string offscreen_context_getinfo(OffscreenContext *ctx)
 	int major, minor;
 	glXQueryVersion(ctx->xdisplay, &major, &minor);
 
-	std::stringstream out;
-	out << "GL context creator: GLX\n"
-	    << "PNG generator: lodepng\n"
-	    << "GLX version: " << major << "." << minor << "\n"
-	    << get_os_info();
-
-	return out.str();
+	return STR("GL context creator: GLX\n" <<
+						 "PNG generator: lodepng\n" <<
+						 "GLX version: " << major << "." << minor << "\n" <<
+						 get_os_info());
 }
 
 static XErrorHandler original_xlib_handler = nullptr;

--- a/src/OffscreenContextWGL.cc
+++ b/src/OffscreenContextWGL.cc
@@ -1,4 +1,4 @@
-﻿*
+﻿/*
 
 Create an OpenGL context without creating an OpenGL Window. for Windows.
 

--- a/src/OffscreenContextWGL.cc
+++ b/src/OffscreenContextWGL.cc
@@ -82,11 +82,9 @@ string get_os_info()
 string offscreen_context_getinfo(OffscreenContext * /*ctx*/)
 {
   // should probably get some info from WGL context here?
-  stringstream out;
-  out << "GL context creator: WGL\n"
-      << "PNG generator: lodepng\n"
-      << get_os_info();
-  return out.str();
+  return STR("GL context creator: WGL\n" <<
+						 "PNG generator: lodepng\n" <<
+						 get_os_info());
 }
 
 LRESULT CALLBACK WndProc(HWND hwnd, UINT message, WPARAM wparam, LPARAM lparam) 

--- a/src/OffscreenContextWGL.cc
+++ b/src/OffscreenContextWGL.cc
@@ -1,4 +1,4 @@
-﻿/*
+﻿*
 
 Create an OpenGL context without creating an OpenGL Window. for Windows.
 
@@ -59,7 +59,7 @@ string get_os_info()
 
   SYSTEM_INFO si;
   GetSystemInfo(&si);
-  map<WORD,const char*> archs;
+	std::map<WORD,const char*> archs;
   archs[PROCESSOR_ARCHITECTURE_AMD64] = "amd64";
   archs[PROCESSOR_ARCHITECTURE_IA64] = "itanium";
   archs[PROCESSOR_ARCHITECTURE_INTEL] = "x86";

--- a/src/OffscreenContextWGL.cc
+++ b/src/OffscreenContextWGL.cc
@@ -27,8 +27,6 @@ For more info:
 #include <string>
 #include <sstream>
 
-using namespace std;
-
 struct OffscreenContext
 {
   HWND window;
@@ -67,7 +65,7 @@ string get_os_info()
   archs[PROCESSOR_ARCHITECTURE_INTEL] = "x86";
   archs[PROCESSOR_ARCHITECTURE_UNKNOWN] = "unknown";
 
-  stringstream out;
+	std::ostringstream out;
   out << "OS info: "
       << "Microsoft(TM) Windows(TM) " << osvi.dwMajorVersion << " "
       << osvi.dwMinorVersion << " " << osvi.dwBuildNumber << " "

--- a/src/OffscreenContextWGL.cc
+++ b/src/OffscreenContextWGL.cc
@@ -49,7 +49,7 @@ void offscreen_context_init(OffscreenContext &ctx, int width, int height)
   ctx.fbo = nullptr;
 }
 
-string get_os_info()
+std::string get_os_info()
 {
   OSVERSIONINFO osvi;
 
@@ -79,7 +79,7 @@ string get_os_info()
   return out.str();
 }
 
-string offscreen_context_getinfo(OffscreenContext * /*ctx*/)
+std::string offscreen_context_getinfo(OffscreenContext * /*ctx*/)
 {
   // should probably get some info from WGL context here?
   return STR("GL context creator: WGL\n" <<
@@ -109,8 +109,8 @@ bool create_wgl_dummy_context(OffscreenContext &ctx)
   ATOM class_atom = RegisterClassW( &wc );
 
   if ( class_atom == 0 ) {
-    cerr << "MS GDI - RegisterClass failed\n";
-    cerr << "last-error code: " << GetLastError() << "\n";
+		std::cerr << "MS GDI - RegisterClass failed\n";
+    std::cerr << "last-error code: " << GetLastError() << "\n";
     return false;
   }
 
@@ -130,8 +130,8 @@ bool create_wgl_dummy_context(OffscreenContext &ctx)
     nWidth, nHeight, hWndParent, hMenu, hInstance, lpParam );
 
   if ( window==nullptr ) {
-    cerr << "MS GDI - CreateWindow failed\n";
-    cerr << "last-error code: " << GetLastError() << "\n";
+    std::cerr << "MS GDI - CreateWindow failed\n";
+    std::cerr << "last-error code: " << GetLastError() << "\n";
     return false;
   }
 
@@ -141,8 +141,8 @@ bool create_wgl_dummy_context(OffscreenContext &ctx)
   int chosenformat;
   HDC dev_context = GetDC( window );
   if ( dev_context == nullptr ) {
-    cerr << "MS GDI - GetDC failed\n";
-    cerr << "last-error code: " << GetLastError() << "\n";
+    std::cerr << "MS GDI - GetDC failed\n";
+    std::cerr << "last-error code: " << GetLastError() << "\n";
     return false;
   }
 
@@ -160,30 +160,30 @@ bool create_wgl_dummy_context(OffscreenContext &ctx)
 
   chosenformat = ChoosePixelFormat( dev_context, &pixformat );
   if (chosenformat==0) {
-    cerr << "MS GDI - ChoosePixelFormat failed\n";
-    cerr << "last-error code: " << GetLastError() << "\n";
+    std::cerr << "MS GDI - ChoosePixelFormat failed\n";
+    std::cerr << "last-error code: " << GetLastError() << "\n";
     return false;
   }
 
   bool spfok = SetPixelFormat( dev_context, chosenformat, &pixformat );
   if (!spfok) {
-    cerr << "MS GDI - SetPixelFormat failed\n";
-    cerr << "last-error code: " << GetLastError() << "\n";
+    std::cerr << "MS GDI - SetPixelFormat failed\n";
+    std::cerr << "last-error code: " << GetLastError() << "\n";
     return false;
   }
 
   HGLRC gl_render_context = wglCreateContext( dev_context );
   if ( gl_render_context == nullptr ) {
-      cerr << "MS WGL - wglCreateContext failed\n";
-    cerr << "last-error code: " << GetLastError() << "\n";
+      std::cerr << "MS WGL - wglCreateContext failed\n";
+			std::cerr << "last-error code: " << GetLastError() << "\n";
       ReleaseDC( ctx.window, ctx.dev_context );
       return false;
   }
 
   bool mcok = wglMakeCurrent( dev_context, gl_render_context );
   if (!mcok) {
-    cerr << "MS WGL - wglMakeCurrent failed\n";
-    cerr << "last-error code: " << GetLastError() << "\n";
+    std::cerr << "MS WGL - wglMakeCurrent failed\n";
+    std::cerr << "last-error code: " << GetLastError() << "\n";
     return false;
   }
 

--- a/src/OffscreenView.cc
+++ b/src/OffscreenView.cc
@@ -39,10 +39,5 @@ bool OffscreenView::save(std::ostream &output)
 
 std::string OffscreenView::getRendererInfo() const
 {
-  std::stringstream out;
-
-  out << glew_dump()
-      << offscreen_context_getinfo(this->ctx);
-
-  return out.str();
+  return STR(glew_dump() << offscreen_context_getinfo(this->ctx));
 }

--- a/src/Polygon2d.cc
+++ b/src/Polygon2d.cc
@@ -39,7 +39,7 @@ BoundingBox Polygon2d::getBoundingBox() const
 
 std::string Polygon2d::dump() const
 {
-	std::stringstream out;
+	std::ostringstream out;
 	for (const auto &o : this->theoutlines) {
 		out << "contour:\n";
 		for (const auto &v : o.vertices) {

--- a/src/QGLView.cc
+++ b/src/QGLView.cc
@@ -112,7 +112,7 @@ void QGLView::initializeGL()
 
 std::string QGLView::getRendererInfo() const
 {
-  std::stringstream info;
+  std::ostringstream info;
   info << glew_dump();
   // Don't translate as translated text in the Library Info dialog is not wanted
 #ifdef USE_QOPENGLWIDGET

--- a/src/boost-utils.h
+++ b/src/boost-utils.h
@@ -20,7 +20,7 @@ On other conversion failures, return 0. */
 template <class Tout,class Tin> Tout boost_numeric_cast( Tin input )
 {
 	Tout result = 0;
-	std::stringstream status;
+	std::ostringstream status;
 	status.str("ok");
 	try {
 		result = boost::numeric_cast<Tout>(input);
@@ -34,12 +34,10 @@ template <class Tout,class Tin> Tout boost_numeric_cast( Tin input )
 		status << e.what();
 		result = 0;
 	}
-	if (status.str()!="ok") {
-		std::stringstream tmp;
-		tmp << input;
-		PRINTB("WARNING: problem converting this number: %s",tmp.str());
-		PRINTB("WARNING: %s", status.str() );
-		PRINTB("WARNING: setting result to %u",result);
+	if (status.str() != "ok") {
+		PRINTB("WARNING: problem converting this number: %s", std::to_string(input));
+		PRINTB("WARNING: %s", status.str());
+		PRINTB("WARNING: setting result to %u", result);
 	}
 	return result;
 }

--- a/src/cgaladv.cc
+++ b/src/cgaladv.cc
@@ -117,7 +117,7 @@ std::string CgaladvNode::name() const
 
 std::string CgaladvNode::toString() const
 {
-	std::stringstream stream;
+	std::ostringstream stream;
 
 	stream << this->name();
 	switch (type) {

--- a/src/cgalutils-polyhedron.cc
+++ b/src/cgalutils-polyhedron.cc
@@ -337,7 +337,7 @@ namespace CGALUtils {
 
 	template <typename Polyhedron>
 	std::string printPolyhedron(const Polyhedron &p) {
-		std::stringstream sstream;
+		std::ostringstream sstream;
 		sstream.precision(20);
 
     Polyhedron_writer writer;

--- a/src/color.cc
+++ b/src/color.cc
@@ -300,11 +300,7 @@ AbstractNode *ColorModule::instantiate(const Context *ctx, const ModuleInstantia
 
 std::string ColorNode::toString() const
 {
-	std::stringstream stream;
-
-	stream << "color([" << this->color[0] << ", " << this->color[1] << ", " << this->color[2] << ", " << this->color[3] << "])";
-
-	return stream.str();
+	return STR("color([" << this->color[0] << ", " << this->color[1] << ", " << this->color[2] << ", " << this->color[3] << "])");
 }
 
 std::string ColorNode::name() const

--- a/src/context.cc
+++ b/src/context.cc
@@ -223,7 +223,7 @@ std::string Context::getAbsolutePath(const std::string &filename) const
 #ifdef DEBUG
 std::string Context::dump(const AbstractModule *mod, const ModuleInstantiation *inst)
 {
-	std::stringstream s;
+	std::ostringstream s;
 	if (inst) {
 		s << boost::format("ModuleContext %p (%p) for %s inst (%p)\n") % this % this->parent % inst->name() % inst;
 	}

--- a/src/control.cc
+++ b/src/control.cc
@@ -33,7 +33,6 @@
 #include "builtin.h"
 #include "printutils.h"
 #include <cstdint>
-#include <sstream>
 
 class ControlModule : public AbstractModule
 {
@@ -267,9 +266,7 @@ AbstractNode *ControlModule::instantiate(const Context* /*ctx*/, const ModuleIns
 
 	case Type::ECHO: {
 		node = new GroupNode(inst);
-		std::stringstream msg;
-		msg << "ECHO: " << *evalctx;
-		PRINTB("%s", msg.str());
+		PRINTB("%s", STR("ECHO: " << *evalctx));
 	}
 		break;
 

--- a/src/csgnode.cc
+++ b/src/csgnode.cc
@@ -194,7 +194,7 @@ void CSGProducts::import(shared_ptr<CSGNode> csgnode, OpenSCADOperator type, CSG
 
 std::string CSGProduct::dump() const
 {
-	std::stringstream dump;
+	std::ostringstream dump;
 	dump << this->intersections.front().leaf->label;
 	for(const auto &csgobj :
 								boost::make_iterator_range(this->intersections.begin() + 1,
@@ -222,7 +222,7 @@ BoundingBox CSGProduct::getBoundingBox() const
 
 std::string CSGProducts::dump() const
 {
-	std::stringstream dump;
+	std::ostringstream dump;
 
 	for(const auto &product : this->products) {
 		dump << "+" << product.dump() << "\n";

--- a/src/csgnode.cc
+++ b/src/csgnode.cc
@@ -27,7 +27,8 @@
 #include "csgnode.h"
 #include "Geometry.h"
 #include "linalg.h"
-#include <sstream>
+#include "printutils.h"
+
 #include <boost/range/iterator_range.hpp>
 
 /*!
@@ -156,18 +157,17 @@ std::string CSGLeaf::dump()
 
 std::string CSGOperation::dump()
 {
-	std::stringstream dump;
-
-	if (type == OpenSCADOperator::UNION)
-		dump << "(" << left()->dump() << " + " << right()->dump() << ")";
-	else if (type == OpenSCADOperator::INTERSECTION)
-		dump << "(" << left()->dump() << " * " << right()->dump() << ")";
-	else if (type == OpenSCADOperator::DIFFERENCE)
-		dump << "(" << left()->dump() << " - " << right()->dump() << ")";
-	else 
+	switch (type) {
+	case OpenSCADOperator::UNION:
+		return STR("(" << left()->dump() << " + " << right()->dump() << ")");
+	case OpenSCADOperator::INTERSECTION:
+		return STR("(" << left()->dump() << " * " << right()->dump() << ")");
+	case OpenSCADOperator::DIFFERENCE:
+		return STR("(" << left()->dump() << " - " << right()->dump() << ")");
+	default:
 		assert(false);
-
-	return dump.str();
+		return "";
+	}
 }
 
 void CSGProducts::import(shared_ptr<CSGNode> csgnode, OpenSCADOperator type, CSGNode::Flag flags)

--- a/src/dxfdata.cc
+++ b/src/dxfdata.cc
@@ -578,7 +578,7 @@ int DxfData::addPoint(double x, double y)
 
 std::string DxfData::dump() const
 {
-	std::stringstream out;
+	std::ostringstream out;
 	out << "DxfData"
 	  << "\n num points: " << points.size()
 	  << "\n num paths: " << paths.size()

--- a/src/dxfdim.cc
+++ b/src/dxfdim.cc
@@ -69,7 +69,6 @@ ValuePtr builtin_dxf_dim(const Context *ctx, const EvalContext *evalctx)
 		if (n == "name") name = v->toString();
 	}
 
-	std::stringstream keystream;
 	fs::path filepath(filename);
 	uintmax_t filesize = -1;
 	time_t lastwritetime = -1;
@@ -77,10 +76,9 @@ ValuePtr builtin_dxf_dim(const Context *ctx, const EvalContext *evalctx)
 		filesize = fs::file_size(filepath);
 		lastwritetime = fs::last_write_time(filepath);
 	}
-	keystream << filename << "|" << layername << "|" << name << "|" << xorigin
-						<< "|" << yorigin <<"|" << scale << "|" << lastwritetime
-						<< "|" << filesize;
-	std::string key = keystream.str();
+	std::string key = STR(filename << "|" << layername << "|" << name << "|" << xorigin
+												<< "|" << yorigin <<"|" << scale << "|" << lastwritetime
+												<< "|" << filesize);
 	if (dxf_dim_cache.find(key) != dxf_dim_cache.end())
 		return dxf_dim_cache.find(key)->second;
 	handle_dep(filepath.string());
@@ -159,7 +157,6 @@ ValuePtr builtin_dxf_cross(const Context *ctx, const EvalContext *evalctx)
 		if (n == "scale") v->getDouble(scale);
 	}
 
-	std::stringstream keystream;
 	fs::path filepath(filename);
 	uintmax_t filesize = -1;
 	time_t lastwritetime = -1;
@@ -167,10 +164,9 @@ ValuePtr builtin_dxf_cross(const Context *ctx, const EvalContext *evalctx)
 		filesize = fs::file_size(filepath);
 		lastwritetime = fs::last_write_time(filepath);
 	}
-	keystream << filename << "|" << layername << "|" << xorigin << "|" << yorigin
-						<< "|" << scale << "|" << lastwritetime
-						<< "|" << filesize;
-	std::string key = keystream.str();
+	std::string key = STR(filename << "|" << layername << "|" << xorigin << "|" << yorigin
+												<< "|" << scale << "|" << lastwritetime
+												<< "|" << filesize);
 
 	if (dxf_cross_cache.find(key) != dxf_cross_cache.end()) {
 		return dxf_cross_cache.find(key)->second;

--- a/src/evalcontext.cc
+++ b/src/evalcontext.cc
@@ -10,7 +10,7 @@
 
 EvalContext::EvalContext(const Context *parent, 
 												 const AssignmentList &args, const Location &loc, const class LocalScope *const scope)
-	: Context(parent), eval_arguments(args), loc(loc), scope(scope)
+	: Context(parent), loc(loc), eval_arguments(args), scope(scope)
 {
 }
 
@@ -107,7 +107,7 @@ std::ostream &operator<<(std::ostream &stream, const EvalContext &ec)
 #ifdef DEBUG
 std::string EvalContext::dump(const AbstractModule *mod, const ModuleInstantiation *inst)
 {
-	std::stringstream s;
+	std::ostringstream s;
 	if (inst)
 		s << boost::format("EvalContext %p (%p) for %s inst (%p)") % this % this->parent % inst->name() % inst;
 	else

--- a/src/exceptions.h
+++ b/src/exceptions.h
@@ -3,6 +3,7 @@
 #include <stdexcept>
 #include <sstream>
 #include "expression.h"
+#include "printutils.h"
 
 class EvaluationException : public std::runtime_error {
 public:
@@ -21,10 +22,8 @@ public:
 
 class RecursionException: public EvaluationException {
 public:
-	static RecursionException create(const char *recursiontype, const std::string &name, const Location &loc) {
-		std::stringstream out;
-		out << "ERROR: Recursion detected calling " << recursiontype << " '" << name << "'";
-		return RecursionException(out.str(), loc);
+	static RecursionException create(const std::string &recursiontype, const std::string &name, const Location &loc) {
+		return RecursionException{STR("ERROR: Recursion detected calling " << recursiontype << " '" << name << "'"), loc};
 	}
 	~RecursionException() throw() {}
 

--- a/src/export_amf.cc
+++ b/src/export_amf.cc
@@ -86,15 +86,9 @@ static void append_amf(const CGAL_Nef_polyhedron &root_N, std::ostream &output)
 				double x3 = CGAL::to_double(v3.point().x());
 				double y3 = CGAL::to_double(v3.point().y());
 				double z3 = CGAL::to_double(v3.point().z());
-				std::stringstream stream;
-				stream << x1 << " " << y1 << " " << z1;
-				std::string vs1 = stream.str();
-				stream.str("");
-				stream << x2 << " " << y2 << " " << z2;
-				std::string vs2 = stream.str();
-				stream.str("");
-				stream << x3 << " " << y3 << " " << z3;
-				std::string vs3 = stream.str();
+				std::string vs1{STR(x1 << " " << y1 << " " << z1)};
+				std::string vs2{STR(x2 << " " << y2 << " " << z2)};
+				std::string vs3{STR(x3 << " " << y3 << " " << z3)};
 				if (std::find(vertices.begin(), vertices.end(), vs1) == vertices.end())
 					vertices.push_back(vs1);
 				if (std::find(vertices.begin(), vertices.end(), vs2) == vertices.end())

--- a/src/export_stl.cc
+++ b/src/export_stl.cc
@@ -34,13 +34,11 @@
 #include "cgal.h"
 #include "cgalutils.h"
 
-#define OSS(X) static_cast<std::ostringstream &&>(std::ostringstream() << X).str()
-
 namespace {
 
 std::string toString(const Vector3d &v)
 {
-	return OSS(v[0] << " " << v[1] << " " << v[2]);
+	return STR(v[0] << " " << v[1] << " " << v[2]);
 }
 
 Vector3d fromString(const std::string &vertexString)

--- a/src/expr.cc
+++ b/src/expr.cc
@@ -733,7 +733,7 @@ void evaluate_assert(const Context &context, const class EvalContext *evalctx)
 	const ValuePtr condition = c.lookup_variable("condition");
 
 	if (!condition->toBool()) {
-		std::stringstream msg;
+		std::ostringstream msg;
 		msg << "ERROR: Assertion";
 		const Expression *expr = assignments["condition"];
 		if (expr) msg << " '" << *expr << "'";

--- a/src/expr.cc
+++ b/src/expr.cc
@@ -491,10 +491,8 @@ Echo::Echo(const AssignmentList &args, Expression *expr, const Location &loc)
 
 ValuePtr Echo::evaluate(const Context *context) const
 {
-	std::stringstream msg;
-	EvalContext echo_context(context, this->arguments, this->loc);
-	msg << "ECHO: " << echo_context;
-	PRINTB("%s", msg.str());
+	EvalContext echo_context(context, this->arguments, this->loc);	
+	PRINTB("%s", STR("ECHO: " << echo_context));
 
 	ValuePtr result = expr ? expr->evaluate(context) : ValuePtr::undefined;
 	return result;

--- a/src/feature.cc
+++ b/src/feature.cc
@@ -99,8 +99,6 @@ ExperimentalFeatureException::~ExperimentalFeatureException() throw()
 void ExperimentalFeatureException::check(const Feature &feature)
 {
 	if (!feature.is_enabled()) {
-		std::stringstream out;
-		out << "ERROR: Experimental feature not enabled: '" << feature.get_name() << "'. Please check preferences.";
-		throw ExperimentalFeatureException(out.str());
+		throw ExperimentalFeatureException(STR("ERROR: Experimental feature not enabled: '" << feature.get_name() << "'. Please check preferences."));
 	}
 }

--- a/src/func.cc
+++ b/src/func.cc
@@ -394,7 +394,7 @@ ValuePtr builtin_ln(const Context *, const EvalContext *evalctx)
 
 ValuePtr builtin_str(const Context *, const EvalContext *evalctx)
 {
-	std::stringstream stream;
+	std::ostringstream stream;
 
 	for (size_t i = 0; i < evalctx->numArgs(); i++) {
 		stream << evalctx->getArgValue(i)->toString();
@@ -404,7 +404,7 @@ ValuePtr builtin_str(const Context *, const EvalContext *evalctx)
 
 ValuePtr builtin_chr(const Context *, const EvalContext *evalctx)
 {
-	std::stringstream stream;
+	std::ostringstream stream;
 	
 	for (size_t i = 0; i < evalctx->numArgs(); i++) {
 		ValuePtr v = evalctx->getArgValue(i);

--- a/src/handle_dep.cc
+++ b/src/handle_dep.cc
@@ -1,4 +1,5 @@
 #include "handle_dep.h"
+#include "printutils.h"
 #include <string>
 #include <sstream>
 #include <stdlib.h> // for system()
@@ -20,9 +21,7 @@ void handle_dep(const std::string &filename)
 	dependencies.insert(dep);
 
 	if (make_command && !fs::exists(filepath)) {
-		std::stringstream buf;
-		buf << make_command << " '" << boost::regex_replace(filename, boost::regex("'"), "'\\''") << "'";
-		system(buf.str().c_str()); // FIXME: Handle error
+		system(STR(make_command << " '" << boost::regex_replace(filename, boost::regex("'"), "'\\''") << "'").c_str()); // FIXME: Handle error
 	}
 }
 

--- a/src/import.cc
+++ b/src/import.cc
@@ -190,7 +190,7 @@ const Geometry *ImportNode::createGeometry() const
 
 std::string ImportNode::toString() const
 {
-	std::stringstream stream;
+	std::ostringstream stream;
 	fs::path path((std::string)this->filename);
 
 	stream << this->name();

--- a/src/input/HidApiInputDriver.cc
+++ b/src/input/HidApiInputDriver.cc
@@ -30,7 +30,6 @@
  */
 
 #include <iomanip>
-#include <iostream>
 #include <bitset>
 
 #include "input/HidApiInputDriver.h"
@@ -195,13 +194,9 @@ bool HidApiInputDriver::open()
         hid_dev = hid_open(device_ids[idx].vendor_id, device_ids[idx].product_id, NULL);
         if (hid_dev != NULL) {
             dev = &device_ids[idx];
-            std::stringstream sstream;
-            sstream << std::setfill('0') << std::setw(4) << std::hex
-                << "HidApiInputDriver ("
-                << dev->vendor_id << ":" << dev->product_id
-                 << " - " << dev->name
-                << ")";
-            name = sstream.str();
+            name = STR(std::setfill('0') << std::setw(4) << std::hex
+											 << "HidApiInputDriver (" << dev->vendor_id << ":" << dev->product_id
+											 << " - " << dev->name << ")");
             start();
             return true;
         }

--- a/src/input/InputDriverManager.cc
+++ b/src/input/InputDriverManager.cc
@@ -118,7 +118,7 @@ void InputDriverManager::doOpen(bool firstOpen)
 
 std::string InputDriverManager::listDrivers() const
 {
-    std::stringstream stream;
+    std::ostringstream stream;
     const char *sep = "";
     for (auto driver : drivers) {
         stream << sep << driver->get_name();

--- a/src/libsvg/transformation.cc
+++ b/src/libsvg/transformation.cc
@@ -37,7 +37,7 @@ transformation::add_arg(const std::string arg)
 
 const std::string
 transformation::get_args() {
-	std::stringstream str;
+	std::ostringstream str;
 	for (unsigned int a = 0;a < args.size();a++) {
 		str << ((a == 0) ? "(" : ", ") << args[a];
 	}

--- a/src/linearextrude.cc
+++ b/src/linearextrude.cc
@@ -137,7 +137,7 @@ AbstractNode *LinearExtrudeModule::instantiate(const Context *ctx, const ModuleI
 
 std::string LinearExtrudeNode::toString() const
 {
-	std::stringstream stream;
+	std::ostringstream stream;
 
 	stream << this->name() << "(";
 	if (!this->filename.empty()) { // Ignore deprecated parameters if empty 

--- a/src/modcontext.cc
+++ b/src/modcontext.cc
@@ -135,7 +135,7 @@ AbstractNode *ModuleContext::instantiate_module(const ModuleInstantiation &inst,
 #ifdef DEBUG
 std::string ModuleContext::dump(const AbstractModule *mod, const ModuleInstantiation *inst)
 {
-	std::stringstream s;
+	std::ostringstream s;
 	if (inst) {
 		s << boost::format("ModuleContext %p (%p) for %s inst (%p) ") % this % this->parent % inst->name() % inst;
 	}

--- a/src/module.cc
+++ b/src/module.cc
@@ -27,7 +27,6 @@
 #include "module.h"
 #include "context.h"
 #include "value.h"
-#include <sstream>
 
 AbstractModule::~AbstractModule()
 {

--- a/src/nodedumper.cc
+++ b/src/nodedumper.cc
@@ -56,9 +56,7 @@ Response NodeDumper::visit(State &state, const AbstractNode &node)
 		if (this->idString) {
 			
 			const boost::regex re("[^\\s\\\"]+|\\\"(?:[^\\\"\\\\]|\\\\.)*\\\"");
-			std::stringstream namestream;
-			namestream << node;
-			std::string name = namestream.str();
+			const auto name = STR(node);
 			boost::sregex_token_iterator it(name.begin(), name.end(), re, 0);
 			std::copy(it, boost::sregex_token_iterator(), std::ostream_iterator<std::string>(this->dumpstream));
 		

--- a/src/offset.cc
+++ b/src/offset.cc
@@ -92,7 +92,7 @@ AbstractNode *OffsetModule::instantiate(const Context *ctx, const ModuleInstanti
 
 std::string OffsetNode::toString() const
 {
-	std::stringstream stream;
+	std::ostringstream stream;
 
 	bool isRadius = this->join_type == ClipperLib::jtRound;
 	auto var = isRadius ? "(r = " : "(delta = ";

--- a/src/openscad.cc
+++ b/src/openscad.cc
@@ -60,8 +60,6 @@
 #include "csgnode.h"
 #include "CSGTreeEvaluator.h"
 
-#include <sstream>
-
 #include "Camera.h"
 #include <boost/algorithm/string.hpp>
 #include <boost/algorithm/string/split.hpp>
@@ -132,10 +130,8 @@ public:
 
 static void help(const char *arg0, const po::options_description &desc, bool failure = false)
 {
-	std::stringstream ss;
-	ss << desc;
 	const fs::path progpath(arg0);
-	PRINTB("Usage: %s [options] file.scad\n%s", progpath.filename().string() % ss.str());
+	PRINTB("Usage: %s [options] file.scad\n%s", progpath.filename().string() % STR(desc));
 	exit(failure ? 1 : 0);
 }
 

--- a/src/polyset.cc
+++ b/src/polyset.cc
@@ -59,7 +59,7 @@ PolySet::~PolySet()
 
 std::string PolySet::dump() const
 {
-	std::stringstream out;
+	std::ostringstream out;
 	out << "PolySet:"
 	  << "\n dimensions:" << this->dim
 	  << "\n convexity:" << this->convexity

--- a/src/primitives.cc
+++ b/src/primitives.cc
@@ -618,7 +618,7 @@ const Geometry *PrimitiveNode::createGeometry() const
 
 std::string PrimitiveNode::toString() const
 {
-	std::stringstream stream;
+	std::ostringstream stream;
 
 	stream << this->name();
 

--- a/src/printutils.cc
+++ b/src/printutils.cc
@@ -106,11 +106,9 @@ std::string two_digit_exp_format( std::string doublestr )
 	return doublestr;
 }
 
-std::string two_digit_exp_format( double x )
+std::string two_digit_exp_format(double x)
 {
-	std::stringstream s;
-	s << x;
-	return two_digit_exp_format( s.str() );
+	return two_digit_exp_format(std::to_string(x));
 }
 
 #include <set>

--- a/src/printutils.h
+++ b/src/printutils.h
@@ -94,3 +94,5 @@ public:
 		return *this;
 	}
 };
+
+#define STR(s) static_cast<std::ostringstream&&>(std::ostringstream() << s).str()

--- a/src/projection.cc
+++ b/src/projection.cc
@@ -33,7 +33,6 @@
 #include "polyset.h"
 
 #include <assert.h>
-#include <sstream>
 #include <boost/assign/std/vector.hpp>
 using namespace boost::assign; // bring 'operator+=()' into scope
 
@@ -72,12 +71,8 @@ AbstractNode *ProjectionModule::instantiate(const Context *ctx, const ModuleInst
 
 std::string ProjectionNode::toString() const
 {
-	std::stringstream stream;
-
-	stream << "projection(cut = " << (this->cut_mode ? "true" : "false")
-				 << ", convexity = " << this->convexity << ")";
-
-	return stream.str();
+	return STR("projection(cut = " << (this->cut_mode ? "true" : "false")
+						 << ", convexity = " << this->convexity << ")");
 }
 
 void register_builtin_projection()

--- a/src/render.cc
+++ b/src/render.cc
@@ -65,11 +65,7 @@ AbstractNode *RenderModule::instantiate(const Context *ctx, const ModuleInstanti
 
 std::string RenderNode::toString() const
 {
-	std::stringstream stream;
-
-	stream << this->name() << "(convexity = " << convexity << ")";
-
-	return stream.str();
+	return STR(this->name() << "(convexity = " << convexity << ")");
 }
 
 void register_builtin_render()

--- a/src/rotateextrude.cc
+++ b/src/rotateextrude.cc
@@ -104,7 +104,7 @@ AbstractNode *RotateExtrudeModule::instantiate(const Context *ctx, const ModuleI
 
 std::string RotateExtrudeNode::toString() const
 {
-	std::stringstream stream;
+	std::ostringstream stream;
 
 	stream << this->name() << "(";
 	if (!this->filename.empty()) { // Ignore deprecated parameters if empty 

--- a/src/surface.cc
+++ b/src/surface.cc
@@ -300,7 +300,7 @@ const Geometry *SurfaceNode::createGeometry() const
 
 std::string SurfaceNode::toString() const
 {
-	std::stringstream stream;
+	std::ostringstream stream;
 	fs::path path{static_cast<std::string>(this->filename)}; // gcc-4.6
 
 	stream << this->name() << "(file = " << this->filename

--- a/src/svg.cc
+++ b/src/svg.cc
@@ -14,7 +14,7 @@ int svg_px_height = SVG_PXH;
 
 std::string svg_header(int widthpx, int heightpx)
 {
-	std::stringstream out;
+	std::ostringstream out;
 	out << "<svg width='" << widthpx << "px' height='" << heightpx << "px'"
 			<< " xmlns='http://www.w3.org/2000/svg' version='1.1'>\n";
 	out << "<!-- please do not write code depending on this format -->\n";
@@ -24,14 +24,14 @@ std::string svg_header(int widthpx, int heightpx)
 
 std::string svg_label(std::string s)
 {
-	std::stringstream out;
+	std::ostringstream out;
 	out << "   <text fill='black' x='20' y='40' font-size='24'>" << s << "</text>";
 	return out.str();
 }
 
 std::string svg_styleblock(std::string strokewidth)
 {
-	std::stringstream out;
+	std::ostringstream out;
 	// halfedge: f1/f0 = face mark, b1/b0 = body or hole, m1/m0 = halfedge mark
 	out << "\
 	<style type='text/css'>\n\
@@ -51,7 +51,7 @@ std::string svg_styleblock(std::string strokewidth)
 
 std::string svg_border()
 {
-	std::stringstream out;
+	std::ostringstream out;
 	out << " <!-- border -->\n";
 	out << "  <polyline points='0,0 "
 		<< svg_px_width  << ",0 "
@@ -64,7 +64,7 @@ std::string svg_border()
 
 std::string svg_axes()
 {
-	std::stringstream out;
+	std::ostringstream out;
 	out << " <!-- axes -->\n";
 	out << "  <polyline points='10,455 10,475 10,465 18,465 2,465 10,465 14,461 6,469 10,465'"
 		<< " style='fill:none;stroke:black;' />\n";
@@ -117,11 +117,11 @@ std::string dump_cgal_nef_polyhedron2_face_svg(
 	CGAL_Nef_polyhedron2::Explorer explorer,
 	bool facemark, bool body )
 {
-	std::stringstream style;
+	std::ostringstream style;
 	style << "halfedge_f" << facemark << "_b" << body << "_m";
 	auto styleclass = style.str();
 
-	std::stringstream out;
+	std::ostringstream out;
 	CGAL_For_all(c1, c2) {
 		if (explorer.is_standard( explorer.target(c1))) {
 			auto source = explorer.point( explorer.source( c1 ) );
@@ -155,7 +155,7 @@ static CGAL_Iso_rectangle_2e bounding_box(const CGAL_Nef_polyhedron2 &N)
 
 std::string dump_svg(const CGAL_Nef_polyhedron2 &N)
 {
-	std::stringstream out;
+	std::ostringstream out;
 	auto explorer = N.explorer();
 	auto bbox = bounding_box(N);
 
@@ -188,7 +188,7 @@ std::string dump_svg(const CGAL_Nef_polyhedron2 &N)
 
 std::string point_dump( CGAL_Point_3 p )
 {
-  std::stringstream out;
+  std::ostringstream out;
   out << CGAL::to_double(p.x()) << ","
     << CGAL::to_double(p.y()) << ","
     << CGAL::to_double(p.z());
@@ -197,7 +197,7 @@ std::string point_dump( CGAL_Point_3 p )
 
 std::string point_dump( CGAL::Sphere_point<CGAL_Kernel3> p )
 {
-  std::stringstream out;
+  std::ostringstream out;
   out << CGAL::to_double(p.x()) << ","
     << CGAL::to_double(p.y()) << ","
     << CGAL::to_double(p.z());
@@ -220,7 +220,7 @@ see http://doc.cgal.org/latest/Nef_3/index.html
 */
 std::string sphere_map_dump( const CGAL_Nef_polyhedron3& N)
 {
-  std::stringstream out;
+  std::ostringstream out;
   typedef CGAL_Nef_polyhedron3::Vertex_const_iterator Vertex_const_iterator;
   typedef CGAL_Nef_polyhedron3::Nef_polyhedron_S2 Nef_polyhedron_S2;
   typedef Nef_polyhedron_S2::SVertex_const_handle SVertex_const_handle;
@@ -277,7 +277,7 @@ std::string sphere_map_dump( const CGAL_Nef_polyhedron3& N)
 // http://www.cgal.org/Manual/latest/doc_html/cgal_manual/Nef_3/Chapter_main.html#Subsection_29.7.2
 class NefPoly3_dumper_svg {
 public:
-	std::stringstream out;
+	std::ostringstream out;
 	CGAL_Iso_cuboid_3 bbox;
 	NefPoly3_dumper_svg(const CGAL_Nef_polyhedron3& N)
 	{
@@ -348,7 +348,7 @@ public:
 
 std::string dump_svg( const CGAL_Nef_polyhedron3 &N )
 {
-	std::stringstream out;
+	std::ostringstream out;
 	std::string linewidth = "0.05";
 	out << "<!--CGAL_Nef_polyhedron3 dump begin-->\n";
 	out << svg_header() << "\n" << svg_border() << "\n";

--- a/src/system-gl.cc
+++ b/src/system-gl.cc
@@ -10,25 +10,26 @@
 #include <boost/algorithm/string.hpp>
 #include <boost/format.hpp>
 
-using namespace std;
-using namespace boost;
+#include "printutils.h"
 
 double gl_version()
 {
-	string tmp((const char*)glGetString( GL_VERSION ));
-	vector<string> strs;
-	split(strs, tmp, is_any_of("."));
-	stringstream out;
-	if ( strs.size() >= 2)
+	std::string tmp((const char*)glGetString( GL_VERSION ));
+	std::vector<std::string> strs;
+	boost::split(strs, tmp, boost::is_any_of("."));
+	std::stringstream out;
+	if (strs.size() >= 2) {
 		out << strs[0] << "." << strs[1];
-	else
+	}
+	else {
 		out << "0.0";
+	}
 	double d;
 	out >> d;
 	return d;
 }
 
-string glew_extensions_dump()
+std::string glew_extensions_dump()
 {
 	std::string tmp;
 	if ( gl_version() >= 3.0 ) {
@@ -41,17 +42,18 @@ string glew_extensions_dump()
 	} else {
  	 tmp = (const char *) glGetString(GL_EXTENSIONS);
 	}
-	vector<string> extensions;
-	split( extensions, tmp, is_any_of(" "));
-	sort( extensions.begin(), extensions.end() );
-	stringstream out;
+	std::vector<std::string> extensions;
+	boost::split(extensions, tmp, boost::is_any_of(" "));
+	std::sort(extensions.begin(), extensions.end());
+	std::ostringstream out;
 	out << "GL Extensions:";
-	for ( unsigned int i=0;i<extensions.size();i++ )
+	for (unsigned int i=0;i<extensions.size();i++) {
 		out << extensions[i] << "\n";
+	}
 	return out.str();
 }
 
-string glew_dump()
+std::string glew_dump()
 {
   GLint rbits, gbits, bbits, abits, dbits, sbits;
   glGetIntegerv(GL_RED_BITS, &rbits);
@@ -61,7 +63,7 @@ string glew_dump()
   glGetIntegerv(GL_DEPTH_BITS, &dbits);
   glGetIntegerv(GL_STENCIL_BITS, &sbits);
 
-  stringstream out;
+	std::ostringstream out;
   out << "GLEW version: " << glewGetString(GLEW_VERSION)
       << "\nOpenGL Version: " << (const char *)glGetString(GL_VERSION)
       << "\nGL Renderer: " << (const char *)glGetString(GL_RENDERER)
@@ -82,9 +84,7 @@ bool report_glerror(const char * function)
 {
   GLenum tGLErr = glGetError();
   if (tGLErr != GL_NO_ERROR) {
-    std::ostringstream hexErr;
-    hexErr << hex << tGLErr;
-    cerr << "OpenGL error 0x" << hexErr.str() << ": " << gluErrorString(tGLErr) << " after " << function << endl;
+		std::cerr << "OpenGL error 0x" << STR(std::hex << tGLErr) << ": " << gluErrorString(tGLErr) << " after " << function << std::endl;
     return true;
   }
   return false;

--- a/src/text.cc
+++ b/src/text.cc
@@ -103,9 +103,7 @@ FreetypeRenderer::Params TextNode::get_params() const
 
 std::string TextNode::toString() const
 {
-	std::stringstream stream;
-	stream << name() << "(" << this->params << ")";
-	return stream.str();
+	return STR(name() << "(" << this->params << ")");
 }
 
 void register_builtin_text()

--- a/src/transform.cc
+++ b/src/transform.cc
@@ -218,7 +218,7 @@ AbstractNode *TransformModule::instantiate(const Context *ctx, const ModuleInsta
 
 std::string TransformNode::toString() const
 {
-	std::stringstream stream;
+	std::ostringstream stream;
 
 	stream << "multmatrix([";
 	for (int j=0;j<4;j++) {

--- a/src/value.cc
+++ b/src/value.cc
@@ -241,7 +241,7 @@ public:
     }
     // attempt to emulate Qt's QString.sprintf("%g"); from old OpenSCAD.
     // see https://github.com/openscad/openscad/issues/158
-    std::stringstream tmp;
+    std::ostringstream tmp;
     tmp.unsetf(std::ios::floatfield);
     tmp << op1;
     return tmp.str();
@@ -256,7 +256,7 @@ public:
   }
 
   std::string operator()(const Value::VectorType &v) const {
-    std::stringstream stream;
+    std::ostringstream stream;
     stream << '[';
     for (size_t i = 0; i < v.size(); i++) {
       if (i > 0) stream << ", ";
@@ -312,7 +312,7 @@ public:
 
 	std::string operator()(const Value::VectorType &v) const
 		{
-			std::stringstream stream;
+			std::ostringstream stream;
 			for (size_t i = 0; i < v.size(); i++) {
 				stream << v[i]->chrString();
 			}
@@ -327,7 +327,7 @@ public:
 				return "";
 			}
 
-			std::stringstream stream;
+			std::ostringstream stream;
 			RangeType range = v;
 			for (RangeType::iterator it = range.begin();it != range.end();it++) {
 				const Value value(*it);


### PR DESCRIPTION
Introduced the STR macro, making quick string construction less verbose:

Constructs like:
```
    std::stringstream stream;
    stream << some << " piped " << data;
    std::string name = stream.str();
```

..becomes:
```
    std::string name = STR(some << " piped " << data);
```
