### PR TITLE
Don't replace extension of output file

### DIFF
--- a/src/openscad.cc
+++ b/src/openscad.cc
@@ -303,7 +303,7 @@ int cmdline(const char *deps_output_file, const std::string &filename, const cha
 	}
 	
 	curFormat = exportFileFormatOptions.exportFileFormats.at(extsn);
-	std::string filename_str = fs::path(output_file_str).replace_extension(extsn).generic_string();
+	std::string filename_str = fs::path(output_file_str).generic_string();
 	new_output_file = filename_str.c_str();
 
 	set_render_color_scheme(arg_colorscheme, true);


### PR DESCRIPTION
Not sure what the expected behavior should be, but to me the current behavior seems strange.
Running:
```openscad input.scad --export-format stl -o /dev/null```
tries to write a STL file to ```/dev/null.stl```.

With this change, the filename given by "-o" is respected; probably the user knows what they are doing.

Side effect is that extension is no longer lower-cased now:
```openscad input.scad -o output.STL```
now produces ```output.STL``` instead of ```output.stl```.