### PR TITLE
option to disable mouse centric zoom

### DIFF
--- a/src/Preferences.cc
+++ b/src/Preferences.cc
@@ -552,6 +552,7 @@ void Preferences::on_checkBoxMouseCentricZoom_toggled(bool val)
 {
 	Settings::Settings::inst()->set(Settings::Settings::mouseCentricZoom, Value(val));
 	writeSettings();
+	emit updateMouseCentricZoom(val);
 }
 
 void Preferences::on_spinBoxIndentationWidth_valueChanged(int val)

--- a/src/Preferences.cc
+++ b/src/Preferences.cc
@@ -548,6 +548,12 @@ void Preferences::on_checkBoxShowWarningsIn3dView_toggled(bool val)
 	writeSettings();
 }
 
+void Preferences::on_checkBoxMouseCentricZoom_toggled(bool val)
+{
+	Settings::Settings::inst()->set(Settings::Settings::mouseCentricZoom, Value(val));
+	writeSettings();
+}
+
 void Preferences::on_spinBoxIndentationWidth_valueChanged(int val)
 {
 	Settings::Settings::inst()->set(Settings::Settings::indentationWidth, Value(val));
@@ -911,6 +917,7 @@ void Preferences::updateGUI()
 	this->checkBoxHighlightCurrentLine->setChecked(s->get(Settings::Settings::highlightCurrentLine).toBool());
 	this->checkBoxEnableBraceMatching->setChecked(s->get(Settings::Settings::enableBraceMatching).toBool());
 	this->checkBoxShowWarningsIn3dView->setChecked(s->get(Settings::Settings::showWarningsIn3dView).toBool());
+	this->checkBoxMouseCentricZoom->setChecked(s->get(Settings::Settings::mouseCentricZoom).toBool());
 	this->checkBoxEnableLineNumbers->setChecked(s->get(Settings::Settings::enableLineNumbers).toBool());
 	this->spinBoxLineWrapIndentationIndent->setDisabled(this->comboBoxLineWrapIndentationStyle->currentText() == "Same");
 

--- a/src/Preferences.h
+++ b/src/Preferences.h
@@ -109,6 +109,7 @@ signals:
 	void editorTypeChanged(const QString &type);
 	void editorConfigChanged() const;
 	void ExperimentalChanged() const ;
+	void updateMouseCentricZoom(bool state) const;
 
 private:
     Preferences(QWidget *parent = nullptr);

--- a/src/Preferences.h
+++ b/src/Preferences.h
@@ -57,6 +57,7 @@ public slots:
 	void on_enableHardwarningsCheckBox_toggled(bool);
 	void on_enableParameterCheckBox_toggled(bool);
 	void on_checkBoxShowWarningsIn3dView_toggled(bool);
+	void on_checkBoxMouseCentricZoom_toggled(bool);
   //
 	// editor settings
   //

--- a/src/Preferences.ui
+++ b/src/Preferences.ui
@@ -97,6 +97,16 @@
           </property>
          </widget>
         </item>
+        <item>
+         <widget class="QCheckBox" name="checkBoxMouseCentricZoom">
+          <property name="text">
+           <string>mouse centric zoom</string>
+          </property>
+          <property name="checked">
+           <bool>false</bool>
+          </property>
+         </widget>
+        </item>
        </layout>
       </widget>
       <widget class="QWidget" name="pageEditor">

--- a/src/QGLView.cc
+++ b/src/QGLView.cc
@@ -319,7 +319,12 @@ void QGLView::wheelEvent(QWheelEvent *event)
 #else
     const int v = event->delta();
 #endif
-    zoomCursor(pos.x(), pos.y(), v);
+    auto s = Settings::Settings::inst();
+    if(s->get(Settings::Settings::mouseCentricZoom).toBool()){
+        zoomCursor(pos.x(), pos.y(), v);
+    }else{
+        zoom(v, true);
+    }
 }
 
 void QGLView::ZoomIn(void)

--- a/src/QGLView.cc
+++ b/src/QGLView.cc
@@ -319,8 +319,7 @@ void QGLView::wheelEvent(QWheelEvent *event)
 #else
     const int v = event->delta();
 #endif
