### PR TITLE
AbstractNode: location

### DIFF
--- a/src/FileModule.cc
+++ b/src/FileModule.cc
@@ -112,7 +112,7 @@ time_t FileModule::include_modified(const IncludeFile &inc) const
 	if (StatCache::stat(inc.filename.c_str(), st) == 0) {
 		return st.st_mtime;
 	}
-	
+
 	return 0;
 }
 
@@ -180,7 +180,7 @@ time_t FileModule::handleDependencies(bool is_root)
 AbstractNode *FileModule::instantiate(const std::shared_ptr<Context>& ctx, const ModuleInstantiation *inst, const std::shared_ptr<EvalContext>& evalctx) const
 {
 	assert(!evalctx);
-	
+
 	ContextHandle<FileContext> context{Context::create<FileContext>(ctx)};
 	return this->instantiateWithFileContext(context.ctx, inst, evalctx);
 }
@@ -188,8 +188,8 @@ AbstractNode *FileModule::instantiate(const std::shared_ptr<Context>& ctx, const
 AbstractNode *FileModule::instantiateWithFileContext(const std::shared_ptr<FileContext>& ctx, const ModuleInstantiation *inst, const std::shared_ptr<EvalContext>& evalctx) const
 {
 	assert(!evalctx);
-	
-	auto node = new RootNode(inst);
+
+	auto node = new RootNode(inst, evalctx);
 	try {
 		ctx->initializeModule(*this); // May throw an ExperimentalFeatureException
 		// FIXME: Set document path to the path of the module

--- a/src/GroupModule.cc
+++ b/src/GroupModule.cc
@@ -32,7 +32,7 @@
 
 AbstractNode *GroupModule::instantiate(const std::shared_ptr<Context>&, const ModuleInstantiation *inst, const std::shared_ptr<EvalContext>& evalctx) const
 {
-	auto node = new GroupNode(inst);
+	auto node = new GroupNode(inst, evalctx);
 	inst->scope.apply(evalctx);
 	auto instantiatednodes = inst->instantiateChildren(evalctx);
 	node->children.insert(node->children.end(), instantiatednodes.begin(), instantiatednodes.end());

--- a/src/UserModule.cc
+++ b/src/UserModule.cc
@@ -54,7 +54,7 @@ AbstractNode *UserModule::instantiate(const std::shared_ptr<Context>& ctx, const
 	// At this point we know that nobody will modify the dependencies of the local scope
 	// passed to this instance, so we can populate the context
 	inst->scope.apply(evalctx);
-    
+
 	ContextHandle<ModuleContext> c{Context::create<ModuleContext>(ctx, evalctx)};
 	// set $children first since we might have variables depending on it
 	c->set_variable("$children", ValuePtr(double(inst->scope.children_inst.size())));
@@ -66,7 +66,7 @@ AbstractNode *UserModule::instantiate(const std::shared_ptr<Context>& ctx, const
 	c.dump(this, inst);
 #endif
 
-	AbstractNode *node = new GroupNode(inst);
+	AbstractNode *node = new GroupNode(inst, evalctx);
 	std::vector<AbstractNode *> instantiatednodes = this->scope.instantiateChildren(c.ctx);
 	node->children.insert(node->children.end(), instantiatednodes.begin(), instantiatednodes.end());
 	module_stack.pop_back();

--- a/src/cgaladv.cc
+++ b/src/cgaladv.cc
@@ -45,7 +45,7 @@ public:
 
 AbstractNode *CgaladvModule::instantiate(const std::shared_ptr<Context>& ctx, const ModuleInstantiation *inst, const std::shared_ptr<EvalContext>& evalctx) const
 {
-	auto node = new CgaladvNode(inst, type);
+	auto node = new CgaladvNode(inst, evalctx, type);
 
 	AssignmentList args;
 
@@ -63,7 +63,7 @@ AbstractNode *CgaladvModule::instantiate(const std::shared_ptr<Context>& ctx, co
 
 	auto convexity = ValuePtr::undefined;
 	auto path = ValuePtr::undefined;
-	
+
 	if (type == CgaladvType::MINKOWSKI) {
 		convexity = c->lookup_variable("convexity", true);
 	} else if (type == CgaladvType::RESIZE) {

--- a/src/cgaladvnode.h
+++ b/src/cgaladvnode.h
@@ -14,7 +14,7 @@ class CgaladvNode : public AbstractNode
 {
 public:
 	VISITABLE();
-	CgaladvNode(const ModuleInstantiation *mi, CgaladvType type) : AbstractNode(mi), type(type) {
+	CgaladvNode(const ModuleInstantiation *mi, const std::shared_ptr<EvalContext> &ctx, CgaladvType type) : AbstractNode(mi, ctx), type(type) {
 		convexity = 1;
 	}
 	~CgaladvNode() { }

--- a/src/color.cc
+++ b/src/color.cc
@@ -256,7 +256,7 @@ boost::optional<Color4f> parse_hex_color(const std::string& hex) {
 
 AbstractNode *ColorModule::instantiate(const std::shared_ptr<Context>& ctx, const ModuleInstantiation *inst, const std::shared_ptr<EvalContext>& evalctx) const
 {
-	auto node = new ColorNode(inst);
+	auto node = new ColorNode(inst, evalctx);
 
 	AssignmentList args{assignment("c"), assignment("alpha")};
 

--- a/src/colornode.h
+++ b/src/colornode.h
@@ -7,7 +7,7 @@ class ColorNode : public AbstractNode
 {
 public:
 	VISITABLE();
-	ColorNode(const ModuleInstantiation *mi) : AbstractNode(mi), color(-1.0f, -1.0f, -1.0f, 1.0f) { }
+	ColorNode(const ModuleInstantiation *mi, const std::shared_ptr<EvalContext> &ctx) : AbstractNode(mi, ctx), color(-1.0f, -1.0f, -1.0f, 1.0f) { }
 	std::string toString() const override;
 	std::string name() const override;
 

--- a/src/control.cc
+++ b/src/control.cc
@@ -55,11 +55,11 @@ public: // methods
 
 	AbstractNode *instantiate(const std::shared_ptr<Context>& ctx, const ModuleInstantiation *inst, const std::shared_ptr<EvalContext>& evalctx) const override;
 
-	static void for_eval(AbstractNode &node, const ModuleInstantiation &inst, size_t l, 
+	static void for_eval(AbstractNode &node, const ModuleInstantiation &inst, size_t l,
 						 const std::shared_ptr<Context> ctx, const std::shared_ptr<EvalContext> evalctx);
 
 	static const std::shared_ptr<EvalContext> getLastModuleCtx(const std::shared_ptr<EvalContext> evalctx);
-	
+
 	static AbstractNode* getChild(const ValuePtr &value, const std::shared_ptr<EvalContext> modulectx);
 
 private: // data
@@ -67,7 +67,7 @@ private: // data
 
 }; // class ControlModule
 
-void ControlModule::for_eval(AbstractNode &node, const ModuleInstantiation &inst, size_t l, 
+void ControlModule::for_eval(AbstractNode &node, const ModuleInstantiation &inst, size_t l,
 							const std::shared_ptr<Context> ctx, const std::shared_ptr<EvalContext> evalctx)
 {
 	if (evalctx->numArgs() > l) {
@@ -109,7 +109,7 @@ void ControlModule::for_eval(AbstractNode &node, const ModuleInstantiation &inst
 		for (const auto &assignment : inst.scope.assignments) {
 			c->set_variable(assignment->name, assignment->expr->evaluate(c.ctx));
 		}
-		
+
 		std::vector<AbstractNode *> instantiatednodes = inst.instantiateChildren(c.ctx);
 		node.children.insert(node.children.end(), instantiatednodes.begin(), instantiatednodes.end());
 	}
@@ -149,7 +149,7 @@ AbstractNode* ControlModule::getChild(const ValuePtr &value, const std::shared_p
 		PRINTB("WARNING: Bad parameter type (%s) for children, only accept: empty, number, vector, range.", value->toString());
 		return nullptr;
 	}
-		
+
 	int n = static_cast<int>(trunc(v));
 	if (n < 0) {
 		PRINTB("WARNING: Negative children index (%d) not allowed", n);
@@ -198,7 +198,7 @@ AbstractNode *ControlModule::instantiate(const std::shared_ptr<Context>& ctx, co
 		else {
 			// How to deal with negative objects in this case?
 			// (e.g. first child of difference is invalid)
-			PRINTB("WARNING: Child index (%d) out of bounds (%d children), %s", 
+			PRINTB("WARNING: Child index (%d) out of bounds (%d children), %s",
 				n % modulectx->numChildren() % evalctx->loc.toRelativeString(ctx->documentPath()));
 		}
 		return node;
@@ -215,8 +215,8 @@ AbstractNode *ControlModule::instantiate(const std::shared_ptr<Context>& ctx, co
 		if (evalctx->numArgs()<=0) {
 			// no parameters => all children
 			AbstractNode* node;
-			if (Feature::ExperimentalLazyUnion.is_enabled()) node = new ListNode(inst);
-			else node = new GroupNode(inst);
+			if (Feature::ExperimentalLazyUnion.is_enabled()) node = new ListNode(inst, evalctx);
+			else node = new GroupNode(inst, evalctx);
 
 			for (int n = 0; n < (int)modulectx->numChildren(); ++n) {
 				AbstractNode* childnode = modulectx->getChild(n)->evaluate(modulectx);
@@ -233,8 +233,8 @@ AbstractNode *ControlModule::instantiate(const std::shared_ptr<Context>& ctx, co
 			}
 			else if (value->type() == Value::ValueType::VECTOR) {
 				AbstractNode* node;
-				if (Feature::ExperimentalLazyUnion.is_enabled()) node = new ListNode(inst);
-				else node = new GroupNode(inst);
+				if (Feature::ExperimentalLazyUnion.is_enabled()) node = new ListNode(inst, evalctx);
+				else node = new GroupNode(inst, evalctx);
 				const Value::VectorType& vect = value->toVector();
 				for(const auto &vectvalue : vect) {
 					AbstractNode* childnode = getChild(vectvalue,modulectx);
@@ -251,8 +251,8 @@ AbstractNode *ControlModule::instantiate(const std::shared_ptr<Context>& ctx, co
 					return nullptr;
 				}
 				AbstractNode* node;
-				if (Feature::ExperimentalLazyUnion.is_enabled()) node = new ListNode(inst);
-				else node = new GroupNode(inst);
+				if (Feature::ExperimentalLazyUnion.is_enabled()) node = new ListNode(inst, evalctx);
+				else node = new GroupNode(inst, evalctx);
 				for (RangeType::iterator it = range.begin();it != range.end();it++) {
 					AbstractNode* childnode = getChild(ValuePtr(*it),modulectx); // with error cases
 					if (childnode==nullptr) continue; // error
@@ -272,8 +272,8 @@ AbstractNode *ControlModule::instantiate(const std::shared_ptr<Context>& ctx, co
 		break;
 
 	case Type::ECHO: {
-		if (Feature::ExperimentalLazyUnion.is_enabled()) node = new ListNode(inst);
-		else node = new GroupNode(inst);
+		if (Feature::ExperimentalLazyUnion.is_enabled()) node = new ListNode(inst, evalctx);
+		else node = new GroupNode(inst, evalctx);
 		PRINTB("%s", STR("ECHO: " << *evalctx));
 		ContextHandle<Context> c{Context::create<Context>(evalctx)};
 		inst->scope.apply(c.ctx);
@@ -282,8 +282,8 @@ AbstractNode *ControlModule::instantiate(const std::shared_ptr<Context>& ctx, co
 		break;
 
 	case Type::ASSERT: {
-		if (Feature::ExperimentalLazyUnion.is_enabled()) node = new ListNode(inst);
-		else node = new GroupNode(inst);
+		if (Feature::ExperimentalLazyUnion.is_enabled()) node = new ListNode(inst, evalctx);
+		else node = new GroupNode(inst, evalctx);
 		ContextHandle<Context> c{Context::create<Context>(evalctx)};
 		evaluate_assert(c.ctx, evalctx);
 		inst->scope.apply(c.ctx);
@@ -292,8 +292,8 @@ AbstractNode *ControlModule::instantiate(const std::shared_ptr<Context>& ctx, co
 		break;
 
 	case Type::LET: {
-		if (Feature::ExperimentalLazyUnion.is_enabled()) node = new ListNode(inst);
-		else node = new GroupNode(inst);
+		if (Feature::ExperimentalLazyUnion.is_enabled()) node = new ListNode(inst, evalctx);
+		else node = new GroupNode(inst, evalctx);
 		ContextHandle<Context> c{Context::create<Context>(evalctx)};
 
 		evalctx->assignTo(c.ctx);
@@ -305,7 +305,7 @@ AbstractNode *ControlModule::instantiate(const std::shared_ptr<Context>& ctx, co
 		break;
 
 	case Type::ASSIGN: {
-		node = new GroupNode(inst);
+		node = new GroupNode(inst, evalctx);
 		// We create a new context to avoid parameters from influencing each other
 		// -> parallel evaluation. This is to be backwards compatible.
 		ContextHandle<Context> c{Context::create<Context>(evalctx)};
@@ -321,19 +321,19 @@ AbstractNode *ControlModule::instantiate(const std::shared_ptr<Context>& ctx, co
 		break;
 
 	case Type::FOR:
-		if (Feature::ExperimentalLazyUnion.is_enabled()) node = new ListNode(inst);
-		else node = new GroupNode(inst);
+		if (Feature::ExperimentalLazyUnion.is_enabled()) node = new ListNode(inst, evalctx);
+		else node = new GroupNode(inst, evalctx);
 		for_eval(*node, *inst, 0, evalctx, evalctx);
 		break;
 
 	case Type::INT_FOR:
-		node = new AbstractIntersectionNode(inst);
+		node = new AbstractIntersectionNode(inst, evalctx);
 		for_eval(*node, *inst, 0, evalctx, evalctx);
 		break;
 
 	case Type::IF: {
-		if (Feature::ExperimentalLazyUnion.is_enabled()) node = new ListNode(inst);
-		else node = new GroupNode(inst);
+		if (Feature::ExperimentalLazyUnion.is_enabled()) node = new ListNode(inst, evalctx);
+		else node = new GroupNode(inst, evalctx);
 		const IfElseModuleInstantiation *ifelse = dynamic_cast<const IfElseModuleInstantiation*>(inst);
 		if (evalctx->numArgs() > 0 && evalctx->getArgValue(0)->toBool()) {
 			inst->scope.apply(evalctx);

--- a/src/csgops.cc
+++ b/src/csgops.cc
@@ -45,7 +45,7 @@ public:
 AbstractNode *CsgModule::instantiate(const std::shared_ptr<Context>&, const ModuleInstantiation *inst, const std::shared_ptr<EvalContext>& evalctx) const
 {
 	inst->scope.apply(evalctx);
-	auto node = new CsgOpNode(inst, type);
+	auto node = new CsgOpNode(inst, evalctx, type);
 	auto instantiatednodes = inst->instantiateChildren(evalctx);
 	node->children.insert(node->children.end(), instantiatednodes.begin(), instantiatednodes.end());
 	return node;

--- a/src/csgops.h
+++ b/src/csgops.h
@@ -8,7 +8,7 @@ class CsgOpNode : public AbstractNode
 public:
 	VISITABLE();
 	OpenSCADOperator type;
-	CsgOpNode(const ModuleInstantiation *mi, OpenSCADOperator type) : AbstractNode(mi), type(type) { }
+	CsgOpNode(const ModuleInstantiation *mi, const std::shared_ptr<EvalContext> &ctx, OpenSCADOperator type) : AbstractNode(mi, ctx), type(type) { }
 	std::string toString() const override;
 	std::string name() const override;
 };

--- a/src/import.cc
+++ b/src/import.cc
@@ -50,7 +50,6 @@ namespace fs = boost::filesystem;
 #include <boost/assign/std/vector.hpp>
 using namespace boost::assign; // bring 'operator+=()' into scope
 
-#include <boost/detail/endian.hpp>
 #include <cstdint>
 
 extern PolySet * import_amf(std::string, const Location &loc);
@@ -70,7 +69,7 @@ AbstractNode *ImportModule::instantiate(const std::shared_ptr<Context>& ctx, con
     assignment("file"), assignment("layer"), assignment("convexity"),
 		assignment("origin"), assignment("scale")
 	};
-	
+
 	AssignmentList optargs{
 		assignment("width"), assignment("height"),
 		assignment("filename"), assignment("layername"), assignment("center"), assignment("dpi")
@@ -105,7 +104,7 @@ AbstractNode *ImportModule::instantiate(const std::shared_ptr<Context>& ctx, con
 		else if (ext == ".svg") actualtype = ImportType::SVG;
 	}
 
-	auto node = new ImportNode(inst, actualtype);
+	auto node = new ImportNode(inst, evalctx, actualtype);
 
 	node->fn = c->lookup_variable("$fn")->toDouble();
 	node->fs = c->lookup_variable("$fs")->toDouble();
@@ -156,7 +155,7 @@ AbstractNode *ImportModule::instantiate(const std::shared_ptr<Context>& ctx, con
 	auto height = c->lookup_variable("height", true);
 	node->width = (width->type() == Value::ValueType::NUMBER) ? width->toDouble() : -1;
 	node->height = (height->type() == Value::ValueType::NUMBER) ? height->toDouble() : -1;
-	
+
 	return node;
 }
 

--- a/src/importnode.h
+++ b/src/importnode.h
@@ -20,7 +20,7 @@ public:
 	constexpr static double SVG_DEFAULT_DPI = 72.0;
 
 	VISITABLE();
-	ImportNode(const ModuleInstantiation *mi, ImportType type) : LeafNode(mi), type(type) { }
+	ImportNode(const ModuleInstantiation *mi, const std::shared_ptr<EvalContext> &ctx, ImportType type) : LeafNode(mi, ctx), type(type) { }
 	std::string toString() const override;
 	std::string name() const override;
 

--- a/src/linearextrude.cc
+++ b/src/linearextrude.cc
@@ -53,7 +53,7 @@ public:
 
 AbstractNode *LinearExtrudeModule::instantiate(const std::shared_ptr<Context>& ctx, const ModuleInstantiation *inst, const std::shared_ptr<EvalContext>& evalctx) const
 {
-	auto node = new LinearExtrudeNode(inst);
+	auto node = new LinearExtrudeNode(inst, evalctx);
 
 	AssignmentList args{assignment("file"), assignment("layer"), assignment("height"), assignment("origin"), assignment("scale"), assignment("center"), assignment("twist"), assignment("slices")};
 	AssignmentList optargs{assignment("convexity")};
@@ -152,7 +152,7 @@ std::string LinearExtrudeNode::toString() const
 	std::ostringstream stream;
 
 	stream << this->name() << "(";
-	if (!this->filename.empty()) { // Ignore deprecated parameters if empty 
+	if (!this->filename.empty()) { // Ignore deprecated parameters if empty
 		fs::path path((std::string)this->filename);
 		stream <<
 			"file = " << this->filename << ", "
@@ -165,7 +165,7 @@ std::string LinearExtrudeNode::toString() const
 		"height = " << std::dec << this->height << ", "
 		"center = " << (this->center?"true":"false") << ", "
 		"convexity = " << this->convexity;
-	
+
 	if (this->has_twist) {
 		stream << ", twist = " << this->twist;
 	}
@@ -174,7 +174,7 @@ std::string LinearExtrudeNode::toString() const
 	}
 	stream << ", scale = [" << this->scale_x << ", " << this->scale_y << "]";
 	stream << ", $fn = " << this->fn << ", $fa = " << this->fa << ", $fs = " << this->fs << ")";
-	
+
 	return stream.str();
 }
 

--- a/src/linearextrudenode.h
+++ b/src/linearextrudenode.h
@@ -7,7 +7,7 @@ class LinearExtrudeNode : public AbstractPolyNode
 {
 public:
 	VISITABLE();
-	LinearExtrudeNode(const ModuleInstantiation *mi) : AbstractPolyNode(mi) {
+	LinearExtrudeNode(const ModuleInstantiation *mi, const std::shared_ptr<EvalContext> &ctx) : AbstractPolyNode(mi, ctx) {
 		convexity = slices = 0;
 		fn = fs = fa = height = twist = 0;
 		origin_x = origin_y = 0;

--- a/src/node.cc
+++ b/src/node.cc
@@ -24,6 +24,7 @@
  *
  */
 
+#include "evalcontext.h"
 #include "node.h"
 #include "module.h"
 #include "ModuleInstantiation.h"
@@ -35,7 +36,11 @@
 
 size_t AbstractNode::idx_counter;
 
-AbstractNode::AbstractNode(const ModuleInstantiation *mi) : modinst(mi), progress_mark(0), idx(idx_counter++)
+AbstractNode::AbstractNode(const ModuleInstantiation *mi, const std::shared_ptr<EvalContext> &ctx) :
+    modinst(mi),
+    progress_mark(0),
+    idx(idx_counter++),
+    location((ctx)?ctx->loc:Location(0, 0, 0, 0, nullptr))
 {
 }
 

--- a/src/node.cc
+++ b/src/node.cc
@@ -54,6 +54,18 @@ std::string AbstractNode::toString() const
 	return this->name() + "()";
 }
 
+const AbstractNode *AbstractNode::getNodeByID(int idx) const
+{
+    if (this->idx == idx) { return this; }
+    for (const auto &node : this->children) {
+        auto res = node->getNodeByID(idx);
+        if (res) {
+            return res;
+        }
+    }
+    return nullptr;
+}
+
 std::string GroupNode::name() const
 {
 	return "group";

--- a/src/node.h
+++ b/src/node.h
@@ -62,6 +62,8 @@ public:
 	int idx; // Node index (unique per tree)
 
     const Location location;
+
+    const AbstractNode *getNodeByID(int idx) const;
 };
 
 class AbstractIntersectionNode : public AbstractNode

--- a/src/offset.cc
+++ b/src/offset.cc
@@ -51,7 +51,7 @@ public:
 
 AbstractNode *OffsetModule::instantiate(const std::shared_ptr<Context>& ctx, const ModuleInstantiation *inst, const std::shared_ptr<EvalContext>& evalctx) const
 {
-	auto node = new OffsetNode(inst);
+	auto node = new OffsetNode(inst, evalctx);
 
 	AssignmentList args{assignment("r")};
 	AssignmentList optargs{assignment("delta"),assignment("chamfer")};
@@ -72,7 +72,7 @@ AbstractNode *OffsetModule::instantiate(const std::shared_ptr<Context>& ctx, con
 	const auto r = c->lookup_variable("r", true);
 	const auto delta = c->lookup_variable("delta", true);
 	const auto chamfer = c->lookup_variable("chamfer", true);
-	
+
 	if (r->isDefinedAs(Value::ValueType::NUMBER)) {
 		r->getDouble(node->delta);
 	} else if (delta->isDefinedAs(Value::ValueType::NUMBER)) {
@@ -83,7 +83,7 @@ AbstractNode *OffsetModule::instantiate(const std::shared_ptr<Context>& ctx, con
 			node->join_type = ClipperLib::jtSquare;
 		}
 	}
-	
+
 	auto instantiatednodes = inst->instantiateChildren(evalctx);
 	node->children.insert(node->children.end(), instantiatednodes.begin(), instantiatednodes.end());
 

--- a/src/offsetnode.h
+++ b/src/offsetnode.h
@@ -8,7 +8,7 @@ class OffsetNode : public AbstractPolyNode
 {
 public:
 	VISITABLE();
-	OffsetNode(const ModuleInstantiation *mi) : AbstractPolyNode(mi), chamfer(false), fn(0), fs(0), fa(0), delta(1), miter_limit(1000000.0), join_type(ClipperLib::jtRound) { }
+	OffsetNode(const ModuleInstantiation *mi, const std::shared_ptr<EvalContext> &ctx) : AbstractPolyNode(mi, ctx), chamfer(false), fn(0), fs(0), fa(0), delta(1), miter_limit(1000000.0), join_type(ClipperLib::jtRound) { }
 	std::string toString() const override;
 	std::string name() const override { return "offset"; }
 

--- a/src/projection.cc
+++ b/src/projection.cc
@@ -45,11 +45,11 @@ public:
 
 AbstractNode *ProjectionModule::instantiate(const std::shared_ptr<Context>& ctx, const ModuleInstantiation *inst, const std::shared_ptr<EvalContext>& evalctx) const
 {
-	auto node = new ProjectionNode(inst);
+	auto node = new ProjectionNode(inst, evalctx);
 
 	AssignmentList args{assignment("cut")};
 	AssignmentList optargs{assignment("convexity")};
-	
+
 	ContextHandle<Context> c{Context::create<Context>(ctx)};
 	c->setVariables(evalctx, args, optargs);
 	inst->scope.apply(evalctx);

--- a/src/projectionnode.h
+++ b/src/projectionnode.h
@@ -7,7 +7,7 @@ class ProjectionNode : public AbstractPolyNode
 {
 public:
 	VISITABLE();
-	ProjectionNode(const ModuleInstantiation *mi) : AbstractPolyNode(mi), convexity(1), cut_mode(false) { }
+	ProjectionNode(const ModuleInstantiation *mi, const std::shared_ptr<EvalContext> &ctx) : AbstractPolyNode(mi, ctx), convexity(1), cut_mode(false) { }
 	std::string toString() const override;
 	std::string name() const override { return "projection"; }
 

--- a/src/render.cc
+++ b/src/render.cc
@@ -44,7 +44,7 @@ public:
 
 AbstractNode *RenderModule::instantiate(const std::shared_ptr<Context>& ctx, const ModuleInstantiation *inst, const std::shared_ptr<EvalContext>& evalctx) const
 {
-	auto node = new RenderNode(inst);
+	auto node = new RenderNode(inst, evalctx);
 
 	AssignmentList args{assignment("convexity")};
 

--- a/src/rendernode.h
+++ b/src/rendernode.h
@@ -7,7 +7,7 @@ class RenderNode : public AbstractNode
 {
 public:
 	VISITABLE();
-	RenderNode(const ModuleInstantiation *mi) : AbstractNode(mi), convexity(1) { }
+	RenderNode(const ModuleInstantiation *mi, const std::shared_ptr<EvalContext> &ctx) : AbstractNode(mi, ctx), convexity(1) { }
 	std::string toString() const override;
 	std::string name() const override { return "render"; }
 

--- a/src/rotateextrude.cc
+++ b/src/rotateextrude.cc
@@ -50,7 +50,7 @@ public:
 
 AbstractNode *RotateExtrudeModule::instantiate(const std::shared_ptr<Context>& ctx, const ModuleInstantiation *inst, const std::shared_ptr<EvalContext>& evalctx) const
 {
-	auto node = new RotateExtrudeNode(inst);
+	auto node = new RotateExtrudeNode(inst, evalctx);
 
 	AssignmentList args{assignment("file"), assignment("layer"), assignment("origin"), assignment("scale")};
 	AssignmentList optargs{assignment("convexity"), assignment("angle")};
@@ -62,7 +62,7 @@ AbstractNode *RotateExtrudeModule::instantiate(const std::shared_ptr<Context>& c
 	node->fn = c->lookup_variable("$fn")->toDouble();
 	node->fs = c->lookup_variable("$fs")->toDouble();
 	node->fa = c->lookup_variable("$fa")->toDouble();
-    
+
 
 	auto file = c->lookup_variable("file");
 	auto layer = c->lookup_variable("layer", true);
@@ -70,7 +70,7 @@ AbstractNode *RotateExtrudeModule::instantiate(const std::shared_ptr<Context>& c
 	auto origin = c->lookup_variable("origin", true);
 	auto scale = c->lookup_variable("scale", true);
 	auto angle = c->lookup_variable("angle", true);
-    
+
 	if (!file->isUndefined()) {
 		printDeprecation("Support for reading files in rotate_extrude will be removed in future releases. Use a child import() instead.");
 		auto filename = lookup_file(file->toString(), inst->path(), c->documentPath());
@@ -111,7 +111,7 @@ std::string RotateExtrudeNode::toString() const
 	std::ostringstream stream;
 
 	stream << this->name() << "(";
-	if (!this->filename.empty()) { // Ignore deprecated parameters if empty 
+	if (!this->filename.empty()) { // Ignore deprecated parameters if empty
 		fs::path path((std::string)this->filename);
 		stream <<
 			"file = " << this->filename << ", "

--- a/src/rotateextrudenode.h
+++ b/src/rotateextrudenode.h
@@ -7,7 +7,7 @@ class RotateExtrudeNode : public AbstractPolyNode
 {
 public:
 	VISITABLE();
-	RotateExtrudeNode(const ModuleInstantiation *mi) : AbstractPolyNode(mi) {
+	RotateExtrudeNode(const ModuleInstantiation *mi, const std::shared_ptr<EvalContext> &ctx) : AbstractPolyNode(mi, ctx) {
 		convexity = 0;
 		fn = fs = fa = 0;
 		origin_x = origin_y = scale = 0;

--- a/src/surface.cc
+++ b/src/surface.cc
@@ -63,7 +63,7 @@ class SurfaceNode : public LeafNode
 {
 public:
 	VISITABLE();
-	SurfaceNode(const ModuleInstantiation *mi) : LeafNode(mi), center(false), invert(false), convexity(1) { }
+	SurfaceNode(const ModuleInstantiation *mi, const std::shared_ptr<EvalContext> &ctx) : LeafNode(mi, ctx), center(false), invert(false), convexity(1) { }
 	std::string toString() const override;
 	std::string name() const override { return "surface"; }
 
@@ -71,7 +71,7 @@ public:
 	bool center;
 	bool invert;
 	int convexity;
-	
+
 	const Geometry *createGeometry() const override;
 private:
 	void convert_image(img_data_t &data, std::vector<uint8_t> &img, unsigned int width, unsigned int height) const;
@@ -82,7 +82,7 @@ private:
 
 AbstractNode *SurfaceModule::instantiate(const std::shared_ptr<Context>& ctx, const ModuleInstantiation *inst, const std::shared_ptr<EvalContext>& evalctx) const
 {
-	auto node = new SurfaceNode(inst);
+	auto node = new SurfaceNode(inst, evalctx);
 
 	AssignmentList args{assignment("file"), assignment("center"), assignment("convexity")};
 	AssignmentList optargs{assignment("center"),assignment("invert")};
@@ -136,25 +136,25 @@ img_data_t SurfaceNode::read_png_or_dat(std::string filename) const
 {
 	img_data_t data;
 	std::vector<uint8_t> png;
-	int ret_val = 0;	
+	int ret_val = 0;
 	try{
 		 ret_val = lodepng::load_file(png, filename);
 	}catch(std::bad_alloc &ba){
-		
+
 		PRINTB("WARNING: bad_alloc caught for '%s'.", ba.what());
-		return data;	
+		return data;
 	}
 
 	if(ret_val == 78){
 		PRINTB("WARNING: The file '%s' couldn't be opened.", filename);
-		return data;	
+		return data;
 	}
-	
+
 	if (!is_png(png)) {
 		png.clear();
 		return read_dat(filename);
 	}
-	
+
 	unsigned int width, height;
 	std::vector<uint8_t> img;
 	auto error = lodepng::decode(img, width, height, png);
@@ -163,9 +163,9 @@ img_data_t SurfaceNode::read_png_or_dat(std::string filename) const
 		data.clear();
 		return data;
 	}
-	
+
 	convert_image(data, img, width, height);
-	
+
 	return data;
 }
 
@@ -211,7 +211,7 @@ img_data_t SurfaceNode::read_dat(std::string filename) const
   	}
 		lines++;
 	}
-	
+
 	return data;
 }
 
@@ -221,7 +221,7 @@ const Geometry *SurfaceNode::createGeometry() const
 
 	auto p = new PolySet(3);
 	p->setConvexity(convexity);
-	
+
 	int lines = 0;
 	int columns = 0;
 	double min_val = 0;

--- a/src/text.cc
+++ b/src/text.cc
@@ -46,7 +46,7 @@ public:
 
 AbstractNode *TextModule::instantiate(const std::shared_ptr<Context>& ctx, const ModuleInstantiation *inst, const std::shared_ptr<EvalContext>& evalctx) const
 {
-	auto node = new TextNode(inst);
+	auto node = new TextNode(inst, evalctx);
 
 	AssignmentList args{assignment("text"), assignment("size"), assignment("font")};
 	AssignmentList optargs{

--- a/src/textnode.h
+++ b/src/textnode.h
@@ -11,13 +11,13 @@ class TextNode : public AbstractPolyNode
 {
 public:
 	VISITABLE();
-	TextNode(const ModuleInstantiation *mi) : AbstractPolyNode(mi) {}
-	
+	TextNode(const ModuleInstantiation *mi, const std::shared_ptr<EvalContext> &ctx) : AbstractPolyNode(mi, ctx) {}
+
 	std::string toString() const override;
 	std::string name() const override { return "text"; }
-	
+
 	virtual std::vector<const class Geometry *> createGeometryList() const;
-  
+
 	virtual FreetypeRenderer::Params get_params() const;
 private:
 	FreetypeRenderer::Params params;

--- a/src/transform.cc
+++ b/src/transform.cc
@@ -56,7 +56,7 @@ public:
 
 AbstractNode *TransformModule::instantiate(const std::shared_ptr<Context>& ctx, const ModuleInstantiation *inst, const std::shared_ptr<EvalContext>& evalctx) const
 {
-	auto node = new TransformNode(inst);
+	auto node = new TransformNode(inst, evalctx);
 
 	AssignmentList args;
 
@@ -131,7 +131,7 @@ AbstractNode *TransformModule::instantiate(const std::shared_ptr<Context>& ctx, 
 			if (val_a->toVector().size() > 3) {
 				ok &= false;
 			}
-			
+
 			bool v_supplied = (val_v != ValuePtr::undefined);
 			if(ok){
 				if(v_supplied){
@@ -171,7 +171,7 @@ AbstractNode *TransformModule::instantiate(const std::shared_ptr<Context>& ctx, 
 	else if (this->type == transform_type_e::MIRROR) {
 		auto val_v = c->lookup_variable("v");
 		double x = 1.0, y = 0.0, z = 0.0;
-	
+
 		if (val_v->getVec3(x, y, z, 0.0)) {
 			if (x != 0.0 || y != 0.0 || z != 0.0) {
 				double sn = 1.0 / sqrt(x*x + y*y + z*z);
@@ -207,7 +207,7 @@ AbstractNode *TransformModule::instantiate(const std::shared_ptr<Context>& ctx, 
 			Matrix4d rawmatrix{Matrix4d::Identity()};
 			for (int i = 0; i < 16; i++) {
 				size_t x = i / 4, y = i % 4;
-				if (y < v->toVector().size() && v->toVector()[y]->type() == 
+				if (y < v->toVector().size() && v->toVector()[y]->type() ==
 						Value::ValueType::VECTOR && x < v->toVector()[y]->toVector().size())
 					v->toVector()[y]->toVector()[x]->getDouble(rawmatrix(y, x));
 			}
@@ -243,7 +243,7 @@ std::string TransformNode::toString() const
 	return stream.str();
 }
 
-TransformNode::TransformNode(const ModuleInstantiation *mi) : AbstractNode(mi), matrix(Transform3d::Identity())
+TransformNode::TransformNode(const ModuleInstantiation *mi, const std::shared_ptr<EvalContext> &ctx) : AbstractNode(mi, ctx), matrix(Transform3d::Identity())
 {
 }
 

--- a/src/transformnode.h
+++ b/src/transformnode.h
@@ -8,7 +8,7 @@ class TransformNode : public AbstractNode
 public:
 	VISITABLE();
 	EIGEN_MAKE_ALIGNED_OPERATOR_NEW
-	TransformNode(const ModuleInstantiation *mi);
+	TransformNode(const ModuleInstantiation *mi, const std::shared_ptr<EvalContext> &ctx);
 	std::string toString() const override;
 	std::string name() const override;
 


### PR DESCRIPTION
Added `const std::shared_ptr<EvalContext> &ctx` as the current evaluation context to all constructors of `AbstractNode` and store the declaration location in the node.

This will improve the #3276 mouse selector (AbstractNode is cleaner to resolve than CSGNode!) and other synatx referencing features like #3283 