### PR TITLE
Enable default binary stl output, and ascii option

### DIFF
--- a/src/Preferences.cc
+++ b/src/Preferences.cc
@@ -660,6 +660,12 @@ void Preferences::on_enableRangeCheckBox_toggled(bool state)
 	settings.setValue("advanced/enableParameterRangeCheck", state);
 }
 
+void Preferences::on_useAsciiSTLCheckBox_toggled(bool checked)
+{
+	Settings::Settings::inst()->set(Settings::Settings::exportUseAsciiSTL, Value(checked));
+	writeSettings();
+}
+
 void Preferences::on_enableHidapiTraceCheckBox_toggled(bool checked)
 {
 	Settings::Settings::inst()->set(Settings::Settings::inputEnableDriverHIDAPILog, Value(checked));
@@ -888,6 +894,7 @@ void Preferences::updateGUI()
 	BlockSignals<QCheckBox *>(this->enableHardwarningsCheckBox)->setChecked(getValue("advanced/enableHardwarnings").toBool());
 	BlockSignals<QCheckBox *>(this->enableParameterCheckBox)->setChecked(getValue("advanced/enableParameterCheck").toBool());
 	BlockSignals<QCheckBox *>(this->enableRangeCheckBox)->setChecked(getValue("advanced/enableParameterRangeCheck").toBool());
+	BlockSignals<QCheckBox *>(this->useAsciiSTLCheckBox)->setChecked(s->get(Settings::Settings::exportUseAsciiSTL));
 	BlockSignals<QCheckBox *>(this->enableHidapiTraceCheckBox)->setChecked(s->get(Settings::Settings::inputEnableDriverHIDAPILog));
 	BlockSignals<QCheckBox *>(this->checkBoxEnableAutocomplete)->setChecked(getValue("editor/enableAutocomplete").toBool());
 	BlockSignals<QLineEdit *>(this->lineEditCharacterThreshold)->setText(getValue("editor/characterThreshold").toString());

--- a/src/Preferences.h
+++ b/src/Preferences.h
@@ -51,6 +51,7 @@ public slots:
 	void on_enableHardwarningsCheckBox_toggled(bool);
 	void on_enableParameterCheckBox_toggled(bool);
 	void on_enableRangeCheckBox_toggled(bool);
+	void on_useAsciiSTLCheckBox_toggled(bool);
 	void on_enableHidapiTraceCheckBox_toggled(bool);
 	void on_checkBoxShowWarningsIn3dView_toggled(bool);
 	void on_checkBoxMouseCentricZoom_toggled(bool);

--- a/src/Preferences.ui
+++ b/src/Preferences.ui
@@ -1776,6 +1776,35 @@
              </spacer>
             </item>
             <item>
+             <widget class="QGroupBox" name="groupBox_Export">
+              <property name="title">
+               <string>Export Features</string>
+              </property>
+              <layout class="QVBoxLayout" name="verticalLayout_16">
+               <item>
+                <widget class="QCheckBox" name="useAsciiSTLCheckBox">
+                 <property name="text">
+                  <string>Default to ASCII STL export</string>
+                 </property>
+                </widget>
+               </item>
+              </layout>
+             </widget>
+            </item>
+            <item>
+             <spacer name="verticalSpacer">
+              <property name="orientation">
+               <enum>Qt::Vertical</enum>
+              </property>
+              <property name="sizeHint" stdset="0">
+               <size>
+                <width>20</width>
+                <height>40</height>
+               </size>
+              </property>
+             </spacer>
+            </item>
+            <item>
              <widget class="QGroupBox" name="groupBox_Debug">
               <property name="title">
                <string>Debugging</string>

--- a/src/export.cc
+++ b/src/export.cc
@@ -45,8 +45,11 @@ bool canPreview(const FileFormat format) {
 void exportFile(const shared_ptr<const Geometry> &root_geom, std::ostream &output, FileFormat format)
 {
 	switch (format) {
+	case FileFormat::ASCIISTL:
+		export_stl(root_geom, output, false);
+		break;
 	case FileFormat::STL:
-		export_stl(root_geom, output);
+		export_stl(root_geom, output, true);
 		break;
 	case FileFormat::OFF:
 		export_off(root_geom, output);
@@ -78,7 +81,7 @@ void exportFileByName(const shared_ptr<const Geometry> &root_geom, FileFormat fo
 	const char *name2open, const char *name2display)
 {
 	std::ios::openmode mode = std::ios::out | std::ios::trunc;
-	if (format == FileFormat::_3MF) {
+	if (format == FileFormat::_3MF || format == FileFormat::STL) {
 		mode |= std::ios::binary;
 	}
 	std::ofstream fstream(name2open, mode);

--- a/src/export.h
+++ b/src/export.h
@@ -52,7 +52,8 @@ enum class RenderType { GEOMETRY, CGAL, OPENCSG, THROWNTOGETHER };
 struct ExportFileFormatOptions {
 	const std::map<const std::string, FileFormat> exportFileFormats{
 		{"asciistl", FileFormat::ASCIISTL},
-		{"stl", FileFormat::STL},
+		{"binstl", FileFormat::STL},
+		{"stl", FileFormat::ASCIISTL},  // Deprecated.  Later to FileFormat::STL
 		{"off", FileFormat::OFF},
 		{"amf", FileFormat::AMF},
 		{"3mf", FileFormat::_3MF},

--- a/src/export.h
+++ b/src/export.h
@@ -13,6 +13,7 @@
 class PolySet;
 
 enum class FileFormat {
+  ASCIISTL,
 	STL,
 	OFF,
 	AMF,
@@ -33,7 +34,8 @@ bool canPreview(const FileFormat format);
 void exportFileByName(const shared_ptr<const class Geometry> &root_geom, FileFormat format,
 											const char *name2open, const char *name2display);
 
-void export_stl(const shared_ptr<const Geometry> &geom, std::ostream &output);
+void export_stl(const shared_ptr<const Geometry> &geom, std::ostream &output,
+    bool binary=true);
 void export_3mf(const shared_ptr<const Geometry> &geom, std::ostream &output);
 void export_off(const shared_ptr<const Geometry> &geom, std::ostream &output);
 void export_amf(const shared_ptr<const Geometry> &geom, std::ostream &output);
@@ -49,6 +51,7 @@ enum class RenderType { GEOMETRY, CGAL, OPENCSG, THROWNTOGETHER };
 
 struct ExportFileFormatOptions {
 	const std::map<const std::string, FileFormat> exportFileFormats{
+		{"asciistl", FileFormat::ASCIISTL},
 		{"stl", FileFormat::STL},
 		{"off", FileFormat::OFF},
 		{"amf", FileFormat::AMF},

--- a/src/export_stl.cc
+++ b/src/export_stl.cc
@@ -48,100 +48,180 @@ Vector3d fromString(const std::string &vertexString)
 	stream >> v[0] >> v[1] >> v[2];
 	return v;
 }
+
+void write_vector(std::ostream &output, const Vector3f& v) {
+    for (int i=0; i<3; i++) {
+        static_assert(sizeof(float)==4, "Need 32 bit float");
+        float f = v[i];
+        char *fbeg = reinterpret_cast<char *>(&f);
+        char data[4];
+
+        uint16_t test = 0x0001;
+        if (*reinterpret_cast<char *>(&test) == 1) {
+            std::copy(fbeg, fbeg+4, data);
+        }
+        else {
+            std::reverse_copy(fbeg, fbeg+4, data);
+        }
+        output.write(data, 4);
+    }
+}
+
 	
-void append_stl(const PolySet &ps, std::ostream &output)
+size_t append_stl(const PolySet &ps, std::ostream &output, bool binary)
 {
-	PolySet triangulated(3);
-	PolysetUtils::tessellate_faces(ps, triangulated);
+    size_t triangle_count = 0;
+    PolySet triangulated(3);
+    PolysetUtils::tessellate_faces(ps, triangulated);
 
 	for(const auto &p : triangulated.polygons) {
 		assert(p.size() == 3); // STL only allows triangles
-		std::array<std::string, 3> vertexStrings;
-		std::transform(p.cbegin(), p.cend(), vertexStrings.begin(), toString);
+        triangle_count++;
 
-		if (vertexStrings[0] != vertexStrings[1] &&
-				vertexStrings[0] != vertexStrings[2] &&
-				vertexStrings[1] != vertexStrings[2]) {
-			// The above condition ensures that there are 3 distinct vertices, but
-			// they may be collinear. If they are, the unit normal is meaningless
-			// so the default value of "0 0 0" can be used. If the vertices are not
-			// collinear then the unit normal must be calculated from the
-			// components.
-			output << "  facet normal ";
+        if (binary) {
+            Vector3f p0 = p[0].cast<float>();
+            Vector3f p1 = p[1].cast<float>();
+            Vector3f p2 = p[2].cast<float>();
 
-			Vector3d p0 = fromString(vertexStrings[0]);
-			Vector3d p1 = fromString(vertexStrings[1]);
-			Vector3d p2 = fromString(vertexStrings[2]);
-			
-			Vector3d normal = (p1 - p0).cross(p2 - p0);
-			normal.normalize();
-			if (is_finite(normal) && !is_nan(normal)) {
-				output << normal[0] << " " << normal[1] << " " << normal[2] << "\n";
-			}
-			else {
-				output << "0 0 0\n";
-			}
-			output << "    outer loop\n";
-		
-			for (const auto &vertexString : vertexStrings) {
-				output << "      vertex " << vertexString << "\n";
-			}
-			output << "    endloop\n";
-			output << "  endfacet\n";
-		}
-	}
+            // Ensure 3 distinct vertices.
+            if ((p0 != p1) && (p0 != p2) && (p1 != p2)) {
+                Vector3f normal = (p1 - p0).cross(p2 - p0);
+                normal.normalize();
+                if (!is_finite(normal) || is_nan(normal)) {
+                    // Collinear vertices.
+                    normal << 0, 0, 0;
+                }
+                write_vector(output, normal);
+            }
+            write_vector(output, p0);
+            write_vector(output, p1);
+            write_vector(output, p2);
+            char attrib[2] = {0,0};
+            output.write(attrib, 2);
+        }
+        else { // ascii
+            std::array<std::string, 3> vertexStrings;
+            std::transform(p.cbegin(), p.cend(), vertexStrings.begin(),
+                toString);
+
+            if (vertexStrings[0] != vertexStrings[1] &&
+                vertexStrings[0] != vertexStrings[2] &&
+                vertexStrings[1] != vertexStrings[2]) {
+
+                // The above condition ensures that there are 3 distinct
+                // vertices, but they may be collinear. If they are, the unit
+                // normal is meaningless so the default value of "0 0 0" can
+                // be used. If the vertices are not collinear then the unit
+                // normal must be calculated from the components.
+                output << "  facet normal ";
+
+                Vector3d p0 = fromString(vertexStrings[0]);
+                Vector3d p1 = fromString(vertexStrings[1]);
+                Vector3d p2 = fromString(vertexStrings[2]);
+
+                Vector3d normal = (p1 - p0).cross(p2 - p0);
+                normal.normalize();
+                if (is_finite(normal) && !is_nan(normal)) {
+                    output << normal[0] << " " << normal[1] << " " << normal[2]
+                      << "\n";
+                }
+                else {
+                    output << "0 0 0\n";
+                }
+                output << "    outer loop\n";
+
+                for (const auto &vertexString : vertexStrings) {
+                    output << "      vertex " << vertexString << "\n";
+                }
+                output << "    endloop\n";
+                output << "  endfacet\n";
+            }
+        }
+    }
+
+    return triangle_count;
 }
 
 /*!
 	Saves the current 3D CGAL Nef polyhedron as STL to the given file.
 	The file must be open.
  */
-void append_stl(const CGAL_Nef_polyhedron &root_N, std::ostream &output)
+size_t append_stl(const CGAL_Nef_polyhedron &root_N, std::ostream &output,
+    bool binary)
 {
+  size_t triangle_count = 0;
 	if (!root_N.p3->is_simple()) {
 		PRINT("EXPORT-WARNING: Exported object may not be a valid 2-manifold and may need repair");
 	}
 
 	PolySet ps(3);
 	if (!CGALUtils::createPolySetFromNefPolyhedron3(*(root_N.p3), ps)) {
-		append_stl(ps, output);
+		triangle_count += append_stl(ps, output, binary);
 	}
 	else {
 		PRINT("EXPORT-ERROR: Nef->PolySet failed");
 	}
+
+  return triangle_count;
 }
 
-void append_stl(const shared_ptr<const Geometry> &geom, std::ostream &output)
+size_t append_stl(const shared_ptr<const Geometry> &geom, std::ostream &output,
+    bool binary)
 {
+    size_t triangle_count = 0;
 	if (const auto geomlist = dynamic_pointer_cast<const GeometryList>(geom)) {
 		for(const Geometry::GeometryItem &item : geomlist->getChildren()) {
-			append_stl(item.second, output);
+			triangle_count += append_stl(item.second, output, binary);
 		}
 	}
 	else if (const auto N = dynamic_pointer_cast<const CGAL_Nef_polyhedron>(geom)) {
-		append_stl(*N, output);
+		triangle_count += append_stl(*N, output, binary);
 	}
 	else if (const auto ps = dynamic_pointer_cast<const PolySet>(geom)) {
-		append_stl(*ps, output);
+		triangle_count += append_stl(*ps, output, binary);
 	}
 	else if (dynamic_pointer_cast<const Polygon2d>(geom)) {
 		assert(false && "Unsupported file format");
 	} else {
 		assert(false && "Not implemented");
 	}
+
+    return triangle_count;
 }
 
 } // namespace
 
-void export_stl(const shared_ptr<const Geometry> &geom, std::ostream &output)
+void export_stl(const shared_ptr<const Geometry> &geom, std::ostream &output,
+    bool binary)
 {
-	setlocale(LC_NUMERIC, "C"); // Ensure radix is . (not ,) in output
-	output << "solid OpenSCAD_Model\n";
+    if (binary) {
+      char header[80] = "OpenSCAD Model\n";
+      output.write(header, sizeof(header));
+      char tmp_triangle_count[4] = {0,0,0,0};  // We must fill this in below.
+      output.write(tmp_triangle_count, 4);
+    }
+    else {
+        setlocale(LC_NUMERIC, "C"); // Ensure radix is . (not ,) in output
+        output << "solid OpenSCAD_Model\n";
+    }
 
-	append_stl(geom, output);
+	size_t triangle_count = append_stl(geom, output, binary);
 
-	output << "endsolid OpenSCAD_Model\n";
-	setlocale(LC_NUMERIC, "");      // Set default locale
+    if (binary) {
+        // Fill in triangle count.
+        output.seekp(80, std::ios_base::beg);
+        output.put(triangle_count & 0xff);
+        output.put((triangle_count >> 8) & 0xff);
+        output.put((triangle_count >> 16) & 0xff);
+        output.put((triangle_count >> 24) & 0xff);
+        if (triangle_count > 4294967295) {
+            PRINT("EXPORT-ERROR: Triangle count exceeded 4294967295, so the stl file is not valid");
+        }
+    }
+    else {
+        output << "endsolid OpenSCAD_Model\n";
+        setlocale(LC_NUMERIC, "");      // Set default locale
+    }
 }
 
 #endif // ENABLE_CGAL

--- a/src/mainwin.cc
+++ b/src/mainwin.cc
@@ -1921,6 +1921,8 @@ void MainWindow::sendToOctoPrint()
 	FileFormat exportFileFormat{FileFormat::STL};
 	if (fileFormat == "OFF") {
 		exportFileFormat = FileFormat::OFF;
+	} else if (fileFormat == "ASCIISTL") {
+		exportFileFormat = FileFormat::ASCIISTL;
 	} else if (fileFormat == "AMF") {
 		exportFileFormat = FileFormat::AMF;
 	} else if (fileFormat == "3MF") {
@@ -2418,7 +2420,13 @@ void MainWindow::actionExport(FileFormat format, const char *type_name, const ch
 
 void MainWindow::actionExportSTL()
 {
-	actionExport(FileFormat::STL, "STL", ".stl", 3);
+  const auto *s = Settings::Settings::inst();
+  if (s->get(Settings::Settings::exportUseAsciiSTL).toBool()) {
+	  actionExport(FileFormat::ASCIISTL, "ASCIISTL", ".stl", 3);
+  }
+  else {
+	  actionExport(FileFormat::STL, "STL", ".stl", 3);
+  }
 }
 
 void MainWindow::actionExport3MF()

--- a/src/openscad.cc
+++ b/src/openscad.cc
@@ -478,7 +478,8 @@ int cmdline(const char *deps_output_file, const std::string &filename, const std
 			RenderStatistic().print(*root_geom);
 		}
 
-		if(curFormat == FileFormat::STL ||
+		if(curFormat == FileFormat::ASCIISTL ||
+      curFormat == FileFormat::STL ||
 			curFormat == FileFormat::OFF ||
 			curFormat == FileFormat::AMF ||
 			curFormat == FileFormat::_3MF ||
@@ -853,7 +854,7 @@ int main(int argc, char **argv)
 	ViewOptions viewOptions{};
 	po::options_description desc("Allowed options");
 	desc.add_options()
-		("export-format", po::value<string>(), "overrides format of exported scad file when using option '-o', arg can be any of its supported file extensions\n")
+		("export-format", po::value<string>(), "overrides format of exported scad file when using option '-o', arg can be any of its supported file extensions.  For ascii stl export, specify 'asciistl'.\n")
 		("o,o", po::value<vector<string>>(), "output specified file instead of running the GUI, the file extension specifies the type: stl, off, amf, 3mf, csg, dxf, svg, png, echo, ast, term, nef3, nefdbg. (May be used multiple time for different exports)\n")
 		("D,D", po::value<vector<string>>(), "var=val -pre-define variables")
 		("p,p", po::value<string>(), "customizer parameter file")

--- a/src/openscad.cc
+++ b/src/openscad.cc
@@ -478,17 +478,17 @@ int cmdline(const char *deps_output_file, const std::string &filename, const std
 			RenderStatistic().print(*root_geom);
 		}
 
-		if(curFormat == FileFormat::ASCIISTL ||
-      curFormat == FileFormat::STL ||
-			curFormat == FileFormat::OFF ||
-			curFormat == FileFormat::AMF ||
-			curFormat == FileFormat::_3MF ||
-			curFormat == FileFormat::NEFDBG ||
-			curFormat == FileFormat::NEF3 )
-		{
-			if(!checkAndExport(root_geom, 3, curFormat, new_output_file)) {
-				return 1;
-			}
+        if( curFormat == FileFormat::ASCIISTL ||
+            curFormat == FileFormat::STL ||
+            curFormat == FileFormat::OFF ||
+            curFormat == FileFormat::AMF ||
+            curFormat == FileFormat::_3MF ||
+            curFormat == FileFormat::NEFDBG ||
+            curFormat == FileFormat::NEF3 )
+        {
+            if(!checkAndExport(root_geom, 3, curFormat, new_output_file)) {
+                return 1;
+            }
 		}
 
 		if(curFormat == FileFormat::DXF || curFormat == FileFormat::SVG) {
@@ -854,7 +854,7 @@ int main(int argc, char **argv)
 	ViewOptions viewOptions{};
 	po::options_description desc("Allowed options");
 	desc.add_options()
-		("export-format", po::value<string>(), "overrides format of exported scad file when using option '-o', arg can be any of its supported file extensions.  For ascii stl export, specify 'asciistl'.\n")
+		("export-format", po::value<string>(), "overrides format of exported scad file when using option '-o', arg can be any of its supported file extensions.  For ascii stl export, specify 'asciistl', and for binary stl export, specify 'binstl'.  Ascii export is the current stl default, but binary stl is planned as the future default so asciistl should be explicitly specified in scripts when needed.\n")
 		("o,o", po::value<vector<string>>(), "output specified file instead of running the GUI, the file extension specifies the type: stl, off, amf, 3mf, csg, dxf, svg, png, echo, ast, term, nef3, nefdbg. (May be used multiple time for different exports)\n")
 		("D,D", po::value<vector<string>>(), "var=val -pre-define variables")
 		("p,p", po::value<string>(), "customizer parameter file")

--- a/src/settings.cc
+++ b/src/settings.cc
@@ -188,6 +188,8 @@ SettingsEntry Settings::octoPrintSlicerEngineDesc("printing", "octoPrintSlicerEn
 SettingsEntry Settings::octoPrintSlicerProfile("printing", "octoPrintSlicerProfile", Value(""), Value(""));
 SettingsEntry Settings::octoPrintSlicerProfileDesc("printing", "octoPrintSlicerProfileDesc", Value(""), Value(""));
 
+SettingsEntry Settings::exportUseAsciiSTL("export", "useAsciiSTL", Value(true), Value(false));
+
 SettingsEntry Settings::inputEnableDriverHIDAPI("input", "enableDriverHIDAPI", Value(true), Value(false));
 SettingsEntry Settings::inputEnableDriverHIDAPILog("input", "enableDriverHIDAPILog", Value(true), Value(false));
 SettingsEntry Settings::inputEnableDriverSPNAV("input", "enableDriverSPNAV", Value(true), Value(false));

--- a/src/settings.h
+++ b/src/settings.h
@@ -63,6 +63,8 @@ public:
 	static SettingsEntry octoPrintSlicerProfile;
 	static SettingsEntry octoPrintSlicerProfileDesc;
 
+    static SettingsEntry exportUseAsciiSTL;
+
     static SettingsEntry inputEnableDriverHIDAPI;
     static SettingsEntry inputEnableDriverHIDAPILog;
     static SettingsEntry inputEnableDriverSPNAV;

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -682,8 +682,8 @@ set_test_config(Heavy
   offpngtest_difference
   offpngtest_translation
   cgalstlcgalpngtest_rotate_extrude-tests
+  cgalbinstlcgalpngtest_rotate_extrude-tests
   monotonepngtest_rotate_extrude-tests
-  cgalstlcgalpngtest_rotate_extrude-tests
   openscad-colorscheme-metallic-render_CSG
   cgalpngtest_issue267-normalization-crash
   csgpngtest_issue267-normalization-crash
@@ -722,6 +722,8 @@ foreach(FILE ${BUGS_FILES})
   set_test_config(Bugs ${TEST_FULLNAME})
   get_test_fullname(cgalstlcgalpngtest ${FILE} TEST_FULLNAME)
   set_test_config(Bugs ${TEST_FULLNAME})
+  get_test_fullname(cgalbinstlcgalpngtest ${FILE} TEST_FULLNAME)
+  set_test_config(Bugs ${TEST_FULLNAME})
   get_test_fullname(offpngtest ${FILE} TEST_FULLNAME)
   set_test_config(Bugs ${TEST_FULLNAME})
   get_test_fullname(offcgalpngtest ${FILE} TEST_FULLNAME)
@@ -746,6 +748,8 @@ foreach(FILE ${EXAMPLE_FILES})
   get_test_fullname(stlcgalpngtest ${FILE} TEST_FULLNAME)
   set_test_config(Examples ${TEST_FULLNAME})
   get_test_fullname(cgalstlcgalpngtest ${FILE} TEST_FULLNAME)
+  set_test_config(Examples ${TEST_FULLNAME})
+  get_test_fullname(cgalbinstlcgalpngtest ${FILE} TEST_FULLNAME)
   set_test_config(Examples ${TEST_FULLNAME})
   get_test_fullname(offpngtest ${FILE} TEST_FULLNAME)
   set_test_config(Examples ${TEST_FULLNAME})
@@ -919,7 +923,10 @@ add_cmdline_test(stlpngtest EXE ${PYTHON_EXECUTABLE} SCRIPT ${CMAKE_SOURCE_DIR}/
 # cgalstlpngtest: CGAL STL output, normal rendering
 add_cmdline_test(stlcgalpngtest EXE ${PYTHON_EXECUTABLE} SCRIPT ${CMAKE_SOURCE_DIR}/export_import_pngtest.py ARGS --openscad=${OPENSCAD_BINPATH} --format=STL --require-manifold --render EXPECTEDDIR monotonepngtest SUFFIX png FILES ${EXPORT3D_CGAL_TEST_FILES})
 # cgalstlcgalpngtest: CGAL STL output, CGAL rendering
-add_cmdline_test(cgalstlcgalpngtest EXE ${PYTHON_EXECUTABLE} SCRIPT ${CMAKE_SOURCE_DIR}/export_import_pngtest.py ARGS --openscad=${OPENSCAD_BINPATH} --format=STL --require-manifold --render=cgal EXPECTEDDIR monotonepngtest SUFFIX png FILES ${EXPORT3D_CGALCGAL_TEST_FILES})
+add_cmdline_test(cgalstlcgalpngtest EXE ${PYTHON_EXECUTABLE} SCRIPT ${CMAKE_SOURCE_DIR}/export_import_pngtest.py ARGS --openscad=${OPENSCAD_BINPATH} --format=ASCIISTL --require-manifold --render=cgal EXPECTEDDIR monotonepngtest SUFFIX png FILES ${EXPORT3D_CGALCGAL_TEST_FILES})
+
+# cgalbinstlcgalpngtest: CGAL binary STL output, CGAL rendering
+add_cmdline_test(cgalbinstlcgalpngtest EXE ${PYTHON_EXECUTABLE} SCRIPT ${CMAKE_SOURCE_DIR}/export_import_pngtest.py ARGS --openscad=${OPENSCAD_BINPATH} --format=BINSTL --require-manifold --render=cgal EXPECTEDDIR monotonepngtest SUFFIX png FILES ${EXPORT3D_CGALCGAL_TEST_FILES})
 
 add_cmdline_test(offpngtest EXE ${PYTHON_EXECUTABLE} SCRIPT ${CMAKE_SOURCE_DIR}/export_import_pngtest.py ARGS --openscad=${OPENSCAD_BINPATH} --format=OFF --render EXPECTEDDIR monotonepngtest SUFFIX png FILES ${EXPORT3D_TEST_FILES})
 add_cmdline_test(offcgalpngtest EXE ${PYTHON_EXECUTABLE} SCRIPT ${CMAKE_SOURCE_DIR}/export_import_pngtest.py ARGS --openscad=${OPENSCAD_BINPATH} --format=OFF --render=cgal EXPECTEDDIR monotonepngtest SUFFIX png FILES ${EXPORT3D_CGAL_TEST_FILES})

--- a/tests/export_import_pngtest.py
+++ b/tests/export_import_pngtest.py
@@ -53,7 +53,7 @@ def createImport(inputfile, scadfile):
 #
 # Parse arguments
 #
-formats = ['csg', 'stl','off', 'amf', '3mf', 'dxf', 'svg']
+formats = ['csg', 'asciistl', 'binstl', 'stl', 'off', 'amf', '3mf', 'dxf', 'svg']
 parser = argparse.ArgumentParser()
 parser.add_argument('--openscad', required=True, help='Specify OpenSCAD executable')
 parser.add_argument('--format', required=True, choices=[item for sublist in [(f,f.upper()) for f in formats] for item in sublist], help='Specify 3d export format')
@@ -62,6 +62,15 @@ parser.set_defaults(requiremanifold=False)
 args,remaining_args = parser.parse_known_args()
 
 args.format = args.format.lower()
+
+export_format = None
+if args.format == 'asciistl':
+    export_format = 'asciistl'
+    args.format = 'stl'
+elif args.format == 'binstl':
+    export_format = 'binstl'
+    args.format = 'stl'
+
 inputfile = remaining_args[0]         # Can be .scad file or a file to be imported
 pngfile = remaining_args[-1]
 remaining_args = remaining_args[1:-1] # Passed on to the OpenSCAD executable
@@ -94,6 +103,9 @@ if inputsuffix != '.scad' and inputsuffix != '.csg':
 # For any --render arguments to --render=cgal
 #
 tmpargs =  ['--render=cgal' if arg.startswith('--render') else arg for arg in remaining_args]
+
+if export_format is not None:
+    tmpargs.extend(['--export-format', export_format])
 
 export_cmd = [args.openscad, inputfile, '-o', exportfile] + tmpargs
 print('Running OpenSCAD #1:', file=sys.stderr)

--- a/tests/validatestl.py
+++ b/tests/validatestl.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 #
 # Simple tool to validate an STL.
@@ -20,45 +20,76 @@ import io
 import hashlib
 import os
 import subprocess
+import struct
 import math
 from collections import Counter
 
 def read_stl(filename):
     triangles = list()
-    with open(filename, "r") as fd:
-        triangle = {
-            'normal': [0, 0, 0],
-            'points': list()
-        }
-        for line in fd:
-            line = line.strip()
-            if line.startswith('solid'):
-                continue
-            elif line.startswith('endsolid'):
-                continue
-            elif line.startswith('outer'):
-                continue
-            elif line.startswith('facet'):
-                parts = line.split(' ')
-                for i in range(2, 5):
-                    triangle['normal'][i-2] = float(parts[i])
-                continue
-            elif line.startswith('vertex'):
-                parts = line.split(' ')
-                point = [0, 0, 0]
-                for i in range(1, 4):
-                    point[i-1] = float(parts[i])
-                triangle['points'].append(point)
-                continue
-            elif line.startswith('endloop'):
-                continue
-            elif line.startswith('endfacet'):
-                triangles.append(triangle)
-                triangle = {
-                    "normal": [0, 0, 0],
-                    "points": list()
-                }
-                continue
+
+    with open(filename, "rb") as fd:
+        start = fd.read(5)
+        if start == b'solid':
+            stl_type = 'ascii'
+        else:
+            stl_type = 'binary'
+  
+    print(start)
+
+    if stl_type == 'ascii':
+        with open(filename, "r") as fd:
+            triangle = {
+                'normal': [0, 0, 0],
+                'points': list()
+            }
+            for line in fd:
+                line = line.strip()
+                if line.startswith('solid'):
+                    continue
+                elif line.startswith('endsolid'):
+                    continue
+                elif line.startswith('outer'):
+                    continue
+                elif line.startswith('facet'):
+                    parts = line.split(' ')
+                    for i in range(2, 5):
+                        triangle['normal'][i-2] = float(parts[i])
+                    continue
+                elif line.startswith('vertex'):
+                    parts = line.split(' ')
+                    point = [0, 0, 0]
+                    for i in range(1, 4):
+                        point[i-1] = float(parts[i])
+                    triangle['points'].append(point)
+                    continue
+                elif line.startswith('endloop'):
+                    continue
+                elif line.startswith('endfacet'):
+                    triangles.append(triangle)
+                    triangle = {
+                        "normal": [0, 0, 0],
+                        "points": list()
+                    }
+                    continue
+    else:  # binary
+        with open(filename, "rb") as fd:
+            data = fd.read()
+            count = int.from_bytes(data[80:84], byteorder='little')
+            for offset in range(84, 84+count*(12*4+2), 12*4+2):
+                try:
+                    triangle = {
+                        'points': list()
+                    }
+                    triangle['normal'] = list(
+                        struct.unpack('fff', data[offset:offset+12]))
+                    for p in range(1,4):
+                        pnt = struct.unpack('fff',
+                            data[offset+p*12:offset+p*12+12])
+                        triangle['points'].append(pnt)
+                    triangles.append(triangle)
+                except struct.error:
+                    print("Invalid binary stl format")
+                    return None
 
     return Mesh(
         triangles=triangles
@@ -86,6 +117,14 @@ class Mesh():
 
 def validateSTL(filename):
     mesh = read_stl(filename);
+
+    if mesh is None:
+        print("Loading error")
+        return False
+
+    if len(mesh.triangles) < 1:
+        print("No triangles found")
+        return False
     
     if len([n[i] for i in range(0,3) for n in mesh.points if math.isinf(n[i]) or math.isnan(n[i])]):
         print("NaN of Inf vertices found")


### PR DESCRIPTION
This provides binary stl output, resolving issue #1555.  Since the binary stl files are about 27% the size of the ascii stl files, I've set this as the new default.  Ascii stl file output is still supported, now selectable in the gui under preferences, advanced, export, use ascii stl.  From command-line, ascii stl file output can still be selected by using --export-format asciistl

The binary stl files seem to show up as a correct match to the ascii ones in my tests, load in other programs, and can be successfully reimported into OpenSCAD with the import command.