### PR TITLE
Inputdriver UI: grayout irrelevant UI elements

### DIFF
--- a/src/Preferences.cc
+++ b/src/Preferences.cc
@@ -292,6 +292,7 @@ void Preferences::on_stackedWidget_currentChanged(int)
 {
 	hidePasswords();
 	this->labelOctoPrintCheckConnection->setText("");
+	this->AxisConfig->updateStates();
 }
 
 /**

--- a/src/Preferences.cc
+++ b/src/Preferences.cc
@@ -293,6 +293,7 @@ void Preferences::on_stackedWidget_currentChanged(int)
 	hidePasswords();
 	this->labelOctoPrintCheckConnection->setText("");
 	this->AxisConfig->updateStates();
+	this->ButtonConfig->updateStates();
 }
 
 /**

--- a/src/input/AxisConfigWidget.cc
+++ b/src/input/AxisConfigWidget.cc
@@ -162,7 +162,7 @@ void AxisConfigWidget::init() {
 		progressbar->setAlignment(Qt::AlignCenter);
 	}
 
-	initizalied = true;
+	initialized = true;
 }
 
 void AxisConfigWidget::on_comboBoxTranslationX_activated(int val)
@@ -441,7 +441,7 @@ void AxisConfigWidget::on_AxisTrimReset()
 
 void AxisConfigWidget::on_checkBoxHIDAPI_toggled(bool val)
 {
-	if(initizalied){
+	if(initialized){
 		Settings::Settings::inst()->set(Settings::Settings::inputEnableDriverHIDAPI, Value(val));
 		writeSettings();
 
@@ -453,7 +453,7 @@ void AxisConfigWidget::on_checkBoxHIDAPI_toggled(bool val)
 
 void AxisConfigWidget::on_checkBoxSpaceNav_toggled(bool val)
 {
-	if(initizalied){
+	if(initialized){
 		Settings::Settings::inst()->set(Settings::Settings::inputEnableDriverSPNAV, Value(val));
 		writeSettings();
 		QFont font;
@@ -464,7 +464,7 @@ void AxisConfigWidget::on_checkBoxSpaceNav_toggled(bool val)
 
 void AxisConfigWidget::on_checkBoxJoystick_toggled(bool val)
 {
-	if(initizalied){
+	if(initialized){
 		Settings::Settings::inst()->set(Settings::Settings::inputEnableDriverJOYSTICK, Value(val));
 		writeSettings();
 		QFont font;
@@ -475,7 +475,7 @@ void AxisConfigWidget::on_checkBoxJoystick_toggled(bool val)
 
 void AxisConfigWidget::on_checkBoxQGamepad_toggled(bool val)
 {
-	if(initizalied){
+	if(initialized){
 		Settings::Settings::inst()->set(Settings::Settings::inputEnableDriverQGAMEPAD, Value(val));
 		writeSettings();
 		QFont font;
@@ -486,7 +486,7 @@ void AxisConfigWidget::on_checkBoxQGamepad_toggled(bool val)
 
 void AxisConfigWidget::on_checkBoxDBus_toggled(bool val)
 {
-	if(initizalied){
+	if(initialized){
 		Settings::Settings::inst()->set(Settings::Settings::inputEnableDriverDBUS, Value(val));
 		writeSettings();
 		QFont font;
@@ -569,9 +569,9 @@ void AxisConfigWidget::initComboBox(QComboBox *comboBox, const Settings::Setting
 }
 
 void AxisConfigWidget::updateStates(){
-	if(!initizalied) return;
+	if(!initialized) return;
 
-	int cnt = InputDriverManager::instance()->getAxisCnt();
+	int cnt = InputDriverManager::instance()->getAxisCount();
 	for (int i=0;i<9;i++) {
 		auto progressbar = this->findChild<QProgressBar *>(QString("progressBarAxis%1").arg(i));
 		if( cnt <= i){

--- a/src/input/AxisConfigWidget.cc
+++ b/src/input/AxisConfigWidget.cc
@@ -139,8 +139,6 @@ void AxisConfigWidget::init() {
 	initDoubleSpinBox(this->doubleSpinBoxRotateGain, Settings::Settings::inputRotateGain);
 	initDoubleSpinBox(this->doubleSpinBoxZoomGain, Settings::Settings::inputZoomGain);
 
-	initizalied = true;
-	
 	//use a custom style for the axis indicators,
 	//to prevent getting operating specific
 	//(potentially animated) progressbars
@@ -158,12 +156,13 @@ void AxisConfigWidget::init() {
             "}";
     }
 
-
 	auto progressbars = this->findChildren<QProgressBar *>();
 	for (auto progressbar : progressbars) {
 		progressbar->setStyleSheet(style);
 		progressbar->setAlignment(Qt::AlignCenter);
 	}
+
+	initizalied = true;
 }
 
 void AxisConfigWidget::on_comboBoxTranslationX_activated(int val)
@@ -570,6 +569,8 @@ void AxisConfigWidget::initComboBox(QComboBox *comboBox, const Settings::Setting
 }
 
 void AxisConfigWidget::updateStates(){
+	if(!initizalied) return;
+
 	int cnt = InputDriverManager::instance()->getAxisCnt();
 	for (int i=0;i<9;i++) {
 		auto progressbar = this->findChild<QProgressBar *>(QString("progressBarAxis%1").arg(i));

--- a/src/input/AxisConfigWidget.cc
+++ b/src/input/AxisConfigWidget.cc
@@ -568,3 +568,17 @@ void AxisConfigWidget::initComboBox(QComboBox *comboBox, const Settings::Setting
 	}
 	updateComboBox(comboBox, entry);
 }
+
+void AxisConfigWidget::updateStates(){
+	int cnt = InputDriverManager::instance()->getAxisCnt();
+	for (int i=0;i<9;i++) {
+		auto progressbar = this->findChild<QProgressBar *>(QString("progressBarAxis%1").arg(i));
+		if( cnt <= i){
+			progressbar->setEnabled(false);
+			progressbar->setMinimum(0);
+		}else{
+			progressbar->setEnabled(true);
+			progressbar->setMinimum(-100);
+		}
+	}
+}

--- a/src/input/AxisConfigWidget.h
+++ b/src/input/AxisConfigWidget.h
@@ -88,7 +88,7 @@ private:
 	void applyComboBox(QComboBox *comboBox, int val, Settings::SettingsEntry& entry);
 	void writeSettings();
 	
-	bool initizalied = false;
+	bool initialized = false;
 
 	QString NotEnabledDuringBuild =_("This driver was not enabled during build time and is thus not available.");
 

--- a/src/input/AxisConfigWidget.h
+++ b/src/input/AxisConfigWidget.h
@@ -15,6 +15,8 @@ public:
 	void AxesChanged(int nr, double val) const;
 	void init();
 
+	void updateStates();
+
 public slots:
 	// Input Driver
         void on_AxisTrim();

--- a/src/input/ButtonConfigWidget.cc
+++ b/src/input/ButtonConfigWidget.cc
@@ -42,10 +42,7 @@ ButtonConfigWidget::~ButtonConfigWidget()
 }
 
 void ButtonConfigWidget::updateButtonState(int nr, bool pressed) const{
-	QString style = ButtonConfigWidget::EmptyString;
-	if(pressed){
-		style=ButtonConfigWidget::ActivestyleString;
-	}
+	QString style = pressed ? ButtonConfigWidget::ActiveStyleString : ButtonConfigWidget::EmptyString;
 	std::string number = std::to_string(nr);
 
 	auto label = this->findChild<QLabel *>(QString::fromStdString("labelInputButton"+number));

--- a/src/input/ButtonConfigWidget.cc
+++ b/src/input/ButtonConfigWidget.cc
@@ -233,10 +233,7 @@ void ButtonConfigWidget::updateStates(){
 	int cnt = InputDriverManager::instance()->getButtonCount();
 	for (int i=0;i<16;i++) {
 		auto label = this->findChild<QLabel *>(QString("labelInputButton%1").arg(i));
-		QString style = ButtonConfigWidget::EmptyString;
-		if( cnt <= i){
-			style = ButtonConfigWidget::DisabledstyleString;
-		}
+		QString style =(cnt <= i) ? ButtonConfigWidget::DisabledStyleString : ButtonConfigWidget::EmptyString;
 		label->setStyleSheet(style);
 	}
 }

--- a/src/input/ButtonConfigWidget.cc
+++ b/src/input/ButtonConfigWidget.cc
@@ -42,15 +42,15 @@ ButtonConfigWidget::~ButtonConfigWidget()
 }
 
 void ButtonConfigWidget::updateButtonState(int nr, bool pressed) const{
-	QString Style = ButtonConfigWidget::EmptyString;
+	QString style = ButtonConfigWidget::EmptyString;
 	if(pressed){
-		Style=ButtonConfigWidget::ActiveStyleString;
+		style=ButtonConfigWidget::ActivestyleString;
 	}
 	std::string number = std::to_string(nr);
 
 	auto label = this->findChild<QLabel *>(QString::fromStdString("labelInputButton"+number));
 	if(label==nullptr) return;
-	label->setStyleSheet(Style);
+	label->setStyleSheet(style);
 }
 
 void ButtonConfigWidget::init() {
@@ -69,7 +69,7 @@ void ButtonConfigWidget::init() {
 		comboBox->installEventFilter(wheelIgnorer);
 	}
 
-	initizalied = true;
+	initialized = true;
 }
 
 void ButtonConfigWidget::on_comboBoxButton0_activated(int val)
@@ -228,15 +228,15 @@ void ButtonConfigWidget::initComboBox(QComboBox *comboBox, const Settings::Setti
 }
 
 void ButtonConfigWidget::updateStates(){
-	if(!initizalied) return;
+	if(!initialized) return;
 
-	int cnt = InputDriverManager::instance()->getButtonCnt();
+	int cnt = InputDriverManager::instance()->getButtonCount();
 	for (int i=0;i<16;i++) {
 		auto label = this->findChild<QLabel *>(QString("labelInputButton%1").arg(i));
-		QString Style = ButtonConfigWidget::EmptyString;
+		QString style = ButtonConfigWidget::EmptyString;
 		if( cnt <= i){
-			Style = ButtonConfigWidget::DisabledStyleString;
+			style = ButtonConfigWidget::DisabledstyleString;
 		}
-		label->setStyleSheet(Style);
+		label->setStyleSheet(style);
 	}
 }

--- a/src/input/ButtonConfigWidget.cc
+++ b/src/input/ButtonConfigWidget.cc
@@ -224,3 +224,15 @@ void ButtonConfigWidget::initComboBox(QComboBox *comboBox, const Settings::Setti
 
 	updateComboBox(comboBox, entry);
 }
+
+void ButtonConfigWidget::updateStates(){
+	int cnt = InputDriverManager::instance()->getButtonCnt();
+	for (int i=0;i<16;i++) {
+		auto label = this->findChild<QLabel *>(QString("labelInputButton%1").arg(i));
+		QString Style = ButtonConfigWidget::EmptyString;
+		if( cnt <= i){
+			Style = ButtonConfigWidget::DisabledStyleString;
+		}
+		label->setStyleSheet(Style);
+	}
+}

--- a/src/input/ButtonConfigWidget.cc
+++ b/src/input/ButtonConfigWidget.cc
@@ -68,6 +68,8 @@ void ButtonConfigWidget::init() {
 	for (auto comboBox : comboBoxes) {
 		comboBox->installEventFilter(wheelIgnorer);
 	}
+
+	initizalied = true;
 }
 
 void ButtonConfigWidget::on_comboBoxButton0_activated(int val)
@@ -226,6 +228,8 @@ void ButtonConfigWidget::initComboBox(QComboBox *comboBox, const Settings::Setti
 }
 
 void ButtonConfigWidget::updateStates(){
+	if(!initizalied) return;
+
 	int cnt = InputDriverManager::instance()->getButtonCnt();
 	for (int i=0;i<16;i++) {
 		auto label = this->findChild<QLabel *>(QString("labelInputButton%1").arg(i));

--- a/src/input/ButtonConfigWidget.h
+++ b/src/input/ButtonConfigWidget.h
@@ -48,4 +48,6 @@ private:
 	const QString EmptyString= QString("");
 	const QString ActiveStyleString= QString("font-weight: bold; color: red");
 	const QString DisabledStyleString= QString("color: gray");
+
+	bool initizalied = false;
 };

--- a/src/input/ButtonConfigWidget.h
+++ b/src/input/ButtonConfigWidget.h
@@ -46,8 +46,8 @@ private:
 	void writeSettings();
 
 	const QString EmptyString= QString("");
-	const QString ActivestyleString= QString("font-weight: bold; color: red");
-	const QString DisabledstyleString= QString("color: gray");
+	const QString ActiveStyleString= QString("font-weight: bold; color: red");
+	const QString DisabledStyleString= QString("color: gray");
 
 	bool initialized = false;
 };

--- a/src/input/ButtonConfigWidget.h
+++ b/src/input/ButtonConfigWidget.h
@@ -13,6 +13,7 @@ public:
 	virtual ~ButtonConfigWidget();
 	void updateButtonState(int,bool) const;
 	void init();
+	void updateStates();
 
 public slots:
         void on_comboBoxButton0_activated(int val);
@@ -46,4 +47,5 @@ private:
 
 	const QString EmptyString= QString("");
 	const QString ActiveStyleString= QString("font-weight: bold; color: red");
+	const QString DisabledStyleString= QString("color: gray");
 };

--- a/src/input/ButtonConfigWidget.h
+++ b/src/input/ButtonConfigWidget.h
@@ -46,8 +46,8 @@ private:
 	void writeSettings();
 
 	const QString EmptyString= QString("");
-	const QString ActiveStyleString= QString("font-weight: bold; color: red");
-	const QString DisabledStyleString= QString("color: gray");
+	const QString ActivestyleString= QString("font-weight: bold; color: red");
+	const QString DisabledstyleString= QString("color: gray");
 
-	bool initizalied = false;
+	bool initialized = false;
 };

--- a/src/input/HidApiInputDriver.h
+++ b/src/input/HidApiInputDriver.h
@@ -53,6 +53,13 @@ public:
     void hidapi_decode_axis2(const unsigned char *buf, unsigned int len);
     void hidapi_decode_button2(const unsigned char *buf, unsigned int len);
 
+    int getButtonCnt() const override{
+        return 16;
+    }
+    int getAxisCnt() const override{
+        return 6;
+    }
+
 private:
     void hidapi_input(hid_device* hid_dev);
 };

--- a/src/input/HidApiInputDriver.h
+++ b/src/input/HidApiInputDriver.h
@@ -53,10 +53,10 @@ public:
     void hidapi_decode_axis2(const unsigned char *buf, unsigned int len);
     void hidapi_decode_button2(const unsigned char *buf, unsigned int len);
 
-    int getButtonCnt() const override{
+    int getButtonCount() const override{
         return 16;
     }
-    int getAxisCnt() const override{
+    int getAxisCount() const override{
         return 6;
     }
 

--- a/src/input/InputDriver.h
+++ b/src/input/InputDriver.h
@@ -52,6 +52,6 @@ public:
      */
     virtual bool openOnce() const;
 
