### PR TITLE
Main Window on top of detached console window 

### DIFF
--- a/src/MainWindow.h
+++ b/src/MainWindow.h
@@ -224,6 +224,8 @@ public:
 	void onActionEvent(InputEventAction *event) override;
 	void onZoomEvent(InputEventZoom *event) override;
 
+	void changedTopLevelConsole(bool);
+
 	QList<double> getTranslation() const;
 	QList<double> getRotation() const;
 

--- a/src/mainwin.cc
+++ b/src/mainwin.cc
@@ -615,6 +615,7 @@ MainWindow::MainWindow(const QString &filename)
 	connect(this->consoleDock, SIGNAL(topLevelChanged(bool)), this, SLOT(consoleTopLevelChanged(bool)));
 	connect(this->parameterDock, SIGNAL(topLevelChanged(bool)), this, SLOT(parameterTopLevelChanged(bool)));
 
+
 	// display this window and check for OpenGL 2.0 (OpenCSG) support
 	viewModeThrownTogether();
 	show();
@@ -922,7 +923,7 @@ void MainWindow::setFileName(const QString &filename)
 		this->top_ctx.setDocumentPath(fileinfo.dir().absolutePath().toLocal8Bit().constData());
 	}
 	editorTopLevelChanged(editorDock->isFloating());
-	consoleTopLevelChanged(consoleDock->isFloating());
+	changedTopLevelConsole(consoleDock->isFloating());
  	parameterTopLevelChanged(parameterDock->isFloating());
 }
 
@@ -2859,7 +2860,7 @@ void MainWindow::on_editorDock_visibilityChanged(bool)
 
 void MainWindow::on_consoleDock_visibilityChanged(bool)
 {
-	consoleTopLevelChanged(consoleDock->isFloating());
+	changedTopLevelConsole(consoleDock->isFloating());
 }
 
 void MainWindow::on_parameterDock_visibilityChanged(bool)
@@ -2872,9 +2873,21 @@ void MainWindow::editorTopLevelChanged(bool topLevel)
 	setDockWidgetTitle(editorDock, QString(_("Editor")), topLevel);
 }
 
+void MainWindow::changedTopLevelConsole(bool topLevel)
+{
+	setDockWidgetTitle(consoleDock, QString(_("Console")), topLevel);
+}
+
 void MainWindow::consoleTopLevelChanged(bool topLevel)
 {
 	setDockWidgetTitle(consoleDock, QString(_("Console")), topLevel);
+
+    Qt::WindowFlags flags = (consoleDock->windowFlags() & ~Qt::WindowType_Mask) | Qt::Window;
+	if(topLevel)
+	{
+		consoleDock->setWindowFlags(flags);
+		consoleDock->show();
+	}
 }
 
 void MainWindow::parameterTopLevelChanged(bool topLevel)

--- a/src/mainwin.cc
+++ b/src/mainwin.cc
@@ -615,7 +615,6 @@ MainWindow::MainWindow(const QString &filename)
 	connect(this->consoleDock, SIGNAL(topLevelChanged(bool)), this, SLOT(consoleTopLevelChanged(bool)));
 	connect(this->parameterDock, SIGNAL(topLevelChanged(bool)), this, SLOT(parameterTopLevelChanged(bool)));
 
-
 	// display this window and check for OpenGL 2.0 (OpenCSG) support
 	viewModeThrownTogether();
 	show();


### PR DESCRIPTION
Fix for issue #2871 

Added the functionality such that detached console window can lie behind the main window.

![peeking](https://user-images.githubusercontent.com/32954818/55973797-ee5ce200-5ca3-11e9-9a42-36a0ca738311.gif)
