### PR TITLE
Check for empty URL in OctoPrint settings.

### DIFF
--- a/src/OctoPrint.cc
+++ b/src/OctoPrint.cc
@@ -49,6 +49,10 @@ const std::string OctoPrint::apiKey() const
 
 const QJsonDocument OctoPrint::getJsonData(const QString endpoint) const
 {
+	if (url().trimmed().isEmpty()) {
+		throw NetworkException{QNetworkReply::ProtocolFailure, "OctoPrint URL not configured."};
+	}
+
 	auto networkRequest = NetworkRequest<const QJsonDocument>{QUrl{url() + endpoint}, { 200 }, 30};
 
 	return networkRequest.execute(

--- a/src/mainwin.cc
+++ b/src/mainwin.cc
@@ -2149,6 +2149,13 @@ void MainWindow::action3DPrint()
 void MainWindow::sendToOctoPrint()
 {
 #ifdef ENABLE_3D_PRINTING
+	OctoPrint octoPrint;
+
+	if (octoPrint.url().trimmed().isEmpty()) {
+		PRINT("ERROR: OctoPrint connection not configured. Please check preferences.");
+		return;
+	}
+
 	Settings::Settings *s = Settings::Settings::inst();
 	const QString fileFormat = QString::fromStdString(s->get(Settings::Settings::octoPrintFileFormat).toString());
 	FileFormat exportFileFormat{FileFormat::STL};
@@ -2180,7 +2187,6 @@ void MainWindow::sendToOctoPrint()
 
 	exportFileByName(this->root_geom, exportFileFormat, exportFileName.toLocal8Bit().constData(), exportFileName.toUtf8());
 
-	OctoPrint octoPrint;
 	try {
 		this->progresswidget = new ProgressWidget(this);
 		connect(this->progresswidget, SIGNAL(requestShow()), this, SLOT(showProgress()));


### PR DESCRIPTION
More useful error message if no URL is configured.