### PR TITLE
Optimize away group nodes with <=1 children from node idStrings

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -35,6 +35,12 @@ if(EXPERIMENTAL)
   list(APPEND CONFIG_OPTIONS "EXPERIMENTAL")
 endif()
 
+if(IDPREFIX)
+  add_definitions(-DIDPREFIX)
+  list(APPEND CONFIG_OPTIONS "IDPREFIX")
+  message(WARNING "IDPREFIX set, this will negatively affect cache hits")
+endif()
+
 message(STATUS "Configuration: ${CONFIG_OPTIONS}")
 
 set(CMAKE_LIBRARY_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/objects")

--- a/openscad.pro
+++ b/openscad.pro
@@ -68,7 +68,12 @@ deploy {
 snapshot {
   DEFINES += OPENSCAD_SNAPSHOT
 }
-  
+# add CONFIG+=idprefix to the qmake command-line to debug node ID's in csg output
+idprefix {
+  DEFINES += IDPREFIX
+  message("Setting IDPREFIX for csg debugging")
+  warning("Setting IDPREFIX will negatively affect cache hits")
+}  
 macx {
   TARGET = OpenSCAD
 }

--- a/src/CGALCache.cc
+++ b/src/CGALCache.cc
@@ -12,7 +12,7 @@ shared_ptr<const CGAL_Nef_polyhedron> CGALCache::get(const std::string &id) cons
 {
 	const auto &N = this->cache[id]->N;
 #ifdef DEBUG
-	PRINTB("CGAL Cache hit: %1$X (%2% bytes)", id % (N ? N->memsize() : 0));
+	PRINTB("CGAL Cache hit: %s (%d bytes)", id.substr(0, 40) % (N ? N->memsize() : 0));
 #endif
 	return N;
 }
@@ -21,8 +21,8 @@ bool CGALCache::insert(const std::string &id, const shared_ptr<const CGAL_Nef_po
 {
 	auto inserted = this->cache.insert(id, new cache_entry(N), N ? N->memsize() : 0);
 #ifdef DEBUG
-	if (inserted) PRINTB("CGAL Cache insert: %1$X (%2% bytes)", id % (N ? N->memsize() : 0));
-	else PRINTB("CGAL Cache insert failed: %1$X (%2% bytes)", id % (N ? N->memsize() : 0));
+	if (inserted) PRINTB("CGAL Cache insert: %s (%d bytes)", id.substr(0, 40) % (N ? N->memsize() : 0));
+	else PRINTB("CGAL Cache insert failed: %s (%d bytes)", id.substr(0, 40) % (N ? N->memsize() : 0));
 #endif
 	return inserted;
 }

--- a/src/GeometryCache.cc
+++ b/src/GeometryCache.cc
@@ -14,7 +14,7 @@ shared_ptr<const Geometry> GeometryCache::get(const std::string &id) const
 {
 	const auto &geom = this->cache[id]->geom;
 #ifdef DEBUG
-	PRINTDB("Geometry Cache hit: %1$X (%2% bytes)", id % (geom ? geom->memsize() : 0));
+	PRINTDB("Geometry Cache hit: %s (%d bytes)", id.substr(0, 40) % (geom ? geom->memsize() : 0));
 #endif
 	return geom;
 }
@@ -24,10 +24,10 @@ bool GeometryCache::insert(const std::string &id, const shared_ptr<const Geometr
 	auto inserted = this->cache.insert(id, new cache_entry(geom), geom ? geom->memsize() : 0);
 #ifdef DEBUG
 	assert(!dynamic_cast<const CGAL_Nef_polyhedron*>(geom.get()));
-	if (inserted) PRINTDB("Geometry Cache insert: %1$x (%2% bytes)", 
-                         id % (geom ? geom->memsize() : 0));
-	else PRINTDB("Geometry Cache insert failed: %1$x (%2% bytes)",
-                id % (geom ? geom->memsize() : 0));
+	if (inserted) PRINTDB("Geometry Cache insert: %s (%d bytes)",
+                         id.substr(0, 40) % (geom ? geom->memsize() : 0));
+	else PRINTDB("Geometry Cache insert failed: %s (%d bytes)",
+                id.substr(0, 40) % (geom ? geom->memsize() : 0));
 #endif
 	return inserted;
 }

--- a/src/Tree.cc
+++ b/src/Tree.cc
@@ -20,13 +20,12 @@ const std::string Tree::getString(const AbstractNode &node, const std::string &i
 {
 	assert(this->root_node);
 	bool idString = false;
-	bool idPrefix = false;
 
 	// Retrieve a nodecache given a tuple of NodeDumper constructor options
-	NodeCache &nodecache = this->nodecachemap[std::make_tuple(indent,idString,idPrefix)];
+	NodeCache &nodecache = this->nodecachemap[std::make_tuple(indent,idString)];
 
 	if (!nodecache.contains(node)) {
-		NodeDumper dumper(nodecache, this->root_node, indent, idString, idPrefix);
+		NodeDumper dumper(nodecache, this->root_node, indent, idString);
 		dumper.traverse(*this->root_node);
 		assert(nodecache.contains(*this->root_node) &&
 					 "NodeDumper failed to create a cache");
@@ -47,14 +46,13 @@ const std::string Tree::getIdString(const AbstractNode &node) const
 	assert(this->root_node);
 	const std::string indent = "";
 	const bool idString = true;
-	const bool idPrefix = false;
 
 	// Retrieve a nodecache given a tuple of NodeDumper constructor options
-	NodeCache &nodecache = this->nodecachemap[make_tuple(indent,idString,idPrefix)];
+	NodeCache &nodecache = this->nodecachemap[make_tuple(indent,idString)];
 
 	if (!nodecache.contains(node)) {
 		nodecache.clear();
-		NodeDumper dumper(nodecache, this->root_node, indent, idString, idPrefix);
+		NodeDumper dumper(nodecache, this->root_node, indent, idString);
 		dumper.traverse(*this->root_node);
 		assert(nodecache.contains(*this->root_node) &&
 					 "NodeDumper failed to create id cache");

--- a/src/Tree.h
+++ b/src/Tree.h
@@ -26,6 +26,6 @@ public:
 private:
 	const AbstractNode *root_node;
 	// keep a separate nodecache per tuple of NodeDumper constructor parameters
-	mutable std::map<std::tuple<std::string, bool, bool>, NodeCache>  nodecachemap;
+	mutable std::map<std::tuple<std::string, bool>, NodeCache>  nodecachemap;
 	std::string document_path;
 };

--- a/src/cache.h
+++ b/src/cache.h
@@ -176,7 +176,7 @@ void Cache<Key,T>::trim(size_t m)
 		Node *u = n;
 		n = n->p;
 #ifdef DEBUG
-		PRINTB("Trimming cache: %1$X (%2% bytes)", *u->keyPtr % u->c);
+		PRINTB("Trimming cache: %1% (%2% bytes)", u->keyPtr->substr(0, 40) % u->c);
 #endif
 		unlink(*u);
 	}

--- a/src/nodedumper.cc
+++ b/src/nodedumper.cc
@@ -31,9 +31,6 @@ Response GroupNodeChecker::visit(State &state, const GroupNode &node)
 	if (state.isPrefix()) {
 		// create entry for group node, which children may increment
 		this->groupChildCounts.emplace(std::make_pair(node.index(),0));
-		if (node.getChildren().size() == 0) {
-			return Response::PruneTraversal;
-		}
 	} else if (state.isPostfix()) {
 		if ((this->getChildCount(node.index()) > 0) && state.parent()) {
 		    this->incChildCount(state.parent()->index());

--- a/src/nodedumper.cc
+++ b/src/nodedumper.cc
@@ -91,13 +91,19 @@ Response NodeDumper::visit(State &state, const GroupNode &node)
 		if (node.modinst->isBackground()) this->dumpstream << "%";
 		if (node.modinst->isHighlight()) this->dumpstream << "#";
 
+// If IDPREFIX is set, we will output "/*id*/" in front of each node
+// which is useful for debugging.
+#ifdef IDPREFIX
+		if (this->idString) this->dumpstream << "\n";	
+		this->dumpstream << "/*" << node.index() << "*/";
+#endif
+
 		// insert start index
 		this->cache.insertStart(node.index(), this->dumpstream.tellp());
 		
 		if(this->groupChecker.getChildCount(node.index()) > 1) {
 			this->dumpstream << STR(node) << "{";
 		}
-		if (this->idprefix) this->dumpstream << "n" << node.index() << ":";
 		this->currindent++;
 	} else if (state.isPostfix()) {
 		this->currindent--;
@@ -134,6 +140,13 @@ Response NodeDumper::visit(State &state, const AbstractNode &node)
 		if (node.modinst->isBackground()) this->dumpstream << "%";
 		if (node.modinst->isHighlight()) this->dumpstream << "#";
 
+// If IDPREFIX is set, we will output "/*id*/" in front of each node
+// which is useful for debugging.
+#ifdef IDPREFIX
+		if (this->idString) this->dumpstream << "\n";	
+		this->dumpstream << "/*" << node.index() << "*/";
+#endif
+
 		// insert start index
 		this->cache.insertStart(node.index(), this->dumpstream.tellp());
 		
@@ -158,8 +171,6 @@ Response NodeDumper::visit(State &state, const AbstractNode &node)
 				this->dumpstream << " {\n";
 			}
 		}
-
-		if (this->idprefix) this->dumpstream << "n" << node.index() << ":";
 
 		this->currindent++;
 

--- a/src/nodedumper.cc
+++ b/src/nodedumper.cc
@@ -17,7 +17,7 @@ void GroupNodeChecker::incChildCount(int groupNodeIndex) {
 	}
 }
 
-int GroupNodeChecker::getChildCount(int groupNodeIndex) {
+int GroupNodeChecker::getChildCount(int groupNodeIndex) const {
 	auto search = this->groupChildCounts.find(groupNodeIndex);
 	if (search != this->groupChildCounts.end()) {
 		return search->second;
@@ -30,7 +30,7 @@ Response GroupNodeChecker::visit(State &state, const GroupNode &node)
 {
 	if (state.isPrefix()) {
 		// create entry for group node, which children may increment
-		this->groupChildCounts.emplace(std::make_pair(node.index(),0));
+		this->groupChildCounts.emplace(node.index(),0);
 	} else if (state.isPostfix()) {
 		if ((this->getChildCount(node.index()) > 0) && state.parent()) {
 		    this->incChildCount(state.parent()->index());
@@ -99,7 +99,7 @@ Response NodeDumper::visit(State &state, const GroupNode &node)
 		this->cache.insertStart(node.index(), this->dumpstream.tellp());
 		
 		if(this->groupChecker.getChildCount(node.index()) > 1) {
-			this->dumpstream << STR(node) << "{";
+			this->dumpstream << node << "{";
 		}
 		this->currindent++;
 	} else if (state.isPostfix()) {

--- a/src/nodedumper.h
+++ b/src/nodedumper.h
@@ -1,39 +1,69 @@
 #pragma once
 
 #include <string>
-#include <map>
+#include <unordered_map>
 #include <list>
 #include "NodeVisitor.h"
 #include "node.h"
 #include "nodecache.h"
 
 
+// GroupNodeChecker does a quick first pass to count children of group nodes
+// If a GroupNode has 0 children, don't include in node id strings
+// If a GroupNode has 1 child, we replace it with its child
+// This makes id strings much more compact for deeply nested trees, recursive scad scripts,
+// and increases likelihood of node cache hits.
+class GroupNodeChecker : public NodeVisitor 
+{
+public:
+    GroupNodeChecker(){}
+
+    Response visit(State &state, const AbstractNode &node) override;
+    Response visit(State &state, const GroupNode &node) override;
+    //Response visit(State &state, const RootNode &node) override;
+    void incChildCount(int groupNodeIndex);
+    int getChildCount(int groupNodeIndex);
+    void reset() { groupChildCounts.clear(); }
+
+private:
+    // stores <node_idx,nonEmptyChildCount> for each group node
+    std::unordered_map<int, int> groupChildCounts;
+};
+
 class NodeDumper : public NodeVisitor
 {
 public:
-        /*! If idPrefix is true, we will output "n<id>:" in front of each node,
-          which is useful for debugging. */
-        NodeDumper(NodeCache &cache, const AbstractNode *root_node, const std::string& indent, bool idString, bool idPrefix) :
-                cache(cache), indent(indent), idString(idString), idprefix(idPrefix), currindent(0), root(root_node) { }
-        ~NodeDumper() {}
+    /*! If idPrefix is true, we will output "n<id>:" in front of each node,
+    which is useful for debugging. */
+    NodeDumper(NodeCache &cache, const AbstractNode *root_node, const std::string& indent, bool idString, bool idPrefix) :
+            cache(cache), indent(indent), idString(idString), idprefix(idPrefix), currindent(0), root(root_node) { 
+        if (idString) { 
+            groupChecker.reset();
+            groupChecker.traverse(*root);
+        }
+    }
+    ~NodeDumper() {}
 
-        Response visit(State &state, const AbstractNode &node) override;
-        Response visit(State &state, const RootNode &node) override;
+    Response visit(State &state, const AbstractNode &node) override;
+    Response visit(State &state, const GroupNode &node) override;
+    Response visit(State &state, const RootNode &node) override;
 
 private:
-        void initCache();
-        void finalizeCache();
-        bool isCached(const AbstractNode &node) const;
+    void initCache();
+    void finalizeCache();
+    bool isCached(const AbstractNode &node) const;
 
-        NodeCache &cache;
+    NodeCache &cache;
+    // Output Formatting options
+    std::string indent;
+    bool idString;
+    bool idprefix;
 
-        // Output Formatting options
-        std::string indent;
-        bool idString;
-        bool idprefix;
-
-        int currindent;
-        const AbstractNode *root;
-        std::ostringstream dumpstream;
+    int currindent;
+    const AbstractNode *root;
+    GroupNodeChecker groupChecker;
+    std::ostringstream dumpstream;
 
 };
+
+

--- a/src/nodedumper.h
+++ b/src/nodedumper.h
@@ -7,7 +7,6 @@
 #include "node.h"
 #include "nodecache.h"
 
-
 // GroupNodeChecker does a quick first pass to count children of group nodes
 // If a GroupNode has 0 children, don't include in node id strings
 // If a GroupNode has 1 child, we replace it with its child
@@ -33,10 +32,8 @@ private:
 class NodeDumper : public NodeVisitor
 {
 public:
-    /*! If idPrefix is true, we will output "n<id>:" in front of each node,
-    which is useful for debugging. */
-    NodeDumper(NodeCache &cache, const AbstractNode *root_node, const std::string& indent, bool idString, bool idPrefix) :
-            cache(cache), indent(indent), idString(idString), idprefix(idPrefix), currindent(0), root(root_node) { 
+    NodeDumper(NodeCache &cache, const AbstractNode *root_node, const std::string& indent, bool idString) :
+            cache(cache), indent(indent), idString(idString), currindent(0), root(root_node) { 
         if (idString) { 
             groupChecker.reset();
             groupChecker.traverse(*root);
@@ -57,7 +54,6 @@ private:
     // Output Formatting options
     std::string indent;
     bool idString;
-    bool idprefix;
 
     int currindent;
     const AbstractNode *root;

--- a/src/nodedumper.h
+++ b/src/nodedumper.h
@@ -19,9 +19,8 @@ public:
 
     Response visit(State &state, const AbstractNode &node) override;
     Response visit(State &state, const GroupNode &node) override;
-    //Response visit(State &state, const RootNode &node) override;
     void incChildCount(int groupNodeIndex);
-    int getChildCount(int groupNodeIndex);
+    int getChildCount(int groupNodeIndex) const;
     void reset() { groupChildCounts.clear(); }
 
 private:
@@ -35,7 +34,6 @@ public:
     NodeDumper(NodeCache &cache, const AbstractNode *root_node, const std::string& indent, bool idString) :
             cache(cache), indent(indent), idString(idString), currindent(0), root(root_node) { 
         if (idString) { 
-            groupChecker.reset();
             groupChecker.traverse(*root);
         }
     }


### PR DESCRIPTION
Note: I had a PR already for this, from my master, but recreated it on its own branch now.  I rebased my fork's master(force push) to match openscad which auto-closed the previous PR #2766 since it has no changes now.

This change reduces duplicate cache entries which can be caused by empty or single child groups.

I also changed idPrefix setting to be a preprocessor define, and reverted the cache debug PRINTB/PRINTDB statements to their previous 40character limit.

Here is some sample code
```
module expensive(test, $fn=40) {
    if (test) 
        echo(test);
    difference()  {
        sphere(10);
        translate([5,0,0]) sphere(10);
    }
}

module test2() {
    expensive();
}

expensive();
expensive("hi");
test2();
if(1) test2();
```

Before
```CGAL Cache insert: difference(){sphere($fn=40,$fa=12,$fs=2,r=10);multmatrix([[1,0,0,5],[0,1,0,0],[0,0,1,0],[0,0,0,1]]){sphere($fn=40,$fa=12,$fs=2,r=10);}} (2163808 bytes)
CGAL Cache hit: difference(){sphere($fn=40,$fa=12,$fs=2,r=10);multmatrix([[1,0,0,5],[0,1,0,0],[0,0,1,0],[0,0,0,1]]){sphere($fn=40,$fa=12,$fs=2,r=10);}} (2163808 bytes)
CGAL Cache hit: difference(){sphere($fn=40,$fa=12,$fs=2,r=10);multmatrix([[1,0,0,5],[0,1,0,0],[0,0,1,0],[0,0,0,1]]){sphere($fn=40,$fa=12,$fs=2,r=10);}} (2163808 bytes)
CGAL Cache insert: group(){group();difference(){sphere($fn=40,$fa=12,$fs=2,r=10);multmatrix([[1,0,0,5],[0,1,0,0],[0,0,1,0],[0,0,0,1]]){sphere($fn=40,$fa=12,$fs=2,r=10);}}} (2163808 bytes)
CGAL Cache hit: group(){group();difference(){sphere($fn=40,$fa=12,$fs=2,r=10);multmatrix([[1,0,0,5],[0,1,0,0],[0,0,1,0],[0,0,0,1]]){sphere($fn=40,$fa=12,$fs=2,r=10);}}} (2163808 bytes)
CGAL Cache insert: group(){group(){group();difference(){sphere($fn=40,$fa=12,$fs=2,r=10);multmatrix([[1,0,0,5],[0,1,0,0],[0,0,1,0],[0,0,0,1]]){sphere($fn=40,$fa=12,$fs=2,r=10);}}}} (2163808 bytes)
CGAL Cache insert: group(){group(){group();}difference(){sphere($fn=40,$fa=12,$fs=2,r=10);multmatrix([[1,0,0,5],[0,1,0,0],[0,0,1,0],[0,0,0,1]]){sphere($fn=40,$fa=12,$fs=2,r=10);}}} (2163808 bytes)
CGAL Cache insert: group(){group(){group(){group();difference(){sphere($fn=40,$fa=12,$fs=2,r=10);multmatrix([[1,0,0,5],[0,1,0,0],[0,0,1,0],[0,0,0,1]]){sphere($fn=40,$fa=12,$fs=2,r=10);}}}}} (2163808 bytes)
CGAL Cache insert: group(){group();difference(){sphere($fn=40,$fa=12,$fs=2,r=10);multmatrix([[1,0,0,5],[0,1,0,0],[0,0,1,0],[0,0,0,1]]){sphere($fn=40,$fa=12,$fs=2,r=10);}}}group(){group(){group();}difference(){sphere($fn=40,$fa=12,$fs=2,r=10);multmatrix([[1,0,0,5],[0,1,0,0],[0,0,1,0],[0,0,0,1]]){sphere($fn=40,$fa=12,$fs=2,r=10);}}}group(){group(){group();difference(){sphere($fn=40,$fa=12,$fs=2,r=10);multmatrix([[1,0,0,5],[0,1,0,0],[0,0,1,0],[0,0,0,1]]){sphere($fn=40,$fa=12,$fs=2,r=10);}}}}group(){group(){group(){group();difference(){sphere($fn=40,$fa=12,$fs=2,r=10);multmatrix([[1,0,0,5],[0,1,0,0],[0,0,1,0],[0,0,0,1]]){sphere($fn=40,$fa=12,$fs=2,r=10);}}}}} (2163808 bytes)
Geometries in cache: 4
Geometry cache size in bytes: 223024
CGAL Polyhedrons in cache: 6
CGAL cache size in bytes: 12982848
Total rendering time: 0 hours, 0 minutes, 17 seconds
Top level object is a 3D object:
Simple: yes
Vertices: 918
Halfedges: 5032
Edges: 2516
Halffacets: 3200
Facets: 1600
Volumes: 2
Rendering finished.
```

After (this result was without the 40 char limit, for clarity)
```
CGAL Cache insert: difference(){sphere($fn=40,$fa=12,$fs=2,r=10);multmatrix([[1,0,0,5],[0,1,0,0],[0,0,1,0],[0,0,0,1]]){sphere($fn=40,$fa=12,$fs=2,r=10);}} (2163808 bytes)
CGAL Cache hit: difference(){sphere($fn=40,$fa=12,$fs=2, (2163808 bytes)
CGAL Cache hit: difference(){sphere($fn=40,$fa=12,$fs=2, (2163808 bytes)
CGAL Cache hit: difference(){sphere($fn=40,$fa=12,$fs=2, (2163808 bytes)
CGAL Cache insert: difference(){sphere($fn=40,$fa=12,$fs=2,r=10);multmatrix([[1,0,0,5],[0,1,0,0],[0,0,1,0],[0,0,0,1]]){sphere($fn=40,$fa=12,$fs=2,r=10);}}difference(){sphere($fn=40,$fa=12,$fs=2,r=10);multmatrix([[1,0,0,5],[0,1,0,0],[0,0,1,0],[0,0,0,1]]){sphere($fn=40,$fa=12,$fs=2,r=10);}}difference(){sphere($fn=40,$fa=12,$fs=2,r=10);multmatrix([[1,0,0,5],[0,1,0,0],[0,0,1,0],[0,0,0,1]]){sphere($fn=40,$fa=12,$fs=2,r=10);}}difference(){sphere($fn=40,$fa=12,$fs=2,r=10);multmatrix([[1,0,0,5],[0,1,0,0],[0,0,1,0],[0,0,0,1]]){sphere($fn=40,$fa=12,$fs=2,r=10);}} (2163808 bytes)
Geometries in cache: 3
Geometry cache size in bytes: 223024
CGAL Polyhedrons in cache: 2
CGAL cache size in bytes: 4327616
Total rendering time: 0 hours, 0 minutes, 17 seconds
Top level object is a 3D object:
Simple: yes
Vertices: 918
Halfedges: 5032
Edges: 2516
Halffacets: 3200
Facets: 1600
Volumes: 2
Rendering finished.
```


Right now this only affects the `getIdString` for nodes, not CSG export. With some small tweaks I could change it to do that also. I think it would be nice, but not sure if others agree.
Also that would require massive updates to expected test results, and didn't want to stir things up too much.