### PR TITLE
Add the 3Dconnexion Universal Receiver USB id

### DIFF
--- a/src/Preferences.cc
+++ b/src/Preferences.cc
@@ -656,6 +656,12 @@ void Preferences::on_enableRangeCheckBox_toggled(bool state)
 	settings.setValue("advanced/enableParameterRangeCheck", state);
 }
 
+void Preferences::on_enableHidapiTraceCheckBox_toggled(bool checked)
+{
+	Settings::Settings::inst()->set(Settings::Settings::inputEnableDriverHIDAPILog, Value(checked));
+	writeSettings();
+}
+
 void Preferences::on_comboBoxOctoPrintAction_activated(int val)
 {
 	applyComboBox(comboBoxOctoPrintAction, val, Settings::Settings::octoPrintAction);
@@ -828,6 +834,8 @@ QVariant Preferences::getValue(const QString &key) const
 
 void Preferences::updateGUI()
 {
+	const Settings::Settings *s = Settings::Settings::inst();
+
 	QList<QListWidgetItem *> found = 
 		this->colorSchemeChooser->findItems(getValue("3dview/colorscheme").toString(),
 																				Qt::MatchExactly);
@@ -888,8 +896,9 @@ void Preferences::updateGUI()
 	this->enableHardwarningsCheckBox->setChecked(getValue("advanced/enableHardwarnings").toBool());
 	this->enableParameterCheckBox->setChecked(getValue("advanced/enableParameterCheck").toBool());
 	this->enableRangeCheckBox->setChecked(getValue("advanced/enableParameterRangeCheck").toBool());
-	
-	Settings::Settings *s = Settings::Settings::inst();
+
+	this->enableHidapiTraceCheckBox->setChecked(s->get(Settings::Settings::inputEnableDriverHIDAPILog));
+
 	updateComboBox(this->comboBoxLineWrap, Settings::Settings::lineWrap);
 	updateComboBox(this->comboBoxLineWrapIndentationStyle, Settings::Settings::lineWrapIndentationStyle);
 	updateComboBox(this->comboBoxLineWrapVisualizationStart, Settings::Settings::lineWrapVisualizationBegin);

--- a/src/Preferences.h
+++ b/src/Preferences.h
@@ -57,6 +57,7 @@ public slots:
 	void on_enableHardwarningsCheckBox_toggled(bool);
 	void on_enableParameterCheckBox_toggled(bool);
 	void on_enableRangeCheckBox_toggled(bool);
+	void on_enableHidapiTraceCheckBox_toggled(bool);
 	void on_checkBoxShowWarningsIn3dView_toggled(bool);
 	void on_checkBoxMouseCentricZoom_toggled(bool);
   //

--- a/src/Preferences.ui
+++ b/src/Preferences.ui
@@ -27,7 +27,7 @@
     <item row="0" column="0">
      <widget class="QStackedWidget" name="stackedWidget">
       <property name="currentIndex">
-       <number>4</number>
+       <number>5</number>
       </property>
       <widget class="QWidget" name="page3DView">
        <layout class="QVBoxLayout" name="verticalLayout_4">
@@ -1771,7 +1771,7 @@
                <item>
                 <widget class="QCheckBox" name="enableRangeCheckBox">
                  <property name="text">
-                  <string>check the parameter range for builtin modules</string>
+                  <string>Check the parameter range for builtin modules</string>
                  </property>
                  <property name="checked">
                   <bool>false</bool>
@@ -1793,6 +1793,22 @@
                </size>
               </property>
              </spacer>
+            </item>
+            <item>
+             <widget class="QGroupBox" name="groupBox_Debug">
+              <property name="title">
+               <string>Debugging</string>
+              </property>
+              <layout class="QVBoxLayout" name="verticalLayout_16">
+               <item>
+                <widget class="QCheckBox" name="enableHidapiTraceCheckBox">
+                 <property name="text">
+                  <string>Enable tracing of HIDAPI events (requires restart of OpenSCAD)</string>
+                 </property>
+                </widget>
+               </item>
+              </layout>
+             </widget>
             </item>
            </layout>
           </widget>

--- a/src/input/HidApiInputDriver.cc
+++ b/src/input/HidApiInputDriver.cc
@@ -254,18 +254,18 @@ bool HidApiInputDriver::enumerate()
 
 		hid_device *hid_dev;
 
-		LL("P: %04x:%04x %s", info->vendor_id % info->product_id % info->path);
+		LL("P: %04x:%04x | %s", info->vendor_id % info->product_id % info->path);
 		hid_dev = hid_open_path(info->path);
 
 		if (!hid_dev) {
-			LL("O: %04x:%04x %s", info->vendor_id % info->product_id % to_string(info->serial_number));
+			LL("O: %04x:%04x | %s", info->vendor_id % info->product_id % to_string(info->serial_number));
 			hid_dev = hid_open(info->vendor_id, info->product_id, info->serial_number);
 			if (!hid_dev) {
 				continue;
 			}
 		}
 
-		LL("R: %04x:%04x %s", info->vendor_id % info->product_id % to_string(info->serial_number));
+		LL("R: %04x:%04x | %s", info->vendor_id % info->product_id % to_string(info->serial_number));
 		unsigned char buf[BUFLEN];
 		const int len = hid_read_timeout(hid_dev, buf, BUFLEN, 100);
 		LL("?: %d", len);
@@ -278,10 +278,12 @@ bool HidApiInputDriver::enumerate()
 
 		this->dev = dev;
 		this->hid_dev = hid_dev;
+		break;
 	}
 	hid_free_enumeration(info);
-	L("Done enumerating.");
-	return this->hid_dev != nullptr;
+	const bool ret = this->hid_dev != nullptr;
+	LL("Done enumerating (status = %s).", (ret ? "ok" : "failed"));
+	return ret;
 }
 
 bool HidApiInputDriver::open()

