### PR TITLE
UI Tweaks to Print Service.

### DIFF
--- a/src/PrintInitDialog.cc
+++ b/src/PrintInitDialog.cc
@@ -33,7 +33,7 @@
 PrintInitDialog::PrintInitDialog()
 {
 	setupUi(this);
-	this->radioButtonCancel->setChecked(true);
+	this->radioButtonPrintService->setChecked(true);
 
 	const auto printService = PrintService::inst();
 	QFile html(":/src/PrintInitDialog.html");

--- a/src/PrintInitDialog.ui
+++ b/src/PrintInitDialog.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>493</width>
-    <height>379</height>
+    <width>1100</width>
+    <height>950</height>
    </rect>
   </property>
   <property name="windowTitle">

--- a/src/PrintInitDialog.ui
+++ b/src/PrintInitDialog.ui
@@ -100,13 +100,6 @@
         </property>
        </widget>
       </item>
-      <item>
-       <widget class="QRadioButton" name="radioButtonCancel">
-        <property name="text">
-         <string>Do not upload</string>
-        </property>
-       </widget>
-      </item>
      </layout>
     </widget>
    </item>

--- a/src/PrintService.cc
+++ b/src/PrintService.cc
@@ -38,7 +38,7 @@ PrintService::PrintService()
 		PRINTB("ERROR: %s", e.getErrorMessage().toStdString());
 	}
 	if (enabled) {
-		PRINTB("External print service available: %s (url = %s, upload limit = %d MB)", displayName.toStdString() % infoUrl.toStdString() % fileSizeLimitMB);
+		PRINTB("External print service: %s", displayName.toStdString() );
 	}
 }
 
@@ -117,7 +117,7 @@ const QString PrintService::upload(const QString& fileName, const QString& conte
 	// Due to the base64 encoding having 33% overhead, that should allow for
 	// about 96MB data.
     if (jsonInput.value("file") == QJsonValue::Undefined) {
-		const QString msg = "Could not encode STL into JSON. Perhaps it is too large of a file? Maybe try reducing the model resolution.";
+		const QString msg = "Could not encode STL into JSON. Perhaps it is too large of a file? Try reducing the model resolution.";
         throw NetworkException(QNetworkReply::ProtocolFailure, msg);
 	}
 


### PR DESCRIPTION
This keeps the user from having to manually resize the 3D Print Service dialog box every time it opens.  It is now large enough to show the content.  It also gets rid of a redundant "Do not upload" option that essentially makes the "3D Print" button do nothing at all.  If the user wants to back out, they can always press the cancel button.  Lastly, I made some console output a little more user friendly (IMHO).  