### PR TITLE
Use shared_ptr for Context::document_path

### DIFF
--- a/src/context.cc
+++ b/src/context.cc
@@ -59,6 +59,7 @@ Context::Context(const Context *parent)
 	}
 	else {
 		this->ctx_stack = new Stack;
+		this->document_path = std::make_shared<std::string>();
 	}
 
 	this->ctx_stack->push_back(this);
@@ -217,7 +218,7 @@ AbstractNode *Context::instantiate_module(const ModuleInstantiation &inst, EvalC
 std::string Context::getAbsolutePath(const std::string &filename) const
 {
 	if (!filename.empty() && !fs::path(filename).is_absolute()) {
-		return fs::absolute(fs::path(this->document_path) / filename).string();
+		return fs::absolute(fs::path(*this->document_path) / filename).string();
 	}
 	else {
 		return filename;
@@ -234,7 +235,7 @@ std::string Context::dump(const AbstractModule *mod, const ModuleInstantiation *
 	else {
 		s << boost::format("Context: %p (%p)\n") % this % this->parent;
 	}
-	s << boost::format("  document path: %s\n") % this->document_path;
+	s << boost::format("  document path: %s\n") % *this->document_path;
 	if (mod) {
 		const UserModule *m = dynamic_cast<const UserModule*>(mod);
 		if (m) {

--- a/src/context.h
+++ b/src/context.h
@@ -34,8 +34,8 @@ public:
 
 	bool has_local_variable(const std::string &name) const;
 
-	void setDocumentPath(const std::string &path) { this->document_path = path; }
-	const std::string &documentPath() const { return this->document_path; }
+	void setDocumentPath(const std::string &path) { this->document_path = std::make_shared<std::string>(path); }
+	const std::string &documentPath() const { return *this->document_path; }
 	std::string getAbsolutePath(const std::string &filename) const;
         
 public:
@@ -49,7 +49,7 @@ protected:
 	ValueMap variables;
 	ValueMap config_variables;
 
-	std::string document_path;
+	std::shared_ptr<std::string> document_path;
 
 public:
 #ifdef DEBUG

--- a/src/evalcontext.cc
+++ b/src/evalcontext.cc
@@ -118,7 +118,7 @@ std::string EvalContext::dump(const AbstractModule *mod, const ModuleInstantiati
 		s << boost::format("EvalContext %p (%p) for %s inst (%p)") % this % this->parent % inst->name() % inst;
 	else
 		s << boost::format("Context: %p (%p)") % this % this->parent;
-	s << boost::format("  document path: %s") % this->document_path;
+	s << boost::format("  document path: %s") % *this->document_path;
 
 	s << boost::format("  eval args:");
 	for (size_t i=0;i<this->eval_arguments.size();i++) {

--- a/src/modcontext.cc
+++ b/src/modcontext.cc
@@ -140,7 +140,7 @@ std::string ModuleContext::dump(const AbstractModule *mod, const ModuleInstantia
 	else {
 		s << boost::format("ModuleContext: %p (%p)") % this % this->parent;
 	}
-	s << boost::format("  document path: %s") % this->document_path;
+	s << boost::format("  document path: %s") % *this->document_path;
 	if (mod) {
 		const UserModule *m = dynamic_cast<const UserModule*>(mod);
 		if (m) {
@@ -225,7 +225,7 @@ AbstractNode *FileContext::instantiate_module(const ModuleInstantiation &inst, E
 
 void FileContext::initializeModule(const class FileModule &module)
 {
-	if (!module.modulePath().empty()) this->document_path = module.modulePath();
+	if (!module.modulePath().empty()) this->document_path = std::make_shared<std::string>(module.modulePath());
 	// FIXME: Don't access module members directly
 	this->usedlibs_p = &module.usedlibs;
 	this->functions_p = &module.scope.functions;


### PR DESCRIPTION
While working on another PR to improve tail recursion, I noticed that creating a Context can be faster; the document_path member was always copied.

This wraps it in a shared_ptr. The speedup is about 10% to 15% when doing lots of Context creation.