### PR TITLE
Fix Fedora 30 assertion on empty object

### DIFF
--- a/src/Reindexer.h
+++ b/src/Reindexer.h
@@ -40,7 +40,11 @@ public:
     Return the new element array.
   */
   const T *getArray() {
-    this->vec.resize(this->map.size());
+    auto map_size = this->map.size();
+    this->vec.resize(map_size);
+    if (map_size == 0)
+      return NULL;
+
     typename std::unordered_map<T, int>::const_iterator iter = this->map.begin();
     while (iter != this->map.end()) {
       this->vec[iter->second] = iter->first;


### PR DESCRIPTION
Avoid calling std::vector::operator[] on an empty vector. This causes
assertions on newer glibc when compiling with -D_GLIBCXX_ASSERTIONS.
And arguably it is not correct to ask for a pointer to an empty array
(even when the pointer is never used).

Bug reproduced, and fix verified, in a Fedora 30 container building with
-D_GLIBCXX_ASSERTIONS. There are already tests that trigger this, eg.
cgalpngtest_import_stl-test

Updated the pull request with a new patch, it is probably better to fix the
problem directly in the Reindexer::getArray() method rather than the caller.