### PR TITLE
Fix MacOS build

### DIFF
--- a/c++std.pri
+++ b/c++std.pri
@@ -26,7 +26,7 @@ macx {
 }
 
 c++std {
-  QMAKE_CXXFLAGS += -std=c++14
+  CONFIG += c++14 strict_c++
   message("Using C++14")
 
   *clang*: {

--- a/scripts/macosx-build-homebrew.sh
+++ b/scripts/macosx-build-homebrew.sh
@@ -49,7 +49,16 @@ $TAP tap openscad/homebrew-tap
 # Python 2 conflicts with Python 3 links
 brew unlink python@2
 
-for formula in pkg-config eigen boost cgal glew glib opencsg freetype libzip libxml2 fontconfig harfbuzz qt5 qscintilla2 lib3mf double-conversion imagemagick ccache; do
+for formula in boost; do
+  log "Installing or updating formula $formula"
+  if brew ls --versions $formula; then
+    time brew upgrade $formula
+  else
+    time brew install $formula
+  fi
+done
+
+for formula in pkg-config eigen cgal glew glib opencsg freetype libzip libxml2 fontconfig harfbuzz qt5 qscintilla2 lib3mf double-conversion imagemagick ccache; do
   log "Installing formula $formula"
   brew ls --versions $formula
   time brew install $formula


### PR DESCRIPTION
* Update boost to fix dependency on icu4c.
```
dyld: Library not loaded: /usr/local/opt/icu4c/lib/libicudata.64.dylib
  Referenced from: /usr/local/opt/boost/lib/libboost_regex-mt.dylib
  Reason: image not found
```
* Use c++14 config from Qt instead of directly adding compiler option.