### PR TITLE
datetime() built in function

### DIFF
--- a/color-schemes/editor/visualstudio.json
+++ b/color-schemes/editor/visualstudio.json
@@ -35,7 +35,7 @@
     },
     "keywords" : {
         "keyword-set1" : "if else let for module function true false undef include use",
-        "keyword-set2" : "abs sign rands min max sin cos asin acos tan atan atan2 round ceil floor pow sqrt exp len log ln str chr ord concat isundef lookup search version version_num norm cross parent_module dxf_dim dxf_cross",
+        "keyword-set2" : "abs sign rands min max sin cos asin acos tan atan atan2 round ceil floor pow sqrt exp len log ln str chr ord concat isundef lookup search version version_num norm cross parent_module dxf_dim dxf_cross datetime",
         "keyword-set3" : "cube sphere cylinder polyhedron square circle polygon text minkowski hull resize child echo union difference intersection linear_extrude rotate_extrude import group projection render surface scale rotate mirror translate multmatrix color offset children assert"
     }
 }

--- a/releases/2018.XX.md
+++ b/releases/2018.XX.md
@@ -9,6 +9,7 @@
 * Added is_undef() to look up variables silently (#2535)
 * Extended List-Comprehension (#1536)
 * C-Style for in list comprehensions (#1537)
+* add datetime() function
 
 **Program Features:**
 * Support for using 3D-Mouse / Joystick / Gamepad input devices for controlling the 3D view

--- a/src/func.cc
+++ b/src/func.cc
@@ -840,6 +840,22 @@ ValuePtr builtin_is_undef(const Context *, const EvalContext *evalctx)
 	return ValuePtr::undefined;
 }
 
+ValuePtr builtin_datetime(const Context *, const EvalContext *evalctx)
+{
+	time_t now = time(0);
+	tm *ltm = localtime(&now);
+   
+	(void)evalctx; // unusued parameter
+	Value::VectorType val;
+	val.push_back(double(1900 + ltm->tm_year));
+	val.push_back(double(1 +ltm->tm_mon));
+	val.push_back(double(ltm->tm_mday));
+	val.push_back(double(ltm->tm_hour));
+	val.push_back(double(ltm->tm_min));
+	val.push_back(double(ltm->tm_sec));
+	return ValuePtr(val);
+}
+
 void register_builtin_functions()
 {
 	Builtins::init("abs", new BuiltinFunction(&builtin_abs));
@@ -875,4 +891,5 @@ void register_builtin_functions()
 	Builtins::init("cross", new BuiltinFunction(&builtin_cross));
 	Builtins::init("parent_module", new BuiltinFunction(&builtin_parent_module));
 	Builtins::init("is_undef", new BuiltinFunction(&builtin_is_undef));
+	Builtins::init("datetime", new BuiltinFunction(&builtin_datetime));
 }

--- a/src/scadlexer.cpp
+++ b/src/scadlexer.cpp
@@ -13,7 +13,7 @@ ScadLexer::ScadLexer(QObject *parent) : QsciLexerCPP(parent)
 	keywordSet[1] =
 		"abs sign rands min max sin cos asin acos tan atan atan2 "
 		"round ceil floor pow sqrt exp len log ln str chr ord concat is_undef "
-		"lookup search version version_num norm cross parent_module "
+		"datetime lookup search version version_num norm cross parent_module "
 		"dxf_dim dxf_cross";
 
 	// -> used in comments only like /*! \cube */

--- a/testdata/scad/misc/datetime.scad
+++ b/testdata/scad/misc/datetime.scad
@@ -1,0 +1,49 @@
+ver=version();
+now=datetime();
+
+//echo(ver);
+//echo(now);
+
+echo("current date time should be greater then version")
+if(ver[0]<now[0]){
+    //OK - nothing more to compare
+}else if(ver[0]==now[0]){
+    if(ver[1]<now[1]){
+    //OK - nothing more to compare
+    }else if(ver[1]==now[1]){
+        if(ver[2]<=now[2]){
+            //OK - nothing more to compare
+        }else{
+            echo("Current day smaller then build day");
+            echo(ver[2], now[2]);
+        }
+    }else{
+        echo("Current month smaller then build month");
+        echo(ver[1], now[1]);
+    }
+}else{
+    echo("Current year smaller then build year");
+    echo(ver[0], now[0]);
+}
+
+echo("check the range");
+if(2018>now[0]){
+    echo("year before 2018:", now[0]);
+}
+if(1>now[1] || 12<now[1]){
+    echo("month out of range:", vnow[1]);
+}
+if(1>now[2] || 31<now[2]){
+    echo("day out of range:", now[2]);
+}
+if(0>now[3] || 24<now[3]){
+    echo("hour out of range:", now[3]);
+}
+if(0>now[4] || 59<now[4]){
+    echo("minute out of range:", now[4]);
+}
+if(0>now[5] || 60<now[5]){ //60 is the leap second
+    echo("second out of range:", now[5]);
+}
+
+echo("end of datetime tests");

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1035,6 +1035,8 @@ list(APPEND ECHO_FILES ${FUNCTION_FILES} ${MISC_FILES}
             ${CMAKE_SOURCE_DIR}/../testdata/scad/issues/issue1923.scad
             ${CMAKE_SOURCE_DIR}/../testdata/scad/misc/preview_variable.scad
             ${CMAKE_SOURCE_DIR}/../testdata/scad/issues/issue1851-each-fail-on-scalar.scad
+            ${CMAKE_SOURCE_DIR}/../testdata/scad/misc/datetime.scad
+
             )
 
 list(APPEND ASTDUMPTEST_FILES ${MISC_FILES}

--- a/tests/regression/echotest/datetime-expected.echo
+++ b/tests/regression/echotest/datetime-expected.echo
@@ -1,0 +1,3 @@
+ECHO: "current date time should be greater then version"
+ECHO: "check the range"
+ECHO: "end of datetime tests"


### PR DESCRIPTION
The main idea is, that user can use this to add date and time to the model. Having date and time in the model (and the prints) allows the user to know which version of the scad file was used to create a specific print out. 

A bit of a concern is, that it is the current date time. Users might  get the idea to measure time differences, not realizing that due to the multiphase nature of OpenSCAD, that is not as useful as one might think.

The test case is a bit awkward. It does some sanity checks, but  not an actual functional test.