### PR TITLE
Fix AST dump indentation to not lose track after "inlining" a ModuleInstantiation.

### DIFF
--- a/src/ModuleInstantiation.cc
+++ b/src/ModuleInstantiation.cc
@@ -32,9 +32,9 @@ std::string ModuleInstantiation::getAbsolutePath(const std::string &filename) co
 	}
 }
 
-void ModuleInstantiation::print(std::ostream &stream, const std::string &indent) const
+void ModuleInstantiation::print(std::ostream &stream, const std::string &indent, const bool inlined) const
 {
-	stream << indent;
+	if (!inlined) stream << indent;
 	stream << modname + "(";
 	for (size_t i=0; i < this->arguments.size(); i++) {
 		const Assignment &arg = this->arguments[i];
@@ -44,28 +44,27 @@ void ModuleInstantiation::print(std::ostream &stream, const std::string &indent)
 	}
 	if (scope.numElements() == 0) {
 		stream << ");\n";
-	} else if (scope.numElements() == 1) {	
+	} else if (scope.numElements() == 1) {
 		stream << ") ";
-		scope.print(stream, "");
+		scope.print(stream, indent, true);
 	} else {
 		stream << ") {\n";
-		scope.print(stream, indent + "\t");
+		scope.print(stream, indent + "\t", false);
 		stream << indent << "}\n";
 	}
 }
 
-void IfElseModuleInstantiation::print(std::ostream &stream, const std::string &indent) const
+void IfElseModuleInstantiation::print(std::ostream &stream, const std::string &indent, const bool inlined) const
 {
-	ModuleInstantiation::print(stream, indent);
-	stream << indent;
+	ModuleInstantiation::print(stream, indent, inlined);
 	if (else_scope.numElements() > 0) {
 		stream << indent << "else ";
 		if (else_scope.numElements() == 1) {
-			else_scope.print(stream, "");
+			else_scope.print(stream, indent, true);
 		}
 		else {
 			stream << "{\n";
-			else_scope.print(stream, indent + "\t");
+			else_scope.print(stream, indent + "\t", false);
 			stream << indent << "}\n";
 		}
 	}

--- a/src/ModuleInstantiation.h
+++ b/src/ModuleInstantiation.h
@@ -44,8 +44,6 @@ public:
 	~IfElseModuleInstantiation();
 	std::vector<AbstractNode*> instantiateElseChildren(const Context *evalctx) const;
 	void print(std::ostream &stream, const std::string &indent, const bool inlined) const final;
-	void print(std::ostream &stream, const std::string &indent) const final { print(stream, indent, false); };
 
 	LocalScope else_scope;
 };
-

--- a/src/ModuleInstantiation.h
+++ b/src/ModuleInstantiation.h
@@ -13,7 +13,8 @@ public:
 		: ASTNode(loc), arguments(args), tag_root(false), tag_highlight(false), tag_background(false), modname(name), modpath(source_path) { }
 	~ModuleInstantiation();
 
-	virtual void print(std::ostream &stream, const std::string &indent) const;
+	virtual void print(std::ostream &stream, const std::string &indent, const bool inlined) const;
+	void print(std::ostream &stream, const std::string &indent) const override { print(stream, indent, false); };
 	class AbstractNode *evaluate(const class Context *ctx) const;
 	std::vector<AbstractNode*> instantiateChildren(const Context *evalctx) const;
 
@@ -42,7 +43,8 @@ public:
 	IfElseModuleInstantiation(shared_ptr<class Expression> expr, const std::string &source_path, const Location &loc) : ModuleInstantiation("if", AssignmentList{Assignment("", expr)}, source_path, loc) { }
 	~IfElseModuleInstantiation();
 	std::vector<AbstractNode*> instantiateElseChildren(const Context *evalctx) const;
-	void print(std::ostream &stream, const std::string &indent) const override;
+	void print(std::ostream &stream, const std::string &indent, const bool inlined) const final;
+	void print(std::ostream &stream, const std::string &indent) const final { print(stream, indent, false); };
 
 	LocalScope else_scope;
 };

--- a/src/localscope.cc
+++ b/src/localscope.cc
@@ -44,7 +44,7 @@ void LocalScope::addAssignment(const Assignment &ass)
 	this->assignments.push_back(ass);
 }
 
