### PR TITLE
add is_list builtin

### DIFF
--- a/src/func.cc
+++ b/src/func.cc
@@ -955,6 +955,22 @@ ValuePtr builtin_is_undef(const Context *ctx, const EvalContext *evalctx)
 	return ValuePtr::undefined;
 }
 
+ValuePtr builtin_is_list(const Context *ctx, const EvalContext *evalctx)
+{
+	if (evalctx->numArgs() == 1) {
+		ValuePtr v = evalctx->getArgValue(0);
+		if (v->type() == Value::ValueType::VECTOR){
+			return ValuePtr(true);
+		}else{
+			return ValuePtr(false);
+		}
+	}else{
+		print_argCnt_warning("is_list", ctx, evalctx);
+	}
+
+	return ValuePtr::undefined;
+}
+
 void register_builtin_functions()
 {
 	Builtins::init("abs", new BuiltinFunction(&builtin_abs));
@@ -990,4 +1006,5 @@ void register_builtin_functions()
 	Builtins::init("cross", new BuiltinFunction(&builtin_cross));
 	Builtins::init("parent_module", new BuiltinFunction(&builtin_parent_module));
 	Builtins::init("is_undef", new BuiltinFunction(&builtin_is_undef));
+	Builtins::init("is_list", new BuiltinFunction(&builtin_is_list));
 }

--- a/testdata/scad/misc/islist-test.scad
+++ b/testdata/scad/misc/islist-test.scad
@@ -1,0 +1,18 @@
+echo("returning true");
+echo(is_list([]));
+echo(is_list([1]));
+echo(is_list([1,2]));
+echo(is_list([true]));
+echo(is_list([1,2,[5,6],"test"]));
+echo("--------");
+echo("returning false");
+echo(is_list(1));
+echo(is_list(1/0));
+echo(is_list(((1/0)/(1/0))));
+echo(is_list("test"));
+echo(is_list(true));
+echo(is_list(false));
+echo("--------");
+echo("causing warnings:");
+echo(is_list());
+echo(is_list(1,2));

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1040,6 +1040,7 @@ list(APPEND ECHO_FILES ${FUNCTION_FILES} ${MISC_FILES}
             ${CMAKE_SOURCE_DIR}/../testdata/scad/misc/errors-warnings-included.scad
             ${CMAKE_SOURCE_DIR}/../testdata/scad/misc/children-warnings-tests.scad
             ${CMAKE_SOURCE_DIR}/../testdata/scad/misc/isundef-test.scad
+            ${CMAKE_SOURCE_DIR}/../testdata/scad/misc/islist-test.scad
             ${CMAKE_SOURCE_DIR}/../testdata/scad/misc/operators-tests.scad
             ${CMAKE_SOURCE_DIR}/../testdata/scad/misc/builtins-calling-vec3vec2.scad
             ${CMAKE_SOURCE_DIR}/../testdata/scad/issues/issue1472.scad

--- a/tests/regression/echotest/islist-test-expected.echo
+++ b/tests/regression/echotest/islist-test-expected.echo
@@ -1,0 +1,20 @@
+ECHO: "returning true"
+ECHO: true
+ECHO: true
+ECHO: true
+ECHO: true
+ECHO: true
+ECHO: "--------"
+ECHO: "returning false"
+ECHO: false
+ECHO: false
+ECHO: false
+ECHO: false
+ECHO: false
+ECHO: false
+ECHO: "--------"
+ECHO: "causing warnings:"
+WARNING: is_list() number of parameters does not match, in file islist-test.scad, line 17
+ECHO: undef
+WARNING: is_list() number of parameters does not match, in file islist-test.scad, line 18
+ECHO: undef


### PR DESCRIPTION
partially addressing #1584, but mainly addressing the mailing list thread "A warning too far?":

> WARNING: length() parameter could not be converted, in file global.scad, line 104
> v = is_undef(len(d)) ? [0, 0, d] : d;
> I think this is the standard OpenSCAD idiom to test if a parameter is a vector or a scalar. Is there any other way to do it?
> I think it is sufficient that taking the length of a scalar gives undef and using undef other than in is_undef() gives a warning, so you can't do it accidentally.
