### PR TITLE
initial support for a mouse selecting renderer

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,7 +17,7 @@ endif()
 cmake_minimum_required(VERSION 3.3)
 
 # CMP0071 introduced in 3.10.2
-if (CMAKE_VERSION VERSION_GREATER "3.10.1") 
+if (CMAKE_VERSION VERSION_GREATER "3.10.1")
   cmake_policy(SET CMP0071 OLD)
 endif()
 
@@ -81,7 +81,7 @@ macro(find_graphics)
     find_package(OpenGL REQUIRED QUIET)
     list(APPEND COMMON_LIBRARIES ${OPENGL_LIBRARIES})
 
-    if(MSVC) 
+    if(MSVC)
       find_package(GLEW CONFIG REQUIRED QUIET)
       message(STATUS "GLEW: Using target GLEW::GLEW")
       list(APPEND COMMON_LIBRARIES GLEW::GLEW)
@@ -156,7 +156,7 @@ if (MSVC)
 
   find_package(unofficial-fontconfig CONFIG REQUIRED)
   list(APPEND COMMON_LIBRARIES unofficial::fontconfig::fontconfig)
-  
+
   find_package(unofficial-glib CONFIG REQUIRED)
   include_directories(${GLIB2_INCLUDE_DIRS})
   list(APPEND COMMON_LIBRARIES unofficial::glib::gio unofficial::glib::glib unofficial::glib::gmodule unofficial::glib::gobject)
@@ -310,7 +310,7 @@ if(NOT HEADLESS)
   else()
     message(STATUS "DBus input driver disabled as the QtDBus module could not be found.")
   endif()
-  
+
   find_package(Qt5Gamepad QUIET)
   if (Qt5Gamepad_FOUND)
     message(STATUS "Gamepad input driver enabled")
