### PR TITLE
Fix misc. typos in documentation and source comments

### DIFF
--- a/cgal/export_nef.cpp
+++ b/cgal/export_nef.cpp
@@ -17,7 +17,7 @@
 #pragma pop_macro("NDEBUG")
 
 using namespace CGALUtils;
-namespace fs=boost::fileystem;
+namespace fs=boost::filesystem;
 
 #define STL_FACET_NUMBYTES 4*3*4+2
 // as there is no 'float32_t' standard, we assume the systems 'float'

--- a/cmake/Modules/FindHarfBuzz.cmake
+++ b/cmake/Modules/FindHarfBuzz.cmake
@@ -27,8 +27,8 @@
 # Try to find Harfbuzz include and library directories.
 #
 # After successful discovery, this will set for inclusion where needed:
-# HARFBUZZ_INCLUDE_DIRS - containg the HarfBuzz headers
-# HARFBUZZ_LIBRARIES - containg the HarfBuzz library
+# HARFBUZZ_INCLUDE_DIRS - containing the HarfBuzz headers
+# HARFBUZZ_LIBRARIES - containing the HarfBuzz library
 
 find_package(PkgConfig REQUIRED QUIET)
 

--- a/cmake/Modules/FindQt5QScintilla.cmake
+++ b/cmake/Modules/FindQt5QScintilla.cmake
@@ -6,7 +6,7 @@
 #  QT5QSCINTILLA_INCLUDE_DIR - where to find qsciscintilla.h
 #  QT5QSCINTILLA_INCLUDE_DIRS - qscintilla includes
 #  QT5QSCINTILLA_LIBRARY - where to find the QScintilla library
-#  QT5QSCINTILLA_LIBRARIES - aditional libraries
+#  QT5QSCINTILLA_LIBRARIES - additional libraries
 #  QT5QSCINTILLA_MAJOR_VERSION - major version
 #  QT5QSCINTILLA_MINOR_VERSION - minor version
 #  QT5QSCINTILLA_PATCH_VERSION - patch version

--- a/doc/TODO.txt
+++ b/doc/TODO.txt
@@ -157,8 +157,8 @@ o Built-in modules
 o Advanced Transformations
   - Add statement for intersections in cartesian product of childs
 o Function-Module-Interface
-  - Pass a module instanciation to a function (e.g. for a volume() function)
-  - Pass a function to a module instanciation (e.g. for dynamic extrusion paths)
+  - Pass a module instantiation to a function (e.g. for a volume() function)
+  - Pass a function to a module instantiation (e.g. for dynamic extrusion paths)
 o Language Frontend
   - Allow local variables and functions everywhere (not only on module level)
   - Rethink for vs. intersection_for vs. group. Should for loops

--- a/doc/translation.txt
+++ b/doc/translation.txt
@@ -72,7 +72,7 @@ There is no need to add a context preemptively, please wait until a specific
 need arises.
 
 Please note that message context should follow some constrains:
-   - message context comes at some perfomance penalty
+   - message context comes at some performance penalty
    - Keep the context name short
    - try to pick a context name that is unlikely to change
      (changing the context name requires the translates to update the translation)

--- a/examples/Advanced/animation.scad
+++ b/examples/Advanced/animation.scad
@@ -1,6 +1,6 @@
 // animation.scad - Demo of animation usage
 
-// The animation funtionality is based simply on a variable $t
+// The animation functionality is based simply on a variable $t
 // that is changed automatically by OpenSCAD while repeatedly
 // showing the model.
 // To activate animation, select "View->Animation" from the

--- a/examples/Parametric/candleStand.scad
+++ b/examples/Parametric/candleStand.scad
@@ -16,7 +16,7 @@ count=7; //[3:14]
 centerCandle=true;
 
 /* [ Candle Holder ]*/
-//Lenght of candle holder
+//Length of candle holder
 candleSize=7;
 
 //Width of candle holder

--- a/fonts-osx/conf.d/README
+++ b/fonts-osx/conf.d/README
@@ -9,7 +9,7 @@ enabled/disabled by adjusting the symlinks.
 The files are loaded in numeric order, the structure of the configuration
 has led to the following conventions in usage:
 