-void LocalScope::print(std::ostream &stream, const std::string &indent) const
+void LocalScope::print(std::ostream &stream, const std::string &indent, const bool inlined) const
 {
 	for (const auto &f : this->astFunctions) {
 		f.second->print(stream, indent);
@@ -56,7 +56,7 @@ void LocalScope::print(std::ostream &stream, const std::string &indent) const
 		ass.print(stream, indent);
 	}
 	for (const auto &inst : this->children) {
-		inst->print(stream, indent);
+		inst->print(stream, indent, inlined);
 	}
 }
 

--- a/src/localscope.h
+++ b/src/localscope.h
@@ -10,7 +10,7 @@ public:
 	~LocalScope();
 
 	size_t numElements() const { return assignments.size() + children.size(); }
-	void print(std::ostream &stream, const std::string &indent) const;
+	void print(std::ostream &stream, const std::string &indent, const bool inlined = false) const;
 	std::vector<class AbstractNode*> instantiateChildren(const class Context *evalctx) const;
 	void addChild(class ModuleInstantiation *astnode);
 	void addModule(const std::string &name, class UserModule *module);

--- a/testdata/scad/misc/ifelse-ast-dump.scad
+++ b/testdata/scad/misc/ifelse-ast-dump.scad
@@ -1,0 +1,34 @@
+// This tests many variations of if/else with single/multiple children
+// to verify AST dump indentation behavior.
+if (true) {
+  cube();
+  sphere();
+  translate([10,10,10]) if (false) {
+    cylinder();
+    cube();
+  } else {
+    sphere();
+    cube();
+  }
+} else {
+  echo("hi");
+}
+
+if (true) cube();
+else sphere();
+
+if (true) {
+  if (false) {
+    if (true) {
+      echo("hello");
+      echo("world");
+    } else {
+      if (true) echo("hello"); else echo("bye bye");
+      echo("world");
+    }
+    assert(true);
+  } else {
+    echo("hello world");
+  }
+  echo("!");
+}

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1069,6 +1069,7 @@ list(APPEND ASTDUMPTEST_FILES ${MISC_FILES}
             ${CMAKE_SOURCE_DIR}/../testdata/scad/functions/let-test-single.scad
             ${CMAKE_SOURCE_DIR}/../testdata/scad/functions/let-tests.scad
             ${CMAKE_SOURCE_DIR}/../testdata/scad/functions/list-comprehensions.scad
+            ${CMAKE_SOURCE_DIR}/../testdata/scad/misc/ifelse-ast-dump.scad
             )
 
 list(APPEND DUMPTEST_FILES ${FEATURES_2D_FILES} ${FEATURES_3D_FILES} ${DEPRECATED_3D_FILES} ${MISC_FILES})

--- a/tests/regression/astdumptest/ifelse-ast-dump-expected.ast
+++ b/tests/regression/astdumptest/ifelse-ast-dump-expected.ast
@@ -1,0 +1,31 @@
+if(true) {
+	cube();
+	sphere();
+	translate([10, 10, 10]) if(false) {
+		cylinder();
+		cube();
+	}
+	else {
+		sphere();
+		cube();
+	}
+}
+else echo("hi");
+if(true) cube();
+else sphere();
+if(true) {
+	if(false) {
+		if(true) {
+			echo("hello");
+			echo("world");
+		}
+		else {
+			if(true) echo("hello");
+			else echo("bye bye");
+			echo("world");
+		}
+		assert(true);
+	}
+	else echo("hello world");
+	echo("!");
+}

