### PR TITLE
Fix typo in scripts/check-dependencies.sh

### DIFF
--- a/scripts/check-dependencies.sh
+++ b/scripts/check-dependencies.sh
@@ -250,7 +250,7 @@ qscintilla2_sysver()
   debug using qtincdir: $qtincdir
   debug using qscipath: $qscipath
   if [ ! -e $qscipath ]; then
-    debug qscipath doesn't exist. giving up on version.
+    debug "qscipath doesn't exist. giving up on version."
     return
   fi
 


### PR DESCRIPTION
It looks like #2961 fixed a whole bunch of spelling and punctuation mistakes, but in changing `doesnt` to `doesn't` in `scripts/check-dependencies.sh` it left an unmatched single quote in the script. In case anyone else is searching for this error, the output I got was:

```
./scripts/check-dependencies.sh: line 304: syntax error near unexpected token `)'
./scripts/check-dependencies.sh: line 304: `  bison_sver=`echo $bison_sver | awk -F ")" ' { print $2 } '`'
```

Double-quoting the whole argument to `debug` fixes it for me.
