### PR TITLE
Only enable 30ms joystick timer when needed

### DIFF
--- a/src/input/InputEventMapper.cc
+++ b/src/input/InputEventMapper.cc
@@ -160,7 +160,7 @@ bool InputEventMapper::generateDeferredEvents()
 void InputEventMapper::considerGeneratingDeferredEvents()
 {
     if (!timer->isActive()) {
-        timer->start(30);
+        QMetaObject::invokeMethod(timer, "start", Qt::QueuedConnection, Q_ARG(int, 30));
     }
 }
 

--- a/src/input/InputEventMapper.cc
+++ b/src/input/InputEventMapper.cc
@@ -106,8 +106,9 @@ double InputEventMapper::getAxisValue(int config)
     return scale(val);
 }
 
-void InputEventMapper::onTimer()
+bool InputEventMapper::generateDeferredEvents()
 {
+    bool any = false;
     const double threshold = 0.01;
 
     double tx = getAxisValue(translate[0])*translationGain;
@@ -116,6 +117,7 @@ void InputEventMapper::onTimer()
     if ((fabs(tx) > threshold) || (fabs(ty) > threshold) || (fabs(tz) > threshold)) {
         InputEvent *inputEvent = new InputEventTranslate(tx, ty, tz);
         InputDriverManager::instance()->postEvent(inputEvent);
+        any = true;
     }
     
     double txVPRel = getAxisValue(translate[3])*translationVPRelGain;
@@ -124,6 +126,7 @@ void InputEventMapper::onTimer()
     if ((fabs(txVPRel) > threshold) || (fabs(tyVPRel) > threshold) || (fabs(tzVPRel) > threshold)) {
         InputEvent *inputEvent = new InputEventTranslate(txVPRel, tyVPRel, tzVPRel, true, true, false);
         InputDriverManager::instance()->postEvent(inputEvent);
+        any = true;
     }
     
     double rx = getAxisValue(rotate[0])*rotateGain;
@@ -132,6 +135,7 @@ void InputEventMapper::onTimer()
     if ((fabs(rx) > threshold) || (fabs(ry) > threshold) || (fabs(rz) > threshold)) {
         InputEvent *inputEvent = new InputEventRotate(rx, ry, rz);
         InputDriverManager::instance()->postEvent(inputEvent);
+        any = true;
     }
     
     double rxVPRel = getAxisValue(rotate[3])*rotateVPRelGain;
@@ -140,13 +144,22 @@ void InputEventMapper::onTimer()
     if ((fabs(rxVPRel) > threshold) || (fabs(ryVPRel) > threshold) || (fabs(rzVPRel) > threshold)) {
         InputEvent *inputEvent = new InputEventRotate2(rxVPRel, ryVPRel, rzVPRel);
         InputDriverManager::instance()->postEvent(inputEvent);
+        any = true;
     }
     
     double z = (getAxisValue(zoom)+getAxisValue(zoom2))*zoomGain;
     if (fabs(z) > threshold) {
         InputEvent *inputEvent = new InputEventZoom(z);
         InputDriverManager::instance()->postEvent(inputEvent);
+        any = true;
     }
+
+    return any;
+}
+
+void InputEventMapper::onTimer()
+{
+    generateDeferredEvents();
 
     //update the UI on time, NOT on event as a joystick can fire a high rate of events
     for (int i = 0; i < max_buttons; i++ ){

--- a/src/input/InputEventMapper.h
+++ b/src/input/InputEventMapper.h
@@ -53,6 +53,7 @@ private:
     double getAxisValue(int config);
     int parseSettingValue(const std::string val);
     bool generateDeferredEvents();
+    void considerGeneratingDeferredEvents();
     bool button_state[max_buttons];
     bool button_state_last[max_buttons];
     

--- a/src/input/InputEventMapper.h
+++ b/src/input/InputEventMapper.h
@@ -52,6 +52,7 @@ private:
     double scale(double val);
     double getAxisValue(int config);
     int parseSettingValue(const std::string val);
+    bool generateDeferredEvents();
     bool button_state[max_buttons];
     bool button_state_last[max_buttons];
     


### PR DESCRIPTION
Fixes #2921 

The effect is that the timer is now only enabled when (i) there is a joystick and (ii) either (a) it has been moved or buttons pressed recently and we haven't processed that yet or (b) the joystick is sufficiently off-centre and out of the dead zone that we must generate input events.  When this ceases to be true, the timer is disabled again.  So this should solve the cpu usage (and battery wastage) problem for all users, even those with joysticks.

I have tested this by rebasing these patches onto Debian's 2019.05-3 package, as found in Debian testing.  I observe in strace that the program now only polls every 200ms again.  I don't have a joystick-like device so it is difficult for me to test that my change is correct, but I think it should be.

(As far as I can tell the InputMapper class is only used for joysticks, or similar input devices - ie ones which generate a stream of input events based on a position.  It would have been nice if this had been mentioned somewhere..)