### PR TITLE
add rotation of 3D view by shortkeys

### DIFF
--- a/src/MainWindow.h
+++ b/src/MainWindow.h
@@ -40,6 +40,7 @@ public:
 	QTimer *waitAfterReloadTimer;
 	QTime renderingTime;
 	EditorInterface *customizerEditor;
+    QList<QAction *> rotationActions;
 
 	ContextHandle<BuiltinContext> top_ctx;
 	FileModule *root_module;      // Result of parsing
@@ -122,6 +123,7 @@ private:
 	void setDockWidgetTitle(QDockWidget *dockWidget, QString prefix, bool topLevel);
 	void addKeyboardShortCut(const QList<QAction *> &actions);
 	void updateStatusBar(class ProgressWidget *progressWidget);
+    void rotateViewAngle(int axis, int step);
 
   class LibraryInfoDialog* library_info_dialog;
   class FontListDialog *font_list_dialog;
@@ -255,7 +257,18 @@ public slots:
 	void viewModeShowCrosshairs();
 	void viewModeShowScaleProportional();
 	void viewModeAnimate();
-    void rotateViewAngleSmallX();
+    void viewRotateSmallForwardX();
+    void viewRotateSmallBackwardX();
+    void viewRotateBigForwardX();
+    void viewRotateBigBackwardX();
+    void viewRotateSmallForwardY();
+    void viewRotateSmallBackwardY();
+    void viewRotateBigForwardY();
+    void viewRotateBigBackwardY();
+    void viewRotateSmallForwardZ();
+    void viewRotateSmallBackwardZ();
+    void viewRotateBigForwardZ();
+    void viewRotateBigBackwardZ();
 	void viewAngleTop();
 	void viewAngleBottom();
 	void viewAngleLeft();

--- a/src/MainWindow.h
+++ b/src/MainWindow.h
@@ -255,6 +255,7 @@ public slots:
 	void viewModeShowCrosshairs();
 	void viewModeShowScaleProportional();
 	void viewModeAnimate();
+    void rotateViewAngleSmallX();
 	void viewAngleTop();
 	void viewAngleBottom();
 	void viewAngleLeft();

--- a/src/MainWindow.ui
+++ b/src/MainWindow.ui
@@ -1526,6 +1526,14 @@
     <string>Hide Customizer</string>
    </property>
   </action>
+  <action name="viewActionRotateSmallX">
+   <property name="text">
+    <string>Rotate X Small Step</string>
+   </property>
+   <property name="shortcut">
+    <string>Ctrl+J</string>
+   </property>
+  </action>
  </widget>
  <customwidgets>
   <customwidget>

--- a/src/MainWindow.ui
+++ b/src/MainWindow.ui
@@ -1526,14 +1526,106 @@
     <string>Hide Customizer</string>
    </property>
   </action>
-  <action name="viewActionRotateSmallX">
+
+  <action name="viewActionRotateSmallForwardX">
    <property name="text">
-    <string>Rotate X Small Step</string>
+    <string>Rotate X Forward Small Step</string>
    </property>
    <property name="shortcut">
     <string>Ctrl+J</string>
    </property>
   </action>
+  <action name="viewActionRotateSmallBackwardX">
+   <property name="text">
+    <string>Rotate X Backward Small Step</string>
+   </property>
+   <property name="shortcut">
+    <string>Ctrl+M</string>
+   </property>
+  </action>
+  <action name="viewActionRotateBigForwardX">
+   <property name="text">
+    <string>Rotate X Forward Big Step</string>
+   </property>
+   <property name="shortcut">
+    <string>Ctrl+Shift+J</string>
+   </property>
+  </action>
+  <action name="viewActionRotateBigBackwardX">
+   <property name="text">
+    <string>Rotate X Backward Big Step</string>
+   </property>
+   <property name="shortcut">
+    <string>Ctrl+Shift+M</string>
+   </property>
+  </action>
+
+  <action name="viewActionRotateSmallForwardY">
+   <property name="text">
+    <string>Rotate Y Forward Small Step</string>
+   </property>
+   <property name="shortcut">
+    <string>Ctrl+K</string>
+   </property>
+  </action>
+  <action name="viewActionRotateSmallBackwardY">
+   <property name="text">
+    <string>Rotate Y Backward Small Step</string>
+   </property>
+   <property name="shortcut">
+    <string>Ctrl+,</string>
+   </property>
+  </action>
+  <action name="viewActionRotateBigForwardY">
+   <property name="text">
+    <string>Rotate Y Forward Big Step</string>
+   </property>
+   <property name="shortcut">
+    <string>Ctrl+Shift+K</string>
+   </property>
+  </action>
+  <action name="viewActionRotateBigBackwardY">
+   <property name="text">
+    <string>Rotate Y Backward Big Step</string>
+   </property>
+   <property name="shortcut">
+    <string>Ctrl+Shift+,</string>
+   </property>
+  </action>
+
+  <action name="viewActionRotateSmallForwardZ">
+   <property name="text">
+    <string>Rotate Z Forward Small Step</string>
+   </property>
+   <property name="shortcut">
+    <string>Ctrl+L</string>
+   </property>
+  </action>
+  <action name="viewActionRotateSmallBackwardZ">
+   <property name="text">
+    <string>Rotate Z Backward Small Step</string>
+   </property>
+   <property name="shortcut">
+    <string>Ctrl+.</string>
+   </property>
+  </action>
+  <action name="viewActionRotateBigForwardZ">
+   <property name="text">
+    <string>Rotate Z Forward Big Step</string>
+   </property>
+   <property name="shortcut">
+    <string>Ctrl+Shift+L</string>
+   </property>
+  </action>
+  <action name="viewActionRotateBigBackwardZ">
+   <property name="text">
+    <string>Rotate Z Backward Big Step</string>
+   </property>
+   <property name="shortcut">
+    <string>Ctrl+Shift+.</string>
+   </property>
+  </action>
+
  </widget>
  <customwidgets>
   <customwidget>

