### PR TITLE
fix intrusive autocomplete

### DIFF
--- a/src/scintillaeditor.cpp
+++ b/src/scintillaeditor.cpp
@@ -273,7 +273,8 @@ void ScintillaEditor::applySettings()
 	if(Preferences::inst()->getValue("editor/enableAutocomplete").toBool())
 	{
 		qsci->setAutoCompletionSource(QsciScintilla::AcsAPIs);
-		qsci->setAutoCompletionFillupsEnabled(true);
+		qsci->setAutoCompletionFillupsEnabled(false);
+ 		qsci->setAutoCompletionFillups("(");		
 		qsci->setCallTipsVisible(10);
 		qsci->setCallTipsStyle(QsciScintilla::CallTipsContext);
 	}


### PR DESCRIPTION
Fixed issue #3155 

When you don't select an autocomplete suggestion and press '(', then the first suggestion is selected for auto-completion.
This PR fixes this intrusive behaviour.