### PR TITLE
Fix parent module handling (fixes #3264).

### DIFF
--- a/src/UserModule.h
+++ b/src/UserModule.h
@@ -6,6 +6,22 @@
 #include "module.h"
 #include "localscope.h"
 
+class StaticModuleNameStack {
+public:
+	StaticModuleNameStack(const std::string& name) {
+		stack.push_back(name);
+	}
+	~StaticModuleNameStack() {
+		stack.pop_back();
+	}
+
+	static int size() { return stack.size(); }
+	static const std::string& at(int idx) { return stack[idx]; }
+
+private:
+	static std::vector<std::string> stack;
+};
+
 class UserModule : public AbstractModule, public ASTNode
 {
 public:
@@ -15,13 +31,10 @@ public:
 
 	AbstractNode *instantiate(const std::shared_ptr<Context>& ctx, const ModuleInstantiation *inst, const std::shared_ptr<EvalContext>& evalctx) const override;
 	void print(std::ostream &stream, const std::string &indent) const override;
-	static const std::string& stack_element(int n) { return module_stack[n]; };
-	static int stack_size() { return module_stack.size(); };
+	static const std::string& stack_element(int n) { return StaticModuleNameStack::at(n); };
+	static int stack_size() { return StaticModuleNameStack::size(); };
 
 	std::string name;
 	AssignmentList definition_arguments;
 	LocalScope scope;
-
-private:
-	static std::vector<std::string> module_stack;
 };


### PR DESCRIPTION
This still uses a static vector which should be guarded by the global GUI lock. Using RAII it does ensure that exceptions like "Stop on first Warning" or asserts are cleaning up the stack and prevent leaking module names into later compiles.