### PR TITLE
Fixes #2784.

### DIFF
--- a/src/import.cc
+++ b/src/import.cc
@@ -202,7 +202,7 @@ const Geometry *ImportNode::createGeometry() const
 #endif
 	default:
 		PRINTB("ERROR: Unsupported file format while trying to import file '%s', import() at Line %d", this->filename % loc.firstLine());
-		g = new PolySet(0);
+		g = new PolySet(3);
 	}
 
 	if (g) g->setConvexity(this->convexity);

--- a/testdata/scad/templates/import_dxf-tests-template.scad
+++ b/testdata/scad/templates/import_dxf-tests-template.scad
@@ -1,5 +1,5 @@
-import();
 import("notfound.dxf");
+import();
 translate([-210,0,0]) import(file="../../../dxf/polygons.dxf");
 translate([-210,0,0]) import(file="../../../dxf/polygons.dxf", origin=[0,110]);
 translate([-210,0,0]) import(file="../../../dxf/polygons.dxf", origin=[110,110], scale=0.5);

--- a/tests/regression/dumptest/import_dxf-tests-expected.csg
+++ b/tests/regression/dumptest/import_dxf-tests-expected.csg
@@ -1,5 +1,5 @@
-import(file = "", layer = "", origin = [0, 0], scale = 1, convexity = 1, $fn = 0, $fa = 12, $fs = 2, timestamp = 0);
 import(file = "notfound.dxf", layer = "", origin = [0, 0], scale = 1, convexity = 1, $fn = 0, $fa = 12, $fs = 2, timestamp = 0);
+import(file = "", layer = "", origin = [0, 0], scale = 1, convexity = 1, $fn = 0, $fa = 12, $fs = 2, timestamp = 0);
 multmatrix([[1, 0, 0, -210], [0, 1, 0, 0], [0, 0, 1, 0], [0, 0, 0, 1]]) {
 	import(file = "../../../dxf/polygons.dxf", layer = "", origin = [0, 0], scale = 1, convexity = 1, $fn = 0, $fa = 12, $fs = 2, timestamp = 1340482264);
 }


### PR DESCRIPTION
The bug was caused by passing 0 to the PolySet constructor when the file type is unknown. That gave a zero dimension object. The rendering code assumes it will be 2 or 3.

The simplest test is just
```import();```

F5 and then F6.