--- a/src/input/HidApiInputDriver.cc
+++ b/src/input/HidApiInputDriver.cc
@@ -58,6 +58,8 @@ static const struct device_id device_ids[] = {
     { 0x256f, 0xc631, &HidApiInputDriver::hidapi_decode_axis2, &HidApiInputDriver::hidapi_decode_button2, "3Dconnexion Space Mouse Pro Wireless (cabled)"},
     { 0x256f, 0xc632, &HidApiInputDriver::hidapi_decode_axis2, &HidApiInputDriver::hidapi_decode_button2, "3Dconnexion Space Mouse Pro Wireless"},
     { 0x256f, 0xc635, &HidApiInputDriver::hidapi_decode_axis2, &HidApiInputDriver::hidapi_decode_button2, "3Dconnexion Space Mouse Compact"},
+    // This is reported to be used with a 3Dconnexion Space Mouse Wireless 256f:c62e
+    { 0x256f, 0xc652, &HidApiInputDriver::hidapi_decode_axis2, &HidApiInputDriver::hidapi_decode_button2, "3Dconnexion Universal Receiver"},
     { -1, -1, NULL, NULL, NULL},
 };
 

--- a/src/input/HidApiInputDriver.cc
+++ b/src/input/HidApiInputDriver.cc
@@ -36,6 +36,7 @@
 
 #include <boost/format.hpp>
 
+#include "settings.h"
 #include "PlatformUtils.h"
 #include "input/HidApiInputDriver.h"
 #include "input/InputDriverManager.h"
