### PR TITLE
Minimal fix for #3118  Tail recursion limit not working

### DIFF
--- a/src/expr.cc
+++ b/src/expr.cc
@@ -546,10 +546,14 @@ FunctionCall::FunctionCall(Expression *expr, const AssignmentList &args, const L
 */
 void FunctionCall::prepareTailCallContext(const std::shared_ptr<Context> context, std::shared_ptr<Context> tailCallContext, const AssignmentList &definition_arguments)
 {
-	if (this->resolvedArguments.empty()) {
+	if (this->resolvedArguments.empty() && !this->arguments.empty()) {
 		// Figure out parameter names
 		ContextHandle<EvalContext> ec{Context::create<EvalContext>(context, this->arguments, this->loc)};
 		this->resolvedArguments = ec->resolveArguments(definition_arguments, {}, false);
+	}
+
+	// FIXME: evaluate defaultArguments in FunctionDefinition / UserFunction and pass to FunctionCall instead of definition_arguments ?
+	if (this->defaultArguments.empty() && !definition_arguments.empty()) {
 		// Assign default values for unspecified parameters
 		for (const auto &arg : definition_arguments) {
 			if (this->resolvedArguments.find(arg->name) == this->resolvedArguments.end()) {

--- a/testdata/scad/issues/issue3118-recur-limit.scad
+++ b/testdata/scad/issues/issue3118-recur-limit.scad
@@ -1,0 +1,4 @@
+// Issue #3118
+// Verify recursion limit is reached when no arguments provided in call.
+function sin(x) = sin(); 
+echo(sin(30));

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -457,6 +457,7 @@ list(APPEND ECHO_FILES ${FUNCTION_FILES} ${MISC_FILES}
             ${CMAKE_SOURCE_DIR}/../testdata/scad/misc/preview_variable.scad
             ${CMAKE_SOURCE_DIR}/../testdata/scad/issues/issue1851-each-fail-on-scalar.scad
             ${CMAKE_SOURCE_DIR}/../testdata/scad/issues/issue2342.scad
+            ${CMAKE_SOURCE_DIR}/../testdata/scad/issues/issue3118-recur-limit.scad
             ${CMAKE_SOURCE_DIR}/../testdata/scad/misc/function-scope.scad
             )
 

--- a/tests/regression/echotest/issue3118-recur-limit-expected.echo
+++ b/tests/regression/echotest/issue3118-recur-limit-expected.echo
@@ -1,0 +1,3 @@
+ERROR: Recursion detected calling function 'sin' in file issue3118-recur-limit.scad, line 3
+TRACE: called by 'sin', in file issue3118-recur-limit.scad, line 4.
+TRACE: called by 'echo', in file issue3118-recur-limit.scad, line 4.


### PR DESCRIPTION
This small change addresses the issue defaultArguments growing without bounds when a call has no arguments, which was causing recursion limit to not be reached in any reasonable time frame.