### PR TITLE
fix customizer vectors highest precision bug

### DIFF
--- a/src/parameter/parametervector.cpp
+++ b/src/parameter/parametervector.cpp
@@ -52,9 +52,12 @@ void ParameterVector::setValue()
 	double minV = object->values->toRange().begin_value();
 	double step = object->values->toRange().step_value();
 	double maxV = object->values->toRange().end_value();
+
+	double highestPrecisionValue = getHighestPrecision(vec);
+	
 	if(step==0){
 		step=1;
-		setPrecision(vec.at(0)->toDouble());
+		setPrecision(highestPrecisionValue);
 	}else{
 		setPrecision(step);
 	}

--- a/src/parameter/parametervector.cpp
+++ b/src/parameter/parametervector.cpp
@@ -52,12 +52,10 @@ void ParameterVector::setValue()
 	double minV = object->values->toRange().begin_value();
 	double step = object->values->toRange().step_value();
 	double maxV = object->values->toRange().end_value();
-
-	double highestPrecisionValue = getHighestPrecision(vec);
 	
 	if(step==0){
 		step=1;
-		setPrecision(highestPrecisionValue);
+		setPrecision(vec);
 	}else{
 		setPrecision(step);
 	}

--- a/src/parameter/parametervirtualwidget.cpp
+++ b/src/parameter/parametervirtualwidget.cpp
@@ -69,6 +69,37 @@ void ParameterVirtualWidget::setPrecision(double number){
 	}
 }
 
+double ParameterVirtualWidget::getHighestPrecision(Value::VectorType vec){
+	
+	int highestPrecision= 0,highestPrecisionIndex=0;
+    for(int i=0;i<vec.size();i++)
+	{
+		//convert double to string
+        std::ostringstream bufferStream;
+        bufferStream<<vec[i]->toDouble();
+        std::string numStr= bufferStream.str();
+
+		//find number of digits are decimal
+        int pos = numStr.find(".");
+
+		if(pos>0)
+		{
+        	std::string doubleStr = numStr.substr(pos+1);
+        	if(i == 0)
+			{
+            	highestPrecision = doubleStr.length();
+        	}
+        	else if(doubleStr.length() > highestPrecision)
+			{
+          	 	highestPrecision = doubleStr.length();
+		   		highestPrecisionIndex=i;
+        	}
+		}
+    }
+	return vec[highestPrecisionIndex]->toDouble();
+
+}
+
 void ParameterVirtualWidget::setDescription(const QString& description) {
 	if(!description.isEmpty()){
 		this->labelDescription->show();

--- a/src/parameter/parametervirtualwidget.cpp
+++ b/src/parameter/parametervirtualwidget.cpp
@@ -69,35 +69,15 @@ void ParameterVirtualWidget::setPrecision(double number){
 	}
 }
 
-double ParameterVirtualWidget::getHighestPrecision(Value::VectorType vec){
-	
-	int highestPrecision= 0,highestPrecisionIndex=0;
-    for(int i=0;i<vec.size();i++)
+//functional overloading to handle the case of vectors
+void ParameterVirtualWidget::setPrecision(Value::VectorType vec){
+	int highestPrecision= 0;
+    for(long unsigned int i=0;i<vec.size();i++)
 	{
-		//convert double to string
-        std::ostringstream bufferStream;
-        bufferStream<<vec[i]->toDouble();
-        std::string numStr= bufferStream.str();
-
-		//find number of digits are decimal
-        int pos = numStr.find(".");
-
-		if(pos>0)
-		{
-        	std::string doubleStr = numStr.substr(pos+1);
-        	if(i == 0)
-			{
-            	highestPrecision = doubleStr.length();
-        	}
-        	else if(doubleStr.length() > highestPrecision)
-			{
-          	 	highestPrecision = doubleStr.length();
-		   		highestPrecisionIndex=i;
-        	}
-		}
-    }
-	return vec[highestPrecisionIndex]->toDouble();
-
+		ParameterVirtualWidget::setPrecision(vec[i]->toDouble());
+		if(this->decimalPrecision>highestPrecision) highestPrecision = this->decimalPrecision;
+	}
+	this->decimalPrecision = highestPrecision;
 }
 
 void ParameterVirtualWidget::setDescription(const QString& description) {

--- a/src/parameter/parametervirtualwidget.h
+++ b/src/parameter/parametervirtualwidget.h
@@ -26,6 +26,8 @@ signals:
 protected:
 	int decimalPrecision;
 	virtual void setPrecision(double number);
+	virtual double getHighestPrecision(Value::VectorType vec);
+	
 private:
 	void setName(QString name);
 	void setDescription(const QString& description);

--- a/src/parameter/parametervirtualwidget.h
+++ b/src/parameter/parametervirtualwidget.h
@@ -26,7 +26,7 @@ signals:
 protected:
 	int decimalPrecision;
 	virtual void setPrecision(double number);
-	virtual double getHighestPrecision(Value::VectorType vec);
+	virtual void setPrecision(Value::VectorType vec);
 	
 private:
 	void setName(QString name);


### PR DESCRIPTION
I have tried to do a quick fix for #3243 
Two approaches came into my mind-
1) To look over the highest precision by dividing the value by 10.0 and keeping the count until the value becomes 0.0
2) Converting the value into the string and using string manipulation (I found this approach on the internet), while I was searching for some inbuilt C++ function to do the same.

As, toDouble() already truncates(roundoff) the doubles to 5 decimal places, so both the approaches will take nearly constant time.
I chose the second approach, as working with doubles/floats is always tricky.
