### PR TITLE
GUI: add Scintilla "bookmarks" feature

### DIFF
--- a/src/MainWindow.ui
+++ b/src/MainWindow.ui
@@ -339,6 +339,9 @@
     <addaction name="editActionComment"/>
     <addaction name="editActionUncomment"/>
     <addaction name="editActionConvertTabsToSpaces"/>
+    <addaction name="editActionToggleBookmark"/>
+    <addaction name="editActionNextBookmark"/>
+    <addaction name="editActionPrevBookmark"/>
     <addaction name="separator"/>
     <addaction name="editActionCopyViewport"/>
     <addaction name="editActionCopyVPT"/>
@@ -1432,6 +1435,30 @@
   <action name="editActionConvertTabsToSpaces">
    <property name="text">
     <string>Conv&amp;ert Tabs to Spaces</string>
+   </property>
+  </action>
+  <action name="editActionToggleBookmark">
+   <property name="text">
+    <string>Toggle Bookmark</string>
+   </property>
+   <property name="shortcut">
+    <string>CTRL+F2</string>
+   </property>
+  </action>
+  <action name="editActionNextBookmark">
+   <property name="text">
+    <string>Jump to next bookmark</string>
+   </property>
+   <property name="shortcut">
+    <string>F2</string>
+   </property>
+  </action>
+  <action name="editActionPrevBookmark">
+   <property name="text">
+    <string>Jump to previous bookmark</string>
+   </property>
+   <property name="shortcut">
+    <string>SHIFT+F2</string>
    </property>
   </action>
   <action name="viewActionHideToolBars">

--- a/src/editor.h
+++ b/src/editor.h
@@ -53,6 +53,9 @@ public slots:
 	virtual void paste() = 0;
 	virtual void initFont(const QString&, uint) = 0;
 	virtual void displayTemplates() = 0;
+	virtual void toggleBookmark() = 0;
+	virtual void nextBookmark() = 0;
+	virtual void prevBookmark() = 0;
 
 private:
 	QSize initialSizeHint;

--- a/src/legacyeditor.cc
+++ b/src/legacyeditor.cc
@@ -316,3 +316,15 @@ void LegacyEditor::displayTemplates()
 void LegacyEditor::addTemplate()
 {
 }
+
+void LegacyEditor::toggleBookmark()
+{
+}
+
+void LegacyEditor::nextBookmark()
+{
+}
+
+void LegacyEditor::prevBookmark()
+{
+}

--- a/src/legacyeditor.h
+++ b/src/legacyeditor.h
@@ -43,6 +43,9 @@ public slots:
 	void initFont(const QString&, uint) override;
 	void displayTemplates() override;
 	void addTemplate() override;
+	void toggleBookmark() override;
+	void nextBookmark() override;
+	void prevBookmark() override;
 private:
 	class QTextEdit *textedit;
 	class Highlighter *highlighter;

--- a/src/mainwin.cc
+++ b/src/mainwin.cc
@@ -304,7 +304,6 @@ MainWindow::MainWindow(const QStringList &filenames)
 	connect(this->fileShowLibraryFolder, SIGNAL(triggered()), this, SLOT(actionShowLibraryFolder()));
 #ifndef __APPLE__
 	auto shortcuts = this->fileActionSave->shortcuts();
-	shortcuts.push_back(QKeySequence(Qt::Key_F2));
 	this->fileActionSave->setShortcuts(shortcuts);
 	shortcuts = this->fileActionReload->shortcuts();
 	shortcuts.push_back(QKeySequence(Qt::Key_F3));

--- a/src/scintillaeditor.cpp
+++ b/src/scintillaeditor.cpp
@@ -158,6 +158,7 @@ ScintillaEditor::ScintillaEditor(QWidget *parent) : EditorInterface(parent)
 	qsci->indicatorDefine(QsciScintilla::RoundBoxIndicator, errorIndicatorNumber);
 	qsci->indicatorDefine(QsciScintilla::RoundBoxIndicator , findIndicatorNumber); 
 	qsci->markerDefine(QsciScintilla::Circle, errMarkerNumber);
+	qsci->markerDefine(QsciScintilla::Bookmark, bmMarkerNumber);
 	qsci->setUtf8(true);
 	qsci->setFolding(QsciScintilla::BoxedTreeFoldStyle, 4);
 	qsci->setCaretLineVisible(true);
