### PR TITLE
Use a relative import() path for svg viewbox tests

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -819,7 +819,7 @@ list(APPEND SVG_VIEWBOX_TESTS
     viewbox_600x600_slice_xMinYMin viewbox_600x600_slice_xMinYMid viewbox_600x600_slice_xMinYMax)
 
 foreach(TEST ${SVG_VIEWBOX_TESTS})
-    add_cmdline_test(svgviewbox-${TEST} EXE ${OPENSCAD_BINPATH} ARGS --imgsize 600,600 "-Dfile=\"${CMAKE_SOURCE_DIR}/../testdata/svg/viewbox/${TEST}.svg\";" -o SUFFIX png FILES ${CMAKE_SOURCE_DIR}/../testdata/scad/svg/extruded/viewbox-test.scad)
+    add_cmdline_test(svgviewbox-${TEST} EXE ${OPENSCAD_BINPATH} ARGS --imgsize 600,600 "-Dfile=\"../../../svg/viewbox/${TEST}.svg\";" -o SUFFIX png FILES ${CMAKE_SOURCE_DIR}/../testdata/scad/svg/extruded/viewbox-test.scad)
 endforeach()
 add_cmdline_test(svgimport EXE ${OPENSCAD_BINPATH} ARGS --imgsize 600,600 -o SUFFIX png FILES ${CMAKE_SOURCE_DIR}/../testdata/scad/svg/extruded/box-w-holes.scad)
 add_cmdline_test(svgimport EXE ${OPENSCAD_BINPATH} ARGS --imgsize 600,600 -o SUFFIX png FILES ${CMAKE_SOURCE_DIR}/../testdata/scad/svg/extruded/simple-center.scad)


### PR DESCRIPTION
This fixes failures in these tests for Debian packaging, where the
tests are run out-of-tree.

It also seems to match what other tests do, for example spec-paths-arcs01.scad:

  import("../../../svg/svg-spec/spec-paths-arcs01.svg");

So might be worth it to include upstream as well.

Signed-off-by: Kristian Nielsen <knielsen@knielsen-hq.org>