### PR TITLE
 Autocomplete / CallTips for QScintilla

### DIFF
--- a/openscad.pro
+++ b/openscad.pro
@@ -296,6 +296,7 @@ HEADERS += src/version_check.h \
            src/GroupModule.h \
            src/FileModule.h \
            src/StatCache.h \
+           src/scadapi.h \
            src/builtin.h \
            src/calc.h \
            src/context.h \

--- a/src/scadapi.h
+++ b/src/scadapi.h
@@ -1,0 +1,56 @@
+#pragma once
+
+#include <QObject>
+#include <QString>
+#include <QStringList>
+
+#include <Qsci/qsciapis.h>
+
+class ApiFunc {
+private:
+	QString name;
+	QStringList params;
+
+public:
+
+	ApiFunc(const QString name, const QString param) : name(name), params(QStringList(param)) { }
+	ApiFunc(const QString name, const QString param1, const QString param2) : name(name), params(QStringList(param1) << param2) { }
+	ApiFunc(const QString name, const QStringList params) : name(name), params(params) { }
+
+	virtual ~ApiFunc() { }
+
+	const QString& get_name() const
+	{
+		return name;
+	}
+
+	const QStringList& get_params() const
+	{
+		return params;
+	}
+
+	ApiFunc & operator=(const ApiFunc &other)
+	{
+		if (this != &other) {
+			this->name = other.name;
+			this->params = other.params;
+		}
+		return *this;
+	}
+};
+
+class ScadApi : public QsciAbstractAPIs {
+	Q_OBJECT
+
+private:
+	QsciScintilla *qsci;
+	QList<ApiFunc> funcs;
+
+public:
+	ScadApi(QsciScintilla *qsci, QsciLexer *lexer);
+	virtual ~ScadApi();
+
+	void updateAutoCompletionList(const QStringList &context, QStringList &list);
+	void autoCompletionSelected(const QString &selection);
+	QStringList callTips(const QStringList &context, int commas, QsciScintilla::CallTipsStyle style, QList< int > &shifts);
+};

--- a/src/scadapi.h
+++ b/src/scadapi.h
@@ -12,7 +12,6 @@ private:
 	QStringList params;
 
 public:
-
 	ApiFunc(const QString name, const QString param) : name(name), params(QStringList(param)) { }
 	ApiFunc(const QString name, const QString param1, const QString param2) : name(name), params(QStringList(param1) << param2) { }
 	ApiFunc(const QString name, const QStringList params) : name(name), params(params) { }
@@ -39,7 +38,31 @@ public:
 	}
 };
 
-class ScadApi : public QsciAbstractAPIs {
+class ScadTemplate
+{
+private:
+	QString text;
+	int cursor_offset;
+public:
+
+	ScadTemplate() : text(""), cursor_offset(0) { }
+	ScadTemplate(const QString text, const int cursor_offset) : text(text), cursor_offset(cursor_offset) { }
+	virtual ~ScadTemplate() { }
+	const QString& get_text() const { return text; }
+	int get_cursor_offset() const { return cursor_offset; }
+
+	ScadTemplate & operator=(const ScadTemplate &other)
+	{
+		if (this != &other) {
+			this->text = other.text;
+			this->cursor_offset = other.cursor_offset;
+		}
+		return *this;
+	}
+};
+
+class ScadApi : public QsciAbstractAPIs
+{
 	Q_OBJECT
 
 private:

--- a/src/scadlexer.cpp
+++ b/src/scadlexer.cpp
@@ -38,6 +38,11 @@ ScadLexer::~ScadLexer()
 {
 }
 
+const char *ScadLexer::autoCompletionFillups() const
+{
+    return "(<";
+}
+
 const char *ScadLexer::language() const
 {
 	return "SCAD";

--- a/src/scadlexer.h
+++ b/src/scadlexer.h
@@ -9,13 +9,13 @@ class ScadLexer : public QsciLexerCPP
 {
 public:
 	ScadLexer(QObject *parent);
-	~ScadLexer();
+	virtual ~ScadLexer();
 	const char *language() const override;
-	const char *keywords(int set) const override;	
-
-        void setKeywords(int set, const std::string& keywords);
+	const char *keywords(int set) const override;
+	const char *autoCompletionFillups() const override;
+	void setKeywords(int set, const std::string& keywords);
 private:
-        std::string keywordSet[4];
+	std::string keywordSet[4];
 	ScadLexer(const ScadLexer &);
 	ScadLexer &operator=(const ScadLexer &);
 };

--- a/src/scintillaeditor.h
+++ b/src/scintillaeditor.h
@@ -72,6 +72,8 @@ private:
         void navigateOnNumber(int key);
         bool modifyNumber(int key);
         void noColor();
+	void replaceSelectedText(QString&);
+        void addTemplate(const QString key, const QString text, const int cursor_offset);
 
 signals:
 	void previewRequest(void);
@@ -100,7 +102,8 @@ public slots:
 
 private slots:
 	void onTextChanged();
-        void applySettings();
+	void onUserListSelected(const int id, const QString &text);
+	void applySettings();
 
 private:
 	QVBoxLayout *scintillaLayout;
@@ -110,4 +113,6 @@ private:
 	ScadLexer *lexer;
 	QFont currentFont;
 	ScadApi *api;
+	QStringList userList;
+	QMap<QString, ScadTemplate> templateMap;
 };

--- a/src/scintillaeditor.h
+++ b/src/scintillaeditor.h
@@ -6,8 +6,9 @@
 #include <QWidget>
 #include <QVBoxLayout>
 #include <Qsci/qsciscintilla.h>
-#include <QVBoxLayout>
+
 #include "editor.h"
+#include "scadapi.h"
 #include "scadlexer.h"
 #include "parsersettings.h"
 
@@ -59,6 +60,7 @@ public:
 
 private:
         void getRange(int *lineFrom, int *lineTo);
+        void setLexer(ScadLexer *lexer);
         void setColormap(const EditorColorScheme *colorScheme);
         int readInt(const boost::property_tree::ptree &pt, const std::string name, const int defaultValue);
         std::string readString(const boost::property_tree::ptree &pt, const std::string name, const std::string defaultValue);
@@ -107,4 +109,5 @@ private:
 	static const int markerNumber = 2;
 	ScadLexer *lexer;
 	QFont currentFont;
+	ScadApi *api;
 };


### PR DESCRIPTION
Rebase of #905 / Initial demo of AutoComplete / CallTips feature that is provided by Scintilla.

Things to decide:
- How to format the CallTips display? What information to present?
- What options are needed
  - enable/disable AutoComplete
  - AutoComplete threshold
  - enable/disable CallTips
  - ...

ToDo:
- [ ] Complete list of keywords
- [ ] Move data to separate text file, currently it's just in code

AutoComplete / CallTips
![screencast](https://cloud.githubusercontent.com/assets/1330241/3870071/662ecda6-20b9-11e4-9300-492f879ef4f2.gif)

UserList providing a set of templates to insert at the cursor position (currently triggered by CTRL-I)
![screencast](https://cloud.githubusercontent.com/assets/1330241/3870481/ed35bcee-20d0-11e4-92b2-8f9253db0b39.gif)
