### PR TITLE
Cut to end of the line

### DIFF
--- a/src/MainWindow.h
+++ b/src/MainWindow.h
@@ -21,6 +21,7 @@
 #include "input/InputDriver.h"
 #include "editor.h"
 #include "tabmanager.h"
+#include <QShortcut>
 
 class MainWindow : public QMainWindow, public Ui::MainWindow, public InputEventHandler
 {
@@ -310,6 +311,7 @@ private:
 	QString exportPath(const char *suffix); // look up the last export path and generate one if not found
 	int last_parser_error_pos; // last highlighted error position
 	int tabCount = 0;
+    QShortcut *CtrlK;
 
 signals:
 	void highlightError(int);

--- a/src/editor.h
+++ b/src/editor.h
@@ -30,6 +30,7 @@ public:
 	virtual void setIndicator(const std::vector<IndicatorData>& indicatorData) = 0;
 	virtual QMenu * createStandardContextMenu() = 0;
 	virtual QPoint mapToGlobal(const QPoint &) = 0;
+    virtual QString stringToEndOfTheLine()=0;
 
 signals:
   void contentsChanged();

--- a/src/editor.h
+++ b/src/editor.h
@@ -30,7 +30,7 @@ public:
 	virtual void setIndicator(const std::vector<IndicatorData>& indicatorData) = 0;
 	virtual QMenu * createStandardContextMenu() = 0;
 	virtual QPoint mapToGlobal(const QPoint &) = 0;
-    virtual QString stringToEndOfTheLine()=0;
+    virtual void stringToEndOfTheLine()=0;
 
 signals:
   void contentsChanged();

--- a/src/mainwin.cc
+++ b/src/mainwin.cc
@@ -311,7 +311,7 @@ MainWindow::MainWindow(const QStringList &filenames)
 	this->fileActionReload->setShortcuts(shortcuts);
 
     CtrlK = new QShortcut(QKeySequence(Qt::CTRL + Qt::Key_K),this);
-    connect(CtrlK,SIGNAL(activated()),tabManager,SLOT(copyToEndOfLine()));
+    connect(CtrlK,SIGNAL(activated()),tabManager,SLOT(cutToEndOfLine()));
 
 #endif
 

--- a/src/mainwin.cc
+++ b/src/mainwin.cc
@@ -309,6 +309,10 @@ MainWindow::MainWindow(const QStringList &filenames)
 	shortcuts = this->fileActionReload->shortcuts();
 	shortcuts.push_back(QKeySequence(Qt::Key_F3));
 	this->fileActionReload->setShortcuts(shortcuts);
+
+    CtrlK = new QShortcut(QKeySequence(Qt::CTRL + Qt::Key_K),this);
+    connect(CtrlK,SIGNAL(activated()),tabManager,SLOT(copyToEndOfLine()));
+
 #endif
 
 	this->menuOpenRecent->addSeparator();

--- a/src/scintillaeditor.cpp
+++ b/src/scintillaeditor.cpp
@@ -1208,3 +1208,12 @@ void ScintillaEditor::jumpToNextError()
 {
 	findMarker(1, 0, [this](int line){ return qsci->markerFindNext(line, 1 << errMarkerNumber); });
 }
+
+QString ScintillaEditor::stringToEndOfTheLine(){
+    int line,index,line_len,position_start;
+    qsci->getCursorPosition(&line,&index);
+    position_start = qsci->positionFromLineIndex(line,0);
+    line_len = qsci->lineLength(line);
+    QString textToEnd = qsci->text((position_start+index),(position_start+line_len));
+    return textToEnd;
+}

--- a/src/scintillaeditor.cpp
+++ b/src/scintillaeditor.cpp
@@ -1209,11 +1209,12 @@ void ScintillaEditor::jumpToNextError()
 	findMarker(1, 0, [this](int line){ return qsci->markerFindNext(line, 1 << errMarkerNumber); });
 }
 