@@ -963,12 +964,35 @@ void ScintillaEditor::onCharacterThresholdChanged(int val)
 
 void ScintillaEditor::toggleBookmark()
 {
+	int line, index;
+	qsci->getCursorPosition(&line, &index);
+
+	unsigned int state = qsci->markersAtLine(line);
+
+	if ((state & (1<<bmMarkerNumber))==0)
+		qsci->markerAdd(line, bmMarkerNumber);
+	else
+		qsci->markerDelete(line, bmMarkerNumber);
 }
 
 void ScintillaEditor::nextBookmark()
 {
+	int line, index;
+	qsci->getCursorPosition(&line, &index);
+	line = qsci->markerFindNext(line+1, 1<<bmMarkerNumber);
+	if (line == -1) // wrap around, search from the first line
+		line = qsci->markerFindNext(0, 1<<bmMarkerNumber);
+	if (line != -1)
+		qsci->setCursorPosition(line, index);
 }
 
 void ScintillaEditor::prevBookmark()
 {
+	int line, index;
+	qsci->getCursorPosition(&line, &index);
+	line = qsci->markerFindPrevious(line-1, 1<<bmMarkerNumber);
+	if (line == -1) // wrap around, search backwards from last line
+		line = qsci->markerFindPrevious(qsci->lines()-1, 1<<bmMarkerNumber);
+	if (line != -1)
+		qsci->setCursorPosition(line, index);
 }

--- a/src/scintillaeditor.cpp
+++ b/src/scintillaeditor.cpp
@@ -960,3 +960,15 @@ void ScintillaEditor::onCharacterThresholdChanged(int val)
 {
 	qsci->setAutoCompletionThreshold(val <= 0 ? 1 : val);
 }
+
+void ScintillaEditor::toggleBookmark()
+{
+}
+
+void ScintillaEditor::nextBookmark()
+{
+}
+
+void ScintillaEditor::prevBookmark()
+{
+}

--- a/src/scintillaeditor.cpp
+++ b/src/scintillaeditor.cpp
@@ -157,7 +157,7 @@ ScintillaEditor::ScintillaEditor(QWidget *parent) : EditorInterface(parent)
 
 	qsci->indicatorDefine(QsciScintilla::RoundBoxIndicator, errorIndicatorNumber);
 	qsci->indicatorDefine(QsciScintilla::RoundBoxIndicator , findIndicatorNumber); 
-	qsci->markerDefine(QsciScintilla::Circle, markerNumber);
+	qsci->markerDefine(QsciScintilla::Circle, errMarkerNumber);
 	qsci->setUtf8(true);
 	qsci->setFolding(QsciScintilla::BoxedTreeFoldStyle, 4);
 	qsci->setCaretLineVisible(true);
@@ -305,7 +305,7 @@ void ScintillaEditor::highlightError(int error_pos)
 	int line, index;
 	qsci->lineIndexFromPosition(error_pos, &line, &index);
 	qsci->fillIndicatorRange(line, index, line, index + 1, errorIndicatorNumber);
-	qsci->markerAdd(line, markerNumber);
+	qsci->markerAdd(line, errMarkerNumber);
 }
 
 void ScintillaEditor::unhighlightLastError()
@@ -314,7 +314,7 @@ void ScintillaEditor::unhighlightLastError()
 	int line, index;
 	qsci->lineIndexFromPosition(totalLength, &line, &index);
 	qsci->clearIndicatorRange(0, 0, line, index, errorIndicatorNumber);
-	qsci->markerDeleteAll(markerNumber);
+	qsci->markerDeleteAll(errMarkerNumber);
 }
 
 QColor ScintillaEditor::readColor(const boost::property_tree::ptree &pt, const std::string name, const QColor defaultColor)
@@ -415,7 +415,7 @@ void ScintillaEditor::setColormap(const EditorColorScheme *colorScheme)
 		qsci->setCaretForegroundColor(readColor(caret, "foreground", textColor));
 		qsci->setCaretLineBackgroundColor(readColor(caret, "line-background", paperColor));
 
-		qsci->setMarkerBackgroundColor(readColor(colors, "error-marker", QColor(255, 0, 0, 100)), markerNumber);
+		qsci->setMarkerBackgroundColor(readColor(colors, "error-marker", QColor(255, 0, 0, 100)), errMarkerNumber);
         qsci->setIndicatorForegroundColor(readColor(colors, "error-indicator", QColor(255, 0, 0, 100)), errorIndicatorNumber);//red
         qsci->setIndicatorOutlineColor(readColor(colors, "error-indicator-outline", QColor(255, 0, 0, 100)), errorIndicatorNumber);//red
         qsci->setIndicatorForegroundColor(readColor(colors, "find-indicator", QColor(255, 255, 0, 100)), findIndicatorNumber);//yellow
@@ -443,7 +443,7 @@ void ScintillaEditor::noColor()
 	this->lexer->setColor(Qt::black);
 	qsci->setCaretWidth(2);
 	qsci->setCaretForegroundColor(Qt::black);
