### PR TITLE
Work-around for test failures on mips

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -744,6 +744,11 @@ if ( ${CMAKE_SYSTEM_PROCESSOR} MATCHES "ppc")
   set(CTEST_ENVIRONMENT "${CTEST_ENVIRONMENT};GALLIUM_DRIVER=softpipe")
   set(CTEST_ENVIRONMENT "${CTEST_ENVIRONMENT};DRAW_USE_LLVM=no")
 endif()
+if ( ${CMAKE_SYSTEM_PROCESSOR} MATCHES "mips")
+  message(STATUS "Workaround MIPS bug https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=868745")
+  set(CTEST_ENVIRONMENT "${CTEST_ENVIRONMENT};GALLIUM_DRIVER=softpipe")
+  set(CTEST_ENVIRONMENT "${CTEST_ENVIRONMENT};DRAW_USE_LLVM=no")
+endif()
 
 # Set up custom commands to run before & after Ctest run.
 # 1. Start/stop Virtual Framebuffer for linux/bsd. 2. Pretty Print


### PR DESCRIPTION
The llvmpipe software-renderer of Mesa seems not stable on the MIPS
architecture. There are numerous crashes in the test suite when using
llvmpipe, as seen in the Debian build farm.

This patch implements the similar work-around that already exists for
PowerPC, to use the softpipe renderer (which was significantly faster
than llvmpipe anyway on MIPS in my tests).

Signed-off-by: Kristian Nielsen <knielsen@knielsen-hq.org>