### PR TITLE
Array/String slicing and half open ranges.

### DIFF
--- a/src/comment_parser.y
+++ b/src/comment_parser.y
@@ -63,11 +63,11 @@ expr:
     }
     | '[' num ':' num ']'
     {
-        $$ = new Range($2, $4, Location::NONE);
+        $$ = new Range($2, new Literal(1.0), $4, false, Location::NONE);
     }
     | '[' num ':' num ':' num ']'
     {
-        $$ = new Range($2, $4, $6, Location::NONE);
+        $$ = new Range($2, $4, $6, false, Location::NONE);
     }
     ;
 

--- a/src/expr.cc
+++ b/src/expr.cc
@@ -294,33 +294,43 @@ void Literal::print(std::ostream &stream, const std::string &) const
 }
 
 Range::Range(Expression *begin, Expression *end, const Location &loc)
-	: Expression(loc), begin(begin), end(end)
+	: Expression(loc), exclusive(false), begin(begin), end(end)
 {
 }
 
-Range::Range(Expression *begin, Expression *step, Expression *end, const Location &loc)
-	: Expression(loc), begin(begin), step(step), end(end)
+Range::Range(Expression *begin, Expression *step, Expression *end, bool exclusive, const Location &loc)
+	: Expression(loc), exclusive(exclusive), begin(begin), step(step), end(end)
 {
 }
 
 ValuePtr Range::evaluate(const std::shared_ptr<Context>& context) const
 {
-	ValuePtr beginValue = this->begin->evaluate(context);
-	if (beginValue->type() == Value::ValueType::NUMBER) {
-		ValuePtr endValue = this->end->evaluate(context);
-		if (endValue->type() == Value::ValueType::NUMBER) {
-			if (!this->step) {
-				RangeType range(beginValue->toDouble(), endValue->toDouble());
-				return ValuePtr(range);
-			} else {
-				ValuePtr stepValue = this->step->evaluate(context);
-				if (stepValue->type() == Value::ValueType::NUMBER) {
-					RangeType range(beginValue->toDouble(), stepValue->toDouble(), endValue->toDouble());
-					return ValuePtr(range);
-				}
-			}
+	ValuePtr beginValue = this->begin ? this->begin->evaluate(context) : ValuePtr::undefined;
+	if (beginValue != ValuePtr::undefined && beginValue->type() != Value::ValueType::NUMBER) {
+	  return ValuePtr::undefined;
+	}
+
+	ValuePtr endValue = this->end ? this->end->evaluate(context) : ValuePtr::undefined;
+	if (endValue != ValuePtr::undefined && endValue->type() != Value::ValueType::NUMBER) {
+	  return ValuePtr::undefined;
+	}
+
+	boost::optional<double> b;
+	if (beginValue != ValuePtr::undefined) b = beginValue->toDouble();
+	boost::optional<double> e;
+	if (endValue != ValuePtr::undefined) e = endValue->toDouble();
+
+	if (!this->step) {
+		RangeType range(b, e);
+		return ValuePtr(range);
+	} else {
+		ValuePtr stepValue = this->step->evaluate(context);
+		if (stepValue->type() == Value::ValueType::NUMBER) {
+			RangeType range(b, stepValue->toDouble(), e, exclusive);
+			return ValuePtr(range);
 		}
 	}
+
 	return ValuePtr::undefined;
 }
 
@@ -332,15 +342,15 @@ void Range::print(std::ostream &stream, const std::string &) const
 	stream << "]";
 }
 
-bool Range::isLiteral() const {
-    if(!this->step){ 
-        if( begin->isLiteral() && end->isLiteral())
-            return true;
-    }else{
-        if( begin->isLiteral() && end->isLiteral() && step->isLiteral())
-            return true;
-    }
-    return false;
+bool Range::isLiteral() const
+{
+	const bool boundaryLiteral = (begin && begin->isLiteral()) && (end && end->isLiteral());
+	return step ? boundaryLiteral && step->isLiteral() : boundaryLiteral;
+}
+
+bool Range::isValid() const
+{
+	return begin && end;
 }
 
 Vector::Vector(const Location &loc) : Expression(loc)

--- a/src/expression.h
+++ b/src/expression.h
@@ -104,11 +104,13 @@ class Range : public Expression
 {
 public:
 	Range(Expression *begin, Expression *end, const Location &loc);
-	Range(Expression *begin, Expression *step, Expression *end, const Location &loc);
+	Range(Expression *begin, Expression *step, Expression *end, bool exclusive, const Location &loc);
 	ValuePtr evaluate(const std::shared_ptr<Context>& context) const override;
 	void print(std::ostream &stream, const std::string &indent) const override;
 	bool isLiteral() const override;
+	bool isValid() const;
 private:
+	bool exclusive;
 	shared_ptr<Expression> begin;
 	shared_ptr<Expression> step;
 	shared_ptr<Expression> end;

--- a/src/value.h
+++ b/src/value.h
@@ -9,6 +9,7 @@
 // Workaround for https://bugreports.qt-project.org/browse/QTBUG-22829
 #ifndef Q_MOC_RUN
 #include <boost/variant.hpp>
+#include <boost/optional.hpp>
 #include <boost/lexical_cast.hpp>
 #include <glib.h>
 #endif
@@ -40,9 +41,10 @@ std::ostream &operator<<(std::ostream &stream, const Filename &filename);
 
 class RangeType {
 private:
-	double begin_val;
+	bool exclusive;
+	boost::optional<double> begin_val;
 	double step_val;
-	double end_val;
+	boost::optional<double> end_val;
 	
 	/// inverse begin/end if begin is upper than end
 	void normalize();
@@ -73,25 +75,27 @@ public:
 		void update_type();
 	};
   
-	RangeType(double begin, double end)
-		: begin_val(begin), step_val(1.0), end_val(end)
+	RangeType(boost::optional<double> begin, boost::optional<double> end)
+		: exclusive(false), begin_val(begin), step_val(1.0), end_val(end)
     {
       normalize();
     }
 	
-	RangeType(double begin, double step, double end)
-		: begin_val(begin), step_val(step), end_val(end) {}
+	RangeType(boost::optional<double> begin, double step, boost::optional<double> end, bool exclusive = false)
+		: exclusive(exclusive), begin_val(begin), step_val(step), end_val(end) {}
 	
 	bool operator==(const RangeType &other) const {
 		return this == &other ||
 			(this->begin_val == other.begin_val &&
 			 this->step_val == other.step_val &&
-			 this->end_val == other.end_val);
+			 this->end_val == other.end_val &&
+			 this->exclusive == other.exclusive);
 	}
 	
-	double begin_value() { return begin_val; }
-	double step_value() { return step_val; }
-	double end_value() { return end_val; }
+	double begin_value() const { return *begin_val; }
+	double step_value() const { return step_val; }
+	double end_value() const { return *end_val; }
+	bool is_exclusive() const { return exclusive; }
 	
 	iterator begin() { return iterator(*this, type_t::RANGE_TYPE_BEGIN); }
 	iterator end() { return iterator(*this, type_t::RANGE_TYPE_END); }


### PR DESCRIPTION
This adds slicing notation for arrays and strings. Syntax is based on OpenSCAD ranges, so it looks like `[begin:end]` or `[begin:step:end]` (however step is not yet implemented for slicing). Both begin and end can be omitted and default to begin and end of the base object respectively.

Usage is very similar to `python`, but not identical. Mainly because OpenSCAD ranges are by default closed intervals where python slicing definitions are half-open. Important to note is that the behavior for negative values is different for slicing as compared to ranges.

To allow more flexibility the end defintion for OpenSCAD ranges now allow to specify a half-open interval by prefixing the end value with `<`. This is similar to Swift ranges that use `...` for closed and `..<` for half-open intervals. For OpenSCAD that looks like `[begin:<end]` and `[begin:step:<end]`.

ToDo:
- [ ] Decide on negative values for simple indexing `a = v[-1]`
- [ ] Decide on dropping the deprecated auto swap on ranges (slices will never do that)
- [ ] Implement step for slicing
- [ ] Handle UTF8 strings correctly
- [ ] Add warning for not supported data types
- [ ] Add error when trying to use non integer values for slicing
- [ ] Add test cases
- [ ] Mark as experimental

For later:
- Find vector implementation which supports at least the basic slicing operations ([immer](https://github.com/arximboldi/immer), [immutable-cpp](https://github.com/rsms/immutable-cpp))


**Examples**
```
a = [0,1,2,3,4,5,6,7,8,9];

echo(all = a[:]); // ECHO: all = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
echo(first = a[0:0]); // ECHO: first = [0]
echo(last = a[-1:-1]); // ECHO: last = [9]
echo(skip_first = a[1:]); // ECHO: skip_first = [1, 2, 3, 4, 5, 6, 7, 8, 9]
echo(skip_last_inclusive = a[:-2]); // ECHO: skip_last_inclusive = [0, 1, 2, 3, 4, 5, 6, 7, 8]
echo(skip_last_exclusive = a[:<-1]); // ECHO: skip_last_exclusive = [0, 1, 2, 3, 4, 5, 6, 7, 8]
echo(range1 = a[2:8]); // ECHO: range1 = [2, 3, 4, 5, 6, 7, 8]
echo(range2 = a[-6:6]); // ECHO: range2 = [4, 5, 6]
```
**Implementation of fold/reduce**
```
a = [1, 2, 3, 4, 5, 6, 7, 8, 9];

reduce = function(v, i, f) len(v) > 0 ? reduce(v[1:], f(i, v[0]), f) : i;

sum = function(v) reduce(v, 0, function(x, y) x + y);
prd = function(v) reduce(v, 1, function(x, y) x * y);
cnt = function(v) reduce(v, 0, function(x, y) x + 1);
rev = function(v) reduce(v, [], function(x, y) concat(y, x));

echo(sum = sum(a), prd = prd(a), cnt = cnt(a), rev = rev(a));

// ECHO: sum = 45, prd = 362880, cnt = 9, rev = [9, 8, 7, 6, 5, 4, 3, 2, 1]
```