### PR TITLE
Fixed git mxe url

### DIFF
--- a/scripts/mingw-x-build-dependencies.sh
+++ b/scripts/mingw-x-build-dependencies.sh
@@ -70,7 +70,7 @@ if [ ! -e $MXEDIR ]; then
 	mkdir -p $MXEDIR
 	cd $MXEDIR/..
 	echo "Downloading MXE into " $PWD
-	git clone git://github.com/openscad/mxe.git $MXEDIR
+	git clone https://github.com/openscad/mxe.git $MXEDIR
 fi
 
 echo "entering" $MXEDIR


### PR DESCRIPTION
Fixed git url to clone mxe repo: using git:// protocol does not always work.
Might be a firewall issue but on one machine I got 
$ git clone git://github.com/openscad/mxe.git
Cloning into 'mxe'...
fatal: unable to connect to github.com:
github.com[0: 192.30.253.112]: errno=Connection timed out
github.com[1: 192.30.253.113]: errno=Connection timed out

whereas I have no issue with https