### PR TITLE
Snap updates

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -20,7 +20,7 @@ confinement: strict
 apps:
   openscad-nightly:
     command: desktop-launch openscad-nightly
-    plugs: [desktop, x11, wayland, opengl, home, pulseaudio, network, removable-media]
+    plugs: [desktop, x11, wayland, opengl, home, audio-playback, pulseaudio, network, removable-media]
     desktop: usr/share/applications/openscad-nightly.desktop
 
 parts:

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -22,6 +22,8 @@ apps:
     command: desktop-launch openscad-nightly
     plugs: [desktop, x11, wayland, opengl, home, audio-playback, pulseaudio, network, removable-media]
     desktop: usr/share/applications/openscad-nightly.desktop
+    environment:
+      DISABLE_WAYLAND: 1
 
 parts:
   opencsg:


### PR DESCRIPTION
Update snap build:

- Add 'audio-playback' interface which will replace deprecated 'pulseaudio'
- Disable Wayland as that causes crashes, e.g. on Debian testing