### PR TITLE
Use an absolute path for OPENSCAD_FONT_PATH in the testsuite

### DIFF
--- a/tests/export_import_pngtest.py
+++ b/tests/export_import_pngtest.py
@@ -119,7 +119,7 @@ if args.format != 'csg':
 create_png_cmd = [args.openscad, newscadfile, '-o', pngfile] + remaining_args
 print('Running OpenSCAD #2:', file=sys.stderr)
 print(' '.join(create_png_cmd), file=sys.stderr)
-fontdir =  os.path.join(os.path.dirname(__file__), "..", "testdata/ttf");
+fontdir = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "testdata/ttf"))
 fontenv = os.environ.copy();
 fontenv["OPENSCAD_FONT_PATH"] = fontdir;
 result = subprocess.call(create_png_cmd, env = fontenv);

--- a/tests/test_cmdline_tool.py
+++ b/tests/test_cmdline_tool.py
@@ -248,7 +248,7 @@ def run_test(testname, cmd, args):
         cmdline = [cmd] + args + [outputname]
         sys.stderr.flush()
         print('run_test() cmdline:', ' '.join(cmdline))
-        fontdir =  os.path.join(os.path.dirname(__file__), "..", "testdata/ttf");
+        fontdir = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "testdata/ttf"))
         fontenv = os.environ.copy()
         fontenv["OPENSCAD_FONT_PATH"] = fontdir
         print('using font directory:', fontdir)


### PR DESCRIPTION
This helps fix a few test failures in Debian packaging, where the
testsuite is run out-of-tree, and where we would otherwise fail to
pick up the correct font file.

Signed-off-by: Kristian Nielsen <knielsen@knielsen-hq.org>