### PR TITLE
Rewrite iterative CSGTreeNormalizer::normalizePass to be comprehendible and correct.

### DIFF
--- a/src/CSGTreeNormalizer.cc
+++ b/src/CSGTreeNormalizer.cc
@@ -25,7 +25,6 @@ shared_ptr<CSGNode> CSGTreeNormalizer::normalize(const shared_ptr<CSGNode> &root
 	this->nodecount = 0;
 	shared_ptr<CSGNode> temp = root;
 	temp = normalizePass(temp);
-	PRINTB("Node count from normalizer: %d", this->nodecount);
 	this->rootnode.reset();
 	return temp;
 }


### PR DESCRIPTION
I ended up ditching my original iterative solution since it was really too complex to try to understand and maintain.  This new one is still iterative and manages its own stack but I think its much clearer and deviates minimally from the original recursive implementation.