--- a/src/mainwin.cc
+++ b/src/mainwin.cc
@@ -412,9 +412,42 @@ MainWindow::MainWindow(const QStringList &filenames)
 	connect(this->viewActionHideConsole, SIGNAL(triggered()), this, SLOT(hideConsole()));
     connect(this->viewActionHideParameters, SIGNAL(triggered()), this, SLOT(hideParameters()));
     // View rotation shortcuts
-    connect(this->viewActionRotateSmallX, SIGNAL(triggered()), this, SLOT(rotateViewAngleSmallX()));
+    //connect(this->viewActionRotateSmallX, SIGNAL(triggered()), this, SLOT(rotateViewAngleSmallX()));
 
-    this->addAction(this->viewActionRotateSmallX);
+    //this->addAction(this->viewActionRotateSmallX);
+
+    connect(this->viewActionRotateSmallForwardX, SIGNAL(triggered()), this,  SLOT(viewRotateSmallForwardX()));
+    connect(this->viewActionRotateSmallBackwardX, SIGNAL(triggered()), this, SLOT(viewRotateSmallBackwardX()));
+    connect(this->viewActionRotateBigForwardX, SIGNAL(triggered()), this,    SLOT(viewRotateBigForwardX()));
+    connect(this->viewActionRotateBigBackwardX, SIGNAL(triggered()), this,   SLOT(viewRotateBigBackwardX()));
+    connect(this->viewActionRotateSmallForwardY, SIGNAL(triggered()), this,  SLOT(viewRotateSmallForwardY()));
+    connect(this->viewActionRotateSmallBackwardY, SIGNAL(triggered()), this, SLOT(viewRotateSmallBackwardY()));
+    connect(this->viewActionRotateBigForwardY, SIGNAL(triggered()), this,    SLOT(viewRotateBigForwardY()));
+    connect(this->viewActionRotateBigBackwardY, SIGNAL(triggered()), this,   SLOT(viewRotateBigBackwardY()));
+    connect(this->viewActionRotateSmallForwardZ, SIGNAL(triggered()), this,  SLOT(viewRotateSmallForwardZ()));
+    connect(this->viewActionRotateSmallBackwardZ, SIGNAL(triggered()), this, SLOT(viewRotateSmallBackwardZ()));
+    connect(this->viewActionRotateBigForwardZ, SIGNAL(triggered()), this,    SLOT(viewRotateBigForwardZ()));
+    connect(this->viewActionRotateBigBackwardZ, SIGNAL(triggered()), this,   SLOT(viewRotateBigBackwardZ()));
+
+
+    this->rotationActions.append(this->viewActionRotateSmallForwardX);
+    this->rotationActions.append(this->viewActionRotateSmallBackwardX);
+    this->rotationActions.append(this->viewActionRotateBigForwardX);
+    this->rotationActions.append(this->viewActionRotateBigBackwardX);
+    this->rotationActions.append(this->viewActionRotateSmallForwardY);
+    this->rotationActions.append(this->viewActionRotateSmallBackwardY);
+    this->rotationActions.append(this->viewActionRotateBigForwardY);
+    this->rotationActions.append(this->viewActionRotateBigBackwardY);
+    this->rotationActions.append(this->viewActionRotateSmallForwardZ);
+    this->rotationActions.append(this->viewActionRotateSmallBackwardZ);
+    this->rotationActions.append(this->viewActionRotateBigForwardZ);
+    this->rotationActions.append(this->viewActionRotateBigBackwardZ);
+
+    foreach(QAction* action, this->rotationActions)
+    {
+        this->addAction(action);
+    }
+
 	// Help menu
 	connect(this->helpActionAbout, SIGNAL(triggered()), this, SLOT(helpAbout()));
 	connect(this->helpActionHomepage, SIGNAL(triggered()), this, SLOT(helpHomepage()));