@@ -292,7 +293,10 @@ std::pair<hid_device *, const struct device_id *> HidApiInputDriver::enumerate()
 
 bool HidApiInputDriver::open()
 {
-	logstream.open(PlatformUtils::backupPath() + "/hidapi.log");
+	const auto *s = Settings::Settings::inst();
+	if (s->get(Settings::Settings::inputEnableDriverHIDAPILog).toBool()) {
+		logstream.open(PlatformUtils::backupPath() + "/hidapi.log");
+	}
 
 	HIDAPI_LOG("HidApiInputDriver::open()");
     if (hid_init() < 0) {

--- a/src/input/HidApiInputDriver.cc
+++ b/src/input/HidApiInputDriver.cc
@@ -87,7 +87,7 @@ static void hidapi_log(boost::format format) {
 static void hidapi_log_input(unsigned char *buf, int len)
 {
 	if (logstream) {
-		std::stringstream s;
+		std::ostringstream s;
 
 		s << (boost::format("R: %1$2d/%1$02x:") % len).str();
 		for (int idx = 0;idx < len;idx++) {
@@ -288,7 +288,7 @@ std::pair<hid_device *, const struct device_id *> HidApiInputDriver::enumerate()
 	}
 	hid_free_enumeration(info);
 	HIDAPI_LOGP("Done enumerating (status = %s).", (ret_hid_dev != nullptr ? "ok" : "failed"));
-	return std::make_pair(ret_hid_dev, ret_dev);
+	return {ret_hid_dev, ret_dev};
 }
 
 bool HidApiInputDriver::open()

--- a/src/input/HidApiInputDriver.h
+++ b/src/input/HidApiInputDriver.h
@@ -26,7 +26,7 @@
 
 #pragma once
 
-#include <tuple>
+#include <utility>
 #include <hidapi.h>
 
 #include "input/InputDriver.h"

--- a/src/input/HidApiInputDriver.h
+++ b/src/input/HidApiInputDriver.h
@@ -26,6 +26,7 @@
 
 #pragma once
 
+#include <tuple>
 #include <hidapi.h>
 
 #include "input/InputDriver.h"
@@ -54,7 +55,7 @@ public:
     void hidapi_decode_button2(const unsigned char *buf, unsigned int len);
 
 private:
-	bool enumerate();
+	std::pair<hid_device *, const struct device_id *> enumerate() const;
     void hidapi_input(hid_device* hid_dev);
 };
 

--- a/src/input/HidApiInputDriver.h
+++ b/src/input/HidApiInputDriver.h
@@ -54,6 +54,7 @@ public:
     void hidapi_decode_button2(const unsigned char *buf, unsigned int len);
 
 private:
+	bool enumerate();
     void hidapi_input(hid_device* hid_dev);
 };
 

--- a/src/settings.cc
+++ b/src/settings.cc
@@ -128,12 +128,12 @@ SettingsEntry* Settings::getSettingEntryByName(const std::string &name)
 	return nullptr;
 }
 
-const Value &Settings::defaultValue(const SettingsEntry& entry)
+const Value &Settings::defaultValue(const SettingsEntry& entry) const
 {
 	return entry._default;
 }
 
-const Value &Settings::get(const SettingsEntry& entry)
+const Value &Settings::get(const SettingsEntry& entry) const
 {
 	return entry._value;
 }

--- a/src/settings.cc
+++ b/src/settings.cc
@@ -189,6 +189,7 @@ SettingsEntry Settings::octoPrintSlicerProfile("printing", "octoPrintSlicerProfi
 SettingsEntry Settings::octoPrintSlicerProfileDesc("printing", "octoPrintSlicerProfileDesc", Value(""), Value(""));
 
 SettingsEntry Settings::inputEnableDriverHIDAPI("input", "enableDriverHIDAPI", Value(true), Value(false));
+SettingsEntry Settings::inputEnableDriverHIDAPILog("input", "enableDriverHIDAPILog", Value(true), Value(false));
 SettingsEntry Settings::inputEnableDriverSPNAV("input", "enableDriverSPNAV", Value(true), Value(false));
 SettingsEntry Settings::inputEnableDriverJOYSTICK("input", "enableDriverJOYSTICK", Value(true), Value(false));
 SettingsEntry Settings::inputEnableDriverQGAMEPAD("input", "enableDriverQGAMEPAD", Value(true), Value(false));

--- a/src/settings.h
+++ b/src/settings.h
@@ -64,6 +64,7 @@ public:
 	static SettingsEntry octoPrintSlicerProfileDesc;
 
     static SettingsEntry inputEnableDriverHIDAPI;
+    static SettingsEntry inputEnableDriverHIDAPILog;
     static SettingsEntry inputEnableDriverSPNAV;
     static SettingsEntry inputEnableDriverJOYSTICK;
     static SettingsEntry inputEnableDriverQGAMEPAD;

--- a/src/settings.h
+++ b/src/settings.h
@@ -131,8 +131,8 @@ public:
     void visit(class SettingsVisitor& visitor);
     SettingsEntry* getSettingEntryByName(const std::string &name);
 
-    const Value &defaultValue(const SettingsEntry& entry);
-    const Value &get(const SettingsEntry& entry);
+    const Value &defaultValue(const SettingsEntry& entry) const;
+    const Value &get(const SettingsEntry& entry) const;
     void set(SettingsEntry& entry, const Value &val);
 
 private:


### PR DESCRIPTION
So we could not get the Universal Receiver to work yet, but the tracing code is updated to be mergable and has a Preferences setting to enable/disable.

Logging goes to `${BACKUP_DIR}/hidapi.log` and is limited to max file size of 20k.

Lets merge this and maybe get additional feedback. Also it hopefully helps to get the SpaceMouse Compact running on MacOS (#2810).