- Files begining with:	Contain:
+ Files beginning with:	Contain:
  
  00 through 09		Font directories
  10 through 19		system rendering defaults (AA, etc)

--- a/openscad.pro
+++ b/openscad.pro
@@ -139,7 +139,7 @@ netbsd* {
 !isEmpty(OPENSCAD_LIBDIR) {
   unix:!macx {
     QMAKE_LFLAGS = -Wl,-R$$OPENSCAD_LIBDIR/lib $$QMAKE_LFLAGS
-    # need /lib64 beause GLEW installs itself there on 64 bit machines
+    # need /lib64 because GLEW installs itself there on 64 bit machines
     QMAKE_LFLAGS = -Wl,-R$$OPENSCAD_LIBDIR/lib64 $$QMAKE_LFLAGS
   }
 }

--- a/releases/2019.02.md
+++ b/releases/2019.02.md
@@ -37,5 +37,5 @@
     * Duplicate passed argument
     * Children passed to module not accepting children
     * Reference to inknown $special_variables
-    * Duplicate assigment
+    * Duplicate assignment
 * New translations: Ukrainian, Polish

--- a/scripts/LogicLib.nsh
+++ b/scripts/LogicLib.nsh
@@ -124,7 +124,7 @@
     !ifndef _${Type}
       !error "Cannot use _Pop${Type} without a preceding _Push${Type}"
     !endif
-    !ifdef ${_${Type}}Prev${Type}                         ; If a previous statment was active then restore it
+    !ifdef ${_${Type}}Prev${Type}                         ; If a previous statement was active then restore it
       !define _Cur${Type} ${_${Type}}
       !undef _${Type}
       !define _${Type} ${${_Cur${Type}}Prev${Type}}

--- a/scripts/check-dependencies.sh
+++ b/scripts/check-dependencies.sh
@@ -250,7 +250,7 @@ qscintilla2_sysver()
   debug using qtincdir: $qtincdir
   debug using qscipath: $qscipath
   if [ ! -e $qscipath ]; then
-    debug qscipath doesnt exist. giving up on version.
+    debug qscipath doesn't exist. giving up on version.
     return
   fi
 

--- a/scripts/chrpath_linux.c
+++ b/scripts/chrpath_linux.c
@@ -182,11 +182,11 @@ figure out enough to find and change the rpath string.  That was fun!
 
 This program assumes (unlike your original program) that there is only
 one DT_RPATH tag in the dynamic section as even with multiple '-Wl,-rpath,'
-commands in the link this seems to occur (they all get concatonated into
+commands in the link this seems to occur (they all get concatenated into
 a : separated path).
 
 Thanks for your help.  If you want to use this on non-x86 you have to change
-the occurances of LSB back to MSB:)
+the occurrences of LSB back to MSB:)
 
 Peeter
 --

--- a/scripts/macosx-sanity-check.py
+++ b/scripts/macosx-sanity-check.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 
 #
-# This is be used to verify that all the dependant libraries of a  Mac OS X executable 
+# This is used to verify that all the dependant libraries of a Mac OS X executable
 # are present and that they are backwards compatible with at least 10.9.
 # Run with an executable as parameter
 # Will return 0 if the executable an all libraries are OK
@@ -145,7 +145,7 @@ if __name__ == '__main__':
     lc_rpath = m.group(2)
     if DEBUG: print('Runpath search path: ' + lc_rpath)
 
-    # processed is a dict {libname : [parents]} - each parent is dependant on libname
+    # processed is a dict {libname : [parents]} - each parent is dependent on libname
     processed = {}
     pending = [executable]
     processed[executable] = []

--- a/scripts/release-common.sh
+++ b/scripts/release-common.sh
@@ -157,7 +157,7 @@ case $OS in
         if [ "`command -v makensis`" ]; then
             MAKENSIS=makensis
         elif [ "`command -v i686-pc-mingw32-makensis`" ]; then
