### PR TITLE
Change CGAL Union to join least complex geometries first.

### DIFF
--- a/cgal/decompose.cpp
+++ b/cgal/decompose.cpp
@@ -436,7 +436,7 @@ Geometry const * minkowskitest(const Geometry::Geometries &children)
           fake_children.push_back(std::make_pair((const AbstractNode*)NULL,
                                                  shared_ptr<const Geometry>(createNefPolyhedronFromGeometry(ps))));
         }
-        CGAL_Nef_polyhedron *N = CGALUtils::applyOperator(fake_children, OPENSCAD_UNION);
+        CGAL_Nef_polyhedron *N = CGALUtils::applyUnion(fake_children.begin(), fake_children.end());
         t.stop();
         if (N) PRINTDB("Minkowski: Union done: %f s",t.time());
         else PRINTDB("Minkowski: Union failed: %f s",t.time());
@@ -650,7 +650,7 @@ int main(int argc, char *argv[])
         std::cerr << "Error importing STL " << filename << std::endl;
         exit(1);
       }
-      std::cerr << "Imported " << ps->numPolygons() << " polygons" << std::endl;
+      std::cerr << "Imported " << ps->numFacets() << " polygons" << std::endl;
     }
     else if (suffix == ".nef3") {
       N = new CGAL_Nef_polyhedron(new CGAL_Nef_polyhedron3);

--- a/cgal/export_nef.cpp
+++ b/cgal/export_nef.cpp
@@ -163,7 +163,7 @@ int main(int argc, char *argv[])
         std::cerr << "Error importing STL " << argv[1] << std::endl;
         exit(1);
       }
-      std::cerr << "Imported " << ps->numPolygons() << " polygons" << std::endl;
+      std::cerr << "Imported " << ps->numFacets() << " polygons" << std::endl;
     }
     else if (suffix == ".nef3") {
       N = new CGAL_Nef_polyhedron(new CGAL_Nef_polyhedron3);

--- a/src/CGAL_Nef_polyhedron.cc
+++ b/src/CGAL_Nef_polyhedron.cc
@@ -16,6 +16,11 @@ CGAL_Nef_polyhedron::CGAL_Nef_polyhedron(const CGAL_Nef_polyhedron &src)
 	if (src.p3) this->p3.reset(new CGAL_Nef_polyhedron3(*src.p3));
 }
 
