### PR TITLE
Remove backslashes in paths on Windows earlier.

### DIFF
--- a/src/parser.y
+++ b/src/parser.y
@@ -672,8 +672,8 @@ void yyerror (char const *s)
 
 bool parse(FileModule *&module, const std::string& text, const std::string &filename, const std::string &mainFile, int debug)
 {
-  fs::path parser_sourcefile = fs::absolute(fs::path(filename));
-  main_file_folder = parser_sourcefile.parent_path().generic_string();
+  fs::path parser_sourcefile = fs::path(fs::absolute(fs::path(filename)).generic_string());
+  main_file_folder = parser_sourcefile.parent_path().string();
   lexer_set_parser_sourcefile(parser_sourcefile);
   mainFilePath = fs::absolute(fs::path(mainFile));
 
@@ -682,7 +682,7 @@ bool parse(FileModule *&module, const std::string& text, const std::string &file
   parser_input_buffer = text.c_str();
   fileEnded=false;
 
-  rootmodule = new FileModule(main_file_folder, parser_sourcefile.filename().generic_string());
+  rootmodule = new FileModule(main_file_folder, parser_sourcefile.filename().string());
   scope_stack.push(&rootmodule->scope);
   //        PRINTB_NOCACHE("New module: %s %p", "root" % rootmodule);
 

--- a/src/parsersettings.cc
+++ b/src/parsersettings.cc
@@ -71,9 +71,9 @@ static bool check_valid(const fs::path &p, const std::vector<std::string> *openf
 	Returns the absolute path to a valid file, or an empty path if no
 	valid files could be found.
 */
-fs::path find_valid_path(const fs::path &sourcepath, 
-												 const fs::path &localpath,
-												 const std::vector<std::string> *openfilenames)
+fs::path _find_valid_path(const fs::path &sourcepath,
+                          const fs::path &localpath,
+                          const std::vector<std::string> *openfilenames)
 {
 	if (localpath.is_absolute()) {
 		if (check_valid(localpath, openfilenames)) return boosty::canonical(localpath);
@@ -88,6 +88,13 @@ fs::path find_valid_path(const fs::path &sourcepath,
 	return fs::path();
 }
 
+fs::path find_valid_path(const fs::path &sourcepath,
+                         const fs::path &localpath,
+                         const std::vector<std::string> *openfilenames)
+{
+    return fs::path(_find_valid_path(sourcepath, localpath, openfilenames).generic_string());
+}
+
 void parser_init()
 {
 	// Add paths from OPENSCADPATH before adding built-in paths
@@ -97,7 +104,7 @@ void parser_init()
 		std::string sep = PlatformUtils::pathSeparatorChar();
 		typedef boost::split_iterator<std::string::iterator> string_split_iterator;
 		for (string_split_iterator it = boost::make_split_iterator(paths, boost::first_finder(sep, boost::is_iequal())); it != string_split_iterator(); ++it) {
-			add_librarydir(fs::absolute(fs::path(boost::copy_range<std::string>(*it))).string());
+			add_librarydir(fs::absolute(fs::path(boost::copy_range<std::string>(*it))).generic_string());
 		}
 	}
 


### PR DESCRIPTION
Prevents error messages with mixed slashes on Windows.

Boost seems to think file separators should be \ in Windows, which is a pain. I don't know anywhere where they need to backslash inside a C program.