-            # we cant find systems nsis so look for the MXE's version.
+            # we can't find systems nsis so look for the MXE's version.
             # MXE has its own makensis, but its only available under
             # 32-bit MXE. note that the cross-version in theory works
             # the same as the linux version so we can use them, in
@@ -232,7 +232,7 @@ case $OS in
         touch -t 200012121010 parser_yacc.h parser_yacc.cpp lexer_lex.cpp
     ;;
     UNIX_CROSS_WIN)
-        # kludge to enable paralell make
+        # kludge to enable parallel make
         touch -t 200012121010 $OPENSCADDIR/src/parser_yacc.h
         touch -t 200012121010 $OPENSCADDIR/src/parser_yacc.cpp
         touch -t 200012121010 $OPENSCADDIR/src/parser_yacc.hpp
@@ -252,14 +252,14 @@ case $OS in
             make $TARGET -j$NUMCPU
         fi
         if [ ! -e $TARGET/openscad.exe ]; then
-            echo "cant find $TARGET/openscad.exe. build failed. stopping."
+            echo "can't find $TARGET/openscad.exe. build failed. stopping."
             exit
         fi
         # make console pipe-able openscad.com - see winconsole.pro for info
         qmake ../winconsole/winconsole.pro
         make
         if [ ! -e $TARGET/openscad.com ]; then
-            echo "cant find $TARGET/openscad.com. build failed. stopping."
+            echo "can't find $TARGET/openscad.com. build failed. stopping."
             exit
         fi
         cd $OPENSCADDIR

