### PR TITLE
Added --export-format option to command line argument

### DIFF
--- a/src/export.h
+++ b/src/export.h
@@ -21,6 +21,22 @@ enum class FileFormat {
 	NEF3
 };
 
+enum class ExportFileFormat {
+	STL,
+	OFF,
+	AMF,
+	_3MF,
+	DXF,
+	SVG,
+	NEFDBG,
+	NEF3,
+	CSG,
+	AST,
+	TERM,
+	ECHO,
+	PNG
+};
+
 void exportFileByName(const shared_ptr<const class Geometry> &root_geom, FileFormat format,
 											const char *name2open, const char *name2display);
 
@@ -37,6 +53,24 @@ void export_nef3(const shared_ptr<const Geometry> &geom, std::ostream &output);
 
 enum class Previewer { OPENCSG, THROWNTOGETHER };
 enum class RenderType { GEOMETRY, CGAL, OPENCSG, THROWNTOGETHER };
+
+struct ExportFileFormatOptions {
+	const std::map<const std::string, ExportFileFormat> exportFileFormats{
+		{"stl", ExportFileFormat::STL},
+		{"off", ExportFileFormat::OFF},
+		{"amf", ExportFileFormat::AMF},
+		{"3mf", ExportFileFormat::_3MF},
+		{"dxf", ExportFileFormat::DXF},
+		{"svg", ExportFileFormat::SVG},
+		{"nefdbg", ExportFileFormat::NEFDBG},
+		{"nef3", ExportFileFormat::NEF3},
+		{"csg", ExportFileFormat::CSG},
+		{"ast", ExportFileFormat::AST},
+		{"term", ExportFileFormat::TERM},
+		{"echo", ExportFileFormat::ECHO},
+		{"png", ExportFileFormat::PNG},
+	};
+};
 
 struct ViewOption {
 	const std::string name;

--- a/src/openscad.cc
+++ b/src/openscad.cc
@@ -282,7 +282,7 @@ int cmdline(const char *deps_output_file, const std::string &filename, const cha
 	ExportFileFormat curFormat;
 	const char *extsn = nullptr;
 	const char *new_output_file = nullptr;
-	fs:: path path_output_file = output_file;
+	
 	if(export_format) {
 		PRINT("Using extension of --export-format option");
 		extsn = export_format;
@@ -298,16 +298,15 @@ int cmdline(const char *deps_output_file, const std::string &filename, const cha
 			}
 		}
 	}
-	if(extsn) {		
-		path_output_file.replace_extension(extsn);
-		new_output_file = path_output_file.generic_string().c_str();
-	}
-	else {
+
+	if(!extsn) {
 		PRINTB("Unknown suffix for output file %s\n", output_file);
 		return 1;
 	}
 	
 	curFormat = exportFileFormatOptions.exportFileFormats.at(extsn);
+	fs::path path_output_file(output_file);
+	new_output_file = path_output_file.replace_extension(extsn).generic_string().c_str();
 
 	set_render_color_scheme(arg_colorscheme, true);
 

--- a/src/openscad.cc
+++ b/src/openscad.cc
@@ -305,8 +305,8 @@ int cmdline(const char *deps_output_file, const std::string &filename, const cha
 	}
 	
 	curFormat = exportFileFormatOptions.exportFileFormats.at(extsn);
-	fs::path path_output_file(output_file);
-	new_output_file = path_output_file.replace_extension(extsn).generic_string().c_str();
+	std::string filename_str = fs::path(output_file).replace_extension(extsn).generic_string();
+	new_output_file = filename_str.c_str();
 
 	set_render_color_scheme(arg_colorscheme, true);
 

--- a/src/openscad.cc
+++ b/src/openscad.cc
@@ -305,8 +305,8 @@ int cmdline(const char *deps_output_file, const std::string &filename, const cha
 	}
 	
 	curFormat = exportFileFormatOptions.exportFileFormats.at(extsn);
-	std::string filename_str = fs::path(output_file).replace_extension(extsn).generic_string();
-	new_output_file = filename_str.c_str();
+	fs::path path_output_file = fs::path(output_file).replace_extension(extsn);
+	new_output_file = path_output_file.generic_string().c_str();
 
 	set_render_color_scheme(arg_colorscheme, true);
 


### PR DESCRIPTION
Fix for issue #2877 

The --export-format option will overwrite the file extension provided in -o option. If no -o option is given with --export-format option, --export-format is ignored