-    virtual int getButtonCnt() const {return 0;}
-    virtual int getAxisCnt() const {return 0;}
+    virtual int getButtonCount() const {return 0;}
+    virtual int getAxisCount() const {return 0;}
 };

--- a/src/input/InputDriver.h
+++ b/src/input/InputDriver.h
@@ -51,4 +51,7 @@ public:
      * application start. No attempt to re-open is made.
      */
     virtual bool openOnce() const;
+
+    virtual int getButtonCnt() const {return 0;}
+    virtual int getAxisCnt() const {return 0;}
 };

--- a/src/input/InputDriverManager.cc
+++ b/src/input/InputDriverManager.cc
@@ -199,3 +199,19 @@ void InputDriverManager::onInputGainUpdated()
 {
     mapper.onInputGainUpdated();
 }
+int InputDriverManager::getButtonCnt(){
+	int max=0;
+    for (auto driver : drivers) {
+        std::cout << "getButtonCnt driver: "<< driver->getButtonCnt() << "\n";
+        max = std::max(max, driver->getButtonCnt());
+    }
+    return max;
+}
+
+int InputDriverManager::getAxisCnt(){
+	int max=0;
+    for (auto driver : drivers) {
+		max = std::max(max, driver->getAxisCnt());
+    }
+    return max;
+}

