### PR TITLE
Shortcuts for autocomplete

### DIFF
--- a/src/scintillaeditor.cpp
+++ b/src/scintillaeditor.cpp
@@ -17,7 +17,7 @@
 
 namespace fs=boost::filesystem;
 
-QString ScintillaEditor::cursorPlaceHolder = "^~^";
+const QString ScintillaEditor::cursorPlaceHolder = "^~^";
 
 class SettingsConverter {
 public:

--- a/src/scintillaeditor.cpp
+++ b/src/scintillaeditor.cpp
@@ -7,6 +7,7 @@
 
 #include <QString>
 #include <QChar>
+#include <QShortcut>
 #include <Qsci/qscicommandset.h>
 
 #include "scintillaeditor.h"
@@ -154,6 +155,14 @@ ScintillaEditor::ScintillaEditor(QWidget *parent) : EditorInterface(parent)
 	// Ctrl-Ins displays templates
 	c = qsci->standardCommands()->boundTo(Qt::Key_Insert | Qt::CTRL);
 	c->setAlternateKey(0);
+
+	QShortcut *shortcutCalltip;
+	shortcutCalltip = new QShortcut(Qt::CTRL | Qt::SHIFT | Qt::Key_Space, this);
+	connect(shortcutCalltip, &QShortcut::activated, [=]() { qsci->callTip(); });
+
+	QShortcut *shortcutAutocomplete;
+	shortcutAutocomplete = new QShortcut(Qt::CTRL | Qt::Key_Space, this);
+	connect(shortcutAutocomplete, &QShortcut::activated, [=]() { qsci->autoCompleteFromAll(); });
 
 	scintillaLayout->setContentsMargins(0, 0, 0, 0);
 	scintillaLayout->addWidget(qsci);

--- a/src/scintillaeditor.cpp
+++ b/src/scintillaeditor.cpp
@@ -156,12 +156,18 @@ ScintillaEditor::ScintillaEditor(QWidget *parent) : EditorInterface(parent)
 	c = qsci->standardCommands()->boundTo(Qt::Key_Insert | Qt::CTRL);
 	c->setAlternateKey(0);
 
+#ifdef Q_OS_MAC
+	const unsigned long modifier = Qt::META;
+#else
+	const unsigned long modifier = Qt::CTRL;
+#endif
+
 	QShortcut *shortcutCalltip;
-	shortcutCalltip = new QShortcut(Qt::CTRL | Qt::SHIFT | Qt::Key_Space, this);
+	shortcutCalltip = new QShortcut(modifier | Qt::SHIFT | Qt::Key_Space, this);
 	connect(shortcutCalltip, &QShortcut::activated, [=]() { qsci->callTip(); });
 
 	QShortcut *shortcutAutocomplete;
-	shortcutAutocomplete = new QShortcut(Qt::CTRL | Qt::Key_Space, this);
+	shortcutAutocomplete = new QShortcut(modifier | Qt::Key_Space, this);
 	connect(shortcutAutocomplete, &QShortcut::activated, [=]() { qsci->autoCompleteFromAll(); });
 
 	scintillaLayout->setContentsMargins(0, 0, 0, 0);

--- a/src/scintillaeditor.cpp
+++ b/src/scintillaeditor.cpp
@@ -1,17 +1,20 @@
+#include <ciso646> // C alternative tokens (xor)
 #include <stdlib.h>
 #include <algorithm>
+#include <boost/filesystem.hpp>
+#include <boost/property_tree/ptree.hpp>
+#include <boost/property_tree/json_parser.hpp>
+
 #include <QString>
 #include <QChar>
-#include "scintillaeditor.h"
 #include <Qsci/qscicommandset.h>
+
+#include "scintillaeditor.h"
 #include "Preferences.h"
 #include "PlatformUtils.h"
 #include "settings.h"
 #include "QSettingsCached.h"
-#include <ciso646> // C alternative tokens (xor)
-#include <boost/filesystem.hpp>
-#include <boost/property_tree/ptree.hpp>
-#include <boost/property_tree/json_parser.hpp>
+
 namespace fs=boost::filesystem;
 
 QString ScintillaEditor::cursorPlaceHolder = "^~^";

--- a/src/scintillaeditor.h
+++ b/src/scintillaeditor.h
@@ -1,21 +1,22 @@
 #pragma once
 
+#include <functional>
+#include <boost/property_tree/ptree.hpp>
+#include <boost/property_tree/json_parser.hpp>
+
 #include <QMap>
 #include <QObject>
 #include <QString>
 #include <QWidget>
 #include <QVBoxLayout>
-#include <Qsci/qsciscintilla.h>
 #include <QVBoxLayout>
-#include <functional>
-#include "editor.h"
-#include "scadlexer.h"
-#include "scadapi.h"
-#include "parsersettings.h"
+#include <Qsci/qsciscintilla.h>
 
+#include "editor.h"
 #include "memory.h"
-#include <boost/property_tree/ptree.hpp>
-#include <boost/property_tree/json_parser.hpp>
+#include "scadapi.h"
+#include "scadlexer.h"
+#include "parsersettings.h"
 
 class EditorColorScheme
 {

--- a/src/scintillaeditor.h
+++ b/src/scintillaeditor.h
@@ -148,5 +148,5 @@ private:
 	ScadApi *api;
 	QStringList userList;
 	QMap<QString, ScadTemplate> templateMap;
-	static QString cursorPlaceHolder;
+	static const QString cursorPlaceHolder;
 };


### PR DESCRIPTION
Add shortcuts for:

- Autocomplete: CTRL + Space (pretty much the default for IDEs)
- Calltips: SHIFT + CTRL + Space (function parameters)