-    auto s = Settings::Settings::inst();
-    if(s->get(Settings::Settings::mouseCentricZoom).toBool()){
+    if(this->mouseCentricZoom){
         zoomCursor(pos.x(), pos.y(), v);
     }else{
         zoom(v, true);

--- a/src/QGLView.h
+++ b/src/QGLView.h
@@ -57,6 +57,9 @@ public slots:
 #ifdef USE_QOPENGLWIDGET
 	inline void updateGL() { update(); }
 #endif
+	void setMouseCentricZoom(bool var){
+		this->mouseCentricZoom=var;
+	}
 
 public:
 	QLabel *statusLabel;
@@ -75,6 +78,7 @@ private:
 	void init();
 
 	bool mouse_drag_active;
+	bool mouseCentricZoom=true;
 	QPoint last_mouse;
 	QImage frame; // Used by grabFrame() and save()
 

--- a/src/mainwin.cc
+++ b/src/mainwin.cc
@@ -278,6 +278,9 @@ MainWindow::MainWindow(const QString &filename)
 	this->qglview->statusLabel->setMinimumWidth(100);
 	statusBar()->addWidget(this->qglview->statusLabel);
 
+	auto s = Settings::Settings::inst();
+	this->qglview->setMouseCentricZoom(s->get(Settings::Settings::mouseCentricZoom).toBool());
+
 	animate_timer = new QTimer(this);
 	connect(animate_timer, SIGNAL(timeout()), this, SLOT(updateTVal()));
 
@@ -475,6 +478,7 @@ MainWindow::MainWindow(const QString &filename)
 	connect(this->qglview, SIGNAL(doAnimateUpdate()), this, SLOT(animateUpdate()));
 
 	connect(Preferences::inst(), SIGNAL(requestRedraw()), this->qglview, SLOT(updateGL()));
+	connect(Preferences::inst(), SIGNAL(updateMouseCentricZoom(bool)), this->qglview, SLOT(setMouseCentricZoom(bool)));
 	connect(Preferences::inst(), SIGNAL(updateMdiMode(bool)), this, SLOT(updateMdiMode(bool)));
 	connect(Preferences::inst(), SIGNAL(updateReorderMode(bool)), this, SLOT(updateReorderMode(bool)));
 	connect(Preferences::inst(), SIGNAL(updateUndockMode(bool)), this, SLOT(updateUndockMode(bool)));

--- a/src/settings.cc
+++ b/src/settings.cc
@@ -161,6 +161,7 @@ SettingsVisitor::~SettingsVisitor()
  * can be translated.
  */
 SettingsEntry Settings::showWarningsIn3dView("3dview", "showWarningsIn3dView", Value(true), Value(true));
+SettingsEntry Settings::mouseCentricZoom("3dview", "mouseCentricZoom", Value(true), Value(true));
 SettingsEntry Settings::indentationWidth("editor", "indentationWidth", Value(RangeType(1, 16)), Value(4));
 SettingsEntry Settings::tabWidth("editor", "tabWidth", Value(RangeType(1, 16)), Value(4));
 SettingsEntry Settings::lineWrap("editor", "lineWrap", values("None", _("None"), "Char", _("Wrap at character boundaries"), "Word", _("Wrap at word boundaries")), Value("Word"));

--- a/src/settings.h
+++ b/src/settings.h
@@ -36,6 +36,7 @@ class Settings
 {
 public:
     static SettingsEntry showWarningsIn3dView;
+    static SettingsEntry mouseCentricZoom;
     static SettingsEntry indentationWidth;
     static SettingsEntry tabWidth;
     static SettingsEntry lineWrap;


### PR DESCRIPTION
   * http://forum.openscad.org/Turn-on-off-cursor-centered-mouse-wheel-zoom-td25184.html
   * #1857
   * #2611

Maybe it is not a good idea to potentially read the settings multiple times per second.

I personally prefer mouse centric zoom, but I have other issues with the 3D view, so this option is not in my interest, but adding options in general is in my interest.