### PR TITLE
Corrected reading of Preference settings

### DIFF
--- a/src/mainwin.cc
+++ b/src/mainwin.cc
@@ -695,8 +695,8 @@ void MainWindow::loadViewSettings(){
 		viewPerspective();
 	}
 
-	updateUndockMode(settings.value("advanced/undockableWindows").toBool());
-	updateReorderMode(settings.value("advanced/reorderWindows").toBool());
+	updateUndockMode(Preferences::inst()->getValue("advanced/undockableWindows").toBool());
+	updateReorderMode(Preferences::inst()->getValue("advanced/reorderWindows").toBool());
 }
 
 void MainWindow::loadDesignSettings()

--- a/src/scintillaeditor.cpp
+++ b/src/scintillaeditor.cpp
@@ -246,9 +246,7 @@ void ScintillaEditor::applySettings()
     if (!value) qsci->setMarginWidth(1,20);
     else qsci->setMarginWidth(1,QString(trunc(log10(qsci->lines())+4), '0'));
 
-    QSettingsCached settings;
-
-	if(settings.value("editor/enableAutocomplete").toBool())
+	if(Preferences::inst()->getValue("editor/enableAutocomplete").toBool())
 	{
 		qsci->setAutoCompletionSource(QsciScintilla::AcsAPIs);
 		qsci->setAutoCompletionFillupsEnabled(true);
@@ -262,7 +260,7 @@ void ScintillaEditor::applySettings()
 		qsci->setCallTipsStyle(QsciScintilla::CallTipsNone);
 	}
 
-	int val = settings.value("editor/characterThreshold").toInt();
+	int val = Preferences::inst()->getValue("editor/characterThreshold").toInt();
 	qsci->setAutoCompletionThreshold(val <= 0 ? 1 : val);
 
 }


### PR DESCRIPTION
The dock settings and autocomplete settings were not properly initialized when config file of OpenSCAD was removed. This bug emerged due to blocking of signal in updateGUI() of Preferences.cc 