### PR TITLE
Add GitHub Sponsors button to repo info

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,1 +1,2 @@
-custom: ["https://flattr.com/@openscad", flattr.com]
+open_collective: openscad
+custom: ["https://flattr.com/@openscad", "http://paypal.me/openscad"]

--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,1 @@
+custom: ["https://flattr.com/@openscad", flattr.com]


### PR DESCRIPTION
Adds GitHub sponsors button that links to the flattr page (i.e. 
![image](https://user-images.githubusercontent.com/60588434/83362835-49e3a680-a362-11ea-8c23-e06d9ac2e70f.png)).

Has to be enabled in repo settings per https://help.github.com/en/github/administering-a-repository/displaying-a-sponsor-button-in-your-repository