@@ -403,62 +403,62 @@ set(CORE_SOURCES
   src/linalg.cc
   src/colormap.cc
   src/Camera.cc
-  src/handle_dep.cc 
-  src/value.cc 
-  src/calc.cc 
-  src/hash.cc 
+  src/handle_dep.cc
+  src/value.cc
+  src/calc.cc
+  src/hash.cc
   src/expr.cc
   src/degree_trig.cc
-  src/func.cc 
-  src/function.cc 
+  src/func.cc
+  src/function.cc
   src/stackcheck.h
-  src/localscope.cc 
-  src/module.cc 
-  src/FileModule.cc 
-  src/UserModule.cc 
-  src/GroupModule.cc 
-  src/AST.cc 
-  src/ModuleInstantiation.cc 
-  src/ModuleCache.cc 
+  src/localscope.cc
+  src/module.cc
+  src/FileModule.cc
+  src/UserModule.cc
+  src/GroupModule.cc
+  src/AST.cc
+  src/ModuleInstantiation.cc
+  src/ModuleCache.cc
   src/StatCache.cc
-  src/node.cc 
-  src/NodeVisitor.cc 
-  src/context.cc 
+  src/node.cc
+  src/NodeVisitor.cc
+  src/context.cc
   src/builtincontext.cc
-  src/modcontext.cc 
-  src/evalcontext.cc 
+  src/modcontext.cc
+  src/evalcontext.cc
   src/version.cc
   src/feature.cc
-  src/csgnode.cc 
-  src/CSGTreeNormalizer.cc 
-  src/Geometry.cc 
-  src/Polygon2d.cc 
-  src/csgops.cc 
-  src/transform.cc 
-  src/color.cc 
-  src/primitives.cc 
-  src/projection.cc 
-  src/cgaladv.cc 
-  src/surface.cc 
-  src/control.cc 
-  src/render.cc 
-  src/rendersettings.cc 
-  src/dxfdata.cc 
-  src/dxfdim.cc 
-  src/offset.cc 
-  src/linearextrude.cc 
-  src/rotateextrude.cc 
-  src/text.cc 
-  src/printutils.cc 
-  src/fileutils.cc 
-  src/progress.cc 
-  src/boost-utils.cc 
+  src/csgnode.cc
+  src/CSGTreeNormalizer.cc
+  src/Geometry.cc
+  src/Polygon2d.cc
+  src/csgops.cc
+  src/transform.cc
+  src/color.cc
+  src/primitives.cc
+  src/projection.cc
+  src/cgaladv.cc
+  src/surface.cc
+  src/control.cc
+  src/render.cc
+  src/rendersettings.cc
+  src/dxfdata.cc
+  src/dxfdim.cc
+  src/offset.cc
+  src/linearextrude.cc
+  src/rotateextrude.cc
+  src/text.cc
+  src/printutils.cc
+  src/fileutils.cc
+  src/progress.cc
+  src/boost-utils.cc
   src/FontCache.cc
   src/DrawingCallback.cc
   src/FreetypeRenderer.cc
   src/RenderStatistic.cc
   src/ext/lodepng/lodepng.cpp
-  src/PlatformUtils.cc 
+  src/PlatformUtils.cc
   src/libsvg/circle.cc
   src/libsvg/ellipse.cc
   src/libsvg/group.cc
@@ -477,7 +477,7 @@ set(CORE_SOURCES
   src/libsvg/util.cc
   src/clipper-utils.cc
   src/Assignment.cc
-  src/annotation.cc 
+  src/annotation.cc
   src/ext/polyclipping/clipper.cpp
   ${PLATFORM_SOURCES}
   ${FLEX_openscad_lexer_OUTPUTS}
@@ -486,7 +486,7 @@ set(CORE_SOURCES
   ${BISON_comment_parser_OUTPUTS})
 
 set(NOCGAL_SOURCES
-  src/builtin.cc 
+  src/builtin.cc
   src/import.cc
   src/import_3mf.cc
   src/import_stl.cc
@@ -507,15 +507,15 @@ set(NOCGAL_SOURCES
 
 set(CGAL_SOURCES
   ${NOCGAL_SOURCES}
-  src/CSGTreeEvaluator.cc 
-  src/CGAL_Nef_polyhedron.cc 
+  src/CSGTreeEvaluator.cc
+  src/CGAL_Nef_polyhedron.cc
   src/export_nef.cc
   src/import_nef.cc
-  src/cgalutils.cc 
-  src/cgalutils-applyops.cc 
-  src/cgalutils-project.cc 
-  src/cgalutils-tess.cc 
-  src/cgalutils-polyhedron.cc 
+  src/cgalutils.cc
+  src/cgalutils-applyops.cc
+  src/cgalutils-project.cc
+  src/cgalutils-tess.cc
+  src/cgalutils-polyhedron.cc
   src/CGALCache.cc
   src/Polygon2d-CGAL.cc
   src/svg.cc
@@ -523,9 +523,9 @@ set(CGAL_SOURCES
 
 include_directories("src/ext/libtess2/Include")
 set(COMMON_SOURCES
-  src/nodedumper.cc 
-  src/GeometryCache.cc 
-  src/clipper-utils.cc 
+  src/nodedumper.cc
+  src/GeometryCache.cc
+  src/clipper-utils.cc
   src/Tree.cc
   src/comment.cpp
   src/parameter/parameterset.cpp
@@ -537,7 +537,9 @@ set(COMMON_SOURCES
   src/ext/libtess2/Source/priorityq.c
   src/ext/libtess2/Source/sweep.c
   src/ext/libtess2/Source/tess.c
-  src/Tree.cc)
+  src/Tree.cc
+  src/initConfig.cc
+  )
 
 #
 # Offscreen OpenGL context source code
@@ -565,6 +567,7 @@ else()
     src/ThrownTogetherRenderer.cc
     src/renderer.cc
     src/render.cc
+    src/mouseselector.cc
     src/OpenCSGRenderer.cc)
 endif()
 

--- a/openscad.pro
+++ b/openscad.pro
@@ -361,6 +361,7 @@ HEADERS += src/version_check.h \
            src/LibraryInfo.h \
            src/RenderStatistic.h \
            src/svg.h \
+           src/mouseselector.h \
            \
            src/OffscreenView.h \
            src/OffscreenContext.h \
@@ -539,6 +540,7 @@ SOURCES += \
            src/LibraryInfoDialog.cc\
            \
            src/comment.cpp \
+           src/mouseselector.cc \
            \
            src/parameter/ParameterWidget.cc\
            src/parameter/parameterobject.cpp \

--- a/src/CSGTreeEvaluator.cc
+++ b/src/CSGTreeEvaluator.cc
@@ -29,7 +29,7 @@
 shared_ptr<CSGNode> CSGTreeEvaluator::buildCSGTree(const AbstractNode &node)
 {
 	this->traverse(node);
-	
+
 	shared_ptr<CSGNode> t(this->stored_term[node.index()]);
 	if (t) {
 		if (t->isHighlight()) this->highlightNodes.push_back(t);
@@ -183,7 +183,7 @@ shared_ptr<CSGNode> CSGTreeEvaluator::evaluateCSGNodeFromGeometry(
 		// 3D Polysets are tessellated before inserting into Geometry cache, inside GeometryEvaluator::evaluateGeometry
 	}
 
-	shared_ptr<CSGNode> t(new CSGLeaf(g, state.matrix(), state.color(), STR(node.name() << node.index())));
+	shared_ptr<CSGNode> t(new CSGLeaf(g, state.matrix(), state.color(), STR(node.name() << node.index()), node.index()));
 	if (modinst->isHighlight() || state.isHighlight()) t->setHighlight(true);
 	if (modinst->isBackground() || state.isBackground()) t->setBackground(true);
 	return t;

--- a/src/GLView.cc
+++ b/src/GLView.cc
@@ -147,7 +147,6 @@ void GLView::paintGL()
     // FIXME: This belongs in the OpenCSG renderer, but it doesn't know about this ID yet
     OpenCSG::setContext(this->opencsg_id);
 #endif
-    //this->renderer->draw_with_shader(&selector->shaderinfo);
     this->renderer->draw(showfaces, showedges);
   }
 

--- a/src/GLView.cc
+++ b/src/GLView.cc
@@ -36,7 +36,6 @@ GLView::GLView()
   opencsg_support = true;
   static int sId = 0;
   this->opencsg_id = sId++;
-  for (int i = 0; i < 10; i++) this->shaderinfo[i] = 0;
 #endif
 }
 
@@ -74,8 +73,8 @@ void GLView::setColorScheme(const std::string &cs)
 void GLView::resizeGL(int w, int h)
 {
 #ifdef ENABLE_OPENCSG
-  shaderinfo[9] = w;
-  shaderinfo[10] = h;
+  shaderinfo.vp_size_x = w;
+  shaderinfo.vp_size_y = h;
 #endif
   cam.pixel_width = w;
   cam.pixel_height = h;
@@ -88,7 +87,7 @@ void GLView::setCamera(const Camera &cam)
   this->cam = cam;
 }
 
-void GLView::setupCamera()
+void GLView::setupCamera() const
 {
   glMatrixMode(GL_PROJECTION);
   glLoadIdentity();
@@ -121,7 +120,6 @@ void GLView::setupCamera()
 void GLView::paintGL()
 {
   glDisable(GL_LIGHTING);
-
   auto bgcol = ColorMap::getColor(*this->colorscheme, RenderColor::BACKGROUND_COLOR);
   auto axescolor = ColorMap::getColor(*this->colorscheme, RenderColor::AXES_COLOR);
   auto crosshaircol = ColorMap::getColor(*this->colorscheme, RenderColor::CROSSHAIR_COLOR);
@@ -149,6 +147,7 @@ void GLView::paintGL()
     // FIXME: This belongs in the OpenCSG renderer, but it doesn't know about this ID yet
     OpenCSG::setContext(this->opencsg_id);
 #endif
+    //this->renderer->draw_with_shader(&selector->shaderinfo);
     this->renderer->draw(showfaces, showedges);
   }
 
@@ -213,35 +212,43 @@ void GLView::enable_opencsg_shaders()
       shading
    */
     const char *vs_source =
-      "uniform float xscale, yscale;\n"
-      "attribute vec3 pos_b, pos_c;\n"
-      "attribute vec3 trig, mask;\n"
-      "varying vec3 tp, tr;\n"
-      "varying float shading;\n"
-      "void main() {\n"
-      "  vec4 p0 = gl_ModelViewProjectionMatrix * gl_Vertex;\n"
-      "  vec4 p1 = gl_ModelViewProjectionMatrix * vec4(pos_b, 1.0);\n"
-      "  vec4 p2 = gl_ModelViewProjectionMatrix * vec4(pos_c, 1.0);\n"
-      "  float a = distance(vec2(xscale*p1.x/p1.w, yscale*p1.y/p1.w), vec2(xscale*p2.x/p2.w, yscale*p2.y/p2.w));\n"
-      "  float b = distance(vec2(xscale*p0.x/p0.w, yscale*p0.y/p0.w), vec2(xscale*p1.x/p1.w, yscale*p1.y/p1.w));\n"
-      "  float c = distance(vec2(xscale*p0.x/p0.w, yscale*p0.y/p0.w), vec2(xscale*p2.x/p2.w, yscale*p2.y/p2.w));\n"
-      "  float s = (a + b + c) / 2.0;\n"
-      "  float A = sqrt(s*(s-a)*(s-b)*(s-c));\n"
-      "  float ha = 2.0*A/a;\n"
-      "  gl_Position = p0;\n"
-      "  tp = mask * ha;\n"
-      "  tr = trig;\n"
-      "  vec3 normal, lightDir;\n"
-      "  normal = normalize(gl_NormalMatrix * gl_Normal);\n"
-      "  lightDir = normalize(vec3(gl_LightSource[0].position));\n"
-      "  shading = 0.2 + abs(dot(normal, lightDir));\n"
-      "}\n";
+			// Updated in this->resizeGL
+			"uniform float xscale, yscale;\n"
+	  	// The other two vectors of the triangle
+			"attribute vec3 pos_b, pos_c;\n"
+			// Trig: line width of edge: -1 dont draw
+			// mask: what is the current edge
+			// .x p0->p1, .y: p1->p2, .z p0->p2
+			"attribute vec3 trig, mask;\n"
+			// tp, tr infos for fragment shader edge highlighting
+			"varying vec3 tp, tr;\n"
+			// "darkdness" for fragment shader
+			"varying float shading;\n"
+			"void main() {\n"
+			"  vec4 p0 = gl_ModelViewProjectionMatrix * gl_Vertex;\n"  // projected vector
+			"  vec4 p1 = gl_ModelViewProjectionMatrix * vec4(pos_b, 1.0);\n" // ?? pos_b = argument
+			"  vec4 p2 = gl_ModelViewProjectionMatrix * vec4(pos_c, 1.0);\n" // ?? pos_b = argument
+			// Lengths of the sides of the rendered triangle
+			"  float a = distance(vec2(xscale*p1.x/p1.w, yscale*p1.y/p1.w), vec2(xscale*p2.x/p2.w, yscale*p2.y/p2.w));\n"
+			"  float b = distance(vec2(xscale*p0.x/p0.w, yscale*p0.y/p0.w), vec2(xscale*p1.x/p1.w, yscale*p1.y/p1.w));\n"
+			"  float c = distance(vec2(xscale*p0.x/p0.w, yscale*p0.y/p0.w), vec2(xscale*p2.x/p2.w, yscale*p2.y/p2.w));\n"
+			"  float s = (a + b + c) / 2.0;\n"
+			"  float A = sqrt(s*(s-a)*(s-b)*(s-c));\n"
+			"  float ha = 2.0*A/a;\n"
+			"  gl_Position = p0;\n"
+			"  tp = mask * ha;\n"
+			"  tr = trig;\n"
+			"  vec3 normal, lightDir;\n"
+			"  normal = normalize(gl_NormalMatrix * gl_Normal);\n"
+			"  lightDir = normalize(vec3(gl_LightSource[0].position));\n"
+			"  shading = 0.2 + abs(dot(normal, lightDir));\n"
+			"}\n";
 
     /*
       Inputs:
         tp && tr - if any components of tp < tr, use color2 (edge color)
         shading  - multiplied by color1. color2 is is without lighting
-		*/
+    */
     const char *fs_source =
       "uniform vec4 color1, color2;\n"
       "varying vec3 tp, tr, tmp;\n"
@@ -265,15 +272,16 @@ void GLView::enable_opencsg_shaders()
     glAttachShader(edgeshader_prog, fs);
     glLinkProgram(edgeshader_prog);
 
-    shaderinfo[0] = edgeshader_prog;
-    shaderinfo[1] = glGetUniformLocation(edgeshader_prog, "color1");
-    shaderinfo[2] = glGetUniformLocation(edgeshader_prog, "color2");
-    shaderinfo[3] = glGetAttribLocation(edgeshader_prog, "trig");
-    shaderinfo[4] = glGetAttribLocation(edgeshader_prog, "pos_b");
-    shaderinfo[5] = glGetAttribLocation(edgeshader_prog, "pos_c");
-    shaderinfo[6] = glGetAttribLocation(edgeshader_prog, "mask");
-    shaderinfo[7] = glGetUniformLocation(edgeshader_prog, "xscale");
-    shaderinfo[8] = glGetUniformLocation(edgeshader_prog, "yscale");
+    shaderinfo.progid = edgeshader_prog; // 0
+    shaderinfo.type = GLView::shaderinfo_t::CSG_RENDERING;
+    shaderinfo.data.csg_rendering.color_area = glGetUniformLocation(edgeshader_prog, "color1"); // 1
+    shaderinfo.data.csg_rendering.color_edge = glGetUniformLocation(edgeshader_prog, "color2"); // 2
+    shaderinfo.data.csg_rendering.trig = glGetAttribLocation(edgeshader_prog, "trig"); // 3
+    shaderinfo.data.csg_rendering.point_b = glGetAttribLocation(edgeshader_prog, "pos_b"); // 4
+    shaderinfo.data.csg_rendering.point_c = glGetAttribLocation(edgeshader_prog, "pos_c"); // 5
+    shaderinfo.data.csg_rendering.mask = glGetAttribLocation(edgeshader_prog, "mask"); // 6
+    shaderinfo.data.csg_rendering.xscale = glGetUniformLocation(edgeshader_prog, "xscale"); // 7
+    shaderinfo.data.csg_rendering.yscale = glGetUniformLocation(edgeshader_prog, "yscale"); // 8
 
     auto err = glGetError();
     if (err != GL_NO_ERROR) {
@@ -353,7 +361,7 @@ void GLView::showSmallaxes(const Color4f &col)
   gluLookAt(0.0, -1.0, 0.0,
 						0.0, 0.0, 0.0,
 						0.0, 0.0, 1.0);
-	 
+
   glMatrixMode(GL_MODELVIEW);
   glLoadIdentity();
   glRotated(cam.object_rot.x(), 1.0, 0.0, 0.0);
@@ -419,7 +427,7 @@ void GLView::showSmallaxes(const Color4f &col)
 void GLView::showAxes(const Color4f &col)
 {
   auto l = cam.zoomValue();
-  
+
   // Large gray axis cross inline with the model
   glLineWidth(this->getDPI());
   glColor3f(col[0], col[1], col[2]);

--- a/src/GLView.h
+++ b/src/GLView.h
@@ -72,7 +72,7 @@ public:
 	bool showscale;
 
 #ifdef ENABLE_OPENCSG
-	/// This struct describes the attributes to all shaders in use
+	/// Shader attribute identifiers
 	struct shaderinfo_t {
 		enum shader_type_t {
 			NONE,

--- a/src/GLView.h
+++ b/src/GLView.h
@@ -37,7 +37,7 @@ public:
 	virtual void paintGL();
 
 	void setCamera(const Camera &cam);
-	void setupCamera();
+	void setupCamera() const;
 
 	void setColorScheme(const ColorScheme &cs);
 	void setColorScheme(const std::string &cs);
@@ -72,13 +72,47 @@ public:
 	bool showscale;
 
 #ifdef ENABLE_OPENCSG
-	GLint shaderinfo[11];
+	/// This struct describes the attributes to all shaders in use
+	struct shaderinfo_t {
+		enum shader_type_t {
+			NONE,
+			CSG_RENDERING,
+			SELECT_RENDERING,
+		};
+		int progid = 0;
+		shader_type_t type;
+		union {
+			struct {
+				int color_area;
+				int color_edge;
+				int trig;
+
+				// the other two points of the triangle while rendering
+				int point_b;
+				int point_c;
+
+				int mask;
+				int xscale;
+				int yscale;
+			} csg_rendering;
+			struct {
+				int identifier;
+			} select_rendering;
+		} data;
+
+		// values: Viewport size
+		GLint vp_size_x;
+		GLint vp_size_y;
+	};
+
+	shaderinfo_t shaderinfo;
 	bool is_opencsg_capable;
 	bool has_shaders;
 	void enable_opencsg_shaders();
 	virtual void display_opencsg_warning() = 0;
 	bool opencsg_support;
 	int opencsg_id;
+
 #endif
 private:
 	void showCrosshairs(const Color4f &col);

--- a/src/MainWindow.h
+++ b/src/MainWindow.h
@@ -97,6 +97,7 @@ private slots:
 	void showProgress();
 	void openCSGSettingsChanged();
 	void consoleOutput(const QString &msg);
+	void setCursor();
 
 public:
 	static void consoleOutput(const std::string &msg, void *userdata);

--- a/src/MainWindow.h
+++ b/src/MainWindow.h
@@ -21,6 +21,9 @@
 #include "input/InputDriver.h"
 #include "editor.h"
 #include "tabmanager.h"
+#include <memory>
+
+class MouseSelector;
 
 class MainWindow : public QMainWindow, public Ui::MainWindow, public InputEventHandler
 {
@@ -57,6 +60,7 @@ public:
 #endif
 #ifdef ENABLE_OPENCSG
 	class OpenCSGRenderer *opencsgRenderer;
+	std::unique_ptr<MouseSelector> selector;
 #endif
 	class ThrownTogetherRenderer *thrownTogetherRenderer;
 
@@ -271,6 +275,7 @@ public slots:
 	void viewAll();
 	void animateUpdateDocChanged();
 	void animateUpdate();
+	void selectObject(QPoint coordinate);
 	void dragEnterEvent(QDragEnterEvent *event) override;
 	void dropEvent(QDropEvent *event) override;
 	void helpAbout();

--- a/src/OpenCSGRenderer.cc
+++ b/src/OpenCSGRenderer.cc
@@ -30,13 +30,12 @@
 #include "csgnode.h"
 
 #define OPENGL_TEST(place) \
-{ \
+do { \
 	auto err = glGetError(); \
 	if (err != GL_NO_ERROR) { \
 		fprintf(stderr, "OpenGL error " place ":\n %s\n\n", gluErrorString(err)); \
 	} \
-}
-
+} while (false)
 
 #ifdef ENABLE_OPENCSG
 #include <opencsg.h>

--- a/src/OpenCSGRenderer.cc
+++ b/src/OpenCSGRenderer.cc
@@ -124,9 +124,12 @@ void OpenCSGRenderer::renderCSGProducts(const CSGProducts &products, const GLVie
 		if (shaderinfo) glUseProgram(shaderinfo->progid);
 		OPENGL_TEST("load shader");
 
-		for(const auto &csgobj : product.intersections) {
+		for (const auto &csgobj : product.intersections) {
 			if (shaderinfo && shaderinfo->type == GLView::shaderinfo_t::SELECT_RENDERING) {
-				glVertexAttribI1i(shaderinfo->data.select_rendering.identifier, csgobj.leaf->index);
+				int identifier = csgobj.leaf->index;
+				glUniform3f(shaderinfo->data.select_rendering.identifier,
+										((identifier >> 0) & 0xff) / 255.0f, ((identifier >> 8) & 0xff) / 255.0f,
+										((identifier >> 16) & 0xff) / 255.0f);
 				OPENGL_TEST("setup shader");
 			}
 

--- a/src/OpenCSGRenderer.cc
+++ b/src/OpenCSGRenderer.cc
@@ -29,6 +29,15 @@
 #include "polyset.h"
 #include "csgnode.h"
 
+#define OPENGL_TEST(place) \
+{ \
+	auto err = glGetError(); \
+	if (err != GL_NO_ERROR) { \
+		fprintf(stderr, "OpenGL error " place ":\n %s\n\n", gluErrorString(err)); \
+	} \
+}
+
+
 #ifdef ENABLE_OPENCSG
 #include <opencsg.h>
 
@@ -56,25 +65,32 @@ private:
 OpenCSGRenderer::OpenCSGRenderer(shared_ptr<CSGProducts> root_products,
 																 shared_ptr<CSGProducts> highlights_products,
 																 shared_ptr<CSGProducts> background_products,
-																 GLint *shaderinfo)
-	: root_products(root_products), 
-		highlights_products(highlights_products), 
+																 GLView::shaderinfo_t *shaderinfo)
+	: root_products(root_products),
+		highlights_products(highlights_products),
 		background_products(background_products), shaderinfo(shaderinfo)
 {
 }
 
 void OpenCSGRenderer::draw(bool /*showfaces*/, bool showedges) const
 {
-	GLint *shaderinfo = this->shaderinfo;
-	if (!shaderinfo[0]) shaderinfo = nullptr;
+	GLView::shaderinfo_t *shaderinfo = this->shaderinfo;
+	if (!shaderinfo->progid) shaderinfo = nullptr;
+	if (!showedges) shaderinfo = nullptr;
+
+	this->draw_with_shader(shaderinfo);
+}
+
+void OpenCSGRenderer::draw_with_shader(const GLView::shaderinfo_t *shaderinfo) const
+{
 	if (this->root_products) {
-		renderCSGProducts(*this->root_products, showedges ? shaderinfo : nullptr, false, false);
+		renderCSGProducts(*this->root_products, shaderinfo, false, false);
 	}
 	if (this->background_products) {
-		renderCSGProducts(*this->background_products, showedges ? shaderinfo : nullptr, false, true);
+		renderCSGProducts(*this->background_products, shaderinfo, false, true);
 	}
 	if (this->highlights_products) {
-		renderCSGProducts(*this->highlights_products, showedges ? shaderinfo : nullptr, true, false);
+		renderCSGProducts(*this->highlights_products, shaderinfo, true, false);
 	}
 }
 
@@ -88,7 +104,7 @@ OpenCSGPrim *OpenCSGRenderer::createCSGPrimitive(const CSGChainObject &csgobj, O
 	return prim;
 }
 
-void OpenCSGRenderer::renderCSGProducts(const CSGProducts &products, GLint *shaderinfo, 
+void OpenCSGRenderer::renderCSGProducts(const CSGProducts &products, const GLView::shaderinfo_t *shaderinfo,
 										bool highlight_mode, bool background_mode) const
 {
 #ifdef ENABLE_OPENCSG
@@ -104,12 +120,19 @@ void OpenCSGRenderer::renderCSGProducts(const CSGProducts &products, GLint *shad
 			OpenCSG::render(primitives);
 			glDepthFunc(GL_EQUAL);
 		}
-		if (shaderinfo) glUseProgram(shaderinfo[0]);
+		OPENGL_TEST("start");
+		if (shaderinfo) glUseProgram(shaderinfo->progid);
+		OPENGL_TEST("load shader");
 
 		for(const auto &csgobj : product.intersections) {
+			if (shaderinfo && shaderinfo->type == GLView::shaderinfo_t::SELECT_RENDERING) {
+				glVertexAttribI1i(shaderinfo->data.select_rendering.identifier, csgobj.leaf->index);
+				OPENGL_TEST("setup shader");
+			}
+
 			const Color4f &c = csgobj.leaf->color;
-				csgmode_e csgmode = get_csgmode(highlight_mode, background_mode);
-			
+			csgmode_e csgmode = get_csgmode(highlight_mode, background_mode);
+
 			ColorMode colormode = ColorMode::NONE;
 			if (highlight_mode) {
 				colormode = ColorMode::HIGHLIGHT;
@@ -118,10 +141,10 @@ void OpenCSGRenderer::renderCSGProducts(const CSGProducts &products, GLint *shad
 			} else {
 				colormode = ColorMode::MATERIAL;
 			}
-			
+
 			glPushMatrix();
 			glMultMatrixd(csgobj.leaf->matrix.data());
-			
+
 			const Color4f c1 = setColor(colormode, c.data(), shaderinfo);
 			if (c1[3] == 1.0f) {
 				// object is opaque, draw normally
@@ -135,13 +158,14 @@ void OpenCSGRenderer::renderCSGProducts(const CSGProducts &products, GLint *shad
 				render_surface(csgobj.leaf->geom, csgmode, csgobj.leaf->matrix, shaderinfo);
 				glDisable(GL_CULL_FACE);
 			}
+			OPENGL_TEST("render");
 
 			glPopMatrix();
 		}
 		for(const auto &csgobj : product.subtractions) {
 			const Color4f &c = csgobj.leaf->color;
 				csgmode_e csgmode = get_csgmode(highlight_mode, background_mode, OpenSCADOperator::DIFFERENCE);
-			
+
 			ColorMode colormode = ColorMode::NONE;
 			if (highlight_mode) {
 				colormode = ColorMode::HIGHLIGHT;
@@ -150,7 +174,7 @@ void OpenCSGRenderer::renderCSGProducts(const CSGProducts &products, GLint *shad
 			} else {
 				colormode = ColorMode::CUTOUT;
 			}
-			
+
 			setColor(colormode, c.data(), shaderinfo);
 			glPushMatrix();
 			glMultMatrixd(csgobj.leaf->matrix.data());

--- a/src/OpenCSGRenderer.h
+++ b/src/OpenCSGRenderer.h
@@ -13,18 +13,20 @@ public:
 	OpenCSGRenderer(shared_ptr<class CSGProducts> root_products,
 									shared_ptr<CSGProducts> highlights_products,
 									shared_ptr<CSGProducts> background_products,
-									GLint *shaderinfo);
+									GLView::shaderinfo_t *shaderinfo);
 	void draw(bool showfaces, bool showedges) const override;
+	void draw_with_shader(const GLView::shaderinfo_t *shaderinfo) const;
+
 	BoundingBox getBoundingBox() const override;
 private:
 #ifdef ENABLE_OPENCSG
 	class OpenCSGPrim *createCSGPrimitive(const class CSGChainObject &csgobj, OpenCSG::Operation operation, bool highlight_mode, bool background_mode, OpenSCADOperator type) const;
 #endif
-	void renderCSGProducts(const class CSGProducts &products, GLint *shaderinfo, 
+	void renderCSGProducts(const class CSGProducts &products, const GLView::shaderinfo_t *shaderinfo,
 											bool highlight_mode, bool background_mode) const;
 
 	shared_ptr<CSGProducts> root_products;
 	shared_ptr<CSGProducts> highlights_products;
 	shared_ptr<CSGProducts> background_products;
-	GLint *shaderinfo;
+	GLView::shaderinfo_t *shaderinfo;
 };

--- a/src/QGLView.h
+++ b/src/QGLView.h
@@ -78,6 +78,7 @@ private:
 	void init();
 
 	bool mouse_drag_active;
+	bool mouse_drag_moved = true;
 	bool mouseCentricZoom=true;
 	QPoint last_mouse;
 	QImage frame; // Used by grabFrame() and save()
@@ -102,4 +103,5 @@ private slots:
 
 signals:
 	void doAnimateUpdate();
+	void doSelectObject(QPoint screen_coordinate);
 };

--- a/src/ThrownTogetherRenderer.cc
+++ b/src/ThrownTogetherRenderer.cc
@@ -106,8 +106,11 @@ void ThrownTogetherRenderer::renderChainObject(const CSGChainObject &csgobj, con
 	const Transform3d &m = csgobj.leaf->matrix;
 
 	if (shaderinfo && shaderinfo->type == GLView::shaderinfo_t::SELECT_RENDERING) {
-		glVertexAttribI1i(shaderinfo->data.select_rendering.identifier, csgobj.leaf->index);
-	} else {
+		int identifier = csgobj.leaf->index;
+		glUniform3f(shaderinfo->data.select_rendering.identifier, ((identifier >> 0) & 0xff) / 255.0f,
+								((identifier >> 8) & 0xff) / 255.0f, ((identifier >> 16) & 0xff) / 255.0f);
+	}
+	else {
 		setColor(colormode, c.data());
 	}
 	glPushMatrix();

--- a/src/ThrownTogetherRenderer.cc
+++ b/src/ThrownTogetherRenderer.cc
@@ -39,23 +39,32 @@ ThrownTogetherRenderer::ThrownTogetherRenderer(shared_ptr<CSGProducts> root_prod
 
 void ThrownTogetherRenderer::draw(bool /*showfaces*/, bool showedges) const
 {
+	this->draw_with_shader(nullptr, showedges);
+}
+
+void ThrownTogetherRenderer::draw_with_shader(const GLView::shaderinfo_t *shaderinfo, bool showedges) const {
+
+	if (shaderinfo) glUseProgram(shaderinfo->progid);
+
 	PRINTD("Thrown draw");
  	if (this->root_products) {
 		glEnable(GL_CULL_FACE);
 		glCullFace(GL_BACK);
-		renderCSGProducts(*this->root_products, false, false, showedges, false);
+		renderCSGProducts(*this->root_products, shaderinfo, false, false, showedges, false);
 		glCullFace(GL_FRONT);
 		glColor3ub(255, 0, 255);
-		renderCSGProducts(*this->root_products, false, false, showedges, true);
+		renderCSGProducts(*this->root_products, shaderinfo, false, false, showedges, true);
 		glDisable(GL_CULL_FACE);
 	}
 	if (this->background_products)
-	 	renderCSGProducts(*this->background_products, false, true, showedges, false);
+	 	renderCSGProducts(*this->background_products, shaderinfo, false, true, showedges, false);
 	if (this->highlight_products)
-	 	renderCSGProducts(*this->highlight_products, true, false, showedges, false);
+	 	renderCSGProducts(*this->highlight_products, shaderinfo, true, false, showedges, false);
+
 }
 
-void ThrownTogetherRenderer::renderChainObject(const CSGChainObject &csgobj, bool highlight_mode,
+
+void ThrownTogetherRenderer::renderChainObject(const CSGChainObject &csgobj, const GLView::shaderinfo_t *shaderinfo, bool highlight_mode,
 																							 bool background_mode, bool showedges, bool fberror, OpenSCADOperator type) const
 {
 	if (this->geomVisitMark[std::make_pair(csgobj.leaf->geom.get(), &csgobj.leaf->matrix)]++ > 0) return;
@@ -63,7 +72,7 @@ void ThrownTogetherRenderer::renderChainObject(const CSGChainObject &csgobj, boo
 	csgmode_e csgmode = get_csgmode(highlight_mode, background_mode, type);
 	ColorMode colormode = ColorMode::NONE;
 	ColorMode edge_colormode = ColorMode::NONE;
-	
+
 	if (highlight_mode) {
 		colormode = ColorMode::HIGHLIGHT;
 		edge_colormode = ColorMode::HIGHLIGHT_EDGES;
@@ -93,23 +102,28 @@ void ThrownTogetherRenderer::renderChainObject(const CSGChainObject &csgobj, boo
 		}
 		edge_colormode = ColorMode::MATERIAL_EDGES;
 	}
-	
+
 	const Transform3d &m = csgobj.leaf->matrix;
-	setColor(colormode, c.data());
+
+	if (shaderinfo && shaderinfo->type == GLView::shaderinfo_t::SELECT_RENDERING) {
+		glVertexAttribI1i(shaderinfo->data.select_rendering.identifier, csgobj.leaf->index);
+	} else {
+		setColor(colormode, c.data());
+	}
 	glPushMatrix();
 	glMultMatrixd(m.data());
-	render_surface(csgobj.leaf->geom, csgmode, m);
+	render_surface(csgobj.leaf->geom, csgmode, m, shaderinfo);
 	if (showedges) {
 		// FIXME? glColor4f((c[0]+1)/2, (c[1]+1)/2, (c[2]+1)/2, 1.0);
 		setColor(edge_colormode);
 		render_edges(csgobj.leaf->geom, csgmode);
 	}
 	glPopMatrix();
-	
+
 }
 
-void ThrownTogetherRenderer::renderCSGProducts(const CSGProducts &products, bool highlight_mode,
-																							 bool background_mode, bool showedges, 
+void ThrownTogetherRenderer::renderCSGProducts(const CSGProducts &products, const GLView::shaderinfo_t *shaderinfo,
+																							 bool highlight_mode, bool background_mode, bool showedges,
 																							 bool fberror) const
 {
 	PRINTD("Thrown renderCSGProducts");
@@ -118,10 +132,10 @@ void ThrownTogetherRenderer::renderCSGProducts(const CSGProducts &products, bool
 
 	for(const auto &product : products.products) {
 		for(const auto &csgobj : product.intersections) {
-			renderChainObject(csgobj, highlight_mode, background_mode, showedges, fberror, OpenSCADOperator::INTERSECTION);
+			renderChainObject(csgobj, shaderinfo, highlight_mode, background_mode, showedges, fberror, OpenSCADOperator::INTERSECTION);
 		}
 		for(const auto &csgobj : product.subtractions) {
-			renderChainObject(csgobj, highlight_mode, background_mode, showedges, fberror, OpenSCADOperator::DIFFERENCE);
+			renderChainObject(csgobj, shaderinfo, highlight_mode, background_mode, showedges, fberror, OpenSCADOperator::DIFFERENCE);
 		}
 	}
 }

--- a/src/ThrownTogetherRenderer.h
+++ b/src/ThrownTogetherRenderer.h
@@ -12,11 +12,16 @@ public:
 												 shared_ptr<CSGProducts> highlight_products,
 												 shared_ptr<CSGProducts> background_products);
 	void draw(bool showfaces, bool showedges) const override;
+	void draw_with_shader(const GLView::shaderinfo_t *shaderinfo) const override {
+		this->draw_with_shader(shaderinfo, false);
+	}
+	void draw_with_shader(const GLView::shaderinfo_t *, bool showedges) const;
+
 	BoundingBox getBoundingBox() const override;
 private:
-	void renderCSGProducts(const CSGProducts &products, bool highlight_mode, bool background_mode, bool showedges, 
+	void renderCSGProducts(const CSGProducts &products, const GLView::shaderinfo_t *, bool highlight_mode, bool background_mode, bool showedges,
 											bool fberror) const;
-	void renderChainObject(const class CSGChainObject &csgobj, bool highlight_mode,
+	void renderChainObject(const class CSGChainObject &csgobj, const GLView::shaderinfo_t *, bool highlight_mode,
 												 bool background_mode, bool showedges, bool fberror, OpenSCADOperator type) const;
 
 	shared_ptr<CSGProducts> root_products;

--- a/src/csgnode.cc
+++ b/src/csgnode.cc
@@ -100,8 +100,8 @@ shared_ptr<CSGNode> CSGOperation::createCSGNode(OpenSCADOperator type, shared_pt
 	return shared_ptr<CSGNode>(new CSGOperation(type, left, right), CSGOperationDeleter());
 }
 
-CSGLeaf::CSGLeaf(const shared_ptr<const Geometry> &geom, const Transform3d &matrix, const Color4f &color, const std::string &label)
-	: label(label), matrix(matrix), color(color)
+CSGLeaf::CSGLeaf(const shared_ptr<const Geometry> &geom, const Transform3d &matrix, const Color4f &color, const std::string &label, const int index)
+	: label(label), matrix(matrix), color(color), index(index)
 {
 	if (geom && !geom->isEmpty()) this->geom = geom;
 	initBoundingBox();
@@ -180,10 +180,10 @@ std::string CSGOperation::dump() const
 			}
 
 			out << '(';
-			
+
 			// mark current node as postfix before (maybe) pushing left child
 			ispostfix = std::get<2>(callstack.top()) = true;
-			
+
 			if(auto opl = dynamic_pointer_cast<CSGOperation>(node->left())) {
 				callstack.emplace(opl.get(), lpostfix, false);
 				continue;
@@ -191,9 +191,9 @@ std::string CSGOperation::dump() const
 				out << node->left()->dump() << lpostfix;
 			}
 		}
-		
+
 		// postfix traversal of node, handle right child
-		if (ispostfix) { 
+		if (ispostfix) {
 			callstack.pop();
 			if(auto opr = dynamic_pointer_cast<CSGOperation>(node->right())) {
 				callstack.emplace(opr.get(), ")", false);
@@ -216,10 +216,10 @@ void CSGProducts::import(shared_ptr<CSGNode> csgnode, OpenSCADOperator type, CSG
 	do {
 		auto args = callstack.top();
 		callstack.pop();
-		csgnode = std::get<0>(args); 
-		type = std::get<1>(args); 
+		csgnode = std::get<0>(args);
+		type = std::get<1>(args);
 		flags = std::get<2>(args);
-			
+
 		auto newflags = static_cast<CSGNode::Flag>(csgnode->getFlags() | flags);
 
 		if (auto leaf = dynamic_pointer_cast<CSGLeaf>(csgnode)) {

--- a/src/csgnode.h
+++ b/src/csgnode.h
@@ -45,11 +45,11 @@ public:
 
 	shared_ptr<CSGNode> &left() { return this->children[0]; }
 	shared_ptr<CSGNode> &right() { return this->children[1]; }
-	const shared_ptr<CSGNode> &left() const { return this->children[0]; } 
+	const shared_ptr<CSGNode> &left() const { return this->children[0]; }
 	const shared_ptr<CSGNode> &right() const { return this->children[1]; }
 
 	OpenSCADOperator getType() const { return this->type; }
-	
+
 	static shared_ptr<CSGNode> createCSGNode(OpenSCADOperator type, shared_ptr<CSGNode> left, shared_ptr<CSGNode> right);
 
 private:
@@ -58,7 +58,7 @@ private:
 	std::vector<shared_ptr<CSGNode> > children;
 };
 
-// very large lists of children can overflow stack due to recursive destruction of shared_ptr, 
+// very large lists of children can overflow stack due to recursive destruction of shared_ptr,
 // so move shared_ptrs into a temporary vector
 struct CSGOperationDeleter {
 	void operator()(CSGOperation* node) {
@@ -81,7 +81,7 @@ class CSGLeaf : public CSGNode
 {
 public:
 	EIGEN_MAKE_ALIGNED_OPERATOR_NEW
-	CSGLeaf(const shared_ptr<const class Geometry> &geom, const Transform3d &matrix, const Color4f &color, const std::string &label);
+	CSGLeaf(const shared_ptr<const class Geometry> &geom, const Transform3d &matrix, const Color4f &color, const std::string &label, const int index);
 	~CSGLeaf() {}
 	void initBoundingBox() override;
 	std::string dump() const override;
@@ -89,6 +89,8 @@ public:
 	shared_ptr<const Geometry> geom;
 	Transform3d matrix;
 	Color4f color;
+
+  const int index;
 
 	friend class CSGProducts;
 };
@@ -135,7 +137,7 @@ public:
 	std::vector<CSGProduct> products;
 
 	size_t size() const;
-	
+
 private:
 	void createProduct() {
 		this->products.push_back(CSGProduct());

--- a/src/csgnode.h
+++ b/src/csgnode.h
@@ -2,6 +2,7 @@
 
 #include <string>
 #include <vector>
+#include <deque>
 #include "memory.h"
 #include "linalg.h"
 #include "enums.h"

--- a/src/csgnode.h
+++ b/src/csgnode.h
@@ -2,7 +2,6 @@
 
 #include <string>
 #include <vector>
-#include <deque>
 #include "memory.h"
 #include "linalg.h"
 #include "enums.h"
@@ -91,7 +90,7 @@ public:
 	Transform3d matrix;
 	Color4f color;
 
-  const int index;
+	const int index;
 
 	friend class CSGProducts;
 };
@@ -127,7 +126,7 @@ class CSGProducts
 {
 public:
 	CSGProducts() {
-    this->createProduct();
+		this->createProduct();
 	}
 	~CSGProducts() {}
 

--- a/src/editor.h
+++ b/src/editor.h
@@ -30,10 +30,11 @@ public:
 	virtual void setIndicator(const std::vector<IndicatorData>& indicatorData) = 0;
 	virtual QMenu * createStandardContextMenu() = 0;
 	virtual QPoint mapToGlobal(const QPoint &) = 0;
+	virtual void setCursorPosition(int /*line*/, int /*col*/) {};
 
 signals:
   void contentsChanged();
-  void modificationChanged(bool, EditorInterface *);												
+  void modificationChanged(bool, EditorInterface *);
   void showContextMenuEvent(const QPoint& pos);
 
 public slots:

--- a/src/export_png.cc
+++ b/src/export_png.cc
@@ -66,7 +66,7 @@ std::unique_ptr<OffscreenView> prepare_preview(Tree &tree, const ViewOptions& op
 	}
 
 #ifdef ENABLE_OPENCSG
-	OpenCSGRenderer openCSGRenderer(csgInfo.root_products, csgInfo.highlights_products, csgInfo.background_products, glview->shaderinfo);
+	OpenCSGRenderer openCSGRenderer(csgInfo.root_products, csgInfo.highlights_products, csgInfo.background_products, &glview->shaderinfo);
 #endif
 	ThrownTogetherRenderer thrownTogetherRenderer(csgInfo.root_products, csgInfo.highlights_products, csgInfo.background_products);
 

--- a/src/feature.cc
+++ b/src/feature.cc
@@ -24,6 +24,7 @@ Feature::list_t Feature::feature_list;
 const Feature Feature::ExperimentalInputDriverDBus("input-driver-dbus", "Enable DBus input drivers (requires restart)");
 const Feature Feature::ExperimentalFunctionLiterals("function-literals", "Enable support for function literals");
 const Feature Feature::ExperimentalLazyUnion("lazy-union", "Enable lazy unions.");
+const Feature Feature::ExperimentalMouseSelection("mouse-selection", "Enable mouse selector");
 
 Feature::Feature(const std::string &name, const std::string &description)
 	: enabled(false), name(name), description(description)

--- a/src/feature.h
+++ b/src/feature.h
@@ -17,29 +17,30 @@ public:
 	static const Feature ExperimentalInputDriverDBus;
 	static const Feature ExperimentalFunctionLiterals;
 	static const Feature ExperimentalLazyUnion;
+	static const Feature ExperimentalMouseSelection;
 
 	const std::string& get_name() const;
 	const std::string& get_description() const;
-    
+
 	bool is_enabled() const;
 	void enable(bool status);
 
 	static iterator begin();
 	static iterator end();
-    
+
 	static std::string features();
 	static void enable_feature(const std::string &feature_name, bool status = true);
 
 private:
 	bool enabled;
-  
+
 	const std::string name;
 	const std::string description;
-    
+
 	typedef std::map<std::string, Feature *> map_t;
 	static map_t feature_map;
 	static list_t feature_list;
-    
+
 	Feature(const std::string &name, const std::string &description);
 	virtual ~Feature();
 };

--- a/src/mainwin.cc
+++ b/src/mainwin.cc
@@ -57,6 +57,7 @@
 #include "ThrownTogetherRenderer.h"
 #include "CSGTreeNormalizer.h"
 #include "QGLView.h"
+#include "mouseselector.h"
 #ifdef Q_OS_MAC
 #include "CocoaUtils.h"
 #endif
@@ -128,6 +129,7 @@
 #include "PrintInitDialog.h"
 #include "input/InputDriverManager.h"
 #include <cstdio>
+#include <memory>
 #include <QtNetwork>
 
 // Global application state
@@ -286,7 +288,7 @@ MainWindow::MainWindow(const QStringList &filenames)
 	progressThrottle->start();
 
 	animate_panel->hide();
-	this->hideFind(); 
+	this->hideFind();
 	frameCompileResult->hide();
 	this->labelCompileResultMessage->setOpenExternalLinks(false);
 	connect(this->labelCompileResultMessage, SIGNAL(linkActivated(QString)), SLOT(showConsole()));
@@ -431,6 +433,7 @@ MainWindow::MainWindow(const QStringList &filenames)
 	PRINT(copyrighttext);
 
 	connect(this->qglview, SIGNAL(doAnimateUpdate()), this, SLOT(animateUpdate()));
+	connect(this->qglview, SIGNAL(doSelectObject(QPoint)), this, SLOT(selectObject(QPoint)));
 
 	connect(Preferences::inst(), SIGNAL(requestRedraw()), this->qglview, SLOT(updateGL()));
 	connect(Preferences::inst(), SIGNAL(updateMouseCentricZoom(bool)), this->qglview, SLOT(setMouseCentricZoom(bool)));
@@ -519,7 +522,7 @@ MainWindow::MainWindow(const QStringList &filenames)
 	bool hideCustomizer = settings.value("view/hideCustomizer").toBool();
     bool hideEditorToolbar = settings.value("view/hideEditorToolbar").toBool();
     bool hide3DViewToolbar = settings.value("view/hide3DViewToolbar").toBool();
-	
+
 	// make sure it looks nice..
 	auto windowState = settings.value("window/state", QByteArray()).toByteArray();
 	restoreState(windowState);
@@ -590,6 +593,8 @@ MainWindow::MainWindow(const QStringList &filenames)
 		QAction *beforeAction = viewerToolBar->actions().at(2); //a seperator, not a part of the class
 		viewerToolBar->insertAction(beforeAction, this->fileActionExportSTL);
 	}
+
+	this->selector = std::unique_ptr<MouseSelector>(new MouseSelector(this->qglview));
 }
 
 void MainWindow::initActionIcon(QAction *action, const char *darkResource, const char *lightResource)
@@ -606,12 +611,12 @@ void MainWindow::addKeyboardShortCut(const QList<QAction *> &actions)
 		if (action->toolTip().contains("&nbsp;")) {
 	    continue;
 		}
-		
+
 		const QString shortCut(action->shortcut().toString(QKeySequence::NativeText));
 		if (shortCut.isEmpty()) {
 	    continue;
 		}
-		
+
 		const QString toolTip("%1 &nbsp;<span style=\"color: gray; font-size: small; font-style: italic\">%2</span>");
 		action->setToolTip(toolTip.arg(action->toolTip(), shortCut));
 	}
@@ -649,7 +654,7 @@ void MainWindow::onButtonChanged(InputEventButtonChanged *)
 void MainWindow::onTranslateEvent(InputEventTranslate *event)
 {
     double zoomFactor = 0.001 * qglview->cam.zoomValue();
-    
+
     if(event->viewPortRelative){
 		qglview->translate(event->x, event->y, event->z, event->relative, true);
 	}else{
@@ -892,7 +897,7 @@ void MainWindow::updateTVal()
 	if (viewActionHideParameters->isVisible()) {
 		if (this->parameterWidget->childHasFocus()) return;
 	}
-	
+
 	if (this->anim_numsteps > 1) {
 		this->anim_step = (this->anim_step + 1) % this->anim_numsteps;
 		this->anim_tval = 1.0 * this->anim_step / this->anim_numsteps;
@@ -1126,7 +1131,7 @@ void MainWindow::instantiateRoot()
 		ContextHandle<FileContext> filectx{Context::create<FileContext>(top_ctx.ctx)};
 		this->absolute_root_node = this->root_module->instantiateWithFileContext(filectx.ctx, &this->root_inst, nullptr);
 		this->updateCamera(filectx.ctx);
-		
+
 		if (this->absolute_root_node) {
 			// Do we have an explicit root node (! modifier)?
 			const Location *nextLocation = nullptr;
@@ -1200,7 +1205,7 @@ void MainWindow::compileCSG()
 
 		size_t normalizelimit = 2 * Preferences::inst()->getValue("advanced/openCSGLimit").toUInt();
 		CSGTreeNormalizer normalizer(normalizelimit);
-	
+
 		if (this->csgRoot) {
 			this->normalizedRoot = normalizer.normalize(this->csgRoot);
 			if (this->normalizedRoot) {
@@ -1218,7 +1223,7 @@ void MainWindow::compileCSG()
 		if (highlight_terms.size() > 0) {
 			PRINTB("Compiling highlights (%d CSG Trees)...", highlight_terms.size());
 			this->processEvents();
-		
+
 			this->highlights_products.reset(new CSGProducts());
 			for (unsigned int i = 0; i < highlight_terms.size(); i++) {
 				auto nterm = normalizer.normalize(highlight_terms[i]);
@@ -1230,12 +1235,12 @@ void MainWindow::compileCSG()
 		else {
 			this->highlights_products.reset();
 		}
-	
+
 		const auto &background_terms = csgrenderer.getBackgroundNodes();
 		if (background_terms.size() > 0) {
 			PRINTB("Compiling background (%d CSG Trees)...", background_terms.size());
 			this->processEvents();
-		
+
 			this->background_products.reset(new CSGProducts());
 			for (unsigned int i = 0; i < background_terms.size(); i++) {
 				auto nterm = normalizer.normalize(background_terms[i]);
@@ -1261,7 +1266,7 @@ void MainWindow::compileCSG()
 			this->opencsgRenderer = new OpenCSGRenderer(this->root_products,
 																								this->highlights_products,
 																								this->background_products,
-																								this->qglview->shaderinfo);
+																								&this->qglview->shaderinfo);
 		}
 #endif
 		this->thrownTogetherRenderer = new ThrownTogetherRenderer(this->root_products,
@@ -1323,7 +1328,7 @@ void MainWindow::clearRecentFiles()
 void MainWindow::updateRecentFileActions()
 {
 	auto files = UIUtils::recentFiles();
-	
+
 	for (int i = 0; i < files.size(); ++i) {
 		this->actionRecentFile[i]->setText(QFileInfo(files[i]).fileName().replace("&", "&&"));
 		this->actionRecentFile[i]->setData(files[i]);
@@ -1337,11 +1342,11 @@ void MainWindow::updateRecentFileActions()
 void MainWindow::show_examples()
 {
 	bool found_example = false;
-	
+
 	for (const auto &cat : UIUtils::exampleCategories()) {
 		auto examples = UIUtils::exampleFiles(cat);
 		auto menu = this->menuExamples->addMenu(gettext(cat.toStdString().c_str()));
-		
+
 		for (const auto &ex : examples) {
 			auto openAct = new QAction(ex.fileName().replace("&", "&&"), this);
 			connect(openAct, SIGNAL(triggered()), this, SLOT(actionOpenExample()));
@@ -1374,7 +1379,7 @@ void MainWindow::writeBackup(QFile *file)
 	writer.setCodec("UTF-8");
 	writer << activeEditor->toPlainText();
 	this->parameterWidget->writeBackupFile(file->fileName());
-	
+
 	PRINTB("Saved backup file: %s", file->fileName().toUtf8().constData());
 }
 
@@ -1498,7 +1503,7 @@ void MainWindow::showFind()
 	replaceInputField->hide();
 	replaceButton->hide();
 	replaceAllButton->hide();
-	//replaceLabel->setVisible(false); 
+	//replaceLabel->setVisible(false);
 	find_panel->show();
 	activeEditor->findState = TabManager::FIND_VISIBLE;
 	if (!activeEditor->selectedText().isEmpty()) {
@@ -1517,13 +1522,13 @@ void MainWindow::findString(QString textToFind)
 
 void MainWindow::showFindAndReplace()
 {
-	this->findInputField->setFindCount(activeEditor->updateFindIndicators(this->findInputField->text()));	
+	this->findInputField->setFindCount(activeEditor->updateFindIndicators(this->findInputField->text()));
 	this->processEvents();
-	findTypeComboBox->setCurrentIndex(1); 
+	findTypeComboBox->setCurrentIndex(1);
 	replaceInputField->show();
 	replaceButton->show();
 	replaceAllButton->show();
-	//replaceLabel->setVisible(true); 
+	//replaceLabel->setVisible(true);
 	find_panel->show();
 	activeEditor->findState = TabManager::FIND_REPLACE_VISIBLE;
 	if (!activeEditor->selectedText().isEmpty()) {
@@ -1553,9 +1558,9 @@ void MainWindow::replaceAll()
 void MainWindow::convertTabsToSpaces()
 {
 	const auto text = activeEditor->toPlainText();
-	
+
 	QString converted;
-  
+
 	int cnt = 4;
 	for (int idx = 0;idx < text.length();idx++) {
 		auto c = text.at(idx);
@@ -1971,17 +1976,17 @@ void MainWindow::sendToPrintService()
 {
 #ifdef ENABLE_3D_PRINTING
 	//Keeps track of how many times we've exported and tries to create slightly unique filenames.
-	//Not mission critical, since non-unique file names are fine for the API, just harder to 
+	//Not mission critical, since non-unique file names are fine for the API, just harder to
 	//differentiate between in customer support later.
 	static unsigned int printCounter = 0;
-	
+
 	QTemporaryFile exportFile;
 	if (!exportFile.open()) {
 		PRINT("ERROR: Could not open temporary file.");
 		return;
 	}
 	const QString exportFilename = exportFile.fileName();
-	
+
 	//Render the stl to a temporary file:
 	exportFileByName(this->root_geom, FileFormat::STL, exportFilename.toLocal8Bit().constData(), exportFilename.toUtf8());
 
@@ -2005,7 +2010,7 @@ void MainWindow::sendToPrintService()
 		PRINTB("ERROR: %s", msg.toStdString());
 		return;
 	}
-	
+
 	//Upload the file to the 3D Printing server and get the corresponding url to see it.
 	//The result is put in partUrl.
 	try
@@ -2086,7 +2091,7 @@ void MainWindow::actionRenderDone(shared_ptr<const Geometry> root_geom)
 
 	updateStatusBar(nullptr);
 
-	if (Preferences::inst()->getValue("advanced/enableSoundNotification").toBool() && 
+	if (Preferences::inst()->getValue("advanced/enableSoundNotification").toBool() &&
 		Preferences::inst()->getValue("advanced/timeThresholdOnRenderCompleteSound").toUInt() <= ms.count()/1000)
 	{
 		QSound::play(":sounds/complete.wav");
@@ -2098,6 +2103,47 @@ void MainWindow::actionRenderDone(shared_ptr<const Geometry> root_geom)
 }
 
 #endif /* ENABLE_CGAL */
+
+/**
+ * Call the mouseselection to determine the id of the clicked-on object.
+ * Use the generated ID and try to find it within the list of products
+ * And finally move the cursor to the beginning of the selected object in the editor
+ */
+void MainWindow::selectObject(QPoint mouse)
+{
+	// selecting without a renderer?!
+	if (!this->qglview->renderer) {
+		return;
+	}
+
+	// Nothing to select
+	if (!this->root_products)  {
+		return;
+	}
+
+	// Update the selector with the right image size
+	this->selector->reset(this->qglview);
+
+	// Select the object at mouse coordinates
+	int index = this->selector->select(this->qglview->renderer, mouse.x(), mouse.y());
+  std::deque<const AbstractNode *> path;
+	const AbstractNode *result = this->root_node->getNodeByID(index, path);
+
+	if (result) {
+		// TODO: Create a calltracewidget instead of selecting directly in the editor
+
+		// Caveat: Files that have not been do not have a filename defined, only CWD
+		// Skip opening a specific tab - since unsaved files can not be included
+		// and have to be the currently active root file
+		if (!fs::is_directory(result->location.filePath())) {
+			this->tabManager->open(QString::fromStdString(result->location.fileName()));
+		}
+
+		// move the cursor, the editor is 0 based whereby location is 1 based
+		this->activeEditor->setCursorPosition(result->location.firstLine() - 1,
+		                                      result->location.firstColumn() - 1);
+	}
+}
 
 /**
  * Switch version label and progress widget. When switching to the progress
@@ -2188,7 +2234,7 @@ void MainWindow::actionDisplayCSGProducts()
 	e->setWindowTitle("CSG Products Dump");
 	e->setReadOnly(true);
 	e->setPlainText(QString("\nCSG before normalization:\n%1\n\n\nCSG after normalization:\n%2\n\n\nCSG rendering chain:\n%3\n\n\nHighlights CSG rendering chain:\n%4\n\n\nBackground CSG rendering chain:\n%5\n")
-									
+
 	.arg(QString::fromStdString(this->csgRoot ? this->csgRoot->dump() : NA),
 		QString::fromStdString(this->normalizedRoot ? this->normalizedRoot->dump() : NA),
 		QString::fromStdString(this->root_products ? this->root_products->dump() : NA),
@@ -2280,7 +2326,7 @@ bool MainWindow::canExport(unsigned int dim)
 	if (N && !N->p3->is_simple()) {
 		PRINT("UI-WARNING: Object may not be a valid 2-manifold and may need repair! See https://en.wikibooks.org/wiki/OpenSCAD_User_Manual/STL_Import_and_Export");
 	}
-	
+
 	return true;
 }
 
@@ -2291,12 +2337,12 @@ void MainWindow::actionExport(FileFormat format, const char *type_name, const ch
 #endif
 {
     //Setting filename skips the file selection dialog and uses the path provided instead.
-    
+
 	if (GuiLocker::isLocked()) return;
 	GuiLocker lock;
 #ifdef ENABLE_CGAL
 	setCurrentOutput();
-	
+
 	//Return if something is wrong and we can't export.
 	if (! canExport(dim))
 		return;
@@ -2529,7 +2575,7 @@ bool MainWindow::isEmpty()
 
 void MainWindow::animateUpdateDocChanged()
 {
-	auto current_doc = activeEditor->toPlainText(); 
+	auto current_doc = activeEditor->toPlainText();
 	if (current_doc != last_compiled_doc) {
 		animateUpdate();
 	}
@@ -2642,13 +2688,13 @@ void MainWindow::on_editorDock_visibilityChanged(bool)
 {
 	changedTopLevelEditor(editorDock->isFloating());
 	tabToolBar->setVisible((tabCount > 1) && editorDock->isVisible());
-	
+
 	if (editorDock->isVisible()) viewerToolBar->removeAction(this->fileActionExportSTL);
 	else{
 		 QAction *beforeAction = viewerToolBar->actions().at(2);
 		 viewerToolBar->insertAction(beforeAction, this->fileActionExportSTL);
 	 }
-	 
+
 }
 
 void MainWindow::on_consoleDock_visibilityChanged(bool)

--- a/src/mainwin.cc
+++ b/src/mainwin.cc
@@ -594,7 +594,9 @@ MainWindow::MainWindow(const QStringList &filenames)
 		viewerToolBar->insertAction(beforeAction, this->fileActionExportSTL);
 	}
 
-	this->selector = std::unique_ptr<MouseSelector>(new MouseSelector(this->qglview));
+  if (Feature::ExperimentalMouseSelection.is_enabled()) {
+  	this->selector = std::unique_ptr<MouseSelector>(new MouseSelector(this->qglview));
+  }
 }
 
 void MainWindow::initActionIcon(QAction *action, const char *darkResource, const char *lightResource)
@@ -2111,6 +2113,10 @@ void MainWindow::actionRenderDone(shared_ptr<const Geometry> root_geom)
  */
 void MainWindow::selectObject(QPoint mouse)
 {
+  if (!Feature::ExperimentalMouseSelection.is_enabled()) {
+    return;
+  }
+
 	// selecting without a renderer?!
 	if (!this->qglview->renderer) {
 		return;

--- a/src/mainwin.cc
+++ b/src/mainwin.cc
@@ -24,6 +24,7 @@
  *
  */
 #include <iostream>
+#include "boost-utils.h"
 #include "comment.h"
 #include "openscad.h"
 #include "GeometryCache.h"
@@ -2152,14 +2153,19 @@ void MainWindow::selectObject(QPoint mouse)
 			fs::path libpath = get_library_for_path(location.filePath());
 			if (!libpath.empty()) {
 				// Display the library (without making the window too wide!)
-				ss << step->name() << " (in library "
-					 << location.fileName().substr(libpath.string().length() + 1) << " line "
-					 << location.firstLine() << ")";
+				ss << step->name() << " (library "
+				   << location.fileName().substr(libpath.string().length() + 1) << ":"
+				   << location.firstLine() << ")";
+			}
+			else if (activeEditor->filepath.toStdString() == location.fileName()) {
+				ss << step->name() << " (" << location.filePath().filename().string() << ":"
+				   << location.firstLine() << ")";
 			}
 			else {
+				auto relname = boostfs_uncomplete(location.filePath(), fs::path(activeEditor->filepath.toStdString()).parent_path())
+				  .generic_string();
 				// Set the displayed name relative to the active editor window
-				ss << step->name() << " ("
-					 << location.toRelativeString(activeEditor->filepath.toStdString()) << ")";
+				ss << step->name() << " (" << relname << ":" << location.firstLine() << ")";
 			}
 
 			// Prepare the action to be sent

--- a/src/mainwin.cc
+++ b/src/mainwin.cc
@@ -2140,7 +2140,7 @@ void MainWindow::selectObject(QPoint mouse)
 		QMenu tracemenu(this);
 		std::stringstream ss;
 		for (const auto *step : path) {
-      // Skip certain node types
+			// Skip certain node types
 			if (step->name() == "root") {
 				continue;
 			}
@@ -2148,21 +2148,21 @@ void MainWindow::selectObject(QPoint mouse)
 			auto location = step->location;
 			ss.str("");
 
-      // Check if the path is contained in a library (using parsersettings.h)
-      fs::path libpath = get_library_for_path(location.filePath());
+			// Check if the path is contained in a library (using parsersettings.h)
+			fs::path libpath = get_library_for_path(location.filePath());
 			if (!libpath.empty()) {
-        // Display the library (without making the window too wide!)
+				// Display the library (without making the window too wide!)
 				ss << step->name() << " (in library "
 					 << location.fileName().substr(libpath.string().length() + 1) << " line "
 					 << location.firstLine() << ")";
 			}
 			else {
-        // Set the displayed name relative to the active editor window
+				// Set the displayed name relative to the active editor window
 				ss << step->name() << " ("
 					 << location.toRelativeString(activeEditor->filepath.toStdString()) << ")";
 			}
 
-      // Prepare the action to be sent
+			// Prepare the action to be sent
 			auto action = tracemenu.addAction(QString::fromStdString(ss.str()));
 			action->setProperty("file", QString::fromStdString(location.fileName()));
 			action->setProperty("line", location.firstLine());

--- a/src/mouseselector.cc
+++ b/src/mouseselector.cc
@@ -1,0 +1,208 @@
+#include "mouseselector.h"
+
+#include <QOpenGLFramebufferObject>
+/**
+ * The selection is making use of a special shader, that renders each object in a color
+ * that is derived from its index(), by using the first 24 bits of the identifier as a
+ * 3-tuple for color.
+ *
+ * roghly at most 1/3rd of the index()-es are rendered, therefore exhausting the keyspace
+ * faster than expected.
+ * If this ever becomes a problem, the index-mapping can be adjusted to use 10 up to 16 bit
+ * per color channel to store the identifier.
+ * Increasing this should be done carefully while testing on older graphics cards, they
+ * might do "fancy" optimization.
+ */
+
+#define OPENGL_TEST(place) \
+{ \
+	auto err = glGetError(); \
+	if (err != GL_NO_ERROR) { \
+		fprintf(stderr, "OpenGL error " place ":\n %s\n\n", gluErrorString(err)); \
+	} \
+}
+
+MouseSelector::MouseSelector(GLView *view) {
+  this->view = view;
+  if (view && !view->has_shaders) {
+    return;
+  }
+  this->init_shader();
+
+  if (view) this->reset(view);
+}
+
+/**
+ * Resize the framebuffer whenever it changed
+ */
+void MouseSelector::reset(GLView *view) {
+  this->view = view;
+  this->setup_framebuffer(view);
+}
+
+/**
+ * Initialize the used shaders and setup the shaderinfo_t struct
+ */
+void MouseSelector::init_shader() {
+  /*
+    Attributes:
+      * identifier - index of the currently selected object
+  */
+  const char *vs_source =
+    "#version 130\n"
+    "in int identifier;\n"
+    "out vec4 frag_idcolor;\n"
+    "void main() {\n"
+    "  frag_idcolor = vec4(((identifier >> 0) & 0xff) / 255.0,\n"
+    "                      ((identifier >> 8) & 0xff) / 255.0,\n"
+    "                      ((identifier >> 16) & 0xff) / 255.0, \n"
+    "                      1.0);\n"
+    "  gl_Position = gl_ModelViewProjectionMatrix * gl_Vertex;\n"
+    "}\n";
+
+  const char *fs_source =
+    "#version 130\n"
+    "in vec4 frag_idcolor;\n"
+    "void main() {\n"
+    "  gl_FragColor = frag_idcolor;\n"
+    "}\n";
+
+  GLenum err;
+  int shaderstatus;
+
+  // Compile the shaders
+  auto vs = glCreateShader(GL_VERTEX_SHADER);
+  glShaderSource(vs, 1, (const GLchar**)&vs_source, nullptr);
+  glCompileShader(vs);
+  glGetShaderiv(vs, GL_COMPILE_STATUS, &shaderstatus);
+  if (shaderstatus != GL_TRUE) {
+    int loglen;
+    char logbuffer[1000];
+    glGetShaderInfoLog(vs, sizeof(logbuffer), &loglen, logbuffer);
+    fprintf(stderr, "OpenGL vertex shader Error:\n%.*s\n\n", loglen, logbuffer);
+  }
+
+  auto fs = glCreateShader(GL_FRAGMENT_SHADER);
+  glShaderSource(fs, 1, (const GLchar**)&fs_source, nullptr);
+  glCompileShader(fs);
+  glGetShaderiv(fs, GL_COMPILE_STATUS, &shaderstatus);
+  if (shaderstatus != GL_TRUE) {
+    int loglen;
+    char logbuffer[1000];
+    glGetShaderInfoLog(fs, sizeof(logbuffer), &loglen, logbuffer);
+    fprintf(stderr, "OpenGL fragment shader Error:\n%.*s\n\n", loglen, logbuffer);
+  }
+
+  // Link
+  auto selecthader_prog = glCreateProgram();
+  glAttachShader(selecthader_prog, vs);
+  glAttachShader(selecthader_prog, fs);
+  glLinkProgram(selecthader_prog);
+  OPENGL_TEST("Linking Shader");
+
+  GLint status;
+  glGetProgramiv(selecthader_prog, GL_LINK_STATUS, &status);
+  if (status == GL_FALSE) {
+    int loglen;
+    char logbuffer[1000];
+    glGetProgramInfoLog(selecthader_prog, sizeof(logbuffer), &loglen, logbuffer);
+    fprintf(stderr, "OpenGL Program Linker Error:\n%.*s\n\n", loglen, logbuffer);
+  } else {
+    int loglen;
+    char logbuffer[1000];
+    glGetProgramInfoLog(selecthader_prog, sizeof(logbuffer), &loglen, logbuffer);
+    if (loglen > 0) {
+      fprintf(stderr, "OpenGL Program Link OK:\n%.*s\n\n", loglen, logbuffer);
+    }
+    glValidateProgram(selecthader_prog);
+    glGetProgramInfoLog(selecthader_prog, sizeof(logbuffer), &loglen, logbuffer);
+    if (loglen > 0) {
+      fprintf(stderr, "OpenGL Program Validation results:\n%.*s\n\n", loglen, logbuffer);
+    }
+  }
+
+  // store identifiers for later use
+  this->shaderinfo.progid = selecthader_prog;
+  this->shaderinfo.type = GLView::shaderinfo_t::SELECT_RENDERING;
+  GLint identifier = glGetAttribLocation(selecthader_prog, "identifier");
+  this->shaderinfo.data.select_rendering.identifier = identifier;
+  if (identifier < 0) {
+    fprintf(stderr, "GL symbol retrieval went wrong, id is negative\n\n");
+  }
+
+}
+
+/**
+ * Resize or create the framebuffer
+ */
+void MouseSelector::setup_framebuffer(const GLView *view) {
+  if (!this->framebuffer ||
+      this->framebuffer->width() != view->cam.pixel_width ||
+      this->framebuffer->height() != view->cam.pixel_height) {
+    this->framebuffer.reset(
+      new QOpenGLFramebufferObject(
+      view->cam.pixel_width,
+      view->cam.pixel_width,
+      QOpenGLFramebufferObject::Depth));
+    this->framebuffer->release();
+  }
+}
+
+/**
+ * Setup the shaders, Projection and Model matrix and call the given renderer.
+ * The renderer has to make sure, that the colors are defined accordingly, or
+ * the selection wont work.
+ *
+ * returns 0 if no object was found
+ */
+int MouseSelector::select(const Renderer *renderer, int x, int y) {
+  // x/y is originated topleft, so turn y around
+  y = this->view->cam.pixel_height - y;
+
+  if (x > this->view->cam.pixel_width || x < 0 ||
+      y > this->view->cam.pixel_height || y < 0) {
+    return -1;
+  }
+
+  // Initialize GL to draw to texture
+  // Ideally a texture of only 1x1 or 2x2 pixels as a subset of the viewing frustrum
+  // of the currently selected frame.
+  // For now, i will use a texture the same size as the normal viewport
+  // and select the identifier at the mouse coordinates
+  this->framebuffer->bind();
+  OPENGL_TEST("switch FBO");
+
+  glClearColor(0, 0, 0, 1.0);
+  glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT | GL_STENCIL_BUFFER_BIT);
+
+  glViewport(0, 0, this->view->cam.pixel_width, this->view->cam.pixel_height);
+  this->view->setupCamera();
+  glTranslated(this->view->cam.object_trans.x(),
+               this->view->cam.object_trans.y(),
+               this->view->cam.object_trans.z());
+
+  glDisable(GL_LIGHTING);
+  glDepthFunc(GL_LESS);
+  glCullFace(GL_BACK);
+  glDisable(GL_CULL_FACE);
+  glEnable(GL_DEPTH_TEST);
+
+  // call the renderer with the selector shader
+  renderer->draw_with_shader(&this->shaderinfo);
+  OPENGL_TEST("renderer->draw_with_shader");
+
+  // Not strictly necessary, but a nop if not required.
+  glFlush();
+  glFinish();
+
+  // Grab the color from the framebuffer and convert it back to an identifier
+  GLubyte color[3] = { 0 };
+  glReadPixels(x, y, 1, 1, GL_RGB, GL_UNSIGNED_BYTE, color);
+  OPENGL_TEST("glReadPixels");
+  int index = (uint32_t)color[0] | ((uint32_t)color[1] << 8) | ((uint32_t)color[2] << 16);
+
+  // Switch the active framebuffer back to the default
+  this->framebuffer->release();
+
+  return index;
+}

--- a/src/mouseselector.cc
+++ b/src/mouseselector.cc
@@ -15,12 +15,12 @@
  */
 
 #define OPENGL_TEST(place) \
-{ \
+do { \
   auto err = glGetError(); \
   if (err != GL_NO_ERROR) { \
     fprintf(stderr, "OpenGL error " __FILE__ ":%i:" place ":\n %s\n\n", __LINE__, gluErrorString(err)); \
   } \
-}
+} while (false)
 
 MouseSelector::MouseSelector(GLView *view) {
   this->view = view;
@@ -46,7 +46,7 @@ void MouseSelector::reset(GLView *view) {
 void MouseSelector::init_shader() {
   /*
     Attributes:
-      * identifier - index of the currently selected object
+      * frag_idcolor - (uniform) 24 bit of the selected object's id encoded into R/G/B components as float values
   */
   const char *vs_source =
     "void main() {\n"
@@ -72,7 +72,7 @@ void MouseSelector::init_shader() {
     int loglen;
     char logbuffer[1000];
     glGetShaderInfoLog(vs, sizeof(logbuffer), &loglen, logbuffer);
-    fprintf(stderr, "OpenGL vertex shader Error:\n%.*s\n\n", loglen, logbuffer);
+    fprintf(stderr, __FILE__ ": OpenGL vertex shader Error:\n%.*s\n\n", loglen, logbuffer);
   }
 
   auto fs = glCreateShader(GL_FRAGMENT_SHADER);
@@ -84,7 +84,7 @@ void MouseSelector::init_shader() {
     int loglen;
     char logbuffer[1000];
     glGetShaderInfoLog(fs, sizeof(logbuffer), &loglen, logbuffer);
-    fprintf(stderr, "OpenGL fragment shader Error:\n%.*s\n\n", loglen, logbuffer);
+    fprintf(stderr, __FILE__ ": OpenGL fragment shader Error:\n%.*s\n\n", loglen, logbuffer);
   }
 
   // Link
@@ -100,28 +100,26 @@ void MouseSelector::init_shader() {
     int loglen;
     char logbuffer[1000];
     glGetProgramInfoLog(selecthader_prog, sizeof(logbuffer), &loglen, logbuffer);
-    fprintf(stderr, "OpenGL Program Linker Error:\n%.*s\n\n", loglen, logbuffer);
+    fprintf(stderr, __FILE__ ": OpenGL Program Linker Error:\n%.*s\n\n", loglen, logbuffer);
   } else {
     int loglen;
     char logbuffer[1000];
     glGetProgramInfoLog(selecthader_prog, sizeof(logbuffer), &loglen, logbuffer);
     if (loglen > 0) {
-      fprintf(stderr, "OpenGL Program Link OK:\n%.*s\n\n", loglen, logbuffer);
+      fprintf(stderr, __FILE__ ": OpenGL Program Link OK:\n%.*s\n\n", loglen, logbuffer);
     }
     glValidateProgram(selecthader_prog);
     glGetProgramInfoLog(selecthader_prog, sizeof(logbuffer), &loglen, logbuffer);
     if (loglen > 0) {
-      fprintf(stderr, "OpenGL Program Validation results:\n%.*s\n\n", loglen, logbuffer);
+      fprintf(stderr, __FILE__ ": OpenGL Program Validation results:\n%.*s\n\n", loglen, logbuffer);
     }
   }
 
-  // store identifiers for later use
   this->shaderinfo.progid = selecthader_prog;
   this->shaderinfo.type = GLView::shaderinfo_t::SELECT_RENDERING;
-  // GLint identifier = glGetAttribLocation(selecthader_prog, "identifier");
   GLint identifier = glGetUniformLocation(selecthader_prog, "frag_idcolor");
   if (identifier < 0) {
-    fprintf(stderr, "GL symbol retrieval went wrong, id is %i\n\n", identifier);
+    fprintf(stderr, __FILE__ ": OpenGL symbol retrieval went wrong, id is %i\n\n", identifier);
     this->shaderinfo.data.select_rendering.identifier = 0;
   }
   else {

--- a/src/mouseselector.h
+++ b/src/mouseselector.h
@@ -1,0 +1,35 @@
+#pragma once
+
+#include "GLView.h"
+#include "renderer.h"
+
+#include <QOpenGLFramebufferObject>
+
+#include <memory>
+
+
+class QOpenGLFramebufferObject;
+
+/**
+ * Grab the of the Tree element that was rendered at a specific location
+ */
+class MouseSelector
+{
+public:
+	MouseSelector(GLView *view);
+
+	/// Resize the renderbuffer
+	void reset(GLView *view);
+
+	int select(const Renderer *renderer, int x, int y);
+
+	GLView::shaderinfo_t shaderinfo;
+
+private:
+	void init_shader();
+	void setup_framebuffer(const GLView *view);
+
+	std::unique_ptr<QOpenGLFramebufferObject> framebuffer;
+
+	GLView *view;
+};

--- a/src/node.cc
+++ b/src/node.cc
@@ -54,16 +54,20 @@ std::string AbstractNode::toString() const
 	return this->name() + "()";
 }
 
-const AbstractNode *AbstractNode::getNodeByID(int idx) const
+const AbstractNode *AbstractNode::getNodeByID(int idx, std::deque<const AbstractNode *> &path) const
 {
-    if (this->idx == idx) { return this; }
-    for (const auto &node : this->children) {
-        auto res = node->getNodeByID(idx);
-        if (res) {
-            return res;
-        }
+  if (this->idx == idx) {
+    path.push_back(this);
+    return this;
+  }
+  for (const auto &node : this->children) {
+    auto res = node->getNodeByID(idx, path);
+    if (res) {
+      path.push_back(this);
+      return res;
     }
-    return nullptr;
+  }
+  return nullptr;
 }
 
 std::string GroupNode::name() const

--- a/src/node.h
+++ b/src/node.h
@@ -2,6 +2,7 @@
 
 #include <vector>
 #include <string>
+#include <deque>
 #include "BaseVisitable.h"
 #include "AST.h"
 
@@ -61,9 +62,9 @@ public:
 
 	int idx; // Node index (unique per tree)
 
-    const Location location;
+	const Location location;
 
-    const AbstractNode *getNodeByID(int idx) const;
+	const AbstractNode *getNodeByID(int idx, std::deque<const AbstractNode *> &path) const;
 };
 
 class AbstractIntersectionNode : public AbstractNode

--- a/src/parsersettings.cc
+++ b/src/parsersettings.cc
@@ -95,6 +95,40 @@ fs::path find_valid_path(const fs::path &sourcepath,
     return fs::path(_find_valid_path(sourcepath, localpath, openfilenames).generic_string());
 }
 
+
+static bool path_contains_file(fs::path dir, fs::path file)
+{
+	// from https://stackoverflow.com/a/15549954/1080604
+	// If dir ends with "/" and isn't the root directory, then the final
+	// component returned by iterators will include "." and will interfere
+	// with the std::equal check below, so we strip it before proceeding.
+	if (dir.filename() == ".") dir.remove_filename();
+	// We're also not interested in the file's name.
+	assert(file.has_filename());
+	file.remove_filename();
+
+	// If dir has more components than file, then file can't possibly
+	// reside in dir.
+	auto dir_len = std::distance(dir.begin(), dir.end());
+	auto file_len = std::distance(file.begin(), file.end());
+	if (dir_len > file_len) return false;
+
+	// This stops checking when it reaches dir.end(), so it's OK if file
+	// has more directory components afterward. They won't be checked.
+	return std::equal(dir.begin(), dir.end(), file.begin());
+}
+
+fs::path get_library_for_path(const fs::path &localpath)
+{
+	for (const auto &libpath : librarypath) {
+		if (path_contains_file(fs::path(libpath), localpath)) {
+			return libpath;
+		}
+	}
+	return fs::path();
+}
+
+
 void parser_init()
 {
 	// Add paths from OPENSCADPATH before adding built-in paths

--- a/src/parsersettings.h
+++ b/src/parsersettings.h
@@ -13,6 +13,7 @@ extern int parser_error_pos;
 void parser_init();
 
 fs::path search_libs(const fs::path &localpath);
-fs::path find_valid_path(const fs::path &sourcepath, 
-                         const fs::path &localpath, 
+fs::path find_valid_path(const fs::path &sourcepath,
+                         const fs::path &localpath,
                          const std::vector<std::string> *openfilenames = nullptr);
+fs::path get_library_for_path(const fs::path &localpath);

--- a/src/polyset.h
+++ b/src/polyset.h
@@ -4,6 +4,7 @@
 #include "linalg.h"
 #include "GeometryUtils.h"
 #include "Polygon2d.h"
+#include "GLView.h"
 #include <vector>
 #include <string>
 

--- a/src/renderer.h
+++ b/src/renderer.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "GLView.h"
 #include "system-gl.h"
 #include "linalg.h"
 #include "memory.h"
@@ -17,8 +18,9 @@ public:
 	Renderer();
 	virtual ~Renderer() {}
 	virtual void draw(bool showfaces, bool showedges) const = 0;
+	virtual void draw_with_shader(const GLView::shaderinfo_t *) const  { this->draw(true, true); }
 	virtual BoundingBox getBoundingBox() const = 0;
-	
+
 #define CSGMODE_DIFFERENCE_FLAG 0x10
 	enum csgmode_e {
 		CSGMODE_NONE                  = 0x00,
@@ -46,13 +48,13 @@ public:
 	};
 
 	virtual bool getColor(ColorMode colormode, Color4f &col) const;
-	virtual void setColor(const float color[4], GLint *shaderinfo = nullptr) const;
-	virtual void setColor(ColorMode colormode, GLint *shaderinfo = nullptr) const;
-	virtual Color4f setColor(ColorMode colormode, const float color[4], GLint *shaderinfo = nullptr) const;
+	virtual void setColor(const float color[4], const GLView::shaderinfo_t *shaderinfo = nullptr) const;
+	virtual void setColor(ColorMode colormode, const GLView::shaderinfo_t *shaderinfo = nullptr) const;
+	virtual Color4f setColor(ColorMode colormode, const float color[4], const GLView::shaderinfo_t *shaderinfo = nullptr) const;
 	virtual void setColorScheme(const ColorScheme &cs);
 
 	virtual csgmode_e get_csgmode(const bool highlight_mode, const bool background_mode, const OpenSCADOperator type=OpenSCADOperator::UNION) const;
-	virtual void render_surface(shared_ptr<const class Geometry> geom, csgmode_e csgmode, const Transform3d &m, GLint *shaderinfo = nullptr) const;
+	virtual void render_surface(shared_ptr<const class Geometry> geom, csgmode_e csgmode, const Transform3d &m, const GLView::shaderinfo_t *shaderinfo = nullptr) const;
 	virtual void render_edges(shared_ptr<const Geometry> geom, csgmode_e csgmode) const;
 
 protected:

--- a/src/scintillaeditor.cpp
+++ b/src/scintillaeditor.cpp
@@ -292,7 +292,7 @@ void ScintillaEditor::applySettings()
 	{
 		qsci->setAutoCompletionSource(QsciScintilla::AcsAPIs);
 		qsci->setAutoCompletionFillupsEnabled(false);
- 		qsci->setAutoCompletionFillups("(");		
+ 		qsci->setAutoCompletionFillups("(");
 		qsci->setCallTipsVisible(10);
 		qsci->setCallTipsStyle(QsciScintilla::CallTipsContext);
 	}
@@ -702,13 +702,13 @@ void ScintillaEditor::replaceAll(const QString &findText, const QString &replace
                       false /*wrap*/, true /*forward*/, 0, 0)) {
 #elif QSCINTILLA_VERSION >= 0x020700
   qsci->selectAll();
-  if (qsci->findFirstInSelection(findText, 
-                      false /*re*/, false /*cs*/, false /*wo*/, 
+  if (qsci->findFirstInSelection(findText,
+                      false /*re*/, false /*cs*/, false /*wo*/,
                       false /*wrap*/, true /*forward*/)) {
 #else
     // findFirstInSelection() was introduced in QScintilla 2.7
-  if (qsci->findFirst(findText, 
-                      false /*re*/, false /*cs*/, false /*wo*/, 
+  if (qsci->findFirst(findText,
+                      false /*re*/, false /*cs*/, false /*wo*/,
                       false /*wrap*/, true /*forward*/, 0, 0)) {
 #endif
     qsci->replace(replaceText);
@@ -1171,6 +1171,11 @@ void ScintillaEditor::onIndicatorClicked(int line, int col, Qt::KeyboardModifier
 	if(val >= hyperlinkIndicatorOffset && val <= hyperlinkIndicatorOffset+indicatorData.size())	{
 		emit hyperlinkIndicatorClicked(val - hyperlinkIndicatorOffset);
 	}
+}
+
+void ScintillaEditor::setCursorPosition(int line, int col)
+{
+	qsci->setCursorPosition(line, col);
 }
 
 void ScintillaEditor::updateSymbolMarginVisibility()

--- a/src/scintillaeditor.h
+++ b/src/scintillaeditor.h
@@ -63,6 +63,8 @@ public:
 	QMenu *createStandardContextMenu() override;
 	QPoint mapToGlobal(const QPoint &) override;
 
+	void setCursorPosition(int line, int col) override;
+
 private:
 	void getRange(int *lineFrom, int *lineTo);
 	void setColormap(const EditorColorScheme *colorScheme);


### PR DESCRIPTION
**Click on the Model Jump to the file.**

Or: Make the internal editor more powerful than any external editor.

it is started from two sides: `CSGNode`s do now carry their Index, whereby using the CSGTreeEvaluator we can get back to their parser information and therefore to Line/Column of the definition.

secondly the mouseselector defines its own shader encoding the newly created index into the color of the object.

Currently Working:

* Upon a Click in the renderer, the scene is redrawn into a FBO, and the Object ID is selected
* The object is selected based on its ID.
* The stored location is used to put the cursor in the editor to the beginning of the object defined.
* use tabmanager::open to open the referenced file and jump to the location
* display a context menu with the path through the csg tree to select the "right" node


Major Changes:

* Added support for different shaders for the rendering pass
* Added search-by-id into the root object tree
* Added "jump-to-row/col" for the Editor interface

ah - and sorry for a whole bunch of witespace fixes :)