### PR TITLE
option to enable rotate2 for the mouse

### DIFF
--- a/releases/2018.XX.md
+++ b/releases/2018.XX.md
@@ -25,6 +25,9 @@
    * various new warnings
    * warn when a parameter passed to an buildin module is out of range
      (e.g. 0>=, not a number, infinitie)
+* mouse control of the 3D View
+   * centric zoom
+   * option to use alternate rotate implementation
 
 **Bugfixes/improvements:**
 * Align camera behavior and lighting between GUI and and command line (#2491)

--- a/src/Preferences.cc
+++ b/src/Preferences.cc
@@ -539,6 +539,13 @@ void Preferences::on_checkBoxMouseCentricZoom_toggled(bool val)
 	emit updateMouseCentricZoom(val);
 }
 
+void Preferences::on_checkBoxRotate2_toggled(bool val)
+{
+	Settings::Settings::inst()->set(Settings::Settings::mouseRotate2, Value(val));
+	writeSettings();
+	emit updateUseRotate2(val);
+}
+
 void Preferences::on_spinBoxIndentationWidth_valueChanged(int val)
 {
 	Settings::Settings::inst()->set(Settings::Settings::indentationWidth, Value(val));
@@ -910,6 +917,7 @@ void Preferences::updateGUI()
 	this->checkBoxEnableBraceMatching->setChecked(s->get(Settings::Settings::enableBraceMatching).toBool());
 	this->checkBoxShowWarningsIn3dView->setChecked(s->get(Settings::Settings::showWarningsIn3dView).toBool());
 	this->checkBoxMouseCentricZoom->setChecked(s->get(Settings::Settings::mouseCentricZoom).toBool());
+	this->checkBoxRotate2->setChecked(s->get(Settings::Settings::mouseRotate2).toBool());
 	this->checkBoxEnableLineNumbers->setChecked(s->get(Settings::Settings::enableLineNumbers).toBool());
 	this->spinBoxLineWrapIndentationIndent->setDisabled(this->comboBoxLineWrapIndentationStyle->currentText() == "Same");
 

--- a/src/Preferences.h
+++ b/src/Preferences.h
@@ -59,6 +59,7 @@ public slots:
 	void on_enableRangeCheckBox_toggled(bool);
 	void on_checkBoxShowWarningsIn3dView_toggled(bool);
 	void on_checkBoxMouseCentricZoom_toggled(bool);
+	void on_checkBoxRotate2_toggled(bool);
   //
 	// editor settings
   //
@@ -111,6 +112,7 @@ signals:
 	void editorConfigChanged() const;
 	void ExperimentalChanged() const ;
 	void updateMouseCentricZoom(bool state) const;
+	void updateUseRotate2(bool state) const;
 
 private:
     Preferences(QWidget *parent = nullptr);

--- a/src/Preferences.ui
+++ b/src/Preferences.ui
@@ -107,6 +107,16 @@
           </property>
          </widget>
         </item>
+        <item>
+         <widget class="QCheckBox" name="checkBoxRotate2">
+          <property name="text">
+           <string>use rotate2 (viewport relative rotate) for mouse</string>
+          </property>
+          <property name="checked">
+           <bool>false</bool>
+          </property>
+         </widget>
+        </item>
        </layout>
       </widget>
       <widget class="QWidget" name="pageEditor">

--- a/src/QGLView.cc
+++ b/src/QGLView.cc
@@ -254,10 +254,18 @@ void QGLView::mouseMoveEvent(QMouseEvent *event)
       // Left button rotates in xz, Shift-left rotates in xy
       // On Mac, Ctrl-Left is handled as right button on other platforms
       if ((QApplication::keyboardModifiers() & Qt::ShiftModifier) != 0) {
+            if(this->useRotate2){
+                rotate2(dy, dx, 0.0);
+            }else{
                 rotate(dy, dx, 0.0, true);
+            }
 	}
       else {
+            if(this->useRotate2){
+                rotate2(dy, 0.0, dx);
+            }else{
                 rotate(dy, 0.0, dx, true);
+            }
 	}
 
       normalizeAngle(cam.object_rot.x());

--- a/src/QGLView.h
+++ b/src/QGLView.h
@@ -60,6 +60,9 @@ public slots:
 	void setMouseCentricZoom(bool var){
 		this->mouseCentricZoom=var;
 	}
+	void setUseRotate2(bool var){
+		this->useRotate2=var;
+	}
 
 public:
 	QLabel *statusLabel;
@@ -79,6 +82,7 @@ private:
 
 	bool mouse_drag_active;
 	bool mouseCentricZoom=true;
+	bool useRotate2=false;
 	QPoint last_mouse;
 	QImage frame; // Used by grabFrame() and save()
 

--- a/src/mainwin.cc
+++ b/src/mainwin.cc
@@ -280,6 +280,7 @@ MainWindow::MainWindow(const QString &filename)
 
 	auto s = Settings::Settings::inst();
 	this->qglview->setMouseCentricZoom(s->get(Settings::Settings::mouseCentricZoom).toBool());
+	this->qglview->setUseRotate2(s->get(Settings::Settings::mouseRotate2).toBool());
 
 	animate_timer = new QTimer(this);
 	connect(animate_timer, SIGNAL(timeout()), this, SLOT(updateTVal()));
@@ -473,6 +474,7 @@ MainWindow::MainWindow(const QString &filename)
 
 	connect(Preferences::inst(), SIGNAL(requestRedraw()), this->qglview, SLOT(updateGL()));
 	connect(Preferences::inst(), SIGNAL(updateMouseCentricZoom(bool)), this->qglview, SLOT(setMouseCentricZoom(bool)));
+	connect(Preferences::inst(), SIGNAL(updateUseRotate2(bool)), this->qglview, SLOT(setUseRotate2(bool)));
 	connect(Preferences::inst(), SIGNAL(updateMdiMode(bool)), this, SLOT(updateMdiMode(bool)));
 	connect(Preferences::inst(), SIGNAL(updateReorderMode(bool)), this, SLOT(updateReorderMode(bool)));
 	connect(Preferences::inst(), SIGNAL(updateUndockMode(bool)), this, SLOT(updateUndockMode(bool)));

--- a/src/settings.cc
+++ b/src/settings.cc
@@ -162,6 +162,7 @@ SettingsVisitor::~SettingsVisitor()
  */
 SettingsEntry Settings::showWarningsIn3dView("3dview", "showWarningsIn3dView", Value(true), Value(true));
 SettingsEntry Settings::mouseCentricZoom("3dview", "mouseCentricZoom", Value(true), Value(true));
+SettingsEntry Settings::mouseRotate2("3dview", "mouseRotate2", Value(true), Value(false));
 SettingsEntry Settings::indentationWidth("editor", "indentationWidth", Value(RangeType(1, 16)), Value(4));
 SettingsEntry Settings::tabWidth("editor", "tabWidth", Value(RangeType(1, 16)), Value(4));
 SettingsEntry Settings::lineWrap("editor", "lineWrap", values("None", _("None"), "Char", _("Wrap at character boundaries"), "Word", _("Wrap at word boundaries")), Value("Word"));

--- a/src/settings.h
+++ b/src/settings.h
@@ -37,6 +37,7 @@ class Settings
 public:
     static SettingsEntry showWarningsIn3dView;
     static SettingsEntry mouseCentricZoom;
+    static SettingsEntry mouseRotate2;
     static SettingsEntry indentationWidth;
     static SettingsEntry tabWidth;
     static SettingsEntry lineWrap;


### PR DESCRIPTION
The me, rotate2 feels more natural then rotate.

The quickest test for personal preference is to open any model, spin it clockwise, then to turn the model "up side down" and then again spin it clockwise.

The whole data pluming is based on #2693.