### PR TITLE
Number scroll by mouse

### DIFF
--- a/src/Preferences.cc
+++ b/src/Preferences.cc
@@ -205,7 +205,7 @@ void Preferences::init() {
 	initComboBox(this->comboBoxLineWrapVisualizationEnd, Settings::Settings::lineWrapVisualizationEnd);
 	initComboBox(this->comboBoxLineWrapVisualizationStart, Settings::Settings::lineWrapVisualizationBegin);
 	initComboBox(this->comboBoxShowWhitespace, Settings::Settings::showWhitespace);
-	initComboBox(this->comboBoxTabKeyFunction, Settings::Settings::tabKeyFunction);
+	initComboBox(this->comboBoxModifierNumberScrollWheel, Settings::Settings::modifierNumberScrollWheel);
 	initSpinBoxRange(this->spinBoxIndentationWidth, Settings::Settings::indentationWidth);
 	initSpinBoxRange(this->spinBoxLineWrapIndentationIndent, Settings::Settings::lineWrapIndentation);
 	initSpinBoxRange(this->spinBoxShowWhitespaceSize, Settings::Settings::showWhitespaceSize);
@@ -651,6 +651,11 @@ void Preferences::on_lineEditStepSize_textChanged(const QString &text)
 	emit stepSizeChanged(text.toInt());
 }
 
+void Preferences::on_comboBoxModifierNumberScrollWheel_activated(int val)
+{
+	applyComboBox(comboBoxModifierNumberScrollWheel, val, Settings::Settings::modifierNumberScrollWheel);
+}
+
 void Preferences::on_enableHardwarningsCheckBox_toggled(bool state)
 {
 	QSettingsCached settings;
@@ -917,6 +922,7 @@ void Preferences::updateGUI()
 	updateComboBox(this->comboBoxShowWhitespace, Settings::Settings::showWhitespace);
 	updateComboBox(this->comboBoxIndentUsing, Settings::Settings::indentStyle);
 	updateComboBox(this->comboBoxTabKeyFunction, Settings::Settings::tabKeyFunction);
+	updateComboBox(this->comboBoxModifierNumberScrollWheel, Settings::Settings::modifierNumberScrollWheel);
 	initSpinBoxDouble(this->spinBoxIndentationWidth, Settings::Settings::indentationWidth);
 	initSpinBoxDouble(this->spinBoxTabWidth, Settings::Settings::tabWidth);
 	initSpinBoxDouble(this->spinBoxLineWrapIndentationIndent, Settings::Settings::lineWrapIndentation);

--- a/src/Preferences.cc
+++ b/src/Preferences.cc
@@ -613,6 +613,13 @@ void Preferences::on_checkBoxEnableLineNumbers_toggled(bool checked)
 	writeSettings();
 }
 