-QString ScintillaEditor::stringToEndOfTheLine(){
-    int line,index,line_len,position_start;
+void ScintillaEditor::stringToEndOfTheLine(){
+    int line,index,line_len;
     qsci->getCursorPosition(&line,&index);
-    position_start = qsci->positionFromLineIndex(line,0);
+    //position_start = qsci->positionFromLineIndex(line,0);
     line_len = qsci->lineLength(line);
-    QString textToEnd = qsci->text((position_start+index),(position_start+line_len));
-    return textToEnd;
+    //QString textToEnd = qsci->text((position_start+index),(position_start+line_len));
+    qsci->setSelection(line,index,line,line_len);
+    qsci->cut();
 }

--- a/src/scintillaeditor.h
+++ b/src/scintillaeditor.h
@@ -61,7 +61,7 @@ public:
 	void setIndicator(const std::vector<IndicatorData> &indicatorData) override;
 	QMenu *createStandardContextMenu() override;
 	QPoint mapToGlobal(const QPoint &) override;
-    QString stringToEndOfTheLine() override;
+    void stringToEndOfTheLine() override;
 
 private:
 	void getRange(int *lineFrom, int *lineTo);

--- a/src/scintillaeditor.h
+++ b/src/scintillaeditor.h
@@ -61,6 +61,7 @@ public:
 	void setIndicator(const std::vector<IndicatorData> &indicatorData) override;
 	QMenu *createStandardContextMenu() override;
 	QPoint mapToGlobal(const QPoint &) override;
+    QString stringToEndOfTheLine() override;
 
 private:
 	void getRange(int *lineFrom, int *lineTo);

--- a/src/tabmanager.cc
+++ b/src/tabmanager.cc
@@ -6,10 +6,9 @@
 #include <QTextStream>
 #include <QMessageBox>
 #include <QFileDialog>
-#include <QClipboard>
 #include <Qsci/qscicommand.h>
 #include <Qsci/qscicommandset.h>
-
+#include <QClipboard>
 #include "editor.h"
 #include "tabmanager.h"
 #include "tabwidget.h"
@@ -720,10 +719,6 @@ void TabManager::onHyperlinkIndicatorClicked(int val)
     this->open(filename);
 }
 
-void TabManager::copyToEndOfLine(){
-    clipBoard = QGuiApplication::clipboard();
-    QString textToEnd = editor->stringToEndOfTheLine();
-    std::string str = "Hello ";
-    QString qstr = QString::fromStdString(str);
-    clipBoard->setText(textToEnd);
+void TabManager::cutToEndOfLine(){
+    editor->stringToEndOfTheLine();
 }

--- a/src/tabmanager.cc
+++ b/src/tabmanager.cc
@@ -719,3 +719,11 @@ void TabManager::onHyperlinkIndicatorClicked(int val)
     const QString filename = QString::fromStdString(editor->indicatorData[val].path);
     this->open(filename);
 }
+
+void TabManager::copyToEndOfLine(){
+    clipBoard = QGuiApplication::clipboard();
+    QString textToEnd = editor->stringToEndOfTheLine();
+    std::string str = "Hello ";
+    QString qstr = QString::fromStdString(str);
+    clipBoard->setText(textToEnd);
+}

--- a/src/tabmanager.h
+++ b/src/tabmanager.h
@@ -3,6 +3,7 @@
 #include <functional>
 #include <QObject>
 #include <QSet>
+#include <QClipboard>
 #include "editor.h"
 #include "tabwidget.h"
 
@@ -40,6 +41,7 @@ signals:
 private:
     MainWindow *par;
     TabWidget *tabWidget;
+    QClipboard *clipBoard;
 
     bool maybeSave(int);
     void saveError(const QIODevice &file, const std::string &msg, EditorInterface *edt);
@@ -86,4 +88,6 @@ public slots:
     void closeCurrentTab();
     void nextTab();
     void prevTab();
+    void copyToEndOfLine();
+
 };

--- a/src/tabmanager.h
+++ b/src/tabmanager.h
@@ -3,7 +3,6 @@
 #include <functional>
 #include <QObject>
 #include <QSet>
-#include <QClipboard>
 #include "editor.h"
 #include "tabwidget.h"
 
@@ -41,7 +40,6 @@ signals:
 private:
     MainWindow *par;
     TabWidget *tabWidget;
-    QClipboard *clipBoard;
 
     bool maybeSave(int);
     void saveError(const QIODevice &file, const std::string &msg, EditorInterface *edt);
@@ -88,6 +86,6 @@ public slots:
     void closeCurrentTab();
     void nextTab();
     void prevTab();
-    void copyToEndOfLine();
+    void cutToEndOfLine();
 
 };


### PR DESCRIPTION
#3186 is solved in this branch. Cltr+K will now cut the text after the cursor to the end of the line and place it in the clipboard.