--- a/tests/regression/astdumptest/include-tests-expected.ast
+++ b/tests/regression/astdumptest/include-tests-expected.ast
@@ -25,46 +25,46 @@ module test7() {
 }
 module alignds420(position, rotation, screws = 0, axle_lenght = 0) {
 	translate(position) rotate(rotation) {
-	union() {
-		translate([0, 0, 17]) {
-			cylinder(r = 6, h = 8, $fn = 30);
-			cylinder(r = 2.5, h = 10.5, $fn = 20);
+		union() {
+			translate([0, 0, 17]) {
+				cylinder(r = 6, h = 8, $fn = 30);
+				cylinder(r = 2.5, h = 10.5, $fn = 20);
+			}
+			translate([-6, -6, 0]) {
+				cube([12, 22.8, 19.5], false);
+				translate([0, -5, 17]) cube([12, 7, 2.5]);
+				translate([0, 20.8, 17]) cube([12, 7, 2.5]);
+			}
+			if((screws > 0)) {
+				translate([0, (-10.2 + 1.8), 11.5]) cylinder(r = (1.8 / 2), h = 6, $fn = 6);
+				translate([0, (21 - 1.8), 11.5]) cylinder(r = (1.8 / 2), h = 6, $fn = 6);
+			}
+			translate([-6, 0, 19]) rotate([90, 0, 90]) triangle(4, 18, 12);
+			translate([-6, -6, 19]) cube([12, 6.5, 4]);
 		}
-		translate([-6, -6, 0]) {
-			cube([12, 22.8, 19.5], false);
-			translate([0, -5, 17]) cube([12, 7, 2.5]);
-			translate([0, 20.8, 17]) cube([12, 7, 2.5]);
-		}
-		if((screws > 0)) {
-			translate([0, (-10.2 + 1.8), 11.5]) cylinder(r = (1.8 / 2), h = 6, $fn = 6);
-			translate([0, (21 - 1.8), 11.5]) cylinder(r = (1.8 / 2), h = 6, $fn = 6);
-		}
-				translate([-6, 0, 19]) rotate([90, 0, 90]) triangle(4, 18, 12);
-		translate([-6, -6, 19]) cube([12, 6.5, 4]);
-	}
-	if((axle_lenght > 0)) cylinder(r = 0.9, h = axle_lenght, center = true, $fn = 8);
+		if((axle_lenght > 0)) cylinder(r = 0.9, h = axle_lenght, center = true, $fn = 8);
 	}
 }
 module futabas3003(position, rotation) {
 	translate(position) rotate(rotation) union() {
-	translate([0, 0, 0]) {
-		cube([20.1, 39.9, 36.1], false);
-		translate([1.1, -7.6, 26.6]) difference() {
-	cube([18, 7.6, 2.5]);
-	translate([4, 3.5, 0]) cylinder(100, 2);
-	translate([14, 3.5, 0]) cylinder(100, 2);
-}
-		translate([1.1, 39.9, 26.6]) difference() {
-	cube([18, 7.6, 2.5]);
-	translate([4, 4.5, 0]) cylinder(100, 2);
-	translate([14, 4.5, 0]) cylinder(100, 2);
-}
+		translate([0, 0, 0]) {
+			cube([20.1, 39.9, 36.1], false);
+			translate([1.1, -7.6, 26.6]) difference() {
+				cube([18, 7.6, 2.5]);
+				translate([4, 3.5, 0]) cylinder(100, 2);
+				translate([14, 3.5, 0]) cylinder(100, 2);
+			}
+			translate([1.1, 39.9, 26.6]) difference() {
+				cube([18, 7.6, 2.5]);
+				translate([4, 4.5, 0]) cylinder(100, 2);
+				translate([14, 4.5, 0]) cylinder(100, 2);
+			}
+		}
+		translate([10, 30, 36.1]) {
+			cylinder(r = 6, h = 0.4, $fn = 30);
+			cylinder(r = 2.5, h = 4.9, $fn = 20);
+		}
 	}
-	translate([10, 30, 36.1]) {
-		cylinder(r = 6, h = 0.4, $fn = 30);
-		cylinder(r = 2.5, h = 4.9, $fn = 20);
-	}
-}
 }
 module test_alignds420() {
 	alignds420(screws = 1);

--- a/tests/test_cmdline_tool.py
+++ b/tests/test_cmdline_tool.py
@@ -144,8 +144,8 @@ def compare_default(resultfilename):
     if not expected_text == actual_text:
         if resultfilename: 
             differences = difflib.unified_diff(
-                [line.strip() for line in expected_text.splitlines()],
-                [line.strip() for line in actual_text.splitlines()])
+                [line for line in expected_text.splitlines()],
+                [line for line in actual_text.splitlines()])
             line = None
             for line in differences: sys.stderr.write(line + '\n')
             if not line: return True


### PR DESCRIPTION
Also don't strip leading/trailing whitespace in test output so we can monitor any future changes.

I've looking at the code related to AST and testing the AST dump feature to see how it all works.  I noticed that any inlined/chained module was clearing the indentation, which bugged me so I fixed it.

The only other issue I can see with AST dump, not currently addressed, is that "use"d libraries are not placed in the dump, meaning the result is not re-compilable.