### PR TITLE
Xretry3

### DIFF
--- a/src/OffscreenContextGLX.cc
+++ b/src/OffscreenContextGLX.cc
@@ -256,25 +256,11 @@ bool create_glx_dummy_context(OffscreenContext &ctx)
 	int major;
 	int minor;
 	auto result = false;
-	int tries = 0;
-	auto dpyenv = getenv("DISPLAY");
-	auto retryenv = getenv("OPENSCAD_X_CONN_RETRY");
-	int connect_retry_count = retryenv ? atoi(retryenv) : 0;
 
-	for (;;) {
-		ctx.xdisplay = XOpenDisplay(nullptr);
-		tries++;
-		if (ctx.xdisplay != nullptr) {
-			break;
-		}
-		if (tries <= connect_retry_count) {
-			std::cerr << "Warning: XOpenDisplay(DISPLAY=\""
-				  << (dpyenv?dpyenv:"")
-				  << "\") failed, retrying...\n";
-			sleep(1);
-			continue;
-		}
+	ctx.xdisplay = XOpenDisplay(nullptr);
+	if (ctx.xdisplay == nullptr) {
 		std::cerr << "Unable to open a connection to the X server.\n";
+		auto dpyenv = getenv("DISPLAY");
 		std::cerr << "DISPLAY=" << (dpyenv?dpyenv:"") << "\n";
 		return false;
 	}

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -16,11 +16,6 @@ project(tests)
 
 set(CMAKE_MODULE_PATH {$CMAKE_MODULE_PATH} "${CMAKE_SOURCE_DIR}/../cmake/Modules/")
 
-# Xvfb has a bug where many quick connections in parallel occasionally causes
-# a connection to fail. We work around that by setting this environment variable
-# that makes openscad retry a failed X connection.
-set(CTEST_ENVIRONMENT "${CTEST_ENVIRONMENT};OPENSCAD_X_CONN_RETRY=3")
-
 # MCAD
 if(NOT EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/../libraries/MCAD/__init__.py)
   message(FATAL_ERROR "MCAD not found. You can install from the OpenSCAD root as follows: \n  git submodule update --init")

--- a/tests/virtualfb.sh
+++ b/tests/virtualfb.sh
@@ -43,7 +43,7 @@ start()
 
   if [ "`command -v Xvfb`" ]; then
     VFB_BINARY=Xvfb
-    VFB_OPTIONS='-screen 0 800x600x24'
+    VFB_OPTIONS='-screen 0 800x600x24 -noreset'
   fi
 
   if [ ! $VFB_BINARY ]; then


### PR DESCRIPTION
This pull request goes on top of https://github.com/openscad/openscad/pull/3037 , which is a simpler fix to the -jN test failure issue. This patch removes the retry code again from the openscad program. There was some discussion on the IRC if we should leave in the retry code in case it would be needed another time, so put in a separate pull request for flexibility (I think it's fine to remove the code though, it's unlikely to be needed I think).