### PR TITLE
Use search order fix

### DIFF
--- a/src/FileModule.cc
+++ b/src/FileModule.cc
@@ -71,7 +71,10 @@ void FileModule::registerUse(const std::string path, const Location &loc)
 			PRINTB("ERROR: Can't read font with path '%s'", path);
 		}
 	} else {
-		usedlibs.insert(path);
+		auto pos = std::find(usedlibs.begin(), usedlibs.end(), path);
+		if(pos != usedlibs.end())
+			usedlibs.erase(pos);
+		usedlibs.insert(usedlibs.begin(), path);
 		if (!loc.isNone()) {
 			indicatorData.emplace_back(loc.firstLine(), loc.firstColumn(), loc.lastColumn() - loc.firstColumn(), path);
 		}
@@ -167,8 +170,9 @@ time_t FileModule::handleDependencies(bool is_root)
 
 	// Relative filenames which were located are reinserted as absolute filenames
 	for (const auto &files : updates) {
-		this->usedlibs.erase(files.first);
-		this->usedlibs.insert(files.second);
+		auto pos = std::find(usedlibs.begin(), usedlibs.end(), files.first);
+		f(pos != usedlibs.end())
+			*pos = files.second;
 	}
 	return latest;
 }

--- a/src/FileModule.cc
+++ b/src/FileModule.cc
@@ -171,7 +171,7 @@ time_t FileModule::handleDependencies(bool is_root)
 	// Relative filenames which were located are reinserted as absolute filenames
 	for (const auto &files : updates) {
 		auto pos = std::find(usedlibs.begin(), usedlibs.end(), files.first);
-		f(pos != usedlibs.end())
+		if(pos != usedlibs.end())
 			*pos = files.second;
 	}
 	return latest;

--- a/src/FileModule.h
+++ b/src/FileModule.h
@@ -34,7 +34,7 @@ public:
 	const std::string &getFilename() const { return this->filename; }
 	const std::string getFullpath() const;
 	LocalScope scope;
-	typedef std::unordered_set<std::string> ModuleContainer;
+	typedef std::vector<std::string> ModuleContainer;
 	ModuleContainer usedlibs;
 
 	std::vector<IndicatorData> indicatorData;

--- a/testdata/use-order-test/file1.scad
+++ b/testdata/use-order-test/file1.scad
@@ -1,0 +1,5 @@
+module m1() { echo("file1 m1"); }
+module m2() { echo("file1 m2"); }
+module m3() { echo("file1 m3"); }
+module m4() { echo("file1 m4"); }
+    

--- a/testdata/use-order-test/file2.scad
+++ b/testdata/use-order-test/file2.scad
@@ -1,0 +1,3 @@
+module m2() { echo("file2 m2"); }
+module m3() { echo("file2 m3"); }
+module m4() { echo("file2 m4"); }

--- a/testdata/use-order-test/file3.scad
+++ b/testdata/use-order-test/file3.scad
@@ -1,0 +1,2 @@
+module m3() { echo("file3 m3"); }
+module m4() { echo("file3 m4"); }

--- a/testdata/use-order-test/file4.scad
+++ b/testdata/use-order-test/file4.scad
@@ -1,0 +1,1 @@
+module m4() { echo("file4 m4"); }

--- a/testdata/use-order-test/use-order-test.scad
+++ b/testdata/use-order-test/use-order-test.scad
@@ -1,0 +1,10 @@
+use <file1.scad>
+use <file2.scad>
+use <file3.scad>
+use <file4.scad>
+
+
+m1();
+m2();
+m3();
+m4();

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -459,6 +459,7 @@ list(APPEND ECHO_FILES ${FUNCTION_FILES} ${MISC_FILES}
             ${CMAKE_SOURCE_DIR}/../testdata/scad/issues/issue2342.scad
             ${CMAKE_SOURCE_DIR}/../testdata/scad/issues/issue3118-recur-limit.scad
             ${CMAKE_SOURCE_DIR}/../testdata/scad/misc/function-scope.scad
+            ${CMAKE_SOURCE_DIR}/../testdata/use-order-test/use-order-test.scad
             )
 
 list(APPEND ASTDUMPTEST_FILES ${MISC_FILES}

--- a/tests/regression/echotest/use-order-test-expected.echo
+++ b/tests/regression/echotest/use-order-test-expected.echo
@@ -1,0 +1,4 @@
+ECHO: "file1 m1"
+ECHO: "file2 m2"
+ECHO: "file3 m3"
+ECHO: "file4 m4"


### PR DESCRIPTION
Searches for module and functions in used files are now in reverse order of use. This ensures later uses override earlier ones when they define the same name.