--- a/src/input/InputDriverManager.cc
+++ b/src/input/InputDriverManager.cc
@@ -199,19 +199,23 @@ void InputDriverManager::onInputGainUpdated()
 {
     mapper.onInputGainUpdated();
 }
+
 int InputDriverManager::getButtonCnt(){
-	int max=0;
+    int max=0;
     for (auto driver : drivers) {
-        std::cout << "getButtonCnt driver: "<< driver->getButtonCnt() << "\n";
-        max = std::max(max, driver->getButtonCnt());
+        if(driver->isOpen()){
+            max = std::max(max, driver->getButtonCnt());
+        }
     }
     return max;
 }
 
 int InputDriverManager::getAxisCnt(){
-	int max=0;
+    int max=0;
     for (auto driver : drivers) {
-		max = std::max(max, driver->getAxisCnt());
+        if(driver->isOpen()){
+            max = std::max(max, driver->getAxisCnt());
+        }
     }
     return max;
 }

--- a/src/input/InputDriverManager.cc
+++ b/src/input/InputDriverManager.cc
@@ -200,21 +200,21 @@ void InputDriverManager::onInputGainUpdated()
     mapper.onInputGainUpdated();
 }
 
-int InputDriverManager::getButtonCnt(){
+int InputDriverManager::getButtonCount(){
     int max=0;
     for (auto driver : drivers) {
         if(driver->isOpen()){
-            max = std::max(max, driver->getButtonCnt());
+            max = std::max(max, driver->getButtonCount());
         }
     }
     return max;
 }
 
-int InputDriverManager::getAxisCnt(){
+int InputDriverManager::getAxisCount(){
     int max=0;
     for (auto driver : drivers) {
         if(driver->isOpen()){
-            max = std::max(max, driver->getAxisCnt());
+            max = std::max(max, driver->getAxisCount());
         }
     }
     return max;

--- a/src/input/InputDriverManager.h
+++ b/src/input/InputDriverManager.h
@@ -78,8 +78,8 @@ public:
 	QList<double> getTranslation() const;
 	QList<double> getRotation() const;
 	
-	int getButtonCnt();
-	int getAxisCnt();
+	int getButtonCount();
+	int getAxisCount();
 
 public slots:
     void onInputMappingUpdated();

--- a/src/input/InputDriverManager.h
+++ b/src/input/InputDriverManager.h
@@ -77,6 +77,9 @@ public:
 	const std::list<ActionStruct> & getActions() const;
 	QList<double> getTranslation() const;
 	QList<double> getRotation() const;
+	
+	int getButtonCnt();
+	int getAxisCnt();
 
 public slots:
     void onInputMappingUpdated();

--- a/src/input/JoystickInputDriver.h
+++ b/src/input/JoystickInputDriver.h
@@ -39,10 +39,10 @@ public:
     void setJoystickNr(std::string jnr);
 
     int getButtonCnt() const override{
-		return buttons;
+        return buttons;
     }
     int getAxisCnt() const override{
-		return axes;
+        return axes;
     }
 
 private:

--- a/src/input/JoystickInputDriver.h
+++ b/src/input/JoystickInputDriver.h
@@ -38,10 +38,10 @@ public:
     const std::string & get_name() const  override;
     void setJoystickNr(std::string jnr);
 
-    int getButtonCnt() const override{
+    int getButtonCount() const override{
         return buttons;
     }
-    int getAxisCnt() const override{
+    int getAxisCount() const override{
         return axes;
     }
 

--- a/src/input/JoystickInputDriver.h
+++ b/src/input/JoystickInputDriver.h
@@ -38,6 +38,13 @@ public:
     const std::string & get_name() const  override;
     void setJoystickNr(std::string jnr);
 
+    int getButtonCnt() const override{
+		return buttons;
+    }
+    int getAxisCnt() const override{
+		return axes;
+    }
+
 private:
     int fd;
     int version;

--- a/src/input/QGamepadInputDriver.h
+++ b/src/input/QGamepadInputDriver.h
@@ -40,6 +40,14 @@ public:
     void close() override;
 
     const std::string & get_name() const override;
+
+	int getButtonCnt() const override{
+		return 16;
+    }
+	int getAxisCnt() const override{
+		return 6;
+    }
+
 private:
 	std::unique_ptr<QGamepad> gamepad;
 };

--- a/src/input/QGamepadInputDriver.h
+++ b/src/input/QGamepadInputDriver.h
@@ -41,10 +41,10 @@ public:
 
     const std::string & get_name() const override;
 
-    int getButtonCnt() const override{
+    int getButtonCount() const override{
         return 16;
     }
-    int getAxisCnt() const override{
+    int getAxisCount() const override{
         return 6;
     }
 

--- a/src/input/QGamepadInputDriver.h
+++ b/src/input/QGamepadInputDriver.h
@@ -41,11 +41,11 @@ public:
 
     const std::string & get_name() const override;
 
-	int getButtonCnt() const override{
-		return 16;
+    int getButtonCnt() const override{
+        return 16;
     }
-	int getAxisCnt() const override{
-		return 6;
+    int getAxisCnt() const override{
+        return 6;
     }
 
 private:

--- a/src/input/SpaceNavInputDriver.h
+++ b/src/input/SpaceNavInputDriver.h
@@ -42,10 +42,10 @@ public:
 
     const std::string & get_name() const override;
 
-    int getButtonCnt() const override{
+    int getButtonCount() const override{
         return 16;
     };
-    int getAxisCnt() const override{
+    int getAxisCount() const override{
         return 6;
     };
 

--- a/src/input/SpaceNavInputDriver.h
+++ b/src/input/SpaceNavInputDriver.h
@@ -42,12 +42,12 @@ public:
 
     const std::string & get_name() const override;
 
-	int getButtonCnt() const override{
-		return 16;
-	};
-	int getAxisCnt() const override{
-		return 6;
-	};
+    int getButtonCnt() const override{
+        return 16;
+    };
+    int getAxisCnt() const override{
+        return 6;
+    };
 
 private:
     bool spnav_input();

--- a/src/input/SpaceNavInputDriver.h
+++ b/src/input/SpaceNavInputDriver.h
@@ -42,6 +42,13 @@ public:
 
     const std::string & get_name() const override;
 
+	int getButtonCnt() const override{
+		return 16;
+	};
+	int getAxisCnt() const override{
+		return 6;
+	};
+
 private:
     bool spnav_input();
     bool dominantAxisOnly{true};


### PR DESCRIPTION
XBox 360 Controller has 8 axis, meaning axis 0 to 7 are active and 8 is grayed out:
![bildschirmfoto von 2019-02-23 19-04-43-1](https://user-images.githubusercontent.com/24962768/53289982-4300d800-379e-11e9-94f8-ea0ed2ab8d90.png)
XBox 360 Controller has 11 buttons, meaning buttons 0 to 10 are active and 11 to 15 are grayed out:
![bildschirmfoto von 2019-02-23 19-04-55-1](https://user-images.githubusercontent.com/24962768/53289983-45fbc880-379e-11e9-9a6b-8a5cdf1b1aee.png)

I will do a double check on Windows with QGamepad. In QGamepad, the D-Pad is consider 4 more buttons, but that means two axis less.
