### PR TITLE
Avoid undefined behavior for `convexity' parameter to linear_extrude

### DIFF
--- a/src/linearextrude.cc
+++ b/src/linearextrude.cc
@@ -95,7 +95,12 @@ AbstractNode *LinearExtrudeModule::instantiate(const Context *ctx, const ModuleI
 	node->layername = layer->isUndefined() ? "" : layer->toString();
 	node->height = 100;
 	height->getFiniteDouble(node->height);
-	node->convexity = static_cast<int>(convexity->toDouble());
+	double tmp_convexity;
+	if (convexity->getFiniteDouble(tmp_convexity)) {
+	  node->convexity = static_cast<int>(tmp_convexity);
+	} else {
+	  node->convexity = 0;
+	}
 	bool originOk = origin->getVec2(node->origin_x, node->origin_y);
 	originOk &= std::isfinite(node->origin_x) && std::isfinite(node->origin_y);
 	if(origin!=ValuePtr::undefined && !originOk){


### PR DESCRIPTION
Casting inf/nan to int is undefined behaviour. In practice the
behaviour differs between linux x86, arm, and mips, causing a failure
in the test liniear_extrude-parameter-tests on non-x86 platforms.

This patch adds an explicit test for non-finite double value to make
the behavior consistent between platforms.

Fixes #3015

Signed-off-by: Kristian Nielsen <knielsen@knielsen-hq.org>