### PR TITLE
Speed up handle dependencies

### DIFF
--- a/src/FileModule.cc
+++ b/src/FileModule.cc
@@ -99,9 +99,12 @@ time_t FileModule::include_modified(const IncludeFile &inc) const
 	Check if any dependencies have been modified and recompile them.
 	Returns true if anything was recompiled.
 */
-time_t FileModule::handleDependencies()
+time_t FileModule::handleDependencies(bool is_root)
 {
-	if (this->is_handling_dependencies) return 0;
+	if(is_root)
+		ModuleCache::clear_markers();
+	else
+		if (this->is_handling_dependencies) return 0;
 	this->is_handling_dependencies = true;
 
 	std::vector<std::pair<std::string,std::string>> updates;
@@ -155,7 +158,6 @@ time_t FileModule::handleDependencies()
 		this->usedlibs.erase(files.first);
 		this->usedlibs.insert(files.second);
 	}
-	this->is_handling_dependencies = false;
 	return latest;
 }
 

--- a/src/FileModule.cc
+++ b/src/FileModule.cc
@@ -115,12 +115,10 @@ time_t FileModule::handleDependencies(bool is_root)
 	time_t latest = 0;
 	for (auto filename : this->usedlibs) {
 
-		auto wasmissing = false;
 		auto found = true;
 
 		// Get an absolute filename for the module
 		if (!fs::path(filename).is_absolute()) {
-			wasmissing = true;
 			auto fullpath = find_valid_path(this->path, filename);
 			if (!fullpath.empty()) {
 				auto newfilename = fullpath.generic_string();
@@ -145,10 +143,6 @@ time_t FileModule::handleDependencies(bool is_root)
 			}
 			else {
 				PRINTDB("  %s: %p", filename % oldmodule);
-			}
-			// Only print warning if we're not part of an automatic reload
-			if (!newmodule && !oldmodule && !wasmissing) {
-				PRINTB_NOCACHE("WARNING: Failed to compile library '%s'.", filename);
 			}
 		}
 	}

--- a/src/FileModule.h
+++ b/src/FileModule.h
@@ -24,7 +24,7 @@ public:
 	void registerUse(const std::string path);
 	void registerInclude(const std::string &localpath, const std::string &fullpath);
 	std::time_t includesChanged() const;
-	std::time_t handleDependencies();
+	std::time_t handleDependencies(bool is_root = true);
 	bool hasIncludes() const { return !this->includes.empty(); }
 	bool usesLibraries() const { return !this->usedlibs.empty(); }
 	bool isHandlingDependencies() const { return this->is_handling_dependencies; }
@@ -34,6 +34,7 @@ public:
 	LocalScope scope;
 	typedef std::unordered_set<std::string> ModuleContainer;
 	ModuleContainer usedlibs;
