### PR TITLE
fix to issue #3229 

### DIFF
--- a/src/GeometryEvaluator.cc
+++ b/src/GeometryEvaluator.cc
@@ -1111,9 +1111,9 @@ Response GeometryEvaluator::visit(State &state, const ProjectionNode &node)
 					shared_ptr<const PolySet> chPS = dynamic_pointer_cast<const PolySet>(chgeom);
 					if (!chPS) {
 						shared_ptr<const CGAL_Nef_polyhedron> chN = dynamic_pointer_cast<const CGAL_Nef_polyhedron>(chgeom);
-						if (chN) {
+                        if (!chN->isEmpty()) {
 							PolySet *ps = new PolySet(3);
-							bool err = CGALUtils::createPolySetFromNefPolyhedron3(*chN->p3, *ps);
+                            bool err = CGALUtils::createPolySetFromNefPolyhedron3(*chN->p3, *ps);
 							if (err) {
 								PRINT("ERROR: Nef->PolySet failed");
 							}

--- a/src/GeometryEvaluator.cc
+++ b/src/GeometryEvaluator.cc
@@ -1111,7 +1111,7 @@ Response GeometryEvaluator::visit(State &state, const ProjectionNode &node)
 					shared_ptr<const PolySet> chPS = dynamic_pointer_cast<const PolySet>(chgeom);
 					if (!chPS) {
 						shared_ptr<const CGAL_Nef_polyhedron> chN = dynamic_pointer_cast<const CGAL_Nef_polyhedron>(chgeom);
-                        if (!chN->isEmpty()) {
+                        if (chN && !chN->isEmpty()) {
 							PolySet *ps = new PolySet(3);
                             bool err = CGALUtils::createPolySetFromNefPolyhedron3(*chN->p3, *ps);
 							if (err) {


### PR DESCRIPTION
I think the condition `if (this->x > 0 && this->y > 0 && this->z > 0 && !std::isinf(this->x) && !std::isinf(this->y) && !std::isinf(this->z))`  in PrimitiveNode::createGeometry() method creates an empty nef_polyhedron. and the application crashes when CGAL_forall_halffacets method in createPolySetFromNefPolyhedron3 tries to access that empty nef_polyhedron. issue #3229 