### PR TITLE
Changing apply() to ClipperUtils::apply() to prevert name clash in C++17 (default for GCC 11)

### DIFF
--- a/src/clipper-utils.cc
+++ b/src/clipper-utils.cc
@@ -144,7 +144,7 @@ namespace ClipperUtils {
 			if (!polygon->isSanitized()) ClipperLib::PolyTreeToPaths(sanitize(polypaths), polypaths);
 			pathsvector.push_back(polypaths);
 		}
-		auto res = apply(pathsvector, clipType);
+		auto res = ClipperUtils::apply(pathsvector, clipType);
 		assert(res);
 		return res;
 	}


### PR DESCRIPTION
GCC 11 defaults C++ standard to C++17 (http://www.gnu.org/software//gcc/projects/cxx-status.html#cxx17)

openscad.pro selects the default standard ('CONFIG += c++std')

C++17 introduces a std::apply() function (https://en.cppreference.com/w/cpp/utility/apply)

this leads to a name clash in a call to apply() in src/clipper-utils.cc

Thus adding a namespace qualifier.