+	bool is_handling_dependencies;
 
 private:
 	struct IncludeFile {
@@ -44,7 +45,6 @@ private:
 
 	typedef std::unordered_map<std::string, struct IncludeFile> IncludeContainer;
 	IncludeContainer includes;
-	bool is_handling_dependencies;
 
 	std::string path;
 	std::string filename;

--- a/src/FileModule.h
+++ b/src/FileModule.h
@@ -28,13 +28,13 @@ public:
 	bool hasIncludes() const { return !this->includes.empty(); }
 	bool usesLibraries() const { return !this->usedlibs.empty(); }
 	bool isHandlingDependencies() const { return this->is_handling_dependencies; }
+	void clearHandlingDependencies() { this->is_handling_dependencies = false; }
 	void setFilename(const std::string &filename) { this->filename = filename; }
 	const std::string &getFilename() const { return this->filename; }
 	const std::string getFullpath() const;
 	LocalScope scope;
 	typedef std::unordered_set<std::string> ModuleContainer;
 	ModuleContainer usedlibs;
-	bool is_handling_dependencies;
 
 private:
 	struct IncludeFile {
@@ -45,6 +45,7 @@ private:
 
 	typedef std::unordered_map<std::string, struct IncludeFile> IncludeContainer;
 	IncludeContainer includes;
+	bool is_handling_dependencies;
 
 	std::string path;
 	std::string filename;

--- a/src/ModuleCache.cc
+++ b/src/ModuleCache.cc
@@ -107,7 +107,7 @@ std::time_t ModuleCache::evaluate(const std::string &mainFile,const std::string 
 		PRINTDB("compiled module: %s", filename);
 		cacheEntry.module = lib_mod;
 		cacheEntry.cache_id = cache_id;
-		if(!found)
+		if(!found && lib_mod)
 			cacheEntry.includes_mtime = lib_mod->includesChanged();
 		print_messages_pop();
 	}
@@ -132,5 +132,6 @@ FileModule *ModuleCache::lookup(const std::string &filename)
 
 void ModuleCache::clear_markers() {
 	for (auto entry : instance()->entries)
-		entry.second.module->clearHandlingDependencies();
+        if(auto lib = entry.second.module)
+            lib->clearHandlingDependencies();
 }

--- a/src/ModuleCache.cc
+++ b/src/ModuleCache.cc
@@ -132,5 +132,5 @@ FileModule *ModuleCache::lookup(const std::string &filename)
 
 void ModuleCache::clear_markers() {
 	for (auto entry : instance()->entries)
-		entry.second.module->is_handling_dependencies = false;
+		entry.second.module->clearHandlingDependencies();
 }

--- a/src/ModuleCache.cc
+++ b/src/ModuleCache.cc
@@ -125,10 +125,7 @@ void ModuleCache::clear()
 
 FileModule *ModuleCache::lookup(const std::string &filename)
 {
-	return isCached(filename) ? this->entries[filename].module : nullptr;
+	auto it = this->entries.find(filename);
+	return it != this->entries.end() ? it->second.module : nullptr;
 }
 
-bool ModuleCache::isCached(const std::string &filename)
-{
-	return this->entries.find(filename) != this->entries.end();
-}

--- a/src/ModuleCache.cc
+++ b/src/ModuleCache.cc
@@ -104,7 +104,7 @@ std::time_t ModuleCache::evaluate(const std::string &mainFile,const std::string 
 		
 		delete cacheEntry.parsed_module;
 		lib_mod = parse(cacheEntry.parsed_module, text, filename, mainFile, false) ? cacheEntry.parsed_module : nullptr;
-		PRINTB("compiled module: %s", filename);
+		PRINTDB("compiled module: %s", filename);
 		cacheEntry.module = lib_mod;
 		cacheEntry.cache_id = cache_id;
 		if(!found)

--- a/src/ModuleCache.h
+++ b/src/ModuleCache.h
@@ -14,7 +14,6 @@ public:
 
 	std::time_t evaluate(const std::string &mainFile, const std::string &filename, class FileModule *&module);
 	class FileModule *lookup(const std::string &filename);
-	bool isCached(const std::string &filename);
 	size_t size() { return this->entries.size(); }
 	void clear();
 

--- a/src/ModuleCache.h
+++ b/src/ModuleCache.h
@@ -16,6 +16,7 @@ public:
 	class FileModule *lookup(const std::string &filename);
 	size_t size() { return this->entries.size(); }
 	void clear();
+	static void clear_markers();
 
 private:
 	ModuleCache() {}

--- a/src/StatCache.cc
+++ b/src/StatCache.cc
@@ -33,7 +33,7 @@
 
 namespace {
 
-const float stale = 0.190;  // Maximum lifetime of a cache entry chosen to be shorter than the automatic reload poll time
+const float stale = 190;  // Maximum lifetime of a cache entry chosen to be shorter than the automatic reload poll time
 
 double millis_clock(void)
 {

--- a/src/StatCache.cc
+++ b/src/StatCache.cc
@@ -33,7 +33,7 @@
 
 namespace {
 
-const float stale = 190;  // Maximum lifetime of a cache entry chosen to be shorter than the automatic reload poll time
+const float stale = 190;  // 190ms, maximum lifetime of a cache entry chosen to be shorter than the automatic reload poll time
 
 double millis_clock(void)
 {

--- a/src/lexer.l
+++ b/src/lexer.l
@@ -144,8 +144,9 @@ use[ \t\r\n]*"<"	{ BEGIN(cond_use); }
           PRINTB("WARNING: Can't open library '%s'.", filename);
           parserlval.text = strdup(filename.c_str());
 	} else {
-          handle_dep(fullpath.generic_string());
-          parserlval.text = strdup(fullpath.string().c_str());
+          auto used_path = fullpath.generic_string();
+          handle_dep(used_path);
+          parserlval.text = strdup(used_path.c_str());
 	}
         return TOK_USE;
     }

--- a/src/mainwin.cc
+++ b/src/mainwin.cc
@@ -625,7 +625,7 @@ MainWindow::MainWindow(const QString &filename)
 	setAcceptDrops(true);
 	clearCurrentOutput();
 
-	this->console->setMaximumBlockCount(500);
+	this->console->setMaximumBlockCount(5000);
 }
 
 void MainWindow::initActionIcon(QAction *action, const char *darkResource, const char *lightResource)
@@ -1969,7 +1969,6 @@ void MainWindow::actionReloadRenderPreview()
 	this->afterCompileSlot = "csgReloadRender";
 	this->procevents = true;
 	this->top_ctx.set_variable("$preview", ValuePtr(true));
-
 	compile(true);
 }
 


### PR DESCRIPTION
Massive speed up in handleDepedencies by only checking each module once.
Fixed StatCache timeout being 1000 times too small since using chrono.
Made module cache paths generic to avoid mixed slashes on Windows.
Stopped double compilation when file is first loaded by initialising the includes time.
Made console buffer 10 times bigger.
