### PR TITLE
Fixes#2278 Surface errors should reflect the file type

### DIFF
--- a/src/surface.cc
+++ b/src/surface.cc
@@ -146,7 +146,7 @@ img_data_t SurfaceNode::read_png_or_dat(std::string filename) const
 	}
 
 	if(ret_val == 78){
-		PRINTB("WARNING: The file '%s'. does not exists or is too large to load", filename);
+		PRINTB("WARNING: The file '%s' couldn't be opened.", filename);
 		return data;	
 	}
 	

--- a/src/surface.cc
+++ b/src/surface.cc
@@ -136,9 +136,15 @@ img_data_t SurfaceNode::read_png_or_dat(std::string filename) const
 {
 	img_data_t data;
 	std::vector<uint8_t> png;
-	
-	int ret_val = lodepng::load_file(png, filename);
-	
+	int ret_val = 0;	
+	try{
+		 ret_val = lodepng::load_file(png, filename);
+	}catch(std::bad_alloc &ba){
+		
+		PRINTB("WARNING: bad_alloc caught for '%s'.", ba.what());
+		return data;	
+	}
+
 	if(ret_val == 78){
 		PRINTB("WARNING: The file '%s'. does not exists or is too large to load", filename);
 		return data;	

--- a/src/surface.cc
+++ b/src/surface.cc
@@ -137,7 +137,12 @@ img_data_t SurfaceNode::read_png_or_dat(std::string filename) const
 	img_data_t data;
 	std::vector<uint8_t> png;
 	
-	lodepng::load_file(png, filename);
+	int ret_val = lodepng::load_file(png, filename);
+	
+	if(ret_val == 78){
+		PRINTB("WARNING: The file '%s'. does not exits or is too large to load", filename);
+		return data;	
+	}
 	
 	if (!is_png(png)) {
 		png.clear();

--- a/src/surface.cc
+++ b/src/surface.cc
@@ -140,7 +140,7 @@ img_data_t SurfaceNode::read_png_or_dat(std::string filename) const
 	int ret_val = lodepng::load_file(png, filename);
 	
 	if(ret_val == 78){
-		PRINTB("WARNING: The file '%s'. does not exits or is too large to load", filename);
+		PRINTB("WARNING: The file '%s'. does not exists or is too large to load", filename);
 		return data;	
 	}
 	


### PR DESCRIPTION
This commit Fixes issue no #2278. To solve this issue, we are checking the return value returned by the lodepng_filesize() function (from /ext/lodepng/lodepng.cpp file) which is been called from the load_file() function(from the surface.cc file), the load_file() function (is from ext/lodepng/lodepng.cpp file) .The function lodepng_filesize return a  -1   when the file to be open is not found or when the file to open is too big.

This solves the issue that the a file which was not exits was identified as a dat file, now instead a warning message is been shown which informs that the file doesn't exits or its to big to open. 