### PR TITLE
Generic tail recursion

### DIFF
--- a/src/context.cc
+++ b/src/context.cc
@@ -123,6 +123,24 @@ void Context::apply_variables(const Context &other)
 	}
 }
 
+/*!
+  Apply config variables of 'other' to this context, from the full context stack of 'other', bottom-up.
+*/
+void Context::apply_config_variables(const Context &other)
+{
+	if (&other == this) {
+		// Anything in 'other' and its ancestors is already part of this context, no need to descend any further.
+		return;
+	}
+	if (other.parent) {
+		// Assign parent's variables first, since they might be overridden by a child
+		apply_config_variables(*other.parent);
+	}
+	for (const auto &var : other.config_variables) {
+		set_variable(var.first, var.second);
+	}
+}
+
 ValuePtr Context::lookup_variable(const std::string &name, bool silent, const Location &loc) const
 {
 	if (!this->ctx_stack) {

--- a/src/context.h
+++ b/src/context.h
@@ -28,6 +28,7 @@ public:
 	void set_constant(const std::string &name, const Value &value);
 
 	void apply_variables(const Context &other);
+	void apply_config_variables(const Context &other);
 	ValuePtr lookup_variable(const std::string &name, bool silent = false, const Location &loc=Location::NONE) const;
 	double lookup_variable_with_default(const std::string &variable, const double &def, const Location &loc=Location::NONE) const;
 	std::string lookup_variable_with_default(const std::string &variable, const std::string &def, const Location &loc=Location::NONE) const;

--- a/src/expr.cc
+++ b/src/expr.cc
@@ -490,6 +490,8 @@ void FunctionCall::prepareTailCallContext(const Context *context, Context *tailC
 	for (const auto &var : variables) {
 		tailCallContext->set_variable(var.first, var.second);
 	}
+	// Apply config variables ($...)
+	tailCallContext->apply_config_variables(context);
 }
 
 ValuePtr FunctionCall::evaluate(const Context *context) const

--- a/src/expression.h
+++ b/src/expression.h
@@ -154,12 +154,15 @@ class FunctionCall : public Expression
 {
 public:
 	FunctionCall(const std::string &funcname, const AssignmentList &arglist, const Location &loc);
+	void prepareTailCallContext(const Context *context, Context *tailCallContext, const AssignmentList &definition_arguments);
 	ValuePtr evaluate(const class Context *context) const override;
 	void print(std::ostream &stream, const std::string &indent) const override;
 	static Expression * create(const std::string &funcname, const AssignmentList &arglist, Expression *expr, const Location &loc);
 public:
 	std::string name;
 	AssignmentList arguments;
+	AssignmentMap resolvedArguments;
+	std::vector<std::pair<std::string, ValuePtr>> defaultArguments; // Only the ones not mentioned in 'resolvedArguments'
 };
 
 class Assert : public Expression

--- a/src/expression.h
+++ b/src/expression.h
@@ -71,9 +71,10 @@ class TernaryOp : public Expression
 {
 public:
 	TernaryOp(Expression *cond, Expression *ifexpr, Expression *elseexpr, const Location &loc);
+	const shared_ptr<Expression> &evaluateStep(const Context *context) const;
 	ValuePtr evaluate(const class Context *context) const override;
 	void print(std::ostream &stream, const std::string &indent) const override;
-
+private:
 	shared_ptr<Expression> cond;
 	shared_ptr<Expression> ifexpr;
 	shared_ptr<Expression> elseexpr;
@@ -165,6 +166,7 @@ class Assert : public Expression
 {
 public:
 	Assert(const AssignmentList &args, Expression *expr, const Location &loc);
+	const shared_ptr<Expression> &evaluateStep(const Context *context) const;
 	ValuePtr evaluate(const class Context *context) const override;
 	void print(std::ostream &stream, const std::string &indent) const override;
 private:
@@ -176,6 +178,7 @@ class Echo : public Expression
 {
 public:
 	Echo(const AssignmentList &args, Expression *expr, const Location &loc);
+	const shared_ptr<Expression> &evaluateStep(const Context *context) const;
 	ValuePtr evaluate(const class Context *context) const override;
 	void print(std::ostream &stream, const std::string &indent) const override;
 private:
@@ -187,6 +190,7 @@ class Let : public Expression
 {
 public:
 	Let(const AssignmentList &args, Expression *expr, const Location &loc);
+	const shared_ptr<Expression> &evaluateStep(Context *context) const;
 	ValuePtr evaluate(const class Context *context) const override;
 	void print(std::ostream &stream, const std::string &indent) const override;
 private:

--- a/src/function.cc
+++ b/src/function.cc
@@ -29,6 +29,8 @@
 #include "expression.h"
 #include "printutils.h"
 
+#include <typeinfo>
+
 AbstractFunction::~AbstractFunction()
 {
 }
@@ -64,19 +66,24 @@ ValuePtr UserFunction::evaluate(const Context *ctx, const EvalContext *evalctx) 
 				result = ValuePtr::undefined;
 				break;
 			}
-			else if (shared_ptr<TernaryOp> ternary = dynamic_pointer_cast<TernaryOp>(subExpr)) {
+			else if (typeid(*subExpr) == typeid(TernaryOp)) {
+				const shared_ptr<TernaryOp> &ternary = static_pointer_cast<TernaryOp>(subExpr);
 				subExpr = ternary->evaluateStep(&c_local);
 			}
-			else if (shared_ptr<Assert> assertion = dynamic_pointer_cast<Assert>(subExpr)) {
+			else if (typeid(*subExpr) == typeid(Assert)) {
+				const shared_ptr<Assert> &assertion = static_pointer_cast<Assert>(subExpr);
 				subExpr = assertion->evaluateStep(&c_local);
 			}
-			else if (shared_ptr<Echo> echo = dynamic_pointer_cast<Echo>(subExpr)) {
+			else if (typeid(*subExpr) == typeid(Echo)) {
+				const shared_ptr<Echo> &echo = static_pointer_cast<Echo>(subExpr);
 				subExpr = echo->evaluateStep(&c_local);
 			}
-			else if (shared_ptr<Let> let = dynamic_pointer_cast<Let>(subExpr)) {
+			else if (typeid(*subExpr) == typeid(Let)) {
+				const shared_ptr<Let> &let = static_pointer_cast<Let>(subExpr);
 				subExpr = let->evaluateStep(&c_local);
 			}
-			else if (shared_ptr<FunctionCall> call = dynamic_pointer_cast<FunctionCall>(subExpr)) {
+			else if (typeid(*subExpr) == typeid(FunctionCall)) {
+				const shared_ptr<FunctionCall> &call = static_pointer_cast<FunctionCall>(subExpr);
 				if (name == call->name) {
 					// Update c_next with new parameters for tail call
 					call->prepareTailCallContext(&c_local, &c_next, definition_arguments);

--- a/src/function.cc
+++ b/src/function.cc
@@ -67,6 +67,15 @@ ValuePtr UserFunction::evaluate(const Context *ctx, const EvalContext *evalctx) 
 			else if (shared_ptr<TernaryOp> ternary = dynamic_pointer_cast<TernaryOp>(subExpr)) {
 				subExpr = ternary->evaluateStep(&c_local);
 			}
+			else if (shared_ptr<Assert> assertion = dynamic_pointer_cast<Assert>(subExpr)) {
+				subExpr = assertion->evaluateStep(&c_local);
+			}
+			else if (shared_ptr<Echo> echo = dynamic_pointer_cast<Echo>(subExpr)) {
+				subExpr = echo->evaluateStep(&c_local);
+			}
+			else if (shared_ptr<Let> let = dynamic_pointer_cast<Let>(subExpr)) {
+				subExpr = let->evaluateStep(&c_local);
+			}
 			else if (shared_ptr<FunctionCall> call = dynamic_pointer_cast<FunctionCall>(subExpr)) {
 				if (name == call->name) {
 					// Update c_next with new parameters for tail call

--- a/src/function.cc
+++ b/src/function.cc
@@ -64,69 +64,6 @@ void UserFunction::print(std::ostream &stream, const std::string &indent) const
 	stream << ") = " << *expr << ";\n";
 }
 
-class FunctionTailRecursion : public UserFunction
-{
-private:
-	bool invert;
-	shared_ptr<TernaryOp> op;
-	shared_ptr<FunctionCall> call;
-	shared_ptr<Expression> endexpr;
-
-public:
-	FunctionTailRecursion(const char *name, AssignmentList &definition_arguments,
-												shared_ptr<TernaryOp> expr, shared_ptr<FunctionCall> call,
-												shared_ptr<Expression> endexpr, bool invert,
-												const Location &loc)
-		: UserFunction(name, definition_arguments, expr, loc),
-			invert(invert), op(expr), call(call), endexpr(endexpr) {
-	}
-
-	~FunctionTailRecursion() { }
-
-	ValuePtr evaluate(const Context *ctx, const EvalContext *evalctx) const override {
-		if (!expr) return ValuePtr::undefined;
-		
-		Context c(ctx);
-		c.setVariables(evalctx, definition_arguments);
-		
-		EvalContext ec(&c, call->arguments, loc);
-		Context tmp(&c);
-		unsigned int counter = 0;
-		while (invert ^ this->op->cond->evaluate(&c)) {
-			tmp.setVariables(&ec, definition_arguments);
-			c.apply_variables(tmp);
-			
-			if (counter++ == 1000000){
-				std::string locs = loc.toRelativeString(ctx->documentPath());
-				PRINTB("ERROR: Recursion detected calling function '%s' %s", this->name % locs);
-				throw RecursionException::create("function", this->name,loc);
-			}
-		}
-		
-		ValuePtr result = endexpr->evaluate(&c);
-		
-		return result;
-	}
-};
-
-UserFunction *UserFunction::create(const char *name, AssignmentList &definition_arguments, shared_ptr<Expression> expr, const Location &loc)
-{
-	if (shared_ptr<TernaryOp> ternary = dynamic_pointer_cast<TernaryOp>(expr)) {
-		shared_ptr<FunctionCall> ifcall = dynamic_pointer_cast<FunctionCall>(ternary->ifexpr);
-		shared_ptr<FunctionCall> elsecall = dynamic_pointer_cast<FunctionCall>(ternary->elseexpr);
-		if (ifcall && !elsecall) {
-			if (name == ifcall->name) {
-				return new FunctionTailRecursion(name, definition_arguments, ternary, ifcall, ternary->elseexpr, false, loc);
-			}
-		} else if (elsecall && !ifcall) {
-			if (name == elsecall->name) {
-				return new FunctionTailRecursion(name, definition_arguments, ternary, elsecall, ternary->ifexpr, true, loc);
-			}
-		}
-	}
-	return new UserFunction(name, definition_arguments, expr, loc);
-}
-
 BuiltinFunction::~BuiltinFunction()
 {
 }

--- a/src/function.cc
+++ b/src/function.cc
@@ -69,11 +69,8 @@ ValuePtr UserFunction::evaluate(const Context *ctx, const EvalContext *evalctx) 
 			}
 			else if (shared_ptr<FunctionCall> call = dynamic_pointer_cast<FunctionCall>(subExpr)) {
 				if (name == call->name) {
-					// Set new parameters for tail call
-					EvalContext ec(&c_local, call->arguments, call->location());
-					Context tmp(&c_local);
-					tmp.setVariables(&ec, definition_arguments);
-					c_next.apply_variables(tmp);
+					// Update c_next with new parameters for tail call
+					call->prepareTailCallContext(&c_local, &c_next, definition_arguments);
 					tailCall = true;
 				}
 				else {

--- a/src/function.cc
+++ b/src/function.cc
@@ -47,7 +47,31 @@ ValuePtr UserFunction::evaluate(const Context *ctx, const EvalContext *evalctx) 
 	if (!expr) return ValuePtr::undefined;
 	Context c(ctx);
 	c.setVariables(evalctx, definition_arguments);
-	ValuePtr result = expr->evaluate(&c);
+
+	// Outer loop: to allow tail calls
+	unsigned int counter = 0;
+	ValuePtr result;
+	while (true) {
+		// Inner loop: to follow a single execution path
+		// Before a 'break', must either assign result, or set tailCall to true.
+		shared_ptr<Expression> subExpr = expr;
+		bool tailCall = false;
+		while (true) {
+			if (true) {
+				result = subExpr->evaluate(&c);
+				break;
+			}
+		}
+		if (!tailCall) {
+			break;
+		}
+
+		if (counter++ == 1000000){
+			std::string locs = loc.toRelativeString(ctx->documentPath());
+			PRINTB("ERROR: Recursion detected calling function '%s' %s", this->name % locs);
+			throw RecursionException::create("function", this->name,loc);
+		}
+	}
 
 	return result;
 }

--- a/src/function.h
+++ b/src/function.h
@@ -47,6 +47,4 @@ public:
 
 	ValuePtr evaluate(const Context *ctx, const EvalContext *evalctx) const override;
 	void print(std::ostream &stream, const std::string &indent) const override;
-        
-	static UserFunction *create(const char *name, AssignmentList &definition_arguments, shared_ptr<Expression> expr, const Location &loc);
 };

--- a/src/parser.y
+++ b/src/parser.y
@@ -191,7 +191,7 @@ statement:
             }
         | TOK_FUNCTION TOK_ID '(' arguments_decl optional_commas ')' '=' expr
             {
-              UserFunction *func = UserFunction::create($2, *$4, shared_ptr<Expression>($8), LOC(@$));
+              UserFunction *func = new UserFunction($2, *$4, shared_ptr<Expression>($8), LOC(@$));
               scope_stack.top()->addFunction(func);
               free($2);
               delete $4;

--- a/testdata/scad/misc/function-scope.scad
+++ b/testdata/scad/misc/function-scope.scad
@@ -1,0 +1,15 @@
+// Each 'let' creates a new context, allowing variable override
+function duplicate_let() = let(x=42) let(x=33) x;
+echo(duplicate_let=duplicate_let()); // 33
+
+// Default value (x=42) must be used, if not given in call
+function defaults(b, x=42) = b ? x : defaults(true);
+echo(defaults=defaults(false, 33)); // 42
+
+// Regular local variables should not survive to the next tail recursion call
+function scope_leak(b=false) = b ? x : let(x=42) scope_leak(true);
+echo(scope_leak=scope_leak()); // undef
+
+// ...however, "config variables" should
+function scope_leak_config(b=false) = b ? $x : let($x=33) let($x=42) scope_leak_config(true);
+echo(scope_leak_config=scope_leak_config()); // 42

--- a/testdata/scad/misc/tail-recursion-tests.scad
+++ b/testdata/scad/misc/tail-recursion-tests.scad
@@ -29,3 +29,24 @@ echo(len(s1), substring(s1, 0, 40));
 function f2b(x, y = 0, t = "") = x > 0 ? f2b(x - 1, y + 1, str(t, chr((y % 26) + 97))) : t;
 s2 = f2b(50000);
 echo(len(s2), substring(s2, 0, 40));
+
+// tail recursion with a complicated mix of let/assert/echo and nested ternary operators
+function ftail_mixed(n) =
+    let(x = 42 + n)
+    assert(x >= 42)
+    n == 0 ? (
+        x
+    ) : n < 10 ? (
+        n < 5 ? (
+            let(y = 33 + x)
+            echo(n=n, x=x, y=y)
+            ftail_mixed(n - 1)
+        ) : (
+            assert(n >= 0)
+            ftail_mixed(n - 1)
+        )
+    ) : (
+        let(y = let(z = n - 1) z)
+        ftail_mixed(y)
+    );
+echo(ftail_mixed=ftail_mixed(10000)); // 42

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -451,6 +451,7 @@ list(APPEND ECHO_FILES ${FUNCTION_FILES} ${MISC_FILES}
             ${CMAKE_SOURCE_DIR}/../testdata/scad/misc/preview_variable.scad
             ${CMAKE_SOURCE_DIR}/../testdata/scad/issues/issue1851-each-fail-on-scalar.scad
             ${CMAKE_SOURCE_DIR}/../testdata/scad/issues/issue2342.scad
+            ${CMAKE_SOURCE_DIR}/../testdata/scad/misc/function-scope.scad
             )
 
 list(APPEND ASTDUMPTEST_FILES ${MISC_FILES}

--- a/tests/regression/echotest/function-scope-expected.echo
+++ b/tests/regression/echotest/function-scope-expected.echo
@@ -1,0 +1,5 @@
+ECHO: duplicate_let = 33
+ECHO: defaults = 42
+WARNING: Ignoring unknown variable 'x', in file function-scope.scad, line 10.
+ECHO: scope_leak = undef
+ECHO: scope_leak_config = 42

--- a/tests/regression/echotest/recursion-test-function-expected.echo
+++ b/tests/regression/echotest/recursion-test-function-expected.echo
@@ -1,6 +1,3 @@
 ERROR: Recursion detected calling function 'crash' in file recursion-test-function.scad, line 1
-TRACE: called by 'crash', in file recursion-test-function.scad, line 1.
-TRACE: called by 'crash', in file recursion-test-function.scad, line 1.
-TRACE: called by 'crash', in file recursion-test-function.scad, line 1.
-TRACE: called by 'crash', in file recursion-test-function.scad, line 1.
-TRACE: called by 'crash', in file recursion-test-function.scad, line 1.
+TRACE: called by 'crash', in file recursion-test-function.scad, line 3.
+TRACE: called by 'echo', in file recursion-test-function.scad, line 3.

--- a/tests/regression/echotest/recursion-test-function2-expected.echo
+++ b/tests/regression/echotest/recursion-test-function2-expected.echo
@@ -1,6 +1,2 @@
 ERROR: Recursion detected calling function 'crash' in file recursion-test-function2.scad, line 2
-TRACE: called by 'crash', in file recursion-test-function2.scad, line 2.
-TRACE: called by 'crash', in file recursion-test-function2.scad, line 2.
-TRACE: called by 'crash', in file recursion-test-function2.scad, line 2.
-TRACE: called by 'crash', in file recursion-test-function2.scad, line 2.
-TRACE: called by 'crash', in file recursion-test-function2.scad, line 2.
+TRACE: called by 'crash', in file recursion-test-function2.scad, line 3.

--- a/tests/regression/echotest/tail-recursion-tests-expected.echo
+++ b/tests/regression/echotest/tail-recursion-tests-expected.echo
@@ -4,3 +4,8 @@ ECHO: "with tail-recursion eliminiation: ", 2.001e+6
 ECHO: [1980, 1980]
 ECHO: 50000, "ACEGIKMOQSUWYACEGIKMOQSUWYACEGIKMOQSUWYA"
 ECHO: 50000, "abcdefghijklmnopqrstuvwxyzabcdefghijklmn"
+ECHO: n = 4, x = 46, y = 79
+ECHO: n = 3, x = 45, y = 78
+ECHO: n = 2, x = 44, y = 77
+ECHO: n = 1, x = 43, y = 76
+ECHO: ftail_mixed = 42


### PR DESCRIPTION
This re-implements tail recursion of functions; now any self-call in tail position gets to enjoy tail recursion, instead of functions that follow a very specific structure. In particular, let/assert/echo and nested ternary operators can be used freely now.

Unlike at parse time as before, now the decision to use tail recursion is made at run-time, and for each function call instead of each function declaration.

Tried to separate it in a few commits. Here's a summary of changes:
- Remove FunctionTailRecursion and its factory method
- For a few Expression subclasses, factor out method ```evaluateStep``` from ```evaluate```. It returns the following Expression, instead of evaluating it.
- Use a nested while-loop for function evaluation; the inner loop iteratively follows a single execution path where possible, and falls back to a regular recursive call otherwise (for binary operators etc)
- Add a few tests

A word on performance; I benchmarked using this silly example:
```function speed(n=1000000) = n == 0 ? 42 : speed(n-1);```
Initial results weren't too good; it was almost twice as slow as master. So, had to hunt down a few optimizations:
- custom function to prepare new tail call context, caching some stuff: ```FunctionCall::prepareTailCallContext```
- Use typeid check + static_cast, instead of dynamic cast
- Reduce Context creation overhead (not in this PR though; see PR #3019 )

Now the speed is more or less the same as on master.