### PR TITLE
Fix missing warning about double assignment

### DIFF
--- a/src/parser.y
+++ b/src/parser.y
@@ -675,7 +675,7 @@ bool parse(FileModule *&module, const std::string& text, const std::string &file
   fs::path parser_sourcefile = fs::absolute(fs::path(filename));
   main_file_folder = parser_sourcefile.parent_path().generic_string();
   lexer_set_parser_sourcefile(parser_sourcefile);
-  mainFilePath = mainFile;
+  mainFilePath = fs::absolute(fs::path(mainFile));
 
   lexerin = NULL;
   parser_error_pos = -1;


### PR DESCRIPTION
Ensure that mainFilePath is an absolute path during parsing.

The logic for generating warnings about double assignment generally
seems to assume relative paths, and in fact mainFilePath is made
absolute in the recursive parse() call for a use <...> statement. So
if mainFilePath is not absolute from the start the code gets confused.

Signed-off-by: Kristian Nielsen <knielsen@knielsen-hq.org>