### PR TITLE
Add basic completion-at-point function for Emacs OpenSCAD mode.

### DIFF
--- a/contrib/scad-mode.el
+++ b/contrib/scad-mode.el
@@ -174,6 +174,11 @@
   nil. If you want to set the style with file local variables use
   the `c-file-style' variable")
 
+(defvar scad-completions
+  (append '("module" "function" "use" "include")
+          scad-keywords scad-functions scad-modules)
+  "List of known words for completion.")
+
 (put 'scad-mode 'c-mode-prefix "scad-")
 ;;;###autoload
 (define-derived-mode scad-mode prog-mode "SCAD"
@@ -186,6 +191,8 @@ initialization, then `scad-mode-hook'.
 
 Key bindings:
 \\{scad-mode-map}"
+  (add-hook 'completion-at-point-functions
+            'scad-completion-at-point nil 'local)
   (c-initialize-cc-mode)
   ;; (setq local-abbrev-table scad-mode-abbrev-table
   ;; 	abbrev-mode t)
@@ -195,6 +202,14 @@ Key bindings:
   (c-font-lock-init)
   (c-run-mode-hooks 'c-mode-common-hook 'scad-mode-hook)
   (c-update-modeline))
+
+(defun scad-completion-at-point ()
+  "Completion at point function."
+  (let ((bounds (bounds-of-thing-at-point 'word)))
+    (when bounds
+      (list (car bounds) (cdr bounds)
+            scad-completions
+            :exclusive "no"))))
 
 ;; From: http://stackoverflow.com/questions/14520073/add-words-for-dynamic-expansion-to-emacs-mode
 (defun scad-prime-dabbrev ()


### PR DESCRIPTION
This adds a basic "completion at point" function (`capf`) for builtin keywords, functions and modules in `scad-mode.el` (Emacs), directly usable with Emacs autocompletion packages (e.g. `company-mode`), as an alternative to `dabbrev`-based completion.