### PR TITLE
Restore Option+Arrow behavior on Mac.

### DIFF
--- a/src/scintillaeditor.cpp
+++ b/src/scintillaeditor.cpp
@@ -652,7 +652,12 @@ bool ScintillaEditor::eventFilter(QObject* obj, QEvent *e)
 
 	if (e->type()==QEvent::KeyPress || e->type()==QEvent::KeyRelease) {
 		auto *ke = static_cast<QKeyEvent*>(e);
-		if ((ke->modifiers() & ~Qt::KeypadModifier) == Qt::AltModifier) {
+#ifdef Q_OS_MAC
+                int navigateOnNumberModifiers = Qt::AltModifier | Qt::ShiftModifier | Qt :: KeypadModifier;
+#else
+                int navigateOnNumberModifiers = Qt::AltModifier;
+#endif
+		if (ke->modifiers()  == navigateOnNumberModifiers) {
 			switch (ke->key())
 			{
 				case Qt::Key_Left:


### PR DESCRIPTION
As noted in [#2885](https://github.com/openscad/openscad/issues/2885),
Option+Arrow keys don't work in OpenSCAD on OS X anymore.  This updates
OpenSCAD so that Alt+Shift (AKA Option+Shift) is the modifier to use
the number precision extension that is bound to Alt+Left and Alt+Right
on other OSes.