### PR TITLE
Install Start shortcut for all users on Windows

### DIFF
--- a/scripts/installer.nsi
+++ b/scripts/installer.nsi
@@ -17,6 +17,7 @@ File /r /x mingw-cross-env locale
 File /r /x mingw-cross-env color-schemes
 File /r /x mingw-cross-env templates
 ${registerExtension} "$INSTDIR\openscad.exe" ".scad" "OpenSCAD_File"
+SetShellVarContext all
 CreateShortCut $SMPROGRAMS\OpenSCAD.lnk $INSTDIR\openscad.exe
 WriteUninstaller $INSTDIR\Uninstall.exe
 # see https://msdn.microsoft.com/en-us/library/aa372105(v=vs.85).aspx
@@ -33,6 +34,7 @@ Section "Uninstall"
 ${unregisterExtension} ".scad" "OpenSCAD_File"
 Delete $INSTDIR\Uninstall.exe
 Delete $INSTDIR\MyProg.exe
+SetShellVarContext all
 Delete $SMPROGRAMS\OpenSCAD.lnk
 DeleteRegKey HKEY_LOCAL_MACHINE "SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\OpenSCAD"
 RMDir /r $INSTDIR\fonts


### PR DESCRIPTION
The default shell context in NSIS is for the current user. This causes $SMPROGRAMS to put the link in the current user's profile. Other users on the system get no start menu link.

Docs for SetShellVarContext at https://nsis.sourceforge.io/Docs/Chapter4.html 
Fixes #2763 