### PR TITLE
Unbreak build with Boost 1.72

### DIFF
--- a/src/parser.y
+++ b/src/parser.y
@@ -46,6 +46,7 @@
 #include "printutils.h"
 #include "memory.h"
 #include <sstream>
+#include <stack>
 #include <boost/filesystem.hpp>
 #include "boost-utils.h"
 #include "feature.h"


### PR DESCRIPTION
Regressed by boostorg/filesystem@9a14c37d6f95. See [error log](https://github.com/openscad/openscad/files/3772674/openscad-2019.05.10_3.log).