### PR TITLE
Improved float accuracy of mirror matrix calculation.

### DIFF
--- a/testdata/scad/3D/features/mirror-tests.scad
+++ b/testdata/scad/3D/features/mirror-tests.scad
@@ -1,1 +1,6 @@
-render() mirror([1,0,0]) cube();
+// tranformation matrices should consist of all -1, 0, and 1 values
+for(mx=[0,1],my=[0,1],mz=[0,1]) {
+  m = [mx,my,mz];
+  if (m == [1,1,1]) scale(-1) cube(); // can't mirror all 3 axes with single mirror operation
+  else mirror(m) cube();
+}

--- a/tests/regression/dumptest/mirror-tests-expected.csg
+++ b/tests/regression/dumptest/mirror-tests-expected.csg
@@ -1,5 +1,43 @@
-render(convexity = 1) {
-	multmatrix([[-1, 0, 0, 0], [0, 1, 0, 0], [0, 0, 1, 0], [0, 0, 0, 1]]) {
-		cube(size = [1, 1, 1], center = false);
+group() {
+	group() {
+		multmatrix([[1, 0, 0, 0], [0, 1, 0, 0], [0, 0, 1, 0], [0, 0, 0, 1]]) {
+			cube(size = [1, 1, 1], center = false);
+		}
+	}
+	group() {
+		multmatrix([[1, 0, 0, 0], [0, 1, 0, 0], [0, 0, -1, 0], [0, 0, 0, 1]]) {
+			cube(size = [1, 1, 1], center = false);
+		}
+	}
+	group() {
+		multmatrix([[1, 0, 0, 0], [0, -1, 0, 0], [0, 0, 1, 0], [0, 0, 0, 1]]) {
+			cube(size = [1, 1, 1], center = false);
+		}
+	}
+	group() {
+		multmatrix([[1, 0, 0, 0], [0, 0, -1, 0], [0, -1, 0, 0], [0, 0, 0, 1]]) {
+			cube(size = [1, 1, 1], center = false);
+		}
+	}
+	group() {
+		multmatrix([[-1, 0, 0, 0], [0, 1, 0, 0], [0, 0, 1, 0], [0, 0, 0, 1]]) {
+			cube(size = [1, 1, 1], center = false);
+		}
+	}
+	group() {
+		multmatrix([[0, 0, -1, 0], [0, 1, 0, 0], [-1, 0, 0, 0], [0, 0, 0, 1]]) {
+			cube(size = [1, 1, 1], center = false);
+		}
+	}
+	group() {
+		multmatrix([[0, -1, 0, 0], [-1, 0, 0, 0], [0, 0, 1, 0], [0, 0, 0, 1]]) {
+			cube(size = [1, 1, 1], center = false);
+		}
+	}
+	group() {
+		multmatrix([[-1, 0, 0, 0], [0, -1, 0, 0], [0, 0, -1, 0], [0, 0, 0, 1]]) {
+			cube(size = [1, 1, 1], center = false);
+		}
 	}
 }
+


### PR DESCRIPTION
Less operations and avoiding sqrt makes for more accurate matrix values.

Previous code resulted in some small non-zero values:
```
group() {
  group() {
    multmatrix([[1, 0, 0, 0], [0, 1, 0, 0], [0, 0, 1, 0], [0, 0, 0, 1]]) {
      cube(size = [1, 1, 1], center = false);
    }
  }
  group() {
    multmatrix([[1, 0, 0, 0], [0, 1, 0, 0], [0, 0, -1, 0], [0, 0, 0, 1]]) {
      cube(size = [1, 1, 1], center = false);
    }
  }
  group() {
    multmatrix([[1, 0, 0, 0], [0, -1, 0, 0], [0, 0, 1, 0], [0, 0, 0, 1]]) {
      cube(size = [1, 1, 1], center = false);
    }
  }
  group() {
    multmatrix([[1, 0, 0, 0], [0, 2.22045e-16, -1, 0], [0, -1, 2.22045e-16, 0], [0, 0, 0, 1]]) {
      cube(size = [1, 1, 1], center = false);
    }
  }
  group() {
    multmatrix([[-1, 0, 0, 0], [0, 1, 0, 0], [0, 0, 1, 0], [0, 0, 0, 1]]) {
      cube(size = [1, 1, 1], center = false);
    }
  }
  group() {
    multmatrix([[2.22045e-16, 0, -1, 0], [0, 1, 0, 0], [-1, 0, 2.22045e-16, 0], [0, 0, 0, 1]]) {
      cube(size = [1, 1, 1], center = false);
    }
  }
  group() {
    multmatrix([[2.22045e-16, -1, 0, 0], [-1, 2.22045e-16, 0, 0], [0, 0, 1, 0], [0, 0, 0, 1]]) {
      cube(size = [1, 1, 1], center = false);
    }
  }
  group() {
    multmatrix([[-1, 0, 0, 0], [0, -1, 0, 0], [0, 0, -1, 0], [0, 0, 0, 1]]) {
      cube(size = [1, 1, 1], center = false);
    }
  }
}
```

Dump with fix is contains matrices with all -1,0,1 values.