+CGAL_Nef_polyhedron CGAL_Nef_polyhedron::operator+(const CGAL_Nef_polyhedron &other) const
+{
+	return CGAL_Nef_polyhedron(new CGAL_Nef_polyhedron3((*this->p3) + (*other.p3)));
+}
+
 CGAL_Nef_polyhedron& CGAL_Nef_polyhedron::operator+=(const CGAL_Nef_polyhedron &other)
 {
 	(*this->p3) += (*other.p3);

--- a/src/CGAL_Nef_polyhedron.h
+++ b/src/CGAL_Nef_polyhedron.h
@@ -10,6 +10,7 @@ class CGAL_Nef_polyhedron : public Geometry
 {
 public:
 	CGAL_Nef_polyhedron(CGAL_Nef_polyhedron3 *p = nullptr);
+	CGAL_Nef_polyhedron(shared_ptr<CGAL_Nef_polyhedron3> p) : p3(p) {}
 	CGAL_Nef_polyhedron(const CGAL_Nef_polyhedron &src);
 	~CGAL_Nef_polyhedron() {}
 
@@ -21,8 +22,10 @@ public:
   // Empty means it is a geometric node which has zero area/volume
 	bool isEmpty() const override;
 	Geometry *copy() const override { return new CGAL_Nef_polyhedron(*this); }
+	size_t numFacets() const override { return p3->number_of_facets(); }
 
 	void reset() { p3.reset(); }
+	CGAL_Nef_polyhedron operator+(const CGAL_Nef_polyhedron &other) const;
 	CGAL_Nef_polyhedron &operator+=(const CGAL_Nef_polyhedron &other);
 	CGAL_Nef_polyhedron &operator*=(const CGAL_Nef_polyhedron &other);
 	CGAL_Nef_polyhedron &operator-=(const CGAL_Nef_polyhedron &other);

--- a/src/Geometry.h
+++ b/src/Geometry.h
@@ -22,6 +22,7 @@ public:
 	virtual unsigned int getDimension() const = 0;
 	virtual bool isEmpty() const = 0;
 	virtual Geometry *copy() const = 0;
+	virtual size_t numFacets() const = 0;
 
 	unsigned int getConvexity() const { return convexity; }
 	void setConvexity(int c) { this->convexity = c; }

--- a/src/Polygon2d.h
+++ b/src/Polygon2d.h
@@ -3,6 +3,7 @@
 #include <vector>
 #include "Geometry.h"
 #include "linalg.h"
+#include <numeric>
 
 /*!
 	A single contour.
@@ -24,7 +25,11 @@ public:
 	unsigned int getDimension() const override { return 2; }
 	bool isEmpty() const override;
 	Geometry *copy() const override { return new Polygon2d(*this); }
-
+	size_t numFacets() const override {
+		return std::accumulate(theoutlines.begin(), theoutlines.end(), 0,
+			[](size_t a, const Outline2d& b) { return a + b.vertices.size(); }
+		);
+	};
 	void addOutline(const Outline2d &outline) { this->theoutlines.push_back(outline); }
 	class PolySet *tessellate() const;
 

--- a/src/cgalutils.h
+++ b/src/cgalutils.h
@@ -24,6 +24,7 @@ namespace /* anonymous */ {
 namespace CGALUtils {
 	bool applyHull(const Geometry::Geometries &children, PolySet &P);
 	CGAL_Nef_polyhedron *applyOperator(const Geometry::Geometries &children, OpenSCADOperator op);
+	CGAL_Nef_polyhedron *applyUnion(Geometry::Geometries::iterator chbegin, Geometry::Geometries::iterator chend);
 	//FIXME: Old, can be removed:
 	//void applyBinaryOperator(CGAL_Nef_polyhedron &target, const CGAL_Nef_polyhedron &src, OpenSCADOperator op);
 	Polygon2d *project(const CGAL_Nef_polyhedron &N, bool cut);

--- a/src/import_3mf.cc
+++ b/src/import_3mf.cc
@@ -197,7 +197,7 @@ Geometry * import_3mf(const std::string &filename, const Location &loc)
 		for (polysets_t::iterator it = meshes.begin();it != meshes.end();it++) {
 			children.push_back(std::make_pair((const AbstractNode*)NULL,  shared_ptr<const Geometry>(*it)));
 		}
-		CGAL_Nef_polyhedron *N = CGALUtils::applyOperator(children, OpenSCADOperator::UNION);
+		CGAL_Nef_polyhedron *N = CGALUtils::applyUnion(children.begin(), children.end());
 
 		CGALUtils::createPolySetFromNefPolyhedron3(*N->p3, *p);
 		delete N;

--- a/src/import_amf.cc
+++ b/src/import_amf.cc
@@ -269,7 +269,7 @@ PolySet * AmfImporter::read(const std::string filename)
 		for (std::vector<PolySet *>::iterator it = polySets.begin();it != polySets.end();it++) {
 			children.push_back(std::make_pair((const AbstractNode*)nullptr,  shared_ptr<const Geometry>(*it)));
 		}
-		CGAL_Nef_polyhedron *N = CGALUtils::applyOperator(children, OpenSCADOperator::UNION);
+		CGAL_Nef_polyhedron *N = CGALUtils::applyUnion(children.begin(), children.end());
 		PolySet *result = new PolySet(3);
 		if (CGALUtils::createPolySetFromNefPolyhedron3(*N->p3, *result)) {
 			delete result;

--- a/src/mainwin.cc
+++ b/src/mainwin.cc
@@ -2084,7 +2084,7 @@ void MainWindow::actionRenderDone(shared_ptr<const Geometry> root_geom)
 			else if (const PolySet *ps = dynamic_cast<const PolySet *>(root_geom.get())) {
 				assert(ps->getDimension() == 3);
 				PRINT("   Top level object is a 3D object:");
-				PRINTB("   Facets:     %6d", ps->numPolygons());
+				PRINTB("   Facets:     %6d", ps->numFacets());
 			} else if (const Polygon2d *poly = dynamic_cast<const Polygon2d *>(root_geom.get())) {
 				PRINT("   Top level object is a 2D object:");
 				PRINTB("   Contours:     %6d", poly->outlines().size());

--- a/src/polyset.h
+++ b/src/polyset.h
@@ -29,7 +29,7 @@ public:
 	Geometry *copy() const override { return new PolySet(*this); }
 
 	void quantizeVertices();
-	size_t numPolygons() const { return polygons.size(); }
+	size_t numFacets() const override { return polygons.size(); }
 	void append_poly();
 	void append_poly(const Polygon &poly);
 	void append_vertex(double x, double y, double z = 0.0);

--- a/src/progress.cc
+++ b/src/progress.cc
@@ -2,6 +2,7 @@
 #include "node.h"
 
 int progress_report_count;
+int _progress_mark;
 void (*progress_report_f)(const class AbstractNode*, void*, int);
 void *progress_report_userdata;
 
@@ -22,7 +23,14 @@ void progress_report_fin()
 
 void progress_update(const AbstractNode *node, int mark)
 {
-	if (progress_report_f)
-		progress_report_f(node, progress_report_userdata, mark);
+	if (progress_report_f) {
+		_progress_mark = mark;
+		progress_report_f(node, progress_report_userdata, _progress_mark);
+	}
 }
 
+void progress_tick()
+{
+	if (progress_report_f)
+		progress_report_f(nullptr, progress_report_userdata, ++_progress_mark);
+}

--- a/src/progress.h
+++ b/src/progress.h
@@ -9,5 +9,7 @@ extern void *progress_report_userdata;
 void progress_report_prep(AbstractNode *root, void (*f)(const class AbstractNode *node, void *userdata, int mark), void *userdata);
 void progress_report_fin();
 void progress_update(const AbstractNode *node, int mark);
+// CGALUtils::applyUnion may process nodes out of order, so allow for an increment instead of tracking exact node
+void progress_tick();
 
 class ProgressCancelException { };


### PR DESCRIPTION
This change uses a priority_queue (min heap) sorted by number of face(t)s in each geometry.  So the two least complex objects are always merged first.  Temporary results go back into the priority queue so it adapts as complexity changes.  The queue is also secondarily sorted by `node.progress_mark` when complexity matches, which should act as a stable sort.  

Reasoning for keeping the sort stable is based on the assumption/heuristic that consecutive sibling nodes are likely to be close to each other in space, which is more likely to cause reduction in complexity for example in a loop of identical translated objects.

Also change to progress bar update during union.

For issue #1234