### PR TITLE
Work-around for test failure at high -jN

### DIFF
--- a/src/OffscreenContextGLX.cc
+++ b/src/OffscreenContextGLX.cc
@@ -256,11 +256,25 @@ bool create_glx_dummy_context(OffscreenContext &ctx)
 	int major;
 	int minor;
 	auto result = false;
+	int tries = 0;
+	auto dpyenv = getenv("DISPLAY");
+	auto retryenv = getenv("OPENSCAD_X_CONN_RETRY");
+	int connect_retry_count = retryenv ? atoi(retryenv) : 0;
 
-	ctx.xdisplay = XOpenDisplay(nullptr);
-	if (ctx.xdisplay == nullptr) {
+	for (;;) {
+		ctx.xdisplay = XOpenDisplay(nullptr);
+		tries++;
+		if (ctx.xdisplay != nullptr) {
+			break;
+		}
+		if (tries <= connect_retry_count) {
+			std::cerr << "Warning: XOpenDisplay(DISPLAY=\""
+				  << (dpyenv?dpyenv:"")
+				  << "\") failed, retrying...\n";
+			sleep(1);
+			continue;
+		}
 		std::cerr << "Unable to open a connection to the X server.\n";
-		auto dpyenv = getenv("DISPLAY");
 		std::cerr << "DISPLAY=" << (dpyenv?dpyenv:"") << "\n";
 		return false;
 	}

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -16,6 +16,11 @@ project(tests)
 
 set(CMAKE_MODULE_PATH {$CMAKE_MODULE_PATH} "${CMAKE_SOURCE_DIR}/../cmake/Modules/")
 
+# Xvfb has a bug where many quick connections in parallel occasionally causes
+# a connection to fail. We work around that by setting this environment variable
+# that makes openscad retry a failed X connection.
+set(CTEST_ENVIRONMENT "${CTEST_ENVIRONMENT};OPENSCAD_X_CONN_RETRY=3")
+
 # MCAD
 if(NOT EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/../libraries/MCAD/__init__.py)
   message(FATAL_ERROR "MCAD not found. You can install from the OpenSCAD root as follows: \n  git submodule update --init")


### PR DESCRIPTION
So this isn't pretty, but it does provide a possible solution to an annoying problem. With this patch I am able to consistently run the openscad testsuite with -j8 without failures. Whereas without this I'll see random failures every 2-3 test run or something like that.

----

When running the testsuite against an Xvfb $DISPLAY with -jN, there
are occasional failures with "Unable to open a connection to the X
server". This appears to be a bug in Xvfb with rapid parallel connects.

This patch implements a work-around: The testsuite sets the
environment variable OPENSCAD_X_CONN_RETRY; this causes openscad to
retry the X connection in case of failure, which avoids the test
failure.
