### PR TITLE
GUI: Jump to errors

### DIFF
--- a/src/MainWindow.ui
+++ b/src/MainWindow.ui
@@ -357,6 +357,8 @@
     <addaction name="editActionFindPrevious"/>
     <addaction name="editActionUseSelectionForFind"/>
     <addaction name="separator"/>
+    <addaction name="editActionJumpToNextError"/>
+    <addaction name="separator"/>
     <addaction name="editActionZoomTextIn"/>
     <addaction name="editActionZoomTextOut"/>
     <addaction name="editActionPreferences"/>
@@ -1326,6 +1328,14 @@
    </property>
    <property name="shortcut">
     <string>Ctrl+E</string>
+   </property>
+  </action>
+  <action name="editActionJumpToNextError">
+   <property name="text">
+    <string>Jump to next error</string>
+   </property>
+   <property name="shortcut">
+    <string>Ctrl+ALT+E</string>
    </property>
   </action>
   <action name="designActionFlushCaches">

--- a/src/editor.h
+++ b/src/editor.h
@@ -56,6 +56,7 @@ public slots:
 	virtual void toggleBookmark() = 0;
 	virtual void nextBookmark() = 0;
 	virtual void prevBookmark() = 0;
+	virtual void jumpToNextError() = 0;
 
 private:
 	QSize initialSizeHint;

--- a/src/legacyeditor.cc
+++ b/src/legacyeditor.cc
@@ -328,3 +328,7 @@ void LegacyEditor::nextBookmark()
 void LegacyEditor::prevBookmark()
 {
 }
+
+void LegacyEditor::jumpToNextError()
+{
+}

--- a/src/legacyeditor.h
+++ b/src/legacyeditor.h
@@ -46,6 +46,8 @@ public slots:
 	void toggleBookmark() override;
 	void nextBookmark() override;
 	void prevBookmark() override;
+	void jumpToNextError() override;
+
 private:
 	class QTextEdit *textedit;
 	class Highlighter *highlighter;

--- a/src/scintillaeditor.cpp
+++ b/src/scintillaeditor.cpp
@@ -999,4 +999,11 @@ void ScintillaEditor::prevBookmark()
 
 void ScintillaEditor::jumpToNextError()
 {
+	int line, index;
+	qsci->getCursorPosition(&line, &index);
+	line = qsci->markerFindNext(line+1, 1<<errMarkerNumber);
+	if (line == -1) // wrap around, search from the first line
+		line = qsci->markerFindNext(0, 1<<errMarkerNumber);
+	if (line != -1)
+		qsci->setCursorPosition(line, index);
 }

--- a/src/scintillaeditor.cpp
+++ b/src/scintillaeditor.cpp
@@ -996,3 +996,7 @@ void ScintillaEditor::prevBookmark()
 	if (line != -1)
 		qsci->setCursorPosition(line, index);
 }
+
+void ScintillaEditor::jumpToNextError()
+{
+}

--- a/src/scintillaeditor.h
+++ b/src/scintillaeditor.h
@@ -105,6 +105,7 @@ public slots:
 	void toggleBookmark() override;
 	void nextBookmark() override;
 	void prevBookmark() override;
+	void jumpToNextError() override;
 
 private slots:
 	void onTextChanged();

--- a/src/tabmanager.cc
+++ b/src/tabmanager.cc
@@ -55,6 +55,7 @@ TabManager::TabManager(MainWindow *o, const QString &filename)
     connect(par->editActionToggleBookmark, SIGNAL(triggered()), this, SLOT(toggleBookmark()));
     connect(par->editActionNextBookmark, SIGNAL(triggered()), this, SLOT(nextBookmark()));
     connect(par->editActionPrevBookmark, SIGNAL(triggered()), this, SLOT(prevBookmark()));
+    connect(par->editActionJumpToNextError, SIGNAL(triggered()), this, SLOT(jumpToNextError()));
 }
 
 QWidget *TabManager::getTabHeader()
@@ -298,6 +299,11 @@ void TabManager::nextBookmark()
 void TabManager::prevBookmark()
 {
     editor->prevBookmark();
+}
+
+void TabManager::jumpToNextError()
+{
+    editor->jumpToNextError();
 }
 
 void TabManager::updateActionUndoState()

--- a/src/tabmanager.h
+++ b/src/tabmanager.h
@@ -63,6 +63,7 @@ private slots:
     void toggleBookmark();
     void nextBookmark();
     void prevBookmark();
+    void jumpToNextError();
 
     void stopAnimation();
     void updateFindState();


### PR DESCRIPTION
This makes debugging easier: if the source code has an error, a quick keypress jumps to it.
The weird keyboard shortcut (CTRL-ALT-E) is just a suggestions, happy to change it.

(also: this PR conflicts with my other one(#3059), if one is accepted, I'll amend the other accordingly.