### PR TITLE
Update handling of margins.

### DIFF
--- a/src/scintillaeditor.h
+++ b/src/scintillaeditor.h
@@ -76,6 +76,7 @@ private:
         void setLexer(ScadLexer *lexer);
         void replaceSelectedText(QString&);
         void addTemplate(const fs::path path);
+        void updateSymbolMarginVisibility();
 
 signals:
 	void previewRequest(void);
@@ -119,6 +120,8 @@ public:
 
 private:
 	QVBoxLayout *scintillaLayout;
+	static const int symbolMargin = 1;
+	static const int numberMargin = 0;
     static const int errorIndicatorNumber = 8; // first 8 are used by lexers 
     static const int findIndicatorNumber = 9; 
 	static const int errMarkerNumber = 2;


### PR DESCRIPTION
Update handling of margins.

- Separate line number and symbol margins
- Minimize line number margin
- Hide symbol margin (showing errors and bookmarks) if no markers are active
- Add color scheme support for bookmarks

![grafik](https://user-images.githubusercontent.com/1330241/64300823-ad30db80-cf7e-11e9-84a7-f5c136278b0f.png)