-	qsci->setMarkerBackgroundColor(QColor(255, 0, 0, 100), markerNumber);
+	qsci->setMarkerBackgroundColor(QColor(255, 0, 0, 100), errMarkerNumber);
     qsci->setIndicatorForegroundColor(QColor(255, 0, 0, 128), errorIndicatorNumber);//red
     qsci->setIndicatorOutlineColor(QColor(0, 0, 0, 255), errorIndicatorNumber); // only alpha part is used
     qsci->setIndicatorForegroundColor(QColor(255, 255, 0, 128), findIndicatorNumber);//yellow

--- a/src/scintillaeditor.h
+++ b/src/scintillaeditor.h
@@ -102,6 +102,9 @@ public slots:
 	void paste() override;
 	void initFont(const QString&, uint) override;
 	void displayTemplates() override;
+	void toggleBookmark() override;
+	void nextBookmark() override;
+	void prevBookmark() override;
 
 private slots:
 	void onTextChanged();

--- a/src/scintillaeditor.h
+++ b/src/scintillaeditor.h
@@ -122,6 +122,7 @@ private:
     static const int errorIndicatorNumber = 8; // first 8 are used by lexers 
     static const int findIndicatorNumber = 9; 
 	static const int errMarkerNumber = 2;
+	static const int bmMarkerNumber = 3;
 	ScadLexer *lexer;
 	QFont currentFont;
 	ScadApi *api;

--- a/src/scintillaeditor.h
+++ b/src/scintillaeditor.h
@@ -118,7 +118,7 @@ private:
 	QVBoxLayout *scintillaLayout;
     static const int errorIndicatorNumber = 8; // first 8 are used by lexers 
     static const int findIndicatorNumber = 9; 
-	static const int markerNumber = 2;
+	static const int errMarkerNumber = 2;
 	ScadLexer *lexer;
 	QFont currentFont;
 	ScadApi *api;

--- a/src/tabmanager.cc
+++ b/src/tabmanager.cc
@@ -251,14 +251,17 @@ void TabManager::uncommentSelection()
 
 void TabManager::toggleBookmark()
 {
+    editor->toggleBookmark();
 }
 
 void TabManager::nextBookmark()
 {
+    editor->nextBookmark();
 }
 
 void TabManager::prevBookmark()
 {
+    editor->prevBookmark();
 }
 
 void TabManager::updateActionUndoState()

--- a/src/tabmanager.cc
+++ b/src/tabmanager.cc
@@ -51,6 +51,10 @@ TabManager::TabManager(MainWindow *o, const QString &filename)
     connect(par->editActionUnindent, SIGNAL(triggered()), this, SLOT(unindentSelection()));
     connect(par->editActionComment, SIGNAL(triggered()), this, SLOT(commentSelection()));
     connect(par->editActionUncomment, SIGNAL(triggered()), this, SLOT(uncommentSelection()));
+
+    connect(par->editActionToggleBookmark, SIGNAL(triggered()), this, SLOT(toggleBookmark()));
+    connect(par->editActionNextBookmark, SIGNAL(triggered()), this, SLOT(nextBookmark()));
+    connect(par->editActionPrevBookmark, SIGNAL(triggered()), this, SLOT(prevBookmark()));
 }
 
 QWidget *TabManager::getTabHeader()
@@ -243,6 +247,18 @@ void TabManager::commentSelection()
 void TabManager::uncommentSelection()
 {
     editor->uncommentSelection();
+}
+
+void TabManager::toggleBookmark()
+{
+}
+
+void TabManager::nextBookmark()
+{
+}
+
+void TabManager::prevBookmark()
+{
 }
 
 void TabManager::updateActionUndoState()

--- a/src/tabmanager.h
+++ b/src/tabmanager.h
@@ -60,6 +60,9 @@ private slots:
     void commentSelection();
     void uncommentSelection();
     void updateActionUndoState();
+    void toggleBookmark();
+    void nextBookmark();
+    void prevBookmark();
 
     void stopAnimation();
     void updateFindState();


### PR DESCRIPTION
Scintilla/scite has a very useful "bookmarks" feature - allowing a user to
bookmark any line in the code with CTRL-F2,
then jump around between the bookmarks with F2 (next) and SHIFT-F2 (backwards).

This is very helpful when dealing with large code base, jumping from/to specific points.

In the screenshot below, two bookmarks are set at lines 3 and 11.
The cursor is at line 8. Pressing F2 will jump to line 11. Pressing SHIFT-F2 will jump to line 3.
The jumps "wrap around" so pressing F2 endlessly will cycle through all bookmarks.

CTRL-F2 on an existing bookmarks removes the bookmark ( toggle ).

![Screenshot_2019-09-01_19-44-39](https://user-images.githubusercontent.com/523057/64086020-0c7abb80-ccf3-11e9-9aa9-759f32201ae2.png)

The white bookmark icon isn't great (hides the line number), but it can be changed.

This PR is broken into very small patches, one per topic, to ease review.

Comments and suggestions very welcomed.
gordon