### PR TITLE
Better fix for test failures at high -jN

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -16,11 +16,6 @@ project(tests)
 
 set(CMAKE_MODULE_PATH {$CMAKE_MODULE_PATH} "${CMAKE_SOURCE_DIR}/../cmake/Modules/")
 
-# Xvfb has a bug where many quick connections in parallel occasionally causes
-# a connection to fail. We work around that by setting this environment variable
-# that makes openscad retry a failed X connection.
-set(CTEST_ENVIRONMENT "${CTEST_ENVIRONMENT};OPENSCAD_X_CONN_RETRY=3")
-
 # MCAD
 if(NOT EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/../libraries/MCAD/__init__.py)
   message(FATAL_ERROR "MCAD not found. You can install from the OpenSCAD root as follows: \n  git submodule update --init")

--- a/tests/virtualfb.sh
+++ b/tests/virtualfb.sh
@@ -43,7 +43,7 @@ start()
 
   if [ "`command -v Xvfb`" ]; then
     VFB_BINARY=Xvfb
-    VFB_OPTIONS='-screen 0 800x600x24'
+    VFB_OPTIONS='-screen 0 800x600x24 -noreset'
   fi
 
   if [ ! $VFB_BINARY ]; then


### PR DESCRIPTION
Tests fail occasionally at high -jN with a failure to connect to the X
server on Xvfb. By default, the X server resets itself when all
clients disconnect, and this leaves a window where new connects can
fail during the reset. This can be avoided by passing the -noreset
flag to the X server.

This replaces the previous https://github.com/openscad/openscad/pull/3024
patch to solve the same problem.

Signed-off-by: Kristian Nielsen <knielsen@knielsen-hq.org>