### PR TITLE
Update for CGAL 5.0-beta1

### DIFF
--- a/features/cgal.prf
+++ b/features/cgal.prf
@@ -1,4 +1,6 @@
-DEFINES += ENABLE_CGAL
+DEFINES += ENABLE_CGAL CGAL_HEADER_ONLY
+
+QMAKE_CXXFLAGS += -std=c++14
 
 # Optionally specify location of CGAL using the 
 # CGALDIR env. variable
@@ -9,7 +11,7 @@ CGAL_DIR = $$(CGALDIR)
   message("CGAL location: $$CGAL_DIR")
 }
 
-LIBS += -lCGAL -lmpfr -lgmp
+LIBS += -lmpfr -lgmp
 
 *g++* {
   QMAKE_CXXFLAGS += -frounding-math

--- a/features/cgal.prf
+++ b/features/cgal.prf
@@ -1,4 +1,4 @@
-DEFINES += ENABLE_CGAL CGAL_HEADER_ONLY
+DEFINES += ENABLE_CGAL
 
 QMAKE_CXXFLAGS += -std=c++14
 
@@ -11,7 +11,14 @@ CGAL_DIR = $$(CGALDIR)
   message("CGAL location: $$CGAL_DIR")
 }
 
-LIBS += -lmpfr -lgmp
+exists($$CGAL_DIR/include/CGAL/compiler_config.h)|exists(/usr/include/CGAL/compiler_config.h) {
+  LIBS += -lCGAL -lmpfr -lgmp
+} else {
+  # CGAL header-only
+  DEFINES += CGAL_HEADER_ONLY
+  LIBS += -lmpfr -lgmp
+  message("Using CGAL header-only")
+}
 
 *g++* {
   QMAKE_CXXFLAGS += -frounding-math

--- a/src/builtincontext.cc
+++ b/src/builtincontext.cc
@@ -1,3 +1,6 @@
+#define _USE_MATH_DEFINES
+#include <cmath>
+
 #include "builtincontext.h"
 #include "builtin.h"
 #include "expression.h"

--- a/src/calc.cc
+++ b/src/calc.cc
@@ -24,9 +24,11 @@
  *
  */
 
+#define _USE_MATH_DEFINES
+#include <cmath>
+
 #include "calc.h"
 #include "grid.h"
-#include <cmath>
 
 /*!
 	Returns the number of subdivision of a whole circle, given radius and

--- a/src/degree_trig.cc
+++ b/src/degree_trig.cc
@@ -26,9 +26,11 @@
 //
 // Trigonometry function taking degrees, accurate for 30, 45, 60 and 90, etc.
 //
-#include "degree_trig.h"
+#define _USE_MATH_DEFINES
 #include <cmath>
 #include <limits>
+
+#include "degree_trig.h"
 
 #define M_SQRT3   1.73205080756887719318 /* sqrt(3)   */
 #define M_SQRT3_4 0.86602540378443859659 /* sqrt(3/4) == sqrt(3)/2 */

--- a/src/dxfdata.cc
+++ b/src/dxfdata.cc
@@ -24,6 +24,9 @@
  *
  */
 
+#define _USE_MATH_DEFINES
+#include <cmath>
+
 #include "dxfdata.h"
 #include "grid.h"
 #include "printutils.h"


### PR DESCRIPTION
- Use CGAL header-only (possible since CGAL version 4.8 and mandatory since 5.0)
- Use C++14 if CGAL is enabled, because CGAL-5.0 requires C++14.

I have not modified the CMake configuration of OpenSCAD, because `CGALConfig.cmake` will handle all the details (by setting properties on the target `CGAL::CGAL`).
