### PR TITLE
Range Warnings begin<end

### DIFF
--- a/src/expr.cc
+++ b/src/expr.cc
@@ -316,10 +316,10 @@ ValuePtr Range::evaluate(const std::shared_ptr<Context>& context) const
 	if (beginValue->type() == Value::ValueType::NUMBER) {
 		ValuePtr endValue = this->end->evaluate(context);
 		if (endValue->type() == Value::ValueType::NUMBER) {
+			double begin_val = beginValue->toDouble();
+			double end_val   = endValue->toDouble();
+			
 			if (!this->step) {
-				double begin_val = beginValue->toDouble();
-				double end_val   = endValue->toDouble();
-				
 				if(end_val < begin_val){
 					std::swap(begin_val,end_val);
 					PRINT_DEPRECATION("Using ranges of the form [begin:end] with begin value greater than the end value is deprecated. %s", loc.toRelativeString(context->documentPath()));
@@ -330,6 +330,16 @@ ValuePtr Range::evaluate(const std::shared_ptr<Context>& context) const
 			} else {
 				ValuePtr stepValue = this->step->evaluate(context);
 				if (stepValue->type() == Value::ValueType::NUMBER) {
+					double step_val = stepValue->toDouble();
+					if(this->begin->isLiteral() && this->step->isLiteral() && this->end->isLiteral()){
+						if ((step_val>0) && (end_val < begin_val)) {
+							PRINTB("WARNING: begin is greater than the end, but step is positiv %s", loc.toRelativeString(context->documentPath()));
+						}
+						if ((step_val<0) && (end_val > begin_val)) {
+							PRINTB("WARNING: begin is smaller than the end, but step is negativ %s", loc.toRelativeString(context->documentPath()));
+						}
+					}
+
 					RangeType range(beginValue->toDouble(), stepValue->toDouble(), endValue->toDouble());
 					return ValuePtr(range);
 				}

--- a/src/expr.cc
+++ b/src/expr.cc
@@ -331,7 +331,7 @@ ValuePtr Range::evaluate(const std::shared_ptr<Context>& context) const
 				ValuePtr stepValue = this->step->evaluate(context);
 				if (stepValue->type() == Value::ValueType::NUMBER) {
 					double step_val = stepValue->toDouble();
-					if(this->begin->isLiteral() && this->step->isLiteral() && this->end->isLiteral()){
+					if(this->isLiteral()){
 						if ((step_val>0) && (end_val < begin_val)) {
 							PRINTB("WARNING: begin is greater than the end, but step is positiv %s", loc.toRelativeString(context->documentPath()));
 						}

--- a/src/expr.cc
+++ b/src/expr.cc
@@ -317,7 +317,15 @@ ValuePtr Range::evaluate(const std::shared_ptr<Context>& context) const
 		ValuePtr endValue = this->end->evaluate(context);
 		if (endValue->type() == Value::ValueType::NUMBER) {
 			if (!this->step) {
-				RangeType range(beginValue->toDouble(), endValue->toDouble());
+				double begin_val = beginValue->toDouble();
+				double end_val   = endValue->toDouble();
+				
+				if(end_val < begin_val){
+					std::swap(begin_val,end_val);
+					PRINT_DEPRECATION("Using ranges of the form [begin:end] with begin value greater than the end value is deprecated. %s", loc.toRelativeString(context->documentPath()));
+				}
+				
+				RangeType range(begin_val, end_val);
 				return ValuePtr(range);
 			} else {
 				ValuePtr stepValue = this->step->evaluate(context);

--- a/src/value.cc
+++ b/src/value.cc
@@ -987,14 +987,6 @@ Value Value::operator[](const Value &v) const
   return boost::apply_visitor(bracket_visitor(), this->value, v.value);
 }
 
-void RangeType::normalize()
-{
-  if ((step_val>0) && (end_val < begin_val)) {
-    std::swap(begin_val,end_val);
-    printDeprecation("Using ranges of the form [begin:end] with begin value greater than the end value is deprecated.");
-  }
-}
-
 uint32_t RangeType::numValues() const
 {
   if (std::isnan(begin_val) || std::isnan(end_val) || std::isnan(step_val)) {

--- a/src/value.h
+++ b/src/value.h
@@ -44,9 +44,6 @@ private:
 	double step_val;
 	double end_val;
 	
-	/// inverse begin/end if begin is upper than end
-	void normalize();
-	
 public:
 	enum class type_t { RANGE_TYPE_BEGIN, RANGE_TYPE_RUNNING, RANGE_TYPE_END };
   
@@ -74,10 +71,7 @@ public:
 	};
   
 	RangeType(double begin, double end)
-		: begin_val(begin), step_val(1.0), end_val(end)
-    {
-      normalize();
-    }
+		: begin_val(begin), step_val(1.0), end_val(end) {}
 	
 	RangeType(double begin, double step, double end)
 		: begin_val(begin), step_val(step), end_val(end) {}

--- a/tests/regression/echotest/children-tests-expected.echo
+++ b/tests/regression/echotest/children-tests-expected.echo
@@ -31,4 +31,5 @@ ECHO: "child3"
 ECHO: "child1"
 ECHO: "child3"
 ECHO: "child5"
+WARNING: begin is smaller than the end, but step is negativ in file children-tests.scad, line 56
 ECHO: "Children range: end"

--- a/tests/regression/echotest/children-tests-expected.echo
+++ b/tests/regression/echotest/children-tests-expected.echo
@@ -31,5 +31,5 @@ ECHO: "child3"
 ECHO: "child1"
 ECHO: "child3"
 ECHO: "child5"
-WARNING: begin is smaller than the end, but step is negativ in file children-tests.scad, line 56
+WARNING: begin is smaller than the end, but step is negativ, in file children-tests.scad, line 56
 ECHO: "Children range: end"

--- a/tests/regression/echotest/concat-tests-expected.echo
+++ b/tests/regression/echotest/concat-tests-expected.echo
@@ -24,7 +24,7 @@ ECHO: [3, 4, undef]
 ECHO: [3, 4, 5, 6]
 ECHO: [3, 4, 5, 6, true]
 ECHO: [3, 4, "5", 6, "test"]
-WARNING: begin is greater than the end, but step is positiv in file concat-tests.scad, line 33
+WARNING: begin is greater than the end, but step is positiv, in file concat-tests.scad, line 33
 ECHO: [3, 4, true, 6, [4 : 1 : 3]]
 ECHO: "--- element / vector"
 ECHO: [3]

--- a/tests/regression/echotest/concat-tests-expected.echo
+++ b/tests/regression/echotest/concat-tests-expected.echo
@@ -24,6 +24,7 @@ ECHO: [3, 4, undef]
 ECHO: [3, 4, 5, 6]
 ECHO: [3, 4, 5, 6, true]
 ECHO: [3, 4, "5", 6, "test"]
+WARNING: begin is greater than the end, but step is positiv in file concat-tests.scad, line 33
 ECHO: [3, 4, true, 6, [4 : 1 : 3]]
 ECHO: "--- element / vector"
 ECHO: [3]

--- a/tests/regression/echotest/errors-warnings-included-expected.echo
+++ b/tests/regression/echotest/errors-warnings-included-expected.echo
@@ -49,10 +49,10 @@ ECHO: undef
 ECHO: "dim-all.dxf"
 WARNING: module cube() does not support child modules, in file errors-warnings.scad, line 104
 WARNING: module sphere() does not support child modules, in file errors-warnings.scad, line 107
-DEPRECATED: Using ranges of the form [begin:end] with begin value greater than the end value is deprecated. in file ../3D/features/for-tests.scad, line 19
-DEPRECATED: Using ranges of the form [begin:end] with begin value greater than the end value is deprecated. in file ../3D/features/for-tests.scad, line 31
+DEPRECATED: Using ranges of the form [begin:end] with begin value greater than the end value is deprecated, in file ../3D/features/for-tests.scad, line 19
+DEPRECATED: Using ranges of the form [begin:end] with begin value greater than the end value is deprecated, in file ../3D/features/for-tests.scad, line 31
 WARNING: Bad range parameter in for statement: too many elements (4294967295), in file ../3D/features/for-tests.scad, line 35
-WARNING: begin is smaller than the end, but step is negativ in file ../3D/features/for-tests.scad, line 38
+WARNING: begin is smaller than the end, but step is negativ, in file ../3D/features/for-tests.scad, line 38
 ECHO: "a"
 ECHO: "↑"
 ECHO: "b"
@@ -65,9 +65,9 @@ ECHO: "-INF", 0
 ECHO: "INF", 0
 ECHO: "-INF", 1
 WARNING: Bad range parameter in for statement: too many elements (4294967295), in file ../3D/features/for-tests.scad, line 72
-DEPRECATED: Using ranges of the form [begin:end] with begin value greater than the end value is deprecated. in file ../3D/features/for-tests.scad, line 73
+DEPRECATED: Using ranges of the form [begin:end] with begin value greater than the end value is deprecated, in file ../3D/features/for-tests.scad, line 73
 WARNING: Bad range parameter in for statement: too many elements (4294967295), in file ../3D/features/for-tests.scad, line 73
-DEPRECATED: Using ranges of the form [begin:end] with begin value greater than the end value is deprecated. in file ../3D/features/for-tests.scad, line 74
+DEPRECATED: Using ranges of the form [begin:end] with begin value greater than the end value is deprecated, in file ../3D/features/for-tests.scad, line 74
 WARNING: Bad range parameter in for statement: too many elements (4294967295), in file ../3D/features/for-tests.scad, line 74
 WARNING: Bad range parameter in for statement: too many elements (4294967295), in file ../3D/features/for-tests.scad, line 75
 WARNING: Bad range parameter in for statement: too many elements (4294967295), in file ../3D/features/for-tests.scad, line 77

--- a/tests/regression/echotest/errors-warnings-included-expected.echo
+++ b/tests/regression/echotest/errors-warnings-included-expected.echo
@@ -49,8 +49,10 @@ ECHO: undef
 ECHO: "dim-all.dxf"
 WARNING: module cube() does not support child modules, in file errors-warnings.scad, line 104
 WARNING: module sphere() does not support child modules, in file errors-warnings.scad, line 107
-DEPRECATED: Using ranges of the form [begin:end] with begin value greater than the end value is deprecated.
+DEPRECATED: Using ranges of the form [begin:end] with begin value greater than the end value is deprecated. in file ../3D/features/for-tests.scad, line 19
+DEPRECATED: Using ranges of the form [begin:end] with begin value greater than the end value is deprecated. in file ../3D/features/for-tests.scad, line 31
 WARNING: Bad range parameter in for statement: too many elements (4294967295), in file ../3D/features/for-tests.scad, line 35
+WARNING: begin is smaller than the end, but step is negativ in file ../3D/features/for-tests.scad, line 38
 ECHO: "a"
 ECHO: "↑"
 ECHO: "b"
@@ -63,7 +65,9 @@ ECHO: "-INF", 0
 ECHO: "INF", 0
 ECHO: "-INF", 1
 WARNING: Bad range parameter in for statement: too many elements (4294967295), in file ../3D/features/for-tests.scad, line 72
+DEPRECATED: Using ranges of the form [begin:end] with begin value greater than the end value is deprecated. in file ../3D/features/for-tests.scad, line 73
 WARNING: Bad range parameter in for statement: too many elements (4294967295), in file ../3D/features/for-tests.scad, line 73
+DEPRECATED: Using ranges of the form [begin:end] with begin value greater than the end value is deprecated. in file ../3D/features/for-tests.scad, line 74
 WARNING: Bad range parameter in for statement: too many elements (4294967295), in file ../3D/features/for-tests.scad, line 74
 WARNING: Bad range parameter in for statement: too many elements (4294967295), in file ../3D/features/for-tests.scad, line 75
 WARNING: Bad range parameter in for statement: too many elements (4294967295), in file ../3D/features/for-tests.scad, line 77

--- a/tests/regression/echotest/for-tests-expected.echo
+++ b/tests/regression/echotest/for-tests-expected.echo
@@ -1,7 +1,7 @@
-DEPRECATED: Using ranges of the form [begin:end] with begin value greater than the end value is deprecated. in file for-tests.scad, line 19
-DEPRECATED: Using ranges of the form [begin:end] with begin value greater than the end value is deprecated. in file for-tests.scad, line 31
+DEPRECATED: Using ranges of the form [begin:end] with begin value greater than the end value is deprecated, in file for-tests.scad, line 19
+DEPRECATED: Using ranges of the form [begin:end] with begin value greater than the end value is deprecated, in file for-tests.scad, line 31
 WARNING: Bad range parameter in for statement: too many elements (4294967295), in file for-tests.scad, line 35
-WARNING: begin is smaller than the end, but step is negativ in file for-tests.scad, line 38
+WARNING: begin is smaller than the end, but step is negativ, in file for-tests.scad, line 38
 ECHO: "a"
 ECHO: "↑"
 ECHO: "b"
@@ -14,9 +14,9 @@ ECHO: "-INF", 0
 ECHO: "INF", 0
 ECHO: "-INF", 1
 WARNING: Bad range parameter in for statement: too many elements (4294967295), in file for-tests.scad, line 72
-DEPRECATED: Using ranges of the form [begin:end] with begin value greater than the end value is deprecated. in file for-tests.scad, line 73
+DEPRECATED: Using ranges of the form [begin:end] with begin value greater than the end value is deprecated, in file for-tests.scad, line 73
 WARNING: Bad range parameter in for statement: too many elements (4294967295), in file for-tests.scad, line 73
-DEPRECATED: Using ranges of the form [begin:end] with begin value greater than the end value is deprecated. in file for-tests.scad, line 74
+DEPRECATED: Using ranges of the form [begin:end] with begin value greater than the end value is deprecated, in file for-tests.scad, line 74
 WARNING: Bad range parameter in for statement: too many elements (4294967295), in file for-tests.scad, line 74
 WARNING: Bad range parameter in for statement: too many elements (4294967295), in file for-tests.scad, line 75
 WARNING: Bad range parameter in for statement: too many elements (4294967295), in file for-tests.scad, line 77

--- a/tests/regression/echotest/for-tests-expected.echo
+++ b/tests/regression/echotest/for-tests-expected.echo
@@ -1,6 +1,7 @@
 DEPRECATED: Using ranges of the form [begin:end] with begin value greater than the end value is deprecated. in file for-tests.scad, line 19
 DEPRECATED: Using ranges of the form [begin:end] with begin value greater than the end value is deprecated. in file for-tests.scad, line 31
 WARNING: Bad range parameter in for statement: too many elements (4294967295), in file for-tests.scad, line 35
+WARNING: begin is smaller than the end, but step is negativ in file for-tests.scad, line 38
 ECHO: "a"
 ECHO: "↑"
 ECHO: "b"

--- a/tests/regression/echotest/for-tests-expected.echo
+++ b/tests/regression/echotest/for-tests-expected.echo
@@ -1,4 +1,5 @@
-DEPRECATED: Using ranges of the form [begin:end] with begin value greater than the end value is deprecated.
+DEPRECATED: Using ranges of the form [begin:end] with begin value greater than the end value is deprecated. in file for-tests.scad, line 19
+DEPRECATED: Using ranges of the form [begin:end] with begin value greater than the end value is deprecated. in file for-tests.scad, line 31
 WARNING: Bad range parameter in for statement: too many elements (4294967295), in file for-tests.scad, line 35
 ECHO: "a"
 ECHO: "↑"
@@ -12,7 +13,9 @@ ECHO: "-INF", 0
 ECHO: "INF", 0
 ECHO: "-INF", 1
 WARNING: Bad range parameter in for statement: too many elements (4294967295), in file for-tests.scad, line 72
+DEPRECATED: Using ranges of the form [begin:end] with begin value greater than the end value is deprecated. in file for-tests.scad, line 73
 WARNING: Bad range parameter in for statement: too many elements (4294967295), in file for-tests.scad, line 73
+DEPRECATED: Using ranges of the form [begin:end] with begin value greater than the end value is deprecated. in file for-tests.scad, line 74
 WARNING: Bad range parameter in for statement: too many elements (4294967295), in file for-tests.scad, line 74
 WARNING: Bad range parameter in for statement: too many elements (4294967295), in file for-tests.scad, line 75
 WARNING: Bad range parameter in for statement: too many elements (4294967295), in file for-tests.scad, line 77

--- a/tests/regression/echotest/list-comprehensions-expected.echo
+++ b/tests/regression/echotest/list-comprehensions-expected.echo
@@ -6,9 +6,9 @@ ECHO: []
 ECHO: [1]
 ECHO: [0, 1]
 ECHO: [0, 1]
-WARNING: begin is smaller than the end, but step is negativ in file list-comprehensions.scad, line 11
+WARNING: begin is smaller than the end, but step is negativ, in file list-comprehensions.scad, line 11
 ECHO: []
-WARNING: begin is greater than the end, but step is positiv in file list-comprehensions.scad, line 12
+WARNING: begin is greater than the end, but step is positiv, in file list-comprehensions.scad, line 12
 ECHO: []
 ECHO: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
 ECHO: [[0, 10], [0, 11], [0, 12], [0, 13], [1, 10], [1, 11], [1, 12], [1, 13], [2, 10], [2, 11], [2, 12], [2, 13], [3, 10], [3, 11], [3, 12], [3, 13]]

--- a/tests/regression/echotest/list-comprehensions-expected.echo
+++ b/tests/regression/echotest/list-comprehensions-expected.echo
@@ -6,7 +6,9 @@ ECHO: []
 ECHO: [1]
 ECHO: [0, 1]
 ECHO: [0, 1]
+WARNING: begin is smaller than the end, but step is negativ in file list-comprehensions.scad, line 11
 ECHO: []
+WARNING: begin is greater than the end, but step is positiv in file list-comprehensions.scad, line 12
 ECHO: []
 ECHO: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
 ECHO: [[0, 10], [0, 11], [0, 12], [0, 13], [1, 10], [1, 11], [1, 12], [1, 13], [2, 10], [2, 11], [2, 12], [2, 13], [3, 10], [3, 11], [3, 12], [3, 13]]

--- a/tests/regression/echotest/range-tests-expected.echo
+++ b/tests/regression/echotest/range-tests-expected.echo
@@ -4,7 +4,7 @@ ECHO: "[a01] ", 2
 ECHO: "[a01] ", 3
 ECHO: "[a01] ", 4
 ECHO: "[a02] ----- [4:1]"
-DEPRECATED: Using ranges of the form [begin:end] with begin value greater than the end value is deprecated.
+DEPRECATED: Using ranges of the form [begin:end] with begin value greater than the end value is deprecated. in file range-tests.scad, line 2
 ECHO: "[a02] ", 1
 ECHO: "[a02] ", 2
 ECHO: "[a02] ", 3
@@ -22,6 +22,7 @@ ECHO: "[a05] ", -2
 ECHO: "[a05] ", -1
 ECHO: "[a05] ", 0
 ECHO: "[a06] ----- [0:-3]"
+DEPRECATED: Using ranges of the form [begin:end] with begin value greater than the end value is deprecated. in file range-tests.scad, line 6
 ECHO: "[a06] ", -3
 ECHO: "[a06] ", -2
 ECHO: "[a06] ", -1
@@ -33,6 +34,7 @@ ECHO: "[a07] ", 0
 ECHO: "[a07] ", 1
 ECHO: "[a07] ", 2
 ECHO: "[a08] ----- [2:-2]"
+DEPRECATED: Using ranges of the form [begin:end] with begin value greater than the end value is deprecated. in file range-tests.scad, line 8
 ECHO: "[a08] ", -2
 ECHO: "[a08] ", -1
 ECHO: "[a08] ", 0
@@ -49,8 +51,11 @@ ECHO: "[b02] ", 1
 ECHO: "[b02] ", 3
 ECHO: "[b02] ", 5
 ECHO: "[b03] ----- [1:-1:5]"
+WARNING: begin is smaller than the end, but step is negativ in file range-tests.scad, line 12
 ECHO: "[b04] ----- [5:1:1]"
+WARNING: begin is greater than the end, but step is positiv in file range-tests.scad, line 13
 ECHO: "[b05] ----- [5:2:1]"
+WARNING: begin is greater than the end, but step is positiv in file range-tests.scad, line 14
 ECHO: "[b06] ----- [5:-1:1]"
 ECHO: "[b06] ", 5
 ECHO: "[b06] ", 4

--- a/tests/regression/echotest/range-tests-expected.echo
+++ b/tests/regression/echotest/range-tests-expected.echo
@@ -4,7 +4,7 @@ ECHO: "[a01] ", 2
 ECHO: "[a01] ", 3
 ECHO: "[a01] ", 4
 ECHO: "[a02] ----- [4:1]"
-DEPRECATED: Using ranges of the form [begin:end] with begin value greater than the end value is deprecated. in file range-tests.scad, line 2
+DEPRECATED: Using ranges of the form [begin:end] with begin value greater than the end value is deprecated, in file range-tests.scad, line 2
 ECHO: "[a02] ", 1
 ECHO: "[a02] ", 2
 ECHO: "[a02] ", 3
@@ -22,7 +22,7 @@ ECHO: "[a05] ", -2
 ECHO: "[a05] ", -1
 ECHO: "[a05] ", 0
 ECHO: "[a06] ----- [0:-3]"
-DEPRECATED: Using ranges of the form [begin:end] with begin value greater than the end value is deprecated. in file range-tests.scad, line 6
+DEPRECATED: Using ranges of the form [begin:end] with begin value greater than the end value is deprecated, in file range-tests.scad, line 6
 ECHO: "[a06] ", -3
 ECHO: "[a06] ", -2
 ECHO: "[a06] ", -1
@@ -34,7 +34,7 @@ ECHO: "[a07] ", 0
 ECHO: "[a07] ", 1
 ECHO: "[a07] ", 2
 ECHO: "[a08] ----- [2:-2]"
-DEPRECATED: Using ranges of the form [begin:end] with begin value greater than the end value is deprecated. in file range-tests.scad, line 8
+DEPRECATED: Using ranges of the form [begin:end] with begin value greater than the end value is deprecated, in file range-tests.scad, line 8
 ECHO: "[a08] ", -2
 ECHO: "[a08] ", -1
 ECHO: "[a08] ", 0
@@ -51,11 +51,11 @@ ECHO: "[b02] ", 1
 ECHO: "[b02] ", 3
 ECHO: "[b02] ", 5
 ECHO: "[b03] ----- [1:-1:5]"
-WARNING: begin is smaller than the end, but step is negativ in file range-tests.scad, line 12
+WARNING: begin is smaller than the end, but step is negativ, in file range-tests.scad, line 12
 ECHO: "[b04] ----- [5:1:1]"
-WARNING: begin is greater than the end, but step is positiv in file range-tests.scad, line 13
+WARNING: begin is greater than the end, but step is positiv, in file range-tests.scad, line 13
 ECHO: "[b05] ----- [5:2:1]"
-WARNING: begin is greater than the end, but step is positiv in file range-tests.scad, line 14
+WARNING: begin is greater than the end, but step is positiv, in file range-tests.scad, line 14
 ECHO: "[b06] ----- [5:-1:1]"
 ECHO: "[b06] ", 5
 ECHO: "[b06] ", 4


### PR DESCRIPTION
based on http://forum.openscad.org/Infamous-warnings-td28054.html

- [x] remove the now redundant code in value.cc
- [x] consider generalizing warning
   - (just focusing on literals for now)
   - Warn for
      - [x] `for(i=[10:1])` -> swap, deprecated
      - [x] `for(i=[1:-1:10])` -> warning
      - [x] `for(i=[1:0:10])` -> bad range warning (not very specific, but "fair enough" with the line number)
   - correct (do not warn)
      - [x] `for(i=[0:10])` -> fine
      - [x] `for(i=[10:-1:1])` -> fine
   - not addressed with this PR
      -  expression containing variables like `for(i=[0:a])` `for(i=[a:0])` `for(i=[0:a:10])`  `for(i=[a:1:10])`  `for(i=[0:1:a])` 
      - non-numbers like
         - for(r=[1:true:5]) echo(r);
         - for(r=[1:"test":5]) echo(r);
         - for(r=["a":"z"]) echo(r);
- [x] test cases
   - [x] (check list from above)
   - [x] manually review changed test cases
- [x] move the warning to a NOINLINE function to minimize memory footprint?
- [x] rephrase warnings for consistency