+void Preferences::on_checkBoxEnableNumberScrollWheel_toggled(bool val)
+{
+	Settings::Settings::inst()->set(Settings::Settings::enableNumberScrollWheel, Value(val));
+	comboBoxModifierNumberScrollWheel->setDisabled(!checkBoxEnableNumberScrollWheel->isChecked());
+	writeSettings();
+}
+
 void Preferences::on_enableSoundOnRenderCompleteCheckBox_toggled(bool state)
 {
 	QSettingsCached settings;
@@ -931,6 +938,7 @@ void Preferences::updateGUI()
 	initCheckBox(this->checkBoxBackspaceUnindents, Settings::Settings::backspaceUnindents);
 	initCheckBox(this->checkBoxHighlightCurrentLine, Settings::Settings::highlightCurrentLine);
 	initCheckBox(this->checkBoxEnableBraceMatching, Settings::Settings::enableBraceMatching);
+	initCheckBox(this->checkBoxEnableNumberScrollWheel, Settings::Settings::enableNumberScrollWheel);
 	initCheckBox(this->checkBoxShowWarningsIn3dView, Settings::Settings::showWarningsIn3dView);
 	initCheckBox(this->checkBoxMouseCentricZoom, Settings::Settings::mouseCentricZoom);
 	initCheckBox(this->checkBoxEnableLineNumbers, Settings::Settings::enableLineNumbers);
@@ -942,8 +950,7 @@ void Preferences::updateGUI()
 	For normal cases, a similar line, inside the function 'on_comboBoxLineWrapIndentationStyle_activated()' handles the disabling functionality.
 	*/
 	this->spinBoxLineWrapIndentationIndent->setDisabled(comboBoxLineWrapIndentationStyle->currentData() == "Same" || comboBoxLineWrapIndentationStyle->currentData() == "Indented");
-
-
+	this->comboBoxModifierNumberScrollWheel->setDisabled(!checkBoxEnableNumberScrollWheel->isChecked());
 	BlockSignals<QLineEdit *>(this->lineEditOctoPrintURL)->setText(QString::fromStdString(s->get(Settings::Settings::octoPrintUrl).toString()));
 	BlockSignals<QLineEdit *>(this->lineEditOctoPrintApiKey)->setText(QString::fromStdString(s->get(Settings::Settings::octoPrintApiKey).toString()));
 	updateComboBox(this->comboBoxOctoPrintAction, Settings::Settings::octoPrintAction);

--- a/src/Preferences.cc
+++ b/src/Preferences.cc
@@ -156,6 +156,7 @@ void Preferences::init() {
 
 	this->defaultmap["editor/enableAutocomplete"] = true;
 	this->defaultmap["editor/characterThreshold"] = 1;
+	this->defaultmap["editor/stepSize"] = 1;
 
 	// Toolbar
 	QActionGroup *group = new QActionGroup(this);
@@ -196,6 +197,7 @@ void Preferences::init() {
 	this->opencsgLimitEdit->setValidator(validator);
 	this->timeThresholdOnRenderCompleteSoundEdit->setValidator(validator);
 	this->lineEditCharacterThreshold->setValidator(validator1);
+	this->lineEditStepSize->setValidator(validator1);
 
 	initComboBox(this->comboBoxIndentUsing, Settings::Settings::indentStyle);
 	initComboBox(this->comboBoxLineWrap, Settings::Settings::lineWrap);
@@ -642,6 +644,13 @@ void Preferences::on_lineEditCharacterThreshold_textChanged(const QString &text)
 	emit characterThresholdChanged(text.toInt());
 }
 
+void Preferences::on_lineEditStepSize_textChanged(const QString &text)
+{
+	QSettingsCached settings;
+	settings.setValue("editor/stepSize", text);
+	emit stepSizeChanged(text.toInt());
+}
+
 void Preferences::on_enableHardwarningsCheckBox_toggled(bool state)
 {
 	QSettingsCached settings;
@@ -891,6 +900,7 @@ void Preferences::updateGUI()
 	BlockSignals<QCheckBox *>(this->enableHidapiTraceCheckBox)->setChecked(s->get(Settings::Settings::inputEnableDriverHIDAPILog));
 	BlockSignals<QCheckBox *>(this->checkBoxEnableAutocomplete)->setChecked(getValue("editor/enableAutocomplete").toBool());
 	BlockSignals<QLineEdit *>(this->lineEditCharacterThreshold)->setText(getValue("editor/characterThreshold").toString());
+	BlockSignals<QLineEdit *>(this->lineEditStepSize)->setText(getValue("editor/stepSize").toString());
 
 	this->secLabel->setEnabled(getValue("advanced/enableSoundNotification").toBool());
 	this->undockCheckBox->setEnabled(this->reorderCheckBox->isChecked());
@@ -898,6 +908,7 @@ void Preferences::updateGUI()
 	this->timeThresholdOnRenderCompleteSoundEdit->setEnabled(getValue("advanced/enableSoundNotification").toBool());
 	this->labelCharacterThreshold->setEnabled(getValue("editor/enableAutocomplete").toBool());
 	this->lineEditCharacterThreshold->setEnabled(getValue("editor/enableAutocomplete").toBool());
+	this->lineEditStepSize->setEnabled(getValue("editor/stepSize").toBool());
 
 	updateComboBox(this->comboBoxLineWrap, Settings::Settings::lineWrap);
 	updateComboBox(this->comboBoxLineWrapIndentationStyle, Settings::Settings::lineWrapIndentationStyle);
@@ -973,3 +984,5 @@ Preferences *Preferences::inst() {
     
     return instance;
 }
+
+

--- a/src/Preferences.h
+++ b/src/Preferences.h
@@ -77,6 +77,8 @@ public slots:
 	void on_spinBoxLineWrapIndentationIndent_valueChanged(int);
 	void on_comboBoxLineWrapVisualizationStart_activated(int);
 	void on_comboBoxLineWrapVisualizationEnd_activated(int);
+	void on_comboBoxModifierNumberScrollWheel_activated(int);
+
 
 	// Display
 	void on_checkBoxHighlightCurrentLine_toggled(bool);

--- a/src/Preferences.h
+++ b/src/Preferences.h
@@ -115,6 +115,8 @@ signals:
 private slots:
     void on_lineEditStepSize_textChanged(const QString &arg1);
 
+    void on_checkBoxEnableNumberScrollWheel_toggled(bool checked);
+
 private:
     Preferences(QWidget *parent = nullptr);
 	void keyPressEvent(QKeyEvent *e) override;

--- a/src/Preferences.h
+++ b/src/Preferences.h
@@ -108,6 +108,10 @@ signals:
 	void updateMouseCentricZoom(bool state) const;
 	void autocompleteChanged(bool status) const;
 	void characterThresholdChanged(int val) const;
+	void stepSizeChanged(int val) const;
+
+private slots:
+    void on_lineEditStepSize_textChanged(const QString &arg1);
 
 private:
     Preferences(QWidget *parent = nullptr);

--- a/src/Preferences.ui
+++ b/src/Preferences.ui
@@ -137,7 +137,7 @@
              <x>0</x>
              <y>-421</y>
              <width>602</width>
-             <height>872</height>
+             <height>901</height>
             </rect>
            </property>
            <layout class="QGridLayout" name="gridLayout_5">
@@ -160,14 +160,7 @@
                <string>Number Scroll</string>
               </property>
               <layout class="QGridLayout" name="gridLayout_8">
-               <item row="0" column="0">
-                <widget class="QLabel" name="labelStepSize">
-                 <property name="text">
-                  <string>Step Size</string>
-                 </property>
-                </widget>
-               </item>
-               <item row="0" column="1">
+               <item row="1" column="1">
                 <spacer name="horizontalSpacer_7">
                  <property name="orientation">
                   <enum>Qt::Horizontal</enum>
@@ -180,36 +173,7 @@
                  </property>
                 </spacer>
                </item>
-               <item row="0" column="3">
-                <spacer name="horizontalSpacer_34">
-                 <property name="orientation">
-                  <enum>Qt::Horizontal</enum>
-                 </property>
-                 <property name="sizeHint" stdset="0">
-                  <size>
-                   <width>40</width>
-                   <height>20</height>
-                  </size>
-                 </property>
-                </spacer>
-               </item>
-               <item row="0" column="2">
-                <widget class="QLineEdit" name="lineEditStepSize"/>
-               </item>
-               <item row="0" column="4">
-                <spacer name="horizontalSpacer_33">
-                 <property name="orientation">
-                  <enum>Qt::Horizontal</enum>
-                 </property>
-                 <property name="sizeHint" stdset="0">
-                  <size>
-                   <width>40</width>
-                   <height>20</height>
-                  </size>
-                 </property>
-                </spacer>
-               </item>
-               <item row="0" column="5">
+               <item row="1" column="5">
                 <spacer name="horizontalSpacer_28">
                  <property name="orientation">
                   <enum>Qt::Horizontal</enum>
@@ -222,7 +186,7 @@
                  </property>
                 </spacer>
                </item>
-               <item row="1" column="2">
+               <item row="3" column="2">
                 <widget class="QComboBox" name="comboBoxModifierNumberScrollWheel">
                  <item>
                   <property name="text">
@@ -241,7 +205,50 @@
                  </item>
                 </widget>
                </item>
+               <item row="1" column="3">
+                <spacer name="horizontalSpacer_34">
+                 <property name="orientation">
+                  <enum>Qt::Horizontal</enum>
+                 </property>
+                 <property name="sizeHint" stdset="0">
+                  <size>
+                   <width>40</width>
+                   <height>20</height>
+                  </size>
+                 </property>
+                </spacer>
+               </item>
+               <item row="1" column="2">
+                <widget class="QLineEdit" name="lineEditStepSize"/>
+               </item>
                <item row="1" column="0">
+                <widget class="QLabel" name="labelStepSize">
+                 <property name="text">
+                  <string>Step Size</string>
+                 </property>
+                </widget>
+               </item>
+               <item row="1" column="4">
+                <spacer name="horizontalSpacer_33">
+                 <property name="orientation">
+                  <enum>Qt::Horizontal</enum>
+                 </property>
+                 <property name="sizeHint" stdset="0">
+                  <size>
+                   <width>40</width>
+                   <height>20</height>
+                  </size>
+                 </property>
+                </spacer>
+               </item>
+               <item row="2" column="0">
+                <widget class="QCheckBox" name="checkBoxEnableNumberScrollWheel">
+                 <property name="text">
+                  <string>Number Scroll Via Mouse Wheel</string>
+                 </property>
+                </widget>
+               </item>
+               <item row="3" column="0">
                 <widget class="QLabel" name="labelModifierNumberScrollWheel">
                  <property name="text">
                   <string>Modifier For Wheel Scroll </string>

--- a/src/Preferences.ui
+++ b/src/Preferences.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>636</width>
-    <height>498</height>
+    <height>539</height>
    </rect>
   </property>
   <property name="sizePolicy">
@@ -27,7 +27,7 @@
     <item row="0" column="0">
      <widget class="QStackedWidget" name="stackedWidget">
       <property name="currentIndex">
-       <number>5</number>
+       <number>1</number>
       </property>
       <widget class="QWidget" name="page3DView">
        <layout class="QVBoxLayout" name="verticalLayout_4">
@@ -135,157 +135,12 @@
            <property name="geometry">
             <rect>
              <x>0</x>
-             <y>0</y>
-             <width>512</width>
-             <height>793</height>
+             <y>-390</y>
+             <width>602</width>
+             <height>841</height>
             </rect>
            </property>
            <layout class="QGridLayout" name="gridLayout_5">
-            <item row="0" column="0">
-             <layout class="QGridLayout" name="gridLayout_9">
-              <item row="0" column="0">
-               <layout class="QHBoxLayout" name="horizontalLayout_28">
-                <item>
-                 <spacer name="horizontalSpacer_29">
-                  <property name="orientation">
-                   <enum>Qt::Horizontal</enum>
-                  </property>
-                  <property name="sizeType">
-                   <enum>QSizePolicy::Expanding</enum>
-                  </property>
-                  <property name="sizeHint" stdset="0">
-                   <size>
-                    <width>30</width>
-                    <height>20</height>
-                   </size>
-                  </property>
-                 </spacer>
-                </item>
-                <item>
-                 <widget class="QLabel" name="label_3">
-                  <property name="text">
-                   <string>Font</string>
-                  </property>
-                  <property name="scaledContents">
-                   <bool>false</bool>
-                  </property>
-                 </widget>
-                </item>
-               </layout>
-              </item>
-              <item row="0" column="1">
-               <layout class="QHBoxLayout" name="horizontalLayout_5">
-                <item>
-                 <widget class="QFontComboBox" name="fontChooser">
-                  <property name="currentFont">
-                   <font>
-                    <family>Lucida Grande</family>
-                    <pointsize>12</pointsize>
-                   </font>
-                  </property>
-                 </widget>
-                </item>
-                <item>
-                 <widget class="QComboBox" name="fontSize">
-                  <property name="editable">
-                   <bool>true</bool>
-                  </property>
-                 </widget>
-                </item>
-                <item>
-                 <spacer name="horizontalSpacer_5">
-                  <property name="orientation">
-                   <enum>Qt::Horizontal</enum>
-                  </property>
-                  <property name="sizeHint" stdset="0">
-                   <size>
-                    <width>40</width>
-                    <height>20</height>
-                   </size>
-                  </property>
-                 </spacer>
-                </item>
-               </layout>
-              </item>
-              <item row="1" column="0">
-               <layout class="QHBoxLayout" name="horizontalLayout_29">
-                <item>
-                 <spacer name="horizontalSpacer_30">
-                  <property name="orientation">
-                   <enum>Qt::Horizontal</enum>
-                  </property>
-                  <property name="sizeType">
-                   <enum>QSizePolicy::Expanding</enum>
-                  </property>
-                  <property name="sizeHint" stdset="0">
-                   <size>
-                    <width>30</width>
-                    <height>20</height>
-                   </size>
-                  </property>
-                 </spacer>
-                </item>
-                <item>
-                 <widget class="QLabel" name="labelColorSyntaxHighlighting">
-                  <property name="text">
-                   <string>Color syntax highlighting</string>
-                  </property>
-                 </widget>
-                </item>
-               </layout>
-              </item>
-              <item row="2" column="0">
-               <spacer name="horizontalSpacer_6">
-                <property name="orientation">
-                 <enum>Qt::Horizontal</enum>
-                </property>
-                <property name="sizeHint" stdset="0">
-                 <size>
-                  <width>198</width>
-                  <height>20</height>
-                 </size>
-                </property>
-               </spacer>
-              </item>
-              <item row="2" column="1">
-               <widget class="QCheckBox" name="mouseWheelZoomBox">
-                <property name="text">
-                 <string>Ctrl/Cmd-Mouse-wheel zooms text</string>
-                </property>
-               </widget>
-              </item>
-              <item row="1" column="1">
-               <layout class="QHBoxLayout" name="horizontalLayout_26">
-                <item>
-                 <widget class="QComboBox" name="syntaxHighlight">
-                  <property name="sizePolicy">
-                   <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
-                    <horstretch>0</horstretch>
-                    <verstretch>0</verstretch>
-                   </sizepolicy>
-                  </property>
-                 </widget>
-                </item>
-                <item>
-                 <spacer name="horizontalSpacer_3">
-                  <property name="orientation">
-                   <enum>Qt::Horizontal</enum>
-                  </property>
-                  <property name="sizeType">
-                   <enum>QSizePolicy::Expanding</enum>
-                  </property>
-                  <property name="sizeHint" stdset="0">
-                   <size>
-                    <width>30</width>
-                    <height>20</height>
-                   </size>
-                  </property>
-                 </spacer>
-                </item>
-               </layout>
-              </item>
-             </layout>
-            </item>
             <item row="1" column="0">
              <widget class="QGroupBox" name="groupBoxIndentation">
               <property name="title">
@@ -642,13 +497,6 @@
                <string>Display</string>
               </property>
               <layout class="QGridLayout" name="gridLayout">
-               <item row="2" column="0">
-                <widget class="QCheckBox" name="checkBoxEnableBraceMatching">
-                 <property name="text">
-                  <string>Enable brace matching</string>
-                 </property>
-                </widget>
-               </item>
                <item row="1" column="0">
                 <widget class="QCheckBox" name="checkBoxHighlightCurrentLine">
                  <property name="text">
@@ -663,40 +511,17 @@
                  </property>
                 </widget>
                </item>
-              </layout>
-             </widget>
-            </item>
-            <item row="4" column="0">
-             <widget class="QGroupBox" name="groupBoxAutocomplete">
-              <property name="title">
-               <string>Autocomplete</string>
-              </property>
-              <layout class="QGridLayout" name="gridLayout1">
-               <item row="0" column="0">
-                <widget class="QCheckBox" name="checkBoxEnableAutocomplete">
+               <item row="2" column="0">
+                <widget class="QCheckBox" name="checkBoxEnableBraceMatching">
                  <property name="text">
-                  <string>Enable Autocompletion</string>
+                  <string>Enable brace matching</string>
                  </property>
                 </widget>
                </item>
-               <item row="1" column="0">
-                <layout class="QHBoxLayout" name="horizontalLayout_30">
-                  <item>
-                    <widget class="QLabel" name="labelCharacterThreshold">
-                     <property name="text">
-                      <string>Character Threshold</string>
-                     </property>
-                    </widget>
-                 </item>
-                 <item>
-                  <widget class="QLineEdit" name="lineEditCharacterThreshold" />
-                 </item>
-                </layout>
-               </item>
               </layout>
              </widget>
             </item>
-            <item row="5" column="0">
+            <item row="6" column="0">
              <spacer name="verticalSpacer_2">
               <property name="orientation">
                <enum>Qt::Vertical</enum>
@@ -986,6 +811,255 @@
                </size>
               </property>
              </spacer>
+            </item>
+            <item row="0" column="0">
+             <layout class="QGridLayout" name="gridLayout_9">
+              <item row="0" column="0">
+               <layout class="QHBoxLayout" name="horizontalLayout_28">
+                <item>
+                 <spacer name="horizontalSpacer_29">
+                  <property name="orientation">
+                   <enum>Qt::Horizontal</enum>
+                  </property>
+                  <property name="sizeType">
+                   <enum>QSizePolicy::Expanding</enum>
+                  </property>
+                  <property name="sizeHint" stdset="0">
+                   <size>
+                    <width>30</width>
+                    <height>20</height>
+                   </size>
+                  </property>
+                 </spacer>
+                </item>
+                <item>
+                 <widget class="QLabel" name="label_3">
+                  <property name="text">
+                   <string>Font</string>
+                  </property>
+                  <property name="scaledContents">
+                   <bool>false</bool>
+                  </property>
+                 </widget>
+                </item>
+               </layout>
+              </item>
+              <item row="0" column="1">
+               <layout class="QHBoxLayout" name="horizontalLayout_5">
+                <item>
+                 <widget class="QFontComboBox" name="fontChooser">
+                  <property name="currentFont">
+                   <font>
+                    <family>DejaVu Sans</family>
+                    <pointsize>12</pointsize>
+                   </font>
+                  </property>
+                 </widget>
+                </item>
+                <item>
+                 <widget class="QComboBox" name="fontSize">
+                  <property name="editable">
+                   <bool>true</bool>
+                  </property>
+                 </widget>
+                </item>
+                <item>
+                 <spacer name="horizontalSpacer_5">
+                  <property name="orientation">
+                   <enum>Qt::Horizontal</enum>
+                  </property>
+                  <property name="sizeHint" stdset="0">
+                   <size>
+                    <width>40</width>
+                    <height>20</height>
+                   </size>
+                  </property>
+                 </spacer>
+                </item>
+               </layout>
+              </item>
+              <item row="1" column="0">
+               <layout class="QHBoxLayout" name="horizontalLayout_29">
+                <item>
+                 <spacer name="horizontalSpacer_30">
+                  <property name="orientation">
+                   <enum>Qt::Horizontal</enum>
+                  </property>
+                  <property name="sizeType">
+                   <enum>QSizePolicy::Expanding</enum>
+                  </property>
+                  <property name="sizeHint" stdset="0">
+                   <size>
+                    <width>30</width>
+                    <height>20</height>
+                   </size>
+                  </property>
+                 </spacer>
+                </item>
+                <item>
+                 <widget class="QLabel" name="labelColorSyntaxHighlighting">
+                  <property name="text">
+                   <string>Color syntax highlighting</string>
+                  </property>
+                 </widget>
+                </item>
+               </layout>
+              </item>
+              <item row="2" column="0">
+               <spacer name="horizontalSpacer_6">
+                <property name="orientation">
+                 <enum>Qt::Horizontal</enum>
+                </property>
+                <property name="sizeHint" stdset="0">
+                 <size>
+                  <width>198</width>
+                  <height>20</height>
+                 </size>
+                </property>
+               </spacer>
+              </item>
+              <item row="2" column="1">
+               <widget class="QCheckBox" name="mouseWheelZoomBox">
+                <property name="text">
+                 <string>Ctrl/Cmd-Mouse-wheel zooms text</string>
+                </property>
+               </widget>
+              </item>
+              <item row="1" column="1">
+               <layout class="QHBoxLayout" name="horizontalLayout_26">
+                <item>
+                 <widget class="QComboBox" name="syntaxHighlight">
+                  <property name="sizePolicy">
+                   <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+                    <horstretch>0</horstretch>
+                    <verstretch>0</verstretch>
+                   </sizepolicy>
+                  </property>
+                 </widget>
+                </item>
+                <item>
+                 <spacer name="horizontalSpacer_3">
+                  <property name="orientation">
+                   <enum>Qt::Horizontal</enum>
+                  </property>
+                  <property name="sizeType">
+                   <enum>QSizePolicy::Expanding</enum>
+                  </property>
+                  <property name="sizeHint" stdset="0">
+                   <size>
+                    <width>30</width>
+                    <height>20</height>
+                   </size>
+                  </property>
+                 </spacer>
+                </item>
+               </layout>
+              </item>
+             </layout>
+            </item>
+            <item row="4" column="0">
+             <widget class="QGroupBox" name="groupBoxNumberScroll">
+              <property name="title">
+               <string>Number Scroll</string>
+              </property>
+              <layout class="QGridLayout" name="gridLayout_8">
+               <item row="0" column="0">
+                <widget class="QLabel" name="labelStepSize">
+                 <property name="text">
+                  <string>Step Size</string>
+                 </property>
+                </widget>
+               </item>
+               <item row="0" column="2">
+                <widget class="QLineEdit" name="lineEditStepSize"/>
+               </item>
+               <item row="0" column="5">
+                <spacer name="horizontalSpacer_28">
+                 <property name="orientation">
+                  <enum>Qt::Horizontal</enum>
+                 </property>
+                 <property name="sizeHint" stdset="0">
+                  <size>
+                   <width>40</width>
+                   <height>20</height>
+                  </size>
+                 </property>
+                </spacer>
+               </item>
+               <item row="0" column="4">
+                <spacer name="horizontalSpacer_33">
+                 <property name="orientation">
+                  <enum>Qt::Horizontal</enum>
+                 </property>
+                 <property name="sizeHint" stdset="0">
+                  <size>
+                   <width>40</width>
+                   <height>20</height>
+                  </size>
+                 </property>
+                </spacer>
+               </item>
+               <item row="0" column="1">
+                <spacer name="horizontalSpacer_7">
+                 <property name="orientation">
+                  <enum>Qt::Horizontal</enum>
+                 </property>
+                 <property name="sizeHint" stdset="0">
+                  <size>
+                   <width>40</width>
+                   <height>20</height>
+                  </size>
+                 </property>
+                </spacer>
+               </item>
+               <item row="0" column="3">
+                <spacer name="horizontalSpacer_34">
+                 <property name="orientation">
+                  <enum>Qt::Horizontal</enum>
+                 </property>
+                 <property name="sizeHint" stdset="0">
+                  <size>
+                   <width>40</width>
+                   <height>20</height>
+                  </size>
+                 </property>
+                </spacer>
+               </item>
+              </layout>
+             </widget>
+            </item>
+            <item row="5" column="0">
+             <widget class="QGroupBox" name="groupBoxAutocomplete">
+              <property name="title">
+               <string>Autocomplete</string>
+              </property>
+              <layout class="QGridLayout" name="gridLayout1">
+               <property name="rightMargin">
+                <number>9</number>
+               </property>
+               <item row="0" column="0">
+                <widget class="QCheckBox" name="checkBoxEnableAutocomplete">
+                 <property name="text">
+                  <string>Enable Autocompletion</string>
+                 </property>
+                </widget>
+               </item>
+               <item row="1" column="0">
+                <layout class="QHBoxLayout" name="horizontalLayout_30">
+                 <item>
+                  <widget class="QLabel" name="labelCharacterThreshold">
+                   <property name="text">
+                    <string>Character Threshold</string>
+                   </property>
+                  </widget>
+                 </item>
+                 <item>
+                  <widget class="QLineEdit" name="lineEditCharacterThreshold"/>
+                 </item>
+                </layout>
+               </item>
+              </layout>
+             </widget>
             </item>
            </layout>
           </widget>
@@ -1509,7 +1583,7 @@
              <x>0</x>
              <y>0</y>
              <width>602</width>
-             <height>891</height>
+             <height>747</height>
             </rect>
            </property>
            <layout class="QVBoxLayout" name="verticalLayout_12">

--- a/src/Preferences.ui
+++ b/src/Preferences.ui
@@ -135,12 +135,608 @@
            <property name="geometry">
             <rect>
              <x>0</x>
-             <y>-390</y>
+             <y>-421</y>
              <width>602</width>
-             <height>841</height>
+             <height>872</height>
             </rect>
            </property>
            <layout class="QGridLayout" name="gridLayout_5">
+            <item row="0" column="1">
+             <spacer name="horizontalSpacer_4">
+              <property name="orientation">
+               <enum>Qt::Horizontal</enum>
+              </property>
+              <property name="sizeHint" stdset="0">
+               <size>
+                <width>40</width>
+                <height>20</height>
+               </size>
+              </property>
+             </spacer>
+            </item>
+            <item row="4" column="0">
+             <widget class="QGroupBox" name="groupBoxNumberScroll">
+              <property name="title">
+               <string>Number Scroll</string>
+              </property>
+              <layout class="QGridLayout" name="gridLayout_8">
+               <item row="0" column="0">
+                <widget class="QLabel" name="labelStepSize">
+                 <property name="text">
+                  <string>Step Size</string>
+                 </property>
+                </widget>
+               </item>
+               <item row="0" column="1">
+                <spacer name="horizontalSpacer_7">
+                 <property name="orientation">
+                  <enum>Qt::Horizontal</enum>
+                 </property>
+                 <property name="sizeHint" stdset="0">
+                  <size>
+                   <width>40</width>
+                   <height>20</height>
+                  </size>
+                 </property>
+                </spacer>
+               </item>
+               <item row="0" column="3">
+                <spacer name="horizontalSpacer_34">
+                 <property name="orientation">
+                  <enum>Qt::Horizontal</enum>
+                 </property>
+                 <property name="sizeHint" stdset="0">
+                  <size>
+                   <width>40</width>
+                   <height>20</height>
+                  </size>
+                 </property>
+                </spacer>
+               </item>
+               <item row="0" column="2">
+                <widget class="QLineEdit" name="lineEditStepSize"/>
+               </item>
+               <item row="0" column="4">
+                <spacer name="horizontalSpacer_33">
+                 <property name="orientation">
+                  <enum>Qt::Horizontal</enum>
+                 </property>
+                 <property name="sizeHint" stdset="0">
+                  <size>
+                   <width>40</width>
+                   <height>20</height>
+                  </size>
+                 </property>
+                </spacer>
+               </item>
+               <item row="0" column="5">
+                <spacer name="horizontalSpacer_28">
+                 <property name="orientation">
+                  <enum>Qt::Horizontal</enum>
+                 </property>
+                 <property name="sizeHint" stdset="0">
+                  <size>
+                   <width>40</width>
+                   <height>20</height>
+                  </size>
+                 </property>
+                </spacer>
+               </item>
+               <item row="1" column="2">
+                <widget class="QComboBox" name="comboBoxModifierNumberScrollWheel">
+                 <item>
+                  <property name="text">
+                   <string>Alt</string>
+                  </property>
+                 </item>
+                 <item>
+                  <property name="text">
+                   <string>Left Mouse Button</string>
+                  </property>
+                 </item>
+                 <item>
+                  <property name="text">
+                   <string>Both</string>
+                  </property>
+                 </item>
+                </widget>
+               </item>
+               <item row="1" column="0">
+                <widget class="QLabel" name="labelModifierNumberScrollWheel">
+                 <property name="text">
+                  <string>Modifier For Wheel Scroll </string>
+                 </property>
+                </widget>
+               </item>
+              </layout>
+             </widget>
+            </item>
+            <item row="6" column="0">
+             <spacer name="verticalSpacer_2">
+              <property name="orientation">
+               <enum>Qt::Vertical</enum>
+              </property>
+              <property name="sizeHint" stdset="0">
+               <size>
+                <width>20</width>
+                <height>40</height>
+               </size>
+              </property>
+             </spacer>
+            </item>
+            <item row="5" column="0">
+             <widget class="QGroupBox" name="groupBoxAutocomplete">
+              <property name="title">
+               <string>Autocomplete</string>
+              </property>
+              <layout class="QGridLayout" name="gridLayout1">
+               <property name="rightMargin">
+                <number>9</number>
+               </property>
+               <item row="0" column="0">
+                <widget class="QCheckBox" name="checkBoxEnableAutocomplete">
+                 <property name="text">
+                  <string>Enable Autocompletion</string>
+                 </property>
+                </widget>
+               </item>
+               <item row="1" column="0">
+                <layout class="QHBoxLayout" name="horizontalLayout_30">
+                 <item>
+                  <widget class="QLabel" name="labelCharacterThreshold">
+                   <property name="text">
+                    <string>Character Threshold</string>
+                   </property>
+                  </widget>
+                 </item>
+                 <item>
+                  <widget class="QLineEdit" name="lineEditCharacterThreshold"/>
+                 </item>
+                </layout>
+               </item>
+              </layout>
+             </widget>
+            </item>
+            <item row="2" column="0">
+             <widget class="QGroupBox" name="groupBoxLineWrap">
+              <property name="title">
+               <string>Line wrap</string>
+              </property>
+              <layout class="QGridLayout" name="gridLayout_4">
+               <item row="0" column="1">
+                <layout class="QHBoxLayout" name="horizontalLayout_25">
+                 <item>
+                  <widget class="QComboBox" name="comboBoxLineWrap">
+                   <item>
+                    <property name="text">
+                     <string>None</string>
+                    </property>
+                   </item>
+                   <item>
+                    <property name="text">
+                     <string>Wrap at character boundaries</string>
+                    </property>
+                   </item>
+                   <item>
+                    <property name="text">
+                     <string>Wrap at word boundaries</string>
+                    </property>
+                   </item>
+                  </widget>
+                 </item>
+                 <item>
+                  <spacer name="horizontalSpacer_25">
+                   <property name="orientation">
+                    <enum>Qt::Horizontal</enum>
+                   </property>
+                   <property name="sizeHint" stdset="0">
+                    <size>
+                     <width>40</width>
+                     <height>20</height>
+                    </size>
+                   </property>
+                  </spacer>
+                 </item>
+                </layout>
+               </item>
+               <item row="1" column="0">
+                <layout class="QHBoxLayout" name="horizontalLayout_21">
+                 <item>
+                  <spacer name="horizontalSpacer_23">
+                   <property name="orientation">
+                    <enum>Qt::Horizontal</enum>
+                   </property>
+                   <property name="sizeHint" stdset="0">
+                    <size>
+                     <width>40</width>
+                     <height>20</height>
+                    </size>
+                   </property>
+                  </spacer>
+                 </item>
+                 <item>
+                  <widget class="QLabel" name="labelLineWrapIndentation">
+                   <property name="text">
+                    <string>Line wrap indentation</string>
+                   </property>
+                  </widget>
+                 </item>
+                </layout>
+               </item>
+               <item row="2" column="0">
+                <layout class="QHBoxLayout" name="horizontalLayout_22">
+                 <item>
+                  <spacer name="horizontalSpacer_24">
+                   <property name="orientation">
+                    <enum>Qt::Horizontal</enum>
+                   </property>
+                   <property name="sizeHint" stdset="0">
+                    <size>
+                     <width>40</width>
+                     <height>20</height>
+                    </size>
+                   </property>
+                  </spacer>
+                 </item>
+                 <item>
+                  <widget class="QLabel" name="labelLineWrapVisualization">
+                   <property name="text">
+                    <string>Line wrap visualization</string>
+                   </property>
+                  </widget>
+                 </item>
+                </layout>
+               </item>
+               <item row="1" column="1">
+                <layout class="QHBoxLayout" name="horizontalLayout_24">
+                 <item>
+                  <widget class="QLabel" name="labelLineWrapIndentationStyle">
+                   <property name="text">
+                    <string>Style</string>
+                   </property>
+                  </widget>
+                 </item>
+                 <item>
+                  <widget class="QComboBox" name="comboBoxLineWrapIndentationStyle">
+                   <item>
+                    <property name="text">
+                     <string>Fixed</string>
+                    </property>
+                   </item>
+                   <item>
+                    <property name="text">
+                     <string>Same</string>
+                    </property>
+                   </item>
+                   <item>
+                    <property name="text">
+                     <string>Indented</string>
+                    </property>
+                   </item>
+                  </widget>
+                 </item>
+                 <item>
+                  <widget class="QLabel" name="labelLineWrapIndentationIndent">
+                   <property name="text">
+                    <string>Indent</string>
+                   </property>
+                  </widget>
+                 </item>
+                 <item>
+                  <widget class="QSpinBox" name="spinBoxLineWrapIndentationIndent">
+                   <property name="alignment">
+                    <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+                   </property>
+                  </widget>
+                 </item>
+                 <item>
+                  <spacer name="horizontalSpacer_26">
+                   <property name="orientation">
+                    <enum>Qt::Horizontal</enum>
+                   </property>
+                   <property name="sizeHint" stdset="0">
+                    <size>
+                     <width>40</width>
+                     <height>20</height>
+                    </size>
+                   </property>
+                  </spacer>
+                 </item>
+                </layout>
+               </item>
+               <item row="2" column="1">
+                <layout class="QHBoxLayout" name="horizontalLayout_23">
+                 <item>
+                  <widget class="QLabel" name="labelLineWrapVisualizationStart">
+                   <property name="text">
+                    <string>Start</string>
+                   </property>
+                  </widget>
+                 </item>
+                 <item>
+                  <widget class="QComboBox" name="comboBoxLineWrapVisualizationStart">
+                   <property name="sizePolicy">
+                    <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+                     <horstretch>0</horstretch>
+                     <verstretch>0</verstretch>
+                    </sizepolicy>
+                   </property>
+                   <item>
+                    <property name="text">
+                     <string>None</string>
+                    </property>
+                   </item>
+                   <item>
+                    <property name="text">
+                     <string>Text</string>
+                    </property>
+                   </item>
+                   <item>
+                    <property name="text">
+                     <string>Border</string>
+                    </property>
+                   </item>
+                   <item>
+                    <property name="text">
+                     <string>Margin</string>
+                    </property>
+                   </item>
+                  </widget>
+                 </item>
+                 <item>
+                  <widget class="QLabel" name="labelLineWrapVisualizationEnd">
+                   <property name="text">
+                    <string>End</string>
+                   </property>
+                  </widget>
+                 </item>
+                 <item>
+                  <widget class="QComboBox" name="comboBoxLineWrapVisualizationEnd">
+                   <property name="sizePolicy">
+                    <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+                     <horstretch>0</horstretch>
+                     <verstretch>0</verstretch>
+                    </sizepolicy>
+                   </property>
+                   <item>
+                    <property name="text">
+                     <string>None</string>
+                    </property>
+                   </item>
+                   <item>
+                    <property name="text">
+                     <string>Text</string>
+                    </property>
+                   </item>
+                   <item>
+                    <property name="text">
+                     <string>Border</string>
+                    </property>
+                   </item>
+                   <item>
+                    <property name="text">
+                     <string>Margin</string>
+                    </property>
+                   </item>
+                  </widget>
+                 </item>
+                 <item>
+                  <spacer name="horizontalSpacer_27">
+                   <property name="orientation">
+                    <enum>Qt::Horizontal</enum>
+                   </property>
+                   <property name="sizeHint" stdset="0">
+                    <size>
+                     <width>40</width>
+                     <height>20</height>
+                    </size>
+                   </property>
+                  </spacer>
+                 </item>
+                </layout>
+               </item>
+               <item row="0" column="0">
+                <layout class="QHBoxLayout" name="horizontalLayout_20">
+                 <item>
+                  <spacer name="horizontalSpacer_22">
+                   <property name="orientation">
+                    <enum>Qt::Horizontal</enum>
+                   </property>
+                   <property name="sizeHint" stdset="0">
+                    <size>
+                     <width>40</width>
+                     <height>20</height>
+                    </size>
+                   </property>
+                  </spacer>
+                 </item>
+                 <item>
+                  <widget class="QLabel" name="labelLineWrap">
+                   <property name="text">
+                    <string>Line wrap</string>
+                   </property>
+                  </widget>
+                 </item>
+                </layout>
+               </item>
+              </layout>
+             </widget>
+            </item>
+            <item row="3" column="0">
+             <widget class="QGroupBox" name="groupBoxDisplay">
+              <property name="title">
+               <string>Display</string>
+              </property>
+              <layout class="QGridLayout" name="gridLayout">
+               <item row="1" column="0">
+                <widget class="QCheckBox" name="checkBoxHighlightCurrentLine">
+                 <property name="text">
+                  <string>Highlight current line</string>
+                 </property>
+                </widget>
+               </item>
+               <item row="3" column="0">
+                <widget class="QCheckBox" name="checkBoxEnableLineNumbers">
+                 <property name="text">
+                  <string>Display Line Numbers</string>
+                 </property>
+                </widget>
+               </item>
+               <item row="2" column="0">
+                <widget class="QCheckBox" name="checkBoxEnableBraceMatching">
+                 <property name="text">
+                  <string>Enable brace matching</string>
+                 </property>
+                </widget>
+               </item>
+              </layout>
+             </widget>
+            </item>
+            <item row="0" column="0">
+             <layout class="QGridLayout" name="gridLayout_9">
+              <item row="0" column="0">
+               <layout class="QHBoxLayout" name="horizontalLayout_28">
+                <item>
+                 <spacer name="horizontalSpacer_29">
+                  <property name="orientation">
+                   <enum>Qt::Horizontal</enum>
+                  </property>
+                  <property name="sizeType">
+                   <enum>QSizePolicy::Expanding</enum>
+                  </property>
+                  <property name="sizeHint" stdset="0">
+                   <size>
+                    <width>30</width>
+                    <height>20</height>
+                   </size>
+                  </property>
+                 </spacer>
+                </item>
+                <item>
+                 <widget class="QLabel" name="label_3">
+                  <property name="text">
+                   <string>Font</string>
+                  </property>
+                  <property name="scaledContents">
+                   <bool>false</bool>
+                  </property>
+                 </widget>
+                </item>
+               </layout>
+              </item>
+              <item row="0" column="1">
+               <layout class="QHBoxLayout" name="horizontalLayout_5">
+                <item>
+                 <widget class="QFontComboBox" name="fontChooser">
+                  <property name="currentFont">
+                   <font>
+                    <family>DejaVu Sans</family>
+                    <pointsize>12</pointsize>
+                   </font>
+                  </property>
+                 </widget>
+                </item>
+                <item>
+                 <widget class="QComboBox" name="fontSize">
+                  <property name="editable">
+                   <bool>true</bool>
+                  </property>
+                 </widget>
+                </item>
+                <item>
+                 <spacer name="horizontalSpacer_5">
+                  <property name="orientation">
+                   <enum>Qt::Horizontal</enum>
+                  </property>
+                  <property name="sizeHint" stdset="0">
+                   <size>
+                    <width>40</width>
+                    <height>20</height>
+                   </size>
+                  </property>
+                 </spacer>
+                </item>
+               </layout>
+              </item>
+              <item row="1" column="0">
+               <layout class="QHBoxLayout" name="horizontalLayout_29">
+                <item>
+                 <spacer name="horizontalSpacer_30">
+                  <property name="orientation">
+                   <enum>Qt::Horizontal</enum>
+                  </property>
+                  <property name="sizeType">
+                   <enum>QSizePolicy::Expanding</enum>
+                  </property>
+                  <property name="sizeHint" stdset="0">
+                   <size>
+                    <width>30</width>
+                    <height>20</height>
+                   </size>
+                  </property>
+                 </spacer>
+                </item>
+                <item>
+                 <widget class="QLabel" name="labelColorSyntaxHighlighting">
+                  <property name="text">
+                   <string>Color syntax highlighting</string>
+                  </property>
+                 </widget>
+                </item>
+               </layout>
+              </item>
+              <item row="2" column="0">
+               <spacer name="horizontalSpacer_6">
+                <property name="orientation">
+                 <enum>Qt::Horizontal</enum>
+                </property>
+                <property name="sizeHint" stdset="0">
+                 <size>
+                  <width>198</width>
+                  <height>20</height>
+                 </size>
+                </property>
+               </spacer>
+              </item>
+              <item row="2" column="1">
+               <widget class="QCheckBox" name="mouseWheelZoomBox">
+                <property name="text">
+                 <string>Ctrl/Cmd-Mouse-wheel zooms text</string>
+                </property>
+               </widget>
+              </item>
+              <item row="1" column="1">
+               <layout class="QHBoxLayout" name="horizontalLayout_26">
+                <item>
+                 <widget class="QComboBox" name="syntaxHighlight">
+                  <property name="sizePolicy">
+                   <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+                    <horstretch>0</horstretch>
+                    <verstretch>0</verstretch>
+                   </sizepolicy>
+                  </property>
+                 </widget>
+                </item>
+                <item>
+                 <spacer name="horizontalSpacer_3">
+                  <property name="orientation">
+                   <enum>Qt::Horizontal</enum>
+                  </property>
+                  <property name="sizeType">
+                   <enum>QSizePolicy::Expanding</enum>
+                  </property>
+                  <property name="sizeHint" stdset="0">
+                   <size>
+                    <width>30</width>
+                    <height>20</height>
+                   </size>
+                  </property>
+                 </spacer>
+                </item>
+               </layout>
+              </item>
+             </layout>
+            </item>
             <item row="1" column="0">
              <widget class="QGroupBox" name="groupBoxIndentation">
               <property name="title">
@@ -485,576 +1081,6 @@
                     </size>
                    </property>
                   </spacer>
-                 </item>
-                </layout>
-               </item>
-              </layout>
-             </widget>
-            </item>
-            <item row="3" column="0">
-             <widget class="QGroupBox" name="groupBoxDisplay">
-              <property name="title">
-               <string>Display</string>
-              </property>
-              <layout class="QGridLayout" name="gridLayout">
-               <item row="1" column="0">
-                <widget class="QCheckBox" name="checkBoxHighlightCurrentLine">
-                 <property name="text">
-                  <string>Highlight current line</string>
-                 </property>
-                </widget>
-               </item>
-               <item row="3" column="0">
-                <widget class="QCheckBox" name="checkBoxEnableLineNumbers">
-                 <property name="text">
-                  <string>Display Line Numbers</string>
-                 </property>
-                </widget>
-               </item>
-               <item row="2" column="0">
-                <widget class="QCheckBox" name="checkBoxEnableBraceMatching">
-                 <property name="text">
-                  <string>Enable brace matching</string>
-                 </property>
-                </widget>
-               </item>
-              </layout>
-             </widget>
-            </item>
-            <item row="6" column="0">
-             <spacer name="verticalSpacer_2">
-              <property name="orientation">
-               <enum>Qt::Vertical</enum>
-              </property>
-              <property name="sizeHint" stdset="0">
-               <size>
-                <width>20</width>
-                <height>40</height>
-               </size>
-              </property>
-             </spacer>
-            </item>
-            <item row="2" column="0">
-             <widget class="QGroupBox" name="groupBoxLineWrap">
-              <property name="title">
-               <string>Line wrap</string>
-              </property>
-              <layout class="QGridLayout" name="gridLayout_4">
-               <item row="0" column="1">
-                <layout class="QHBoxLayout" name="horizontalLayout_25">
-                 <item>
-                  <widget class="QComboBox" name="comboBoxLineWrap">
-                   <item>
-                    <property name="text">
-                     <string>None</string>
-                    </property>
-                   </item>
-                   <item>
-                    <property name="text">
-                     <string>Wrap at character boundaries</string>
-                    </property>
-                   </item>
-                   <item>
-                    <property name="text">
-                     <string>Wrap at word boundaries</string>
-                    </property>
-                   </item>
-                  </widget>
-                 </item>
-                 <item>
-                  <spacer name="horizontalSpacer_25">
-                   <property name="orientation">
-                    <enum>Qt::Horizontal</enum>
-                   </property>
-                   <property name="sizeHint" stdset="0">
-                    <size>
-                     <width>40</width>
-                     <height>20</height>
-                    </size>
-                   </property>
-                  </spacer>
-                 </item>
-                </layout>
-               </item>
-               <item row="1" column="0">
-                <layout class="QHBoxLayout" name="horizontalLayout_21">
-                 <item>
-                  <spacer name="horizontalSpacer_23">
-                   <property name="orientation">
-                    <enum>Qt::Horizontal</enum>
-                   </property>
-                   <property name="sizeHint" stdset="0">
-                    <size>
-                     <width>40</width>
-                     <height>20</height>
-                    </size>
-                   </property>
-                  </spacer>
-                 </item>
-                 <item>
-                  <widget class="QLabel" name="labelLineWrapIndentation">
-                   <property name="text">
-                    <string>Line wrap indentation</string>
-                   </property>
-                  </widget>
-                 </item>
-                </layout>
-               </item>
-               <item row="2" column="0">
-                <layout class="QHBoxLayout" name="horizontalLayout_22">
-                 <item>
-                  <spacer name="horizontalSpacer_24">
-                   <property name="orientation">
-                    <enum>Qt::Horizontal</enum>
-                   </property>
-                   <property name="sizeHint" stdset="0">
-                    <size>
-                     <width>40</width>
-                     <height>20</height>
-                    </size>
-                   </property>
-                  </spacer>
-                 </item>
-                 <item>
-                  <widget class="QLabel" name="labelLineWrapVisualization">
-                   <property name="text">
-                    <string>Line wrap visualization</string>
-                   </property>
-                  </widget>
-                 </item>
-                </layout>
-               </item>
-               <item row="1" column="1">
-                <layout class="QHBoxLayout" name="horizontalLayout_24">
-                 <item>
-                  <widget class="QLabel" name="labelLineWrapIndentationStyle">
-                   <property name="text">
-                    <string>Style</string>
-                   </property>
-                  </widget>
-                 </item>
-                 <item>
-                  <widget class="QComboBox" name="comboBoxLineWrapIndentationStyle">
-                   <item>
-                    <property name="text">
-                     <string>Fixed</string>
-                    </property>
-                   </item>
-                   <item>
-                    <property name="text">
-                     <string>Same</string>
-                    </property>
-                   </item>
-                   <item>
-                    <property name="text">
-                     <string>Indented</string>
-                    </property>
-                   </item>
-                  </widget>
-                 </item>
-                 <item>
-                  <widget class="QLabel" name="labelLineWrapIndentationIndent">
-                   <property name="text">
-                    <string>Indent</string>
-                   </property>
-                  </widget>
-                 </item>
-                 <item>
-                  <widget class="QSpinBox" name="spinBoxLineWrapIndentationIndent">
-                   <property name="alignment">
-                    <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-                   </property>
-                  </widget>
-                 </item>
-                 <item>
-                  <spacer name="horizontalSpacer_26">
-                   <property name="orientation">
-                    <enum>Qt::Horizontal</enum>
-                   </property>
-                   <property name="sizeHint" stdset="0">
-                    <size>
-                     <width>40</width>
-                     <height>20</height>
-                    </size>
-                   </property>
-                  </spacer>
-                 </item>
-                </layout>
-               </item>
-               <item row="2" column="1">
-                <layout class="QHBoxLayout" name="horizontalLayout_23">
-                 <item>
-                  <widget class="QLabel" name="labelLineWrapVisualizationStart">
-                   <property name="text">
-                    <string>Start</string>
-                   </property>
-                  </widget>
-                 </item>
-                 <item>
-                  <widget class="QComboBox" name="comboBoxLineWrapVisualizationStart">
-                   <property name="sizePolicy">
-                    <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
-                     <horstretch>0</horstretch>
-                     <verstretch>0</verstretch>
-                    </sizepolicy>
-                   </property>
-                   <item>
-                    <property name="text">
-                     <string>None</string>
-                    </property>
-                   </item>
-                   <item>
-                    <property name="text">
-                     <string>Text</string>
-                    </property>
-                   </item>
-                   <item>
-                    <property name="text">
-                     <string>Border</string>
-                    </property>
-                   </item>
-                   <item>
-                    <property name="text">
-                     <string>Margin</string>
-                    </property>
-                   </item>
-                  </widget>
-                 </item>
-                 <item>
-                  <widget class="QLabel" name="labelLineWrapVisualizationEnd">
-                   <property name="text">
-                    <string>End</string>
-                   </property>
-                  </widget>
-                 </item>
-                 <item>
-                  <widget class="QComboBox" name="comboBoxLineWrapVisualizationEnd">
-                   <property name="sizePolicy">
-                    <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
-                     <horstretch>0</horstretch>
-                     <verstretch>0</verstretch>
-                    </sizepolicy>
-                   </property>
-                   <item>
-                    <property name="text">
-                     <string>None</string>
-                    </property>
-                   </item>
-                   <item>
-                    <property name="text">
-                     <string>Text</string>
-                    </property>
-                   </item>
-                   <item>
-                    <property name="text">
-                     <string>Border</string>
-                    </property>
-                   </item>
-                   <item>
-                    <property name="text">
-                     <string>Margin</string>
-                    </property>
-                   </item>
-                  </widget>
-                 </item>
-                 <item>
-                  <spacer name="horizontalSpacer_27">
-                   <property name="orientation">
-                    <enum>Qt::Horizontal</enum>
-                   </property>
-                   <property name="sizeHint" stdset="0">
-                    <size>
-                     <width>40</width>
-                     <height>20</height>
-                    </size>
-                   </property>
-                  </spacer>
-                 </item>
-                </layout>
-               </item>
-               <item row="0" column="0">
-                <layout class="QHBoxLayout" name="horizontalLayout_20">
-                 <item>
-                  <spacer name="horizontalSpacer_22">
-                   <property name="orientation">
-                    <enum>Qt::Horizontal</enum>
-                   </property>
-                   <property name="sizeHint" stdset="0">
-                    <size>
-                     <width>40</width>
-                     <height>20</height>
-                    </size>
-                   </property>
-                  </spacer>
-                 </item>
-                 <item>
-                  <widget class="QLabel" name="labelLineWrap">
-                   <property name="text">
-                    <string>Line wrap</string>
-                   </property>
-                  </widget>
-                 </item>
-                </layout>
-               </item>
-              </layout>
-             </widget>
-            </item>
-            <item row="0" column="1">
-             <spacer name="horizontalSpacer_4">
-              <property name="orientation">
-               <enum>Qt::Horizontal</enum>
-              </property>
-              <property name="sizeHint" stdset="0">
-               <size>
-                <width>40</width>
-                <height>20</height>
-               </size>
-              </property>
-             </spacer>
-            </item>
-            <item row="0" column="0">
-             <layout class="QGridLayout" name="gridLayout_9">
-              <item row="0" column="0">
-               <layout class="QHBoxLayout" name="horizontalLayout_28">
-                <item>
-                 <spacer name="horizontalSpacer_29">
-                  <property name="orientation">
-                   <enum>Qt::Horizontal</enum>
-                  </property>
-                  <property name="sizeType">
-                   <enum>QSizePolicy::Expanding</enum>
-                  </property>
-                  <property name="sizeHint" stdset="0">
-                   <size>
-                    <width>30</width>
-                    <height>20</height>
-                   </size>
-                  </property>
-                 </spacer>
-                </item>
-                <item>
-                 <widget class="QLabel" name="label_3">
-                  <property name="text">
-                   <string>Font</string>
-                  </property>
-                  <property name="scaledContents">
-                   <bool>false</bool>
-                  </property>
-                 </widget>
-                </item>
-               </layout>
-              </item>
-              <item row="0" column="1">
-               <layout class="QHBoxLayout" name="horizontalLayout_5">
-                <item>
-                 <widget class="QFontComboBox" name="fontChooser">
-                  <property name="currentFont">
-                   <font>
-                    <family>DejaVu Sans</family>
-                    <pointsize>12</pointsize>
-                   </font>
-                  </property>
-                 </widget>
-                </item>
-                <item>
-                 <widget class="QComboBox" name="fontSize">
-                  <property name="editable">
-                   <bool>true</bool>
-                  </property>
-                 </widget>
-                </item>
-                <item>
-                 <spacer name="horizontalSpacer_5">
-                  <property name="orientation">
-                   <enum>Qt::Horizontal</enum>
-                  </property>
-                  <property name="sizeHint" stdset="0">
-                   <size>
-                    <width>40</width>
-                    <height>20</height>
-                   </size>
-                  </property>
-                 </spacer>
-                </item>
-               </layout>
-              </item>
-              <item row="1" column="0">
-               <layout class="QHBoxLayout" name="horizontalLayout_29">
-                <item>
-                 <spacer name="horizontalSpacer_30">
-                  <property name="orientation">
-                   <enum>Qt::Horizontal</enum>
-                  </property>
-                  <property name="sizeType">
-                   <enum>QSizePolicy::Expanding</enum>
-                  </property>
-                  <property name="sizeHint" stdset="0">
-                   <size>
-                    <width>30</width>
-                    <height>20</height>
-                   </size>
-                  </property>
-                 </spacer>
-                </item>
-                <item>
-                 <widget class="QLabel" name="labelColorSyntaxHighlighting">
-                  <property name="text">
-                   <string>Color syntax highlighting</string>
-                  </property>
-                 </widget>
-                </item>
-               </layout>
-              </item>
-              <item row="2" column="0">
-               <spacer name="horizontalSpacer_6">
-                <property name="orientation">
-                 <enum>Qt::Horizontal</enum>
-                </property>
-                <property name="sizeHint" stdset="0">
-                 <size>
-                  <width>198</width>
-                  <height>20</height>
-                 </size>
-                </property>
-               </spacer>
-              </item>
-              <item row="2" column="1">
-               <widget class="QCheckBox" name="mouseWheelZoomBox">
-                <property name="text">
-                 <string>Ctrl/Cmd-Mouse-wheel zooms text</string>
-                </property>
-               </widget>
-              </item>
-              <item row="1" column="1">
-               <layout class="QHBoxLayout" name="horizontalLayout_26">
-                <item>
-                 <widget class="QComboBox" name="syntaxHighlight">
-                  <property name="sizePolicy">
-                   <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
-                    <horstretch>0</horstretch>
-                    <verstretch>0</verstretch>
-                   </sizepolicy>
-                  </property>
-                 </widget>
-                </item>
-                <item>
-                 <spacer name="horizontalSpacer_3">
-                  <property name="orientation">
-                   <enum>Qt::Horizontal</enum>
-                  </property>
-                  <property name="sizeType">
-                   <enum>QSizePolicy::Expanding</enum>
-                  </property>
-                  <property name="sizeHint" stdset="0">
-                   <size>
-                    <width>30</width>
-                    <height>20</height>
-                   </size>
-                  </property>
-                 </spacer>
-                </item>
-               </layout>
-              </item>
-             </layout>
-            </item>
-            <item row="4" column="0">
-             <widget class="QGroupBox" name="groupBoxNumberScroll">
-              <property name="title">
-               <string>Number Scroll</string>
-              </property>
-              <layout class="QGridLayout" name="gridLayout_8">
-               <item row="0" column="0">
-                <widget class="QLabel" name="labelStepSize">
-                 <property name="text">
-                  <string>Step Size</string>
-                 </property>
-                </widget>
-               </item>
-               <item row="0" column="2">
-                <widget class="QLineEdit" name="lineEditStepSize"/>
-               </item>
-               <item row="0" column="5">
-                <spacer name="horizontalSpacer_28">
-                 <property name="orientation">
-                  <enum>Qt::Horizontal</enum>
-                 </property>
-                 <property name="sizeHint" stdset="0">
-                  <size>
-                   <width>40</width>
-                   <height>20</height>
-                  </size>
-                 </property>
-                </spacer>
-               </item>
-               <item row="0" column="4">
-                <spacer name="horizontalSpacer_33">
-                 <property name="orientation">
-                  <enum>Qt::Horizontal</enum>
-                 </property>
-                 <property name="sizeHint" stdset="0">
-                  <size>
-                   <width>40</width>
-                   <height>20</height>
-                  </size>
-                 </property>
-                </spacer>
-               </item>
-               <item row="0" column="1">
-                <spacer name="horizontalSpacer_7">
-                 <property name="orientation">
-                  <enum>Qt::Horizontal</enum>
-                 </property>
-                 <property name="sizeHint" stdset="0">
-                  <size>
-                   <width>40</width>
-                   <height>20</height>
-                  </size>
-                 </property>
-                </spacer>
-               </item>
-               <item row="0" column="3">
-                <spacer name="horizontalSpacer_34">
-                 <property name="orientation">
-                  <enum>Qt::Horizontal</enum>
-                 </property>
-                 <property name="sizeHint" stdset="0">
-                  <size>
-                   <width>40</width>
-                   <height>20</height>
-                  </size>
-                 </property>
-                </spacer>
-               </item>
-              </layout>
-             </widget>
-            </item>
-            <item row="5" column="0">
-             <widget class="QGroupBox" name="groupBoxAutocomplete">
-              <property name="title">
-               <string>Autocomplete</string>
-              </property>
-              <layout class="QGridLayout" name="gridLayout1">
-               <property name="rightMargin">
-                <number>9</number>
-               </property>
-               <item row="0" column="0">
-                <widget class="QCheckBox" name="checkBoxEnableAutocomplete">
-                 <property name="text">
-                  <string>Enable Autocompletion</string>
-                 </property>
-                </widget>
-               </item>
-               <item row="1" column="0">
-                <layout class="QHBoxLayout" name="horizontalLayout_30">
-                 <item>
-                  <widget class="QLabel" name="labelCharacterThreshold">
-                   <property name="text">
-                    <string>Character Threshold</string>
-                   </property>
-                  </widget>
-                 </item>
-                 <item>
-                  <widget class="QLineEdit" name="lineEditCharacterThreshold"/>
                  </item>
                 </layout>
                </item>
@@ -1582,7 +1608,7 @@
             <rect>
              <x>0</x>
              <y>0</y>
-             <width>602</width>
+             <width>548</width>
              <height>747</height>
             </rect>
            </property>

--- a/src/Preferences.ui
+++ b/src/Preferences.ui
@@ -135,7 +135,7 @@
            <property name="geometry">
             <rect>
              <x>0</x>
-             <y>-421</y>
+             <y>-450</y>
              <width>602</width>
              <height>901</height>
             </rect>
@@ -200,7 +200,7 @@
                  </item>
                  <item>
                   <property name="text">
-                   <string>Both</string>
+                   <string>Either</string>
                   </property>
                  </item>
                 </widget>

--- a/src/scintillaeditor.cpp
+++ b/src/scintillaeditor.cpp
@@ -1098,9 +1098,9 @@ bool ScintillaEditor::modifyNumber(int key)
 
 	auto begin=QRegExp("[-+]?\\d*\\.?\\d*$").indexIn(text.left(index));
 
-	QRegExp rx("[\(=]");
+	QRegExp rx("[a-df-zA-DF-Z]");
 	auto check = text.mid(begin-1,1);
-	if( !rx.exactMatch(check)) return false;
+	if(rx.exactMatch(check)) return false;
 	
 	auto end=text.indexOf(QRegExp("[^0-9.]"),index);
 	if (end<0) end=text.length();

--- a/src/scintillaeditor.cpp
+++ b/src/scintillaeditor.cpp
@@ -1093,7 +1093,7 @@ bool ScintillaEditor::modifyNumber(int key)
 	auto number=(dotpos<0)?nr.toLongLong():(nr.left(dotpos)+nr.mid(dotpos+1)).toLongLong();
 	auto tail=nr.length()-curpos;
 	auto exponent=tail-((dotpos>=curpos)?1:0);
-	long long int step=1;
+	long long int step=Preferences::inst()->getValue("editor/stepSize").toInt();
 	for (int i=exponent; i>0; i--) step*=10;
 
 	switch (key) {

--- a/src/scintillaeditor.cpp
+++ b/src/scintillaeditor.cpp
@@ -784,7 +784,9 @@ QString ScintillaEditor::selectedText()
 
 bool ScintillaEditor::eventFilter(QObject *obj, QEvent *e)
 {
-	if(obj == qsci->viewport())
+	bool enableNumberScrollWheel = Settings::Settings::inst()->get(Settings::Settings::enableNumberScrollWheel).toBool();
+	
+	if(obj == qsci->viewport() && enableNumberScrollWheel)
 	{
 		if(e->type() == QEvent::Wheel)
 		{

--- a/src/scintillaeditor.cpp
+++ b/src/scintillaeditor.cpp
@@ -988,10 +988,25 @@ bool ScintillaEditor::handleKeyEventNavigateNumber(QKeyEvent *keyEvent)
 
 bool ScintillaEditor::handleWheelEventNavigateNumber (QWheelEvent *wheelEvent)
 {
+	auto modifierNumberScrollWheel = Settings::Settings::inst()->get(Settings::Settings::modifierNumberScrollWheel).toString();
+	bool modifier;	
 	static bool wasChanged = false;
 	static bool previewAfterUndo = false;
 
-	if ((wheelEvent->buttons() & Qt::LeftButton) | (wheelEvent->modifiers() & Qt::AltModifier))
+	if(modifierNumberScrollWheel=="Alt")
+	{
+		modifier = wheelEvent->modifiers() & Qt::AltModifier;
+	}
+	else if(modifierNumberScrollWheel=="Left Mouse Button")
+	{
+		modifier = wheelEvent->buttons() & Qt::LeftButton;
+	}
+	else
+	{
+		modifier = (wheelEvent->buttons() & Qt::LeftButton) | (wheelEvent->modifiers() & Qt::AltModifier);	
+	}
+
+	if (modifier)
 	 {
 		if (!wasChanged) qsci->beginUndoAction();
 

--- a/src/scintillaeditor.cpp
+++ b/src/scintillaeditor.cpp
@@ -785,15 +785,16 @@ bool ScintillaEditor::eventFilter(QObject *obj, QEvent *e)
 {
 	if (obj != qsci) return EditorInterface::eventFilter(obj, e);
 
-	if(e->type() == QEvent::Wheel)
+    if(e->type() == QEvent::Wheel)
 	{
 		auto *wheelEvent = static_cast <QWheelEvent*> (e);
+        PRINTDB("%s - modifier: %s",(e->type()==QEvent::Wheel?"Wheel Event":"")%(wheelEvent->buttons() & Qt::LeftButton?"Left":"Other Button"));
 		if(handleWheelEventNavigateNumber(wheelEvent)){
 			return true;
 		}
 	}
 
-	else if (e->type() == QEvent::KeyPress || e->type() == QEvent::KeyRelease) {
+    else if (e->type() == QEvent::KeyPress || e->type() == QEvent::KeyRelease) {
 		auto *keyEvent = static_cast<QKeyEvent*> (e);
 
 		PRINTDB("%10s - modifiers: %s %s %s %s %s %s",
@@ -974,7 +975,7 @@ bool ScintillaEditor::handleWheelEventNavigateNumber (QWheelEvent *wheelEvent)
 	static bool wasChanged = false;
 	static bool previewAfterUndo = false;
 
-	if ((wheelEvent->modifiers() & Qt::AltModifier))
+    if ((wheelEvent->buttons() & Qt::LeftButton))
 	 {
 		if (!wasChanged) qsci->beginUndoAction();
 
@@ -1002,7 +1003,7 @@ bool ScintillaEditor::handleWheelEventNavigateNumber (QWheelEvent *wheelEvent)
 
 	if (previewAfterUndo)
 	{
-		int k = wheelEvent->modifiers() & Qt::AltModifier;
+        int k = wheelEvent->buttons() & Qt::LeftButton;
 		if (wasChanged) qsci->endUndoAction();
 		wasChanged = false;
 		auto *cmd = qsci->standardCommands()->boundTo(k);

--- a/src/scintillaeditor.cpp
+++ b/src/scintillaeditor.cpp
@@ -785,16 +785,17 @@ bool ScintillaEditor::eventFilter(QObject *obj, QEvent *e)
 {
 	if (obj != qsci) return EditorInterface::eventFilter(obj, e);
 
-    if(e->type() == QEvent::Wheel)
+	if(e->type() == QEvent::Wheel)
 	{
 		auto *wheelEvent = static_cast <QWheelEvent*> (e);
-        PRINTDB("%s - modifier: %s",(e->type()==QEvent::Wheel?"Wheel Event":"")%(wheelEvent->buttons() & Qt::LeftButton?"Left":"Other Button"));
-		if(handleWheelEventNavigateNumber(wheelEvent)){
+		PRINTDB("%s - modifier: %s",(e->type()==QEvent::Wheel?"Wheel Event":"")%(wheelEvent->buttons() & Qt::LeftButton?"Left":"Other Button"));
+		if(handleWheelEventNavigateNumber(wheelEvent))
+		{
 			return true;
 		}
 	}
 
-    else if (e->type() == QEvent::KeyPress || e->type() == QEvent::KeyRelease) {
+	else if (e->type() == QEvent::KeyPress || e->type() == QEvent::KeyRelease) {
 		auto *keyEvent = static_cast<QKeyEvent*> (e);
 
 		PRINTDB("%10s - modifiers: %s %s %s %s %s %s",
@@ -977,6 +978,9 @@ bool ScintillaEditor::handleWheelEventNavigateNumber (QWheelEvent *wheelEvent)
 
     if ((wheelEvent->buttons() & Qt::LeftButton))
 	 {
+		QPoint numDegrees = wheelEvent->angleDelta();
+		PRINTDB("Angle delta: %d",(numDegrees.y()/8));
+
 		if (!wasChanged) qsci->beginUndoAction();
 
 		if (wheelEvent->delta() < 0)

--- a/src/scintillaeditor.cpp
+++ b/src/scintillaeditor.cpp
@@ -789,7 +789,7 @@ bool ScintillaEditor::eventFilter(QObject *obj, QEvent *e)
 		if(e->type() == QEvent::Wheel)
 		{
 			auto *wheelEvent = static_cast <QWheelEvent*> (e);
-			PRINTDB("%s - modifier: %s",(e->type()==QEvent::Wheel?"Wheel Event":"")%(wheelEvent->buttons() & Qt::LeftButton?"Left":"Other Button"));
+			PRINTDB("%s - modifier: %s",(e->type()==QEvent::Wheel?"Wheel Event":"")%(wheelEvent->modifiers() & Qt::AltModifier?"Alt":"Other Button"));
 			if(handleWheelEventNavigateNumber(wheelEvent))
 			{
 				return true;
@@ -988,11 +988,8 @@ bool ScintillaEditor::handleWheelEventNavigateNumber (QWheelEvent *wheelEvent)
 	static bool wasChanged = false;
 	static bool previewAfterUndo = false;
 
-    if ((wheelEvent->buttons() & Qt::LeftButton))
+    if ((wheelEvent->modifiers() & Qt::AltModifier))
 	 {
-		QPoint numDegrees = wheelEvent->angleDelta();
-		PRINTDB("Angle delta: %d",(numDegrees.y()/8));
-
 		if (!wasChanged) qsci->beginUndoAction();
 
 		if (wheelEvent->delta() < 0)

--- a/src/scintillaeditor.cpp
+++ b/src/scintillaeditor.cpp
@@ -978,7 +978,6 @@ bool ScintillaEditor::handleWheelEventNavigateNumber (QWheelEvent *wheelEvent)
 	if ((wheelEvent->modifiers() && Qt::AltModifier))
 	 {
 		 	std::cout<<wheelEvent->x()<<" These are the positions"<<wheelEvent->y()<<std::endl;
-			// std::cout<<wheelEvent->delta()<<"****\n";
 			if (!wasChanged) qsci->beginUndoAction();
 
 			if (wheelEvent->delta() < 0) {
@@ -988,16 +987,14 @@ bool ScintillaEditor::handleWheelEventNavigateNumber (QWheelEvent *wheelEvent)
 					previewAfterUndo = true;
 				}
 
-				// std::cout << "Value will be increased\n";
 		}
 		else if (wheelEvent->delta() > 0) {
-			//decrease value
+				//decrease value
 			if (modifyNumberByWheel(-1)) {
 				wasChanged = true;
 				previewAfterUndo = true;
 			}
 
-			// std::cout << "Value will be decreased\n";
 		}
 
 		if (!wasChanged) qsci->endUndoAction();

--- a/src/scintillaeditor.cpp
+++ b/src/scintillaeditor.cpp
@@ -975,40 +975,41 @@ bool ScintillaEditor::handleWheelEventNavigateNumber (QWheelEvent *wheelEvent)
 	static bool wasChanged = false;
 	static bool previewAfterUndo = false;
 
-	if ((wheelEvent->modifiers() && Qt::AltModifier))
+	if ((wheelEvent->modifiers() & Qt::AltModifier))
 	 {
-		 	std::cout<<wheelEvent->x()<<" These are the positions"<<wheelEvent->y()<<std::endl;
-			if (!wasChanged) qsci->beginUndoAction();
+		if (!wasChanged) qsci->beginUndoAction();
 
-			if (wheelEvent->delta() < 0) {
-				// increase value
-				if (modifyNumberByWheel(1)) {
-					wasChanged = true;
-					previewAfterUndo = true;
-				}
-
-		}
-		else if (wheelEvent->delta() > 0) {
-				//decrease value
-			if (modifyNumberByWheel(-1)) {
+		if (wheelEvent->delta() < 0)
+		{
+			// increase value
+			if (modifyNumber(Qt::Key_Up)) 
+			{
 				wasChanged = true;
 				previewAfterUndo = true;
 			}
-
 		}
-
+		else if (wheelEvent->delta() > 0)
+		{
+			//decrease value
+			if (modifyNumber(Qt::Key_Down))
+			{
+				wasChanged = true;
+				previewAfterUndo = true;
+			}
+		}
 		if (!wasChanged) qsci->endUndoAction();
 	}
 
-	
-	if (previewAfterUndo) {
-		int k = wheelEvent->modifiers() && Qt::AltModifier;
+	if (previewAfterUndo)
+	{
+		int k = wheelEvent->modifiers() & Qt::AltModifier;
 		if (wasChanged) qsci->endUndoAction();
 		wasChanged = false;
 		auto *cmd = qsci->standardCommands()->boundTo(k);
 		if (cmd && (cmd->command() == QsciCommand::Undo || cmd->command() == QsciCommand::Redo))
 			QTimer::singleShot(0, this, SIGNAL(previewRequest()));
-		else if (cmd || !wheelEvent->delta()) {
+		else if (cmd || !wheelEvent->delta())
+		{
 			// any insert or command (but not undo/redo) cancels the preview after undo
 			previewAfterUndo = false;
 		}
@@ -1106,65 +1107,6 @@ bool ScintillaEditor::modifyNumber(int key)
 	emit previewRequest();
 	return true;
 }
-
-
-bool ScintillaEditor::modifyNumberByWheel(int key)
-{
-	int line, index;
-	qsci->getCursorPosition(&line, &index);
-	auto text=qsci->text(line);
-
-	int lineFrom, indexFrom, lineTo, indexTo;
-	qsci->getSelection(&lineFrom, &indexFrom, &lineTo, &indexTo);
-	auto hadSelection=qsci->hasSelectedText();
-
-	auto begin=QRegExp("[-+]?\\d*\\.?\\d*$").indexIn(text.left(index));
-	auto end=text.indexOf(QRegExp("[^0-9.]"),index);
-	if (end<0) end=text.length();
-	auto nr=text.mid(begin,end-begin);
-	if ( !(nr.contains(QRegExp("^[-+]?\\d*\\.?\\d*$")) && nr.contains(QRegExp("\\d"))) ) return false;
-	auto sign=nr[0]=='+'||nr[0]=='-';
-	if (nr.endsWith('.')) nr=nr.left(nr.length()-1);
-	auto curpos=index-begin;
-	auto dotpos=nr.indexOf('.');
-	auto decimals=dotpos<0?0:nr.length()-dotpos-1;
-	auto number=(dotpos<0)?nr.toLongLong():(nr.left(dotpos)+nr.mid(dotpos+1)).toLongLong();
-	auto tail=nr.length()-curpos;
-	auto exponent=tail-((dotpos>=curpos)?1:0);
-	long long int step;
-	for (int i=exponent; i>0; i--) step*=10;
-
-	switch (key) {
-		case 1:   step=1; break;
-		case 2: step=(-1); break;
-	}
-	number+=step;
-	auto negative=number<0;
-	if (negative) number=-number;
-	auto newnr=QString::number(number);
-	if (decimals) {
-		if (newnr.length()<=decimals) newnr.prepend(QString(decimals-newnr.length()+1,'0'));
-		newnr=newnr.left(newnr.length()-decimals)+"."+newnr.right(decimals);
-	}
-	if (tail>newnr.length()) {
-		newnr.prepend(QString(tail-newnr.length(),'0'));
-	}
-	if (negative) newnr.prepend('-');
-	else if (sign) newnr.prepend('+');
-	qsci->setSelection(line, begin, line, end);
-	qsci->replaceSelectedText(newnr);
-
-	qsci->selectAll(false);
-	if (hadSelection)
-	{
-		qsci->setSelection(lineFrom, indexFrom, lineTo, indexTo);
-	}
-	qsci->setCursorPosition(line, begin+newnr.length()-tail);
-	emit previewRequest();
-	return true;
-}
-
-
 
 void ScintillaEditor::onUserListSelected(const int, const QString &text)
 {

--- a/src/scintillaeditor.cpp
+++ b/src/scintillaeditor.cpp
@@ -1098,10 +1098,10 @@ bool ScintillaEditor::modifyNumber(int key)
 
 	auto begin=QRegExp("[-+]?\\d*\\.?\\d*$").indexIn(text.left(index));
 
-	QRegExp rx("[a-df-zA-DF-Z]");
+	QRegExp rx("[_a-zA-Z]");
 	auto check = text.mid(begin-1,1);
 	if(rx.exactMatch(check)) return false;
-	
+
 	auto end=text.indexOf(QRegExp("[^0-9.]"),index);
 	if (end<0) end=text.length();
 	auto nr=text.mid(begin,end-begin);
@@ -1117,7 +1117,7 @@ bool ScintillaEditor::modifyNumber(int key)
 	auto exponent=tail-((dotpos>=curpos)?1:0);
 	long long int step=Preferences::inst()->getValue("editor/stepSize").toInt();
 	for (int i=exponent; i>0; i--) step*=10;
-
+	
 	switch (key) {
 		case Qt::Key_Up:   number+=step; break;
 		case Qt::Key_Down: number-=step; break;

--- a/src/scintillaeditor.cpp
+++ b/src/scintillaeditor.cpp
@@ -1098,13 +1098,19 @@ bool ScintillaEditor::modifyNumber(int key)
 	auto hadSelection=qsci->hasSelectedText();
 
 	auto begin=QRegExp("[-+]?\\d*\\.?\\d*$").indexIn(text.left(index));
+
+	QRegExp rx("[\(=]");
+	auto check = text.mid(begin-1,1);
+	if( !rx.exactMatch(check)) return false;
+	
 	auto end=text.indexOf(QRegExp("[^0-9.]"),index);
 	if (end<0) end=text.length();
 	auto nr=text.mid(begin,end-begin);
-	if ( !(nr.contains(QRegExp("^[-+]?\\d*\\.?\\d*$")) && nr.contains(QRegExp("\\d"))) ) return false;
+	if ( !(nr.contains(QRegExp("^[-+]?\\d*\\.?\\d+$")) && nr.contains(QRegExp("\\d"))) ) return false;
 	auto sign=nr[0]=='+'||nr[0]=='-';
 	if (nr.endsWith('.')) nr=nr.left(nr.length()-1);
 	auto curpos=index-begin;
+	if(curpos==0) return false;
 	auto dotpos=nr.indexOf('.');
 	auto decimals=dotpos<0?0:nr.length()-dotpos-1;
 	auto number=(dotpos<0)?nr.toLongLong():(nr.left(dotpos)+nr.mid(dotpos+1)).toLongLong();

--- a/src/scintillaeditor.cpp
+++ b/src/scintillaeditor.cpp
@@ -808,7 +808,6 @@ bool ScintillaEditor::eventFilter(QObject *obj, QEvent *e)
 		if (handleKeyEventNavigateNumber(keyEvent)) {
 			return true;
 		}
-
 		if (handleKeyEventBlockCopy(keyEvent)) {
 			return true;
 		}
@@ -981,23 +980,24 @@ bool ScintillaEditor::handleWheelEventNavigateNumber (QWheelEvent *wheelEvent)
 
 		if (wheelEvent->delta() < 0)
 		{
-			// increase value
-			if (modifyNumber(Qt::Key_Up)) 
+			if (modifyNumber(Qt::Key_Down)) 
 			{
 				wasChanged = true;
 				previewAfterUndo = true;
 			}
 		}
-		else if (wheelEvent->delta() > 0)
+		else
 		{
-			//decrease value
-			if (modifyNumber(Qt::Key_Down))
+			// wheelEvent->delta() > 0
+			if (modifyNumber(Qt::Key_Up))
 			{
 				wasChanged = true;
 				previewAfterUndo = true;
 			}
 		}
 		if (!wasChanged) qsci->endUndoAction();
+
+		return true;
 	}
 
 	if (previewAfterUndo)
@@ -1008,7 +1008,7 @@ bool ScintillaEditor::handleWheelEventNavigateNumber (QWheelEvent *wheelEvent)
 		auto *cmd = qsci->standardCommands()->boundTo(k);
 		if (cmd && (cmd->command() == QsciCommand::Undo || cmd->command() == QsciCommand::Redo))
 			QTimer::singleShot(0, this, SIGNAL(previewRequest()));
-		else if (cmd || !wheelEvent->delta())
+		else if (cmd || wheelEvent->delta())
 		{
 			// any insert or command (but not undo/redo) cancels the preview after undo
 			previewAfterUndo = false;

--- a/src/scintillaeditor.cpp
+++ b/src/scintillaeditor.cpp
@@ -788,12 +788,15 @@ bool ScintillaEditor::eventFilter(QObject *obj, QEvent *e)
 	{
 		if(e->type() == QEvent::Wheel)
 		{
+			qsci->SendScintilla(QsciScintilla::SCI_SETCARETWIDTH, 0);
 			auto *wheelEvent = static_cast <QWheelEvent*> (e);
 			PRINTDB("%s - modifier: %s",(e->type()==QEvent::Wheel?"Wheel Event":"")%(wheelEvent->modifiers() & Qt::AltModifier?"Alt":"Other Button"));
 			if(handleWheelEventNavigateNumber(wheelEvent))
 			{
+				qsci->SendScintilla(QsciScintilla::SCI_SETCARETWIDTH, 1);
 				return true;
 			}
+			qsci->SendScintilla(QsciScintilla::SCI_SETCARETWIDTH, 1);
 		}
 		return false;
 	}
@@ -988,7 +991,7 @@ bool ScintillaEditor::handleWheelEventNavigateNumber (QWheelEvent *wheelEvent)
 	static bool wasChanged = false;
 	static bool previewAfterUndo = false;
 
-    if ((wheelEvent->modifiers() & Qt::AltModifier))
+	if ((wheelEvent->buttons() & Qt::LeftButton) | (wheelEvent->modifiers() & Qt::AltModifier))
 	 {
 		if (!wasChanged) qsci->beginUndoAction();
 

--- a/src/scintillaeditor.h
+++ b/src/scintillaeditor.h
@@ -84,7 +84,6 @@ private:
 	bool handleKeyEventBlockMove(QKeyEvent *);
 	void navigateOnNumber(int key);
 	bool modifyNumber(int key);
-	bool modifyNumberByWheel(int key);
 	void noColor();
 
 	void setLexer(ScadLexer *lexer);

--- a/src/settings.cc
+++ b/src/settings.cc
@@ -179,7 +179,7 @@ SettingsEntry Settings::highlightCurrentLine("editor", "highlightCurrentLine", V
 SettingsEntry Settings::enableBraceMatching("editor", "enableBraceMatching", Value(true), Value(true));
 SettingsEntry Settings::enableLineNumbers("editor", "enableLineNumbers", Value(true), Value(true));
 SettingsEntry Settings::enableNumberScrollWheel("editor", "enableNumberScrollWheel", Value(true), Value(true));
-SettingsEntry Settings::modifierNumberScrollWheel("editor", "modifierNumberScrollWheel", values("Alt", _("Alt"), "Left Mouse Button", _("Left Mouse Button"), "Both", _("Both")), Value("Alt"));
+SettingsEntry Settings::modifierNumberScrollWheel("editor", "modifierNumberScrollWheel", values("Alt", _("Alt"), "Left Mouse Button", _("Left Mouse Button"), "Either", _("Either")), Value("Alt"));
 
 
 SettingsEntry Settings::octoPrintUrl("printing", "octoPrintUrl", Value(""), Value(""));

--- a/src/settings.cc
+++ b/src/settings.cc
@@ -178,6 +178,7 @@ SettingsEntry Settings::tabKeyFunction("editor", "tabKeyFunction", values("Inden
 SettingsEntry Settings::highlightCurrentLine("editor", "highlightCurrentLine", Value(true), Value(true));
 SettingsEntry Settings::enableBraceMatching("editor", "enableBraceMatching", Value(true), Value(true));
 SettingsEntry Settings::enableLineNumbers("editor", "enableLineNumbers", Value(true), Value(true));
+SettingsEntry Settings::enableNumberScrollWheel("editor", "enableNumberScrollWheel", Value(true), Value(true));
 SettingsEntry Settings::modifierNumberScrollWheel("editor", "modifierNumberScrollWheel", values("Alt", _("Alt"), "Left Mouse Button", _("Left Mouse Button"), "Both", _("Both")), Value("Alt"));
 
 

--- a/src/settings.cc
+++ b/src/settings.cc
@@ -178,6 +178,8 @@ SettingsEntry Settings::tabKeyFunction("editor", "tabKeyFunction", values("Inden
 SettingsEntry Settings::highlightCurrentLine("editor", "highlightCurrentLine", Value(true), Value(true));
 SettingsEntry Settings::enableBraceMatching("editor", "enableBraceMatching", Value(true), Value(true));
 SettingsEntry Settings::enableLineNumbers("editor", "enableLineNumbers", Value(true), Value(true));
+SettingsEntry Settings::modifierNumberScrollWheel("editor", "modifierNumberScrollWheel", values("Alt", _("Alt"), "Left Mouse Button", _("Left Mouse Button"), "Both", _("Both")), Value("Alt"));
+
 
 SettingsEntry Settings::octoPrintUrl("printing", "octoPrintUrl", Value(""), Value(""));
 SettingsEntry Settings::octoPrintApiKey("printing", "octoPrintApiKey", Value(""), Value(""));

--- a/src/settings.h
+++ b/src/settings.h
@@ -53,6 +53,7 @@ public:
     static SettingsEntry highlightCurrentLine;
     static SettingsEntry enableBraceMatching;
     static SettingsEntry enableLineNumbers;
+    static SettingsEntry enableNumberScrollWheel;
     static SettingsEntry modifierNumberScrollWheel;
 	static SettingsEntry octoPrintUrl;
 	static SettingsEntry octoPrintApiKey;

--- a/src/settings.h
+++ b/src/settings.h
@@ -53,7 +53,7 @@ public:
     static SettingsEntry highlightCurrentLine;
     static SettingsEntry enableBraceMatching;
     static SettingsEntry enableLineNumbers;
-
+    static SettingsEntry modifierNumberScrollWheel;
 	static SettingsEntry octoPrintUrl;
 	static SettingsEntry octoPrintApiKey;
 	static SettingsEntry octoPrintFileFormat;

--- a/src/settings.h
+++ b/src/settings.h
@@ -55,14 +55,14 @@ public:
     static SettingsEntry enableLineNumbers;
     static SettingsEntry enableNumberScrollWheel;
     static SettingsEntry modifierNumberScrollWheel;
-	static SettingsEntry octoPrintUrl;
-	static SettingsEntry octoPrintApiKey;
-	static SettingsEntry octoPrintFileFormat;
-	static SettingsEntry octoPrintAction;
-	static SettingsEntry octoPrintSlicerEngine;
-	static SettingsEntry octoPrintSlicerEngineDesc;
-	static SettingsEntry octoPrintSlicerProfile;
-	static SettingsEntry octoPrintSlicerProfileDesc;
+    static SettingsEntry octoPrintUrl;
+    static SettingsEntry octoPrintApiKey;
+    static SettingsEntry octoPrintFileFormat;
+    static SettingsEntry octoPrintAction;
+    static SettingsEntry octoPrintSlicerEngine;
+    static SettingsEntry octoPrintSlicerEngineDesc;
+    static SettingsEntry octoPrintSlicerProfile;
+    static SettingsEntry octoPrintSlicerProfileDesc;
 
     static SettingsEntry inputEnableDriverHIDAPI;
     static SettingsEntry inputEnableDriverHIDAPILog;


### PR DESCRIPTION
This feature-PR will allow the user to scroll the numbers in the text-editor by scrolling the mouse wheel.

Done:
- [x] Change the value by mouse wheel scroll.
- [x] Can change the step size from Editor Preferences.
- [x] Can change the modifier from Editor Preferences.
- [x] Can disable the number scroll via mouse wheel from Editor Preferences.
- [x] Handle the cases, so that the numbers present in variable names or some other identifiers are not changed.
<hr>

Todo:
- [ ] Disabling Mouse Movements while changing numbers  -> Abrupt Jump of caret on a single-digit number, when a new digit is added at the front.[Right now, not finding any suitable method/API in Scintilla to override the default behaviour]
- [ ] Delay Preview Until Done