--- a/scripts/setenv-unibuild.sh
+++ b/scripts/setenv-unibuild.sh
@@ -58,7 +58,7 @@ setenv_netbsd()
 {
  setenv_common
  echo --- netbsd build situation is complex. it comes with gcc4.5
- echo --- which is incompatable with updated CGAL. 
+ echo --- which is incompatible with updated CGAL. 
  echo --- you may need to hack with newer gcc to make it work
  QMAKESPEC=netbsd-g++
  QTDIR=/usr/pkg/qt4

--- a/scripts/uni-build-dependencies.sh
+++ b/scripts/uni-build-dependencies.sh
@@ -753,7 +753,7 @@ if [ "`command -v dirname`" ]; then
   cd $RUNDIR
 else
   if [ ! -f openscad.pro ]; then
-    echo "Must be run from the OpenSCAD source root directory (dont have 'dirname')"
+    echo "Must be run from the OpenSCAD source root directory (don't have 'dirname')"
     exit 1
   else
     OPENSCAD_SCRIPTDIR=$PWD

--- a/src/FileModule.cc
+++ b/src/FileModule.cc
@@ -183,8 +183,8 @@ AbstractNode *FileModule::instantiateWithFileContext(FileContext *ctx, const Mod
 }
 
 //please preferably use getFilename
-//if you compare filenames (which is the origin of this methode),
-//please call getFilename first and use this methode only as a fallback
+//if you compare filenames (which is the origin of this method),
+//please call getFilename first and use this method only as a fallback
 const std::string FileModule::getFullpath() const {
 	if(fs::path(this->filename).is_absolute()){
 		return this->filename;

--- a/src/GLView.cc
+++ b/src/GLView.cc
@@ -671,7 +671,7 @@ void GLView::decodeMarkerValue(double i, double l, int size_div_sm)
 				{polarity*((i+((char_num)*dig_wk))+(dig_w/2)),dig_buf,0}};
 
 			// convert the char into lines appropriate for the axis being used
-			// psuedo 7 segment vertices are:
+			// pseudo 7 segment vertices are:
 			// A--B
 			// |  |
 			// C--D

--- a/src/OffscreenContextGLX.cc
+++ b/src/OffscreenContextGLX.cc
@@ -119,7 +119,7 @@ static int XCreateWindow_error(Display *dpy, XErrorEvent *event)
    "failed to create drawable" errors, and Mesa "WARNING: Application calling 
    GLX 1.3 function when GLX 1.3 is not supported! This is an application bug!"
 
-   This function will alter ctx.openGLContext and ctx.xwindow if successfull
+   This function will alter ctx.openGLContext and ctx.xwindow if successful
  */
 bool create_glx_dummy_window(OffscreenContext &ctx)
 {
@@ -252,7 +252,7 @@ bool save_framebuffer(OffscreenContext *ctx, std::ostream &output)
 #pragma GCC diagnostic ignored "-Waddress"
 bool create_glx_dummy_context(OffscreenContext &ctx)
 {
-	// This will alter ctx.openGLContext and ctx.xdisplay and ctx.xwindow if successfull
+	// This will alter ctx.openGLContext and ctx.xdisplay and ctx.xwindow if successful
 	int major;
 	int minor;
 	auto result = false;

--- a/src/OffscreenContextWGL.cc
+++ b/src/OffscreenContextWGL.cc
@@ -95,7 +95,7 @@ LRESULT CALLBACK WndProc(HWND hwnd, UINT message, WPARAM wparam, LPARAM lparam)
 bool create_wgl_dummy_context(OffscreenContext &ctx)
 {
   // this function alters ctx->window and ctx->openGLContext 
-  //  and ctx->dev_context if successfull
+  //  and ctx->dev_context if successful
 
   // create window
 
@@ -202,7 +202,7 @@ OffscreenContext *create_offscreen_context(int w, int h)
 
   // Before an FBO can be setup, a WGL context must be created. 
   // This call alters ctx->window and ctx->openGLContext 
-  //  and ctx->dev_context if successfull
+  //  and ctx->dev_context if successful
   if (!create_wgl_dummy_context( *ctx )) {
     return nullptr;
   }

--- a/src/PlatformUtils.h
+++ b/src/PlatformUtils.h
@@ -74,7 +74,7 @@ namespace PlatformUtils {
 		 * to not leak too detail data about the system but still enough
 		 * to give some indication for troubleshooting on server side.
 		 *
-		 * @return the short system infor
+		 * @return the short system info
 		 */
 		const std::string user_agent();
 

--- a/src/boosty.h
+++ b/src/boosty.h
@@ -9,7 +9,7 @@
  versions of boost found on popular versions of linux, circa early 2012.
 
  design
-  the boost filsystem changed around 1.46-1.48. we do a large #ifdef
+  the boost filesystem changed around 1.46-1.48. we do a large #ifdef
   based on boost version that wraps various functions appropriately.
   in a few years, this file should be deleted as unnecessary.
 

--- a/src/cgalutils-project.cc
+++ b/src/cgalutils-project.cc
@@ -200,7 +200,7 @@ namespace CGALUtils {
 				try {
 					PRINTD("Trying alternative intersection using very large thin box: ");
 					std::vector<CGAL_Point_3> pts;
-					// dont use z of 0. there are bugs in CGAL.
+					// don't use z of 0. there are bugs in CGAL.
 					double inf = 1e8;
 					double eps = 0.001;
 					CGAL_Point_3 minpt(-inf, -inf, -eps);

--- a/src/cgalutils-tess-old.cc
+++ b/src/cgalutils-tess-old.cc
@@ -37,7 +37,7 @@ polygons because they all require input polygons to pass the
 triangles.
 
 There is also the question of which underlying number type to use. Some 
-of the CGAL functions simply dont guarantee good results with a type 
+of the CGAL functions simply don't guarantee good results with a type 
 like double. Although much the math here is somewhat simple, like 
 line-line intersection, and involves only simple algebra, the 
 approximations required when using floating-point types can cause the 
@@ -134,7 +134,7 @@ polygon mirror-image and vice versa.
 
 Now, there is a second curious fact that helps us here. In 3d, we are 
 using the plane equation of ax+by+cz+d=0, where a,b,c determine its 
-direction. If you notice, there are actually mutiple sets of numbers 
+direction. If you notice, there are actually multiple sets of numbers 
 a:b:c that will describe the exact same plane. For example the 'ground' 
 plane, called the XYplane, where z is everywhere 0, has the equation 
 0x+0y+1z+0=0, simplifying to a solution for x,y,z of z=0 and x,y = any 

--- a/src/clipper-utils.cc
+++ b/src/clipper-utils.cc
@@ -242,7 +242,7 @@ namespace ClipperUtils {
 			fill_minkowski_insides(lhs, rhs, minkowski_terms);
 			fill_minkowski_insides(rhs, lhs, minkowski_terms);
 
-			// This union operation must be performed at each interation since the minkowski_terms
+			// This union operation must be performed at each iteration since the minkowski_terms
 			// now contain lots of small quads
 			c.Clear();
 			c.AddPaths(minkowski_terms, ClipperLib::ptSubject, true);

--- a/src/context.cc
+++ b/src/context.cc
@@ -187,10 +187,10 @@ bool Context::has_local_variable(const std::string &name) const
  * noinline prevents compiler optimization, as we here specifically
  * optimize for stack usage during normal operating, not runtime during
  * error handling.
- * 
+ *
  * @param what what is ignored
  * @param name name of the ignored object
- * @param loc location of the function/modul call
+ * @param loc location of the function/module call
  * @param docPath document path of the root file, used to calculate the relative path
  */
 static void NOINLINE print_ignore_warning(const char *what, const char *name, const Location &loc, const char *docPath){

--- a/src/control.cc
+++ b/src/control.cc
@@ -118,7 +118,7 @@ void ControlModule::for_eval(AbstractNode &node, const ModuleInstantiation &inst
 const EvalContext* ControlModule::getLastModuleCtx(const EvalContext *evalctx)
 {
 	// Find the last custom module invocation, which will contain
-	// an eval context with the children of the module invokation
+	// an eval context with the children of the module invocation
 	const Context *tmpc = evalctx;
 	while (tmpc->getParent()) {
 		const ModuleContext *modulectx = dynamic_cast<const ModuleContext*>(tmpc->getParent());
@@ -186,7 +186,7 @@ AbstractNode *ControlModule::instantiate(const Context* ctx, const ModuleInstant
 		}
 
 		// Find the last custom module invocation, which will contain
-		// an eval context with the children of the module invokation
+		// an eval context with the children of the module invocation
 		const EvalContext *modulectx = getLastModuleCtx(evalctx);
 		if (modulectx==nullptr) {
 			return nullptr;

--- a/src/input/AxisConfigWidget.cc
+++ b/src/input/AxisConfigWidget.cc
@@ -51,7 +51,7 @@ void AxisConfigWidget::AxesChanged(int nr, double val) const{
 
 	//QProgressBar generates the shown string from the format string.
 	//By setting a format string without a place holder,
-	//we can set arbitrary text, like a custom formated double.
+	//we can set arbitrary text, like a custom formatted double.
 	//(Note: QProgressBar internally works on int, so has no formating for double values)
 	//(Note: The text of a QProgressBar can not be set directly)
 	QString s =  QString::number(val, 'f', 2 );

--- a/src/parameter/ParameterWidget.cc
+++ b/src/parameter/ParameterWidget.cc
@@ -174,8 +174,8 @@ void ParameterWidget::readFile(QString scadFile)
 }
 
 //Write the json file if the parameter sets are not empty.
-//This prevents creating unneccesary json filess.
-//This methode also updates the UI state (change indicator, file name, ...)
+//This prevents creating unnecessary json filess.
+//This method also updates the UI state (change indicator, file name, ...)
 void ParameterWidget::writeFileIfNotEmpty(QString scadFile)
 {
 	setFile(scadFile);

--- a/src/parameter/parameterset.cpp
+++ b/src/parameter/parameterset.cpp
@@ -73,7 +73,7 @@ void ParameterSet::addParameterSet(const std::string setName, const pt::ptree & 
 }
 
 /*!
-	Returns true if the file was succesfully read
+	Returns true if the file was successfully read
 */
 bool ParameterSet::readParameterSet(const std::string &filename)
 {

--- a/src/parser.y
+++ b/src/parser.y
@@ -221,15 +221,15 @@ assignment:
                         const auto uncPathCurr = boostfs_uncomplete(currFile, mainFilePath.parent_path());
                         const auto uncPathPrev = boostfs_uncomplete(prevFile, mainFilePath.parent_path());
                         if(fileEnded){
-                            //assigments via commandline
+                            //assignments via commandline
                         }else if(prevFile==mainFile && currFile == mainFile){
-                            //both assigments in the mainFile
+                            //both assignments in the mainFile
                             PRINTB("WARNING: %s was assigned on line %i but was overwritten on line %i",
                                     assignment.name%
                                     assignment.location().firstLine()%
                                     LOC(@$).firstLine());
                         }else if(uncPathCurr == uncPathPrev){
-                            //assigment overwritten within the same file
+                            //assignment overwritten within the same file
                             //the line number being equal happens, when a file is included multiple times
                             if(assignment.location().firstLine() != LOC(@$).firstLine()){
                                 PRINTB("WARNING: %s was assigned on line %i of %s but was overwritten on line %i",
@@ -239,7 +239,7 @@ assignment:
                                         LOC(@$).firstLine());
                             }
                         }else if(prevFile==mainFile && currFile != mainFile){
-                            //assigment from the mainFile overwritten by an include
+                            //assignment from the mainFile overwritten by an include
                             PRINTB("WARNING: %s was assigned on line %i of %s but was overwritten on line %i of %s",
                                     assignment.name%
                                     assignment.location().firstLine()%

--- a/src/polyset-utils-old.cc
+++ b/src/polyset-utils-old.cc
@@ -70,7 +70,7 @@ namespace PolysetUtils {
 	 polygons used for tessellation, typically triangles) back up into 3d
 	 space.
 	 
-	 (in reality as of writing, we dont need to do a back-projection from 2d->3d
+	 (in reality as of writing, we don't need to do a back-projection from 2d->3d
 	 because the algorithm we are using doesn't create any new points, and we can
 	 just use a 'map' to associate 3d points with 2d points).
 	 
@@ -103,7 +103,7 @@ namespace PolysetUtils {
 /* Find a 'good' 2d projection for a given 3d polygon. the XY, YZ, or XZ 
 	 plane. This is needed because near-planar polygons in 3d can have 'bad' 
 	 projections into 2d. For example if the square 0,0,0 0,1,0 0,1,1 0,0,1 
-	 is projected onto the XY plane you will not get a polygon, you wil get 
+	 is projected onto the XY plane you will not get a polygon, you will get 
 	 a skinny line thing. It's better to project that square onto the yz 
 	 plane.*/
 	projection_t find_good_projection( PolySet::Polygon pgon ) {

--- a/src/polyset.cc
+++ b/src/polyset.cc
@@ -215,7 +215,7 @@ void PolySet::quantizeVertices()
 		indices.resize(p.size());
 		// Quantize all vertices. Build index list
 		for (unsigned int i=0;i<p.size();i++) indices[i] = grid.align(p[i]);
-		// Remove consequtive duplicate vertices
+		// Remove consecutive duplicate vertices
 		Polygon::iterator currp = p.begin();
 		for (unsigned int i=0;i<indices.size();i++) {
 			if (indices[i] != indices[(i+1)%indices.size()]) {

--- a/src/svg.cc
+++ b/src/svg.cc
@@ -321,7 +321,7 @@ public:
 			}
 			CGAL_Nef_polyhedron3::SHalfedge_around_facet_const_circulator c1(i), c2(c1);
 			CGAL_For_all( c1, c2 ) {
-				// don't know why we use source()->source(), except thats what CGAL does internally
+				// don't know why we use source()->source(), except that's what CGAL does internally
 				auto source = c1->source()->source()->point();
 				auto target = c1->source()->target()->point();
 				auto tp1 = project_svg_3to2 ( source, bbox );

--- a/testdata/scad/3D/features/polyhedron-tests.scad
+++ b/testdata/scad/3D/features/polyhedron-tests.scad
@@ -19,7 +19,7 @@ translate([0,2,0]) difference() {
   translate([3,0,2]) cube([8,3,3], center=true);
 }
 
-// dont crash (issue #703)
+// don't crash (issue #703)
 polyhedron(points = undef, triangles = [[1, 2, 3]]);
 polyhedron(points = [[0,0,0],[1,1,1]], triangles = undef);
 // More malformed polyhedrons

--- a/testdata/scad/misc/include-overwrite-main.scad
+++ b/testdata/scad/misc/include-overwrite-main.scad
@@ -1,10 +1,10 @@
 echo(str("Can a variable be used when it assigned later? ",later))
 
-echo(str("Is overwritting possible? ", overwritten));
+echo(str("Is overwriting possible? ", overwritten));
 
-echo(str("Does an include before the assigment take priority? ", before));
+echo(str("Does an include before the assignment take priority? ", before));
 
-echo(str("Does an include after the assigment take priority? ", after));
+echo(str("Does an include after the assignment take priority? ", after));
 
 use     <include-overwrite-use.scad>;
 include <include-overwrite-before.scad>;

--- a/testdata/scad/templates/include-tests-template.scad
+++ b/testdata/scad/templates/include-tests-template.scad
@@ -1,4 +1,4 @@
-//Test that the entire path is pushed onto the stack upto the last '/' 
+//Test that the entire path is pushed onto the stack up to the last '/' 
 include <sub1/sub2/sub3/sub4/include-test2.scad>
 
 //Subdir

--- a/testdata/scad/templates/use-tests-template.scad
+++ b/testdata/scad/templates/use-tests-template.scad
@@ -1,7 +1,7 @@
 //Test blank
 use <>
 
-//Test that the entire path is pushed onto the stack upto the last '/' 
+//Test that the entire path is pushed onto the stack up to the last '/' 
 use <sub1/sub2/sub3/sub4/use-test2.scad>
 
 //Test that a non existent path/file doesn't screw things up

--- a/tests/diffpng.cpp
+++ b/tests/diffpng.cpp
@@ -615,7 +615,7 @@ public:
 
 	// Here we set up the number of Laplacian Pyramid Levels used
 	// by Yee's algorithm. A MATCH is very reliable with a low level
-	// of max levels, and somehwat fsat. However, a DIFFERENCE with
+	// of max levels, and somewhat fsat. However, a DIFFERENCE with
 	// a low level of levels can be unreliable. So in that case, we can
 	// 'retest' with more levels, starting with the initial, and
 	// ending with the 'final'. Each new level is slower.
@@ -1119,7 +1119,7 @@ Thus, the strategy is as follows.
 Start with a low number of Pyramid Levels.... and if the images match, ,
 then quit the algorithm.
 
-Now, only if the images dont match do we increase the number of
+Now, only if the images don't match do we increase the number of
 pyramid levels.
 
 On a typical regression test system, this can create a good speedup. Why?
@@ -1129,17 +1129,17 @@ Thus, most of the comparisons will be of images that will probably match.
 That means, this comparison will run relatively fast on all those matches.
 
 Now say you create an experimental new feature for your program, and
-want to see if it breaks anything. Well, the algorithm will stil run fast
+want to see if it breaks anything. Well, the algorithm will still run fast
 on the test-output that matches what is expected. . . . it will only slow
 down to do higher-levels of Pyramid processing for those few output images that
-dont match what is expected.
+don't match what is expected.
 
 Lets say your modification of your program causes 5 out of 400 tests to fail.
 That means only those 5 will run really slowly.
 
 Let's say that 'fast' means 2 seconds, and 'slow' means 20 seconds. We have
 thus taken some code that would have run in 400*20 seconds, 8000 (>2 hours)
-and made it run in only 395*2+5*20 seconds. Thats about 15 minutes, roughly
+and made it run in only 395*2+5*20 seconds. That's about 15 minutes, roughly
 ten times faster.
 */
 

--- a/tests/regression/astdumptest/include-overwrite-main-expected.ast
+++ b/tests/regression/astdumptest/include-overwrite-main-expected.ast
@@ -7,8 +7,8 @@ main = true;
 after = true;
 //Parameter("")
 later = true;
-echo(str("Can a variable be used when it assigned later? ", later)) echo(str("Is overwritting possible? ", overwritten));
-echo(str("Does an include before the assigment take priority? ", before));
-echo(str("Does an include after the assigment take priority? ", after));
+echo(str("Can a variable be used when it assigned later? ", later)) echo(str("Is overwriting possible? ", overwritten));
+echo(str("Does an include before the assignment take priority? ", before));
+echo(str("Does an include after the assignment take priority? ", after));
 echo("before");
 echo("after");

--- a/tests/regression/echotest/include-overwrite-main-expected.echo
+++ b/tests/regression/echotest/include-overwrite-main-expected.echo
@@ -2,7 +2,7 @@ WARNING: overwritten was assigned on line 12 but was overwritten on line 16
 WARNING: after was assigned on line 15 of "include-overwrite-main.scad" but was overwritten on line 2 of "include-overwrite-after.scad"
 WARNING: overwriteInuse was assigned on line 1 of "include-overwrite-use.scad" but was overwritten on line 2
 ECHO: "Can a variable be used when it assigned later? true"
-ECHO: "Does an include before the assigment take priority? false"
-ECHO: "Does an include after the assigment take priority? true"
+ECHO: "Does an include before the assignment take priority? false"
+ECHO: "Does an include after the assignment take priority? true"
 ECHO: "before"
 ECHO: "after"

--- a/tests/test_pretty_print.py
+++ b/tests/test_pretty_print.py
@@ -475,7 +475,7 @@ def main():
     builddir = ezsearch('--builddir=(.*?) ', ' '.join(sys.argv) + ' ')
     if not builddir or not os.path.exists(builddir):
         builddir = os.getcwd()
-        print('warning: couldn't find --builddir, trying to use current dir:', builddir)
+        print('warning: could not find --builddir, trying to use current dir:', builddir)
     debug('build dir set to ' +  builddir)
 
     upload = False

--- a/tests/test_pretty_print.py
+++ b/tests/test_pretty_print.py
@@ -58,7 +58,7 @@ def tryread(filename):
         debug( "couldn't open file: [" + filename + "]" )
         debug( str(type(e))+str(e) )
         if filename==None:
-            # dont write a bunch of extra errors during test output. 
+            # don't write a bunch of extra errors during test output. 
             # the reporting of test failure is sufficient to indicate a problem
             pass
     return data
@@ -475,7 +475,7 @@ def main():
     builddir = ezsearch('--builddir=(.*?) ', ' '.join(sys.argv) + ' ')
     if not builddir or not os.path.exists(builddir):
         builddir = os.getcwd()
-        print('warning: couldnt find --builddir, trying to use current dir:', builddir)
+        print('warning: couldn't find --builddir, trying to use current dir:', builddir)
     debug('build dir set to ' +  builddir)
 
     upload = False

--- a/win.pri
+++ b/win.pri
@@ -17,7 +17,7 @@ win32*msvc* {
   QMAKE_CXXFLAGS += -wd4100
   # lexer uses strdup() & other POSIX stuff
   QMAKE_CXXFLAGS += -D_CRT_NONSTDC_NO_DEPRECATE
-  # Treat WChar_t as a builtin type, allows Qt to call boost funcions
+  # Treat WChar_t as a builtin type, allows Qt to call boost functions
   QMAKE_CXXFLAGS += /Zc:wchar_t
   # increases the number of sections in .obj file
   QMAKE_CXXFLAGS += /bigobj

--- a/winconsole/winconsole.pro
+++ b/winconsole/winconsole.pro
@@ -1,7 +1,7 @@
 # Windows console issues workaround stub.
 #
 # This attempts to solve the problem of piping OpenSCAD under windows
-# command line (GUI mode programs in Windows dont allow this). We use
+# command line (GUI mode programs in Windows don't allow this). We use
 # the 'devenv' solution, which means building two binaries:
 # openscad.exe, and openscad.com, the latter being a wrapper for the
 # former. See src/winconsole.c for more details.


### PR DESCRIPTION
Found via `codespell`