@@ -2577,11 +2610,25 @@ void MainWindow::animateUpdate()
 	}
 }
 
-void MainWindow::rotateViewAngleSmallX()
+void MainWindow::rotateViewAngle(int axis, int step)
 {
-	qglview->cam.object_rot[0] += 5; // << 90,0,0;
+	qglview->cam.object_rot[axis] += step;
 	this->qglview->updateGL();
 }
+
+void MainWindow::viewRotateSmallForwardX() {this->rotateViewAngle(0, 1);}
+void MainWindow::viewRotateSmallBackwardX() {this->rotateViewAngle(0, -1);}
+void MainWindow::viewRotateBigForwardX() {this->rotateViewAngle(0, 8);}
+void MainWindow::viewRotateBigBackwardX() {this->rotateViewAngle(0, -8);}
+void MainWindow::viewRotateSmallForwardY() {this->rotateViewAngle(1, 1);}
+void MainWindow::viewRotateSmallBackwardY() {this->rotateViewAngle(1, -1);}
+void MainWindow::viewRotateBigForwardY() {this->rotateViewAngle(1, 8);}
+void MainWindow::viewRotateBigBackwardY() {this->rotateViewAngle(1, -8);}
+void MainWindow::viewRotateSmallForwardZ() {this->rotateViewAngle(2, 1);}
+void MainWindow::viewRotateSmallBackwardZ() {this->rotateViewAngle(2, -1);}
+void MainWindow::viewRotateBigForwardZ() {this->rotateViewAngle(2, 8);}
+void MainWindow::viewRotateBigBackwardZ() {this->rotateViewAngle(2, -8);}
+
 
 void MainWindow::viewAngleTop()
 {

--- a/src/mainwin.cc
+++ b/src/mainwin.cc
@@ -411,6 +411,10 @@ MainWindow::MainWindow(const QStringList &filenames)
 	connect(this->viewActionHideEditor, SIGNAL(triggered()), this, SLOT(hideEditor()));
 	connect(this->viewActionHideConsole, SIGNAL(triggered()), this, SLOT(hideConsole()));
     connect(this->viewActionHideParameters, SIGNAL(triggered()), this, SLOT(hideParameters()));
+    // View rotation shortcuts
+    connect(this->viewActionRotateSmallX, SIGNAL(triggered()), this, SLOT(rotateViewAngleSmallX()));
+
+    this->addAction(this->viewActionRotateSmallX);
 	// Help menu
 	connect(this->helpActionAbout, SIGNAL(triggered()), this, SLOT(helpAbout()));
 	connect(this->helpActionHomepage, SIGNAL(triggered()), this, SLOT(helpHomepage()));
@@ -2571,6 +2575,12 @@ void MainWindow::animateUpdate()
 			animate_timer->start();
 		}
 	}
+}
+
+void MainWindow::rotateViewAngleSmallX()
+{
+	qglview->cam.object_rot[0] += 5; // << 90,0,0;
+	this->qglview->updateGL();
 }
 
 void MainWindow::viewAngleTop()


### PR DESCRIPTION
Solves #3231 .

I'm not a Qt or C++ programmer but I hope it’s not too bad.

Used default shortcuts with their action names:

```
viewActionRotateSmallForwardX
Rotate X Forward Small Step
Ctrl+J

--
viewActionRotateSmallBackwardX
Rotate X Backward Small Step
Ctrl+M

--
viewActionRotateBigForwardX
Rotate X Forward Big Step
Ctrl+Shift+J

--
viewActionRotateBigBackwardX
Rotate X Backward Big Step
Ctrl+Shift+M

--
viewActionRotateSmallForwardY
Rotate Y Forward Small Step
Ctrl+K

--
viewActionRotateSmallBackwardY
Rotate Y Backward Small Step
Ctrl+,

--
viewActionRotateBigForwardY
Rotate Y Forward Big Step
Ctrl+Shift+K

--
viewActionRotateBigBackwardY
Rotate Y Backward Big Step
Ctrl+Shift+,

--
viewActionRotateSmallForwardZ
Rotate Z Forward Small Step
Ctrl+L

--
viewActionRotateSmallBackwardZ
Rotate Z Backward Small Step
Ctrl+.

--
viewActionRotateBigForwardZ
Rotate Z Forward Big Step
Ctrl+Shift+L

--
viewActionRotateBigBackwardZ
Rotate Z Backward Big Step
Ctrl+Shift+.
```

They are not exactly VIM keys but close to them: Rotation can be done with the left hand’s home row ( j k l ) and the buttons beneath ( m , . ), each combined with CTRL. When also using Shift, 8° are used instead of 1° steps.

One observation I don’t understand: The X and Y axis seem to relate to  the camera while the Z axis seems to relate to the model. Does somebody had a clue why?