### PR TITLE
Feature/aconz2 stdio

### DIFF
--- a/src/export.cc
+++ b/src/export.cc
@@ -80,11 +80,12 @@ void exportFile(const shared_ptr<const Geometry> &root_geom, std::ostream &outpu
 void exportFileByName(const shared_ptr<const Geometry> &root_geom, FileFormat format,
 	const char *name2open, const char *name2display)
 {
+#ifndef WIN32
 	if (strcmp(name2open, "-") == 0) {
-		// TODO: on windows, is cout okay for binary?
 		exportFile(root_geom, std::cout, format);
 		return;
 	}
+#endif
 	std::ios::openmode mode = std::ios::out | std::ios::trunc;
 	if (format == FileFormat::_3MF || format == FileFormat::STL) {
 		mode |= std::ios::binary;

--- a/src/export.cc
+++ b/src/export.cc
@@ -80,6 +80,11 @@ void exportFile(const shared_ptr<const Geometry> &root_geom, std::ostream &outpu
 void exportFileByName(const shared_ptr<const Geometry> &root_geom, FileFormat format,
 	const char *name2open, const char *name2display)
 {
+	if (strcmp(name2open, "-") == 0) {
+		// TODO: on windows, is cout okay for binary?
+		exportFile(root_geom, std::cout, format);
+		return;
+	}
 	std::ios::openmode mode = std::ios::out | std::ios::trunc;
 	if (format == FileFormat::_3MF || format == FileFormat::STL) {
 		mode |= std::ios::binary;

--- a/src/openscad.cc
+++ b/src/openscad.cc
@@ -883,7 +883,7 @@ int main(int argc, char **argv)
 	po::options_description desc("Allowed options");
 	desc.add_options()
 		("export-format", po::value<string>(), "overrides format of exported scad file when using option '-o', arg can be any of its supported file extensions.  For ascii stl export, specify 'asciistl', and for binary stl export, specify 'binstl'.  Ascii export is the current stl default, but binary stl is planned as the future default so asciistl should be explicitly specified in scripts when needed.\n")
-		("o,o", po::value<vector<string>>(), "output specified file instead of running the GUI, the file extension specifies the type: stl, off, amf, 3mf, csg, dxf, svg, png, echo, ast, term, nef3, nefdbg. (May be used multiple time for different exports)\n")
+		("o,o", po::value<vector<string>>(), "output specified file instead of running the GUI, the file extension specifies the type: stl, off, amf, 3mf, csg, dxf, svg, png, echo, ast, term, nef3, nefdbg. (May be used multiple time for different exports) Use '-' for stdout\n")
 		("D,D", po::value<vector<string>>(), "var=val -pre-define variables")
 		("p,p", po::value<string>(), "customizer parameter file")
 		("P,P", po::value<string>(), "customizer parameter set")

--- a/src/openscad.cc
+++ b/src/openscad.cc
@@ -149,10 +149,18 @@ static int info()
 template <typename F>
 static bool with_output(const std::string &filename, F f, std::ios::openmode mode = std::ios::out)
 {
+#ifdef WIN32
+    // Windows does not like binary output on stdout
+	if (filename == "-" && mode & std::ios::binary == 0) {
+		f(std::cout);
+		return true;
+	}
+#else
 	if (filename == "-") {
 		f(std::cout);
 		return true;
 	}
+#endif
 	std::ofstream fstream(filename, mode);
 	if (!fstream.is_open()) {
 		PRINTB("Can't open file \"%s\" for export", filename.c_str());

--- a/src/openscad.cc
+++ b/src/openscad.cc
@@ -374,12 +374,20 @@ int cmdline(const char *deps_output_file, const std::string &filename, const std
 
 	handle_dep(filename);
 
-	std::ifstream ifs(filename.c_str());
-	if (!ifs.is_open()) {
-		PRINTB("Can't open input file '%s'!\n", filename.c_str());
-		return 1;
+	std::string text;
+	if (filename == "-") {
+		text =
+				std::string((std::istreambuf_iterator<char>(std::cin)), std::istreambuf_iterator<char>());
 	}
-	std::string text((std::istreambuf_iterator<char>(ifs)), std::istreambuf_iterator<char>());
+	else {
+		std::ifstream ifs(filename.c_str());
+		if (!ifs.is_open()) {
+			PRINTB("Can't open input file '%s'!\n", filename.c_str());
+			return 1;
+		}
+		text = std::string((std::istreambuf_iterator<char>(ifs)), std::istreambuf_iterator<char>());
+	}
+
 	text += "\n\x03\n" + commandline_commands;
 	if (!parse(root_module, text, filename, filename, false)) {
 		delete root_module;  // parse failed

--- a/src/openscad.cc
+++ b/src/openscad.cc
@@ -153,7 +153,7 @@ static bool with_output(const std::string &filename, F f, std::ios::openmode mod
 		f(std::cout);
 		return true;
 	}
-	std::ofstream fstream(filename);
+	std::ofstream fstream(filename, mode);
 	if (!fstream.is_open()) {
 		PRINTB("Can't open file \"%s\" for export", filename.c_str());
 		return false;

--- a/src/openscad.cc
+++ b/src/openscad.cc
@@ -151,7 +151,7 @@ static bool with_output(const std::string &filename, F f, std::ios::openmode mod
 {
 #ifdef WIN32
     // Windows does not like binary output on stdout
-	if (filename == "-" && mode & std::ios::binary == 0) {
+	if (filename == "-" && (mode & std::ios::binary) == 0) {
 		f(std::cout);
 		return true;
 	}

--- a/src/openscad.cc
+++ b/src/openscad.cc
@@ -391,12 +391,14 @@ int cmdline(const char *deps_output_file, const std::string &filename, const std
 	}
 
 	text += "\n\x03\n" + commandline_commands;
-	if (!parse(root_module, text, filename, filename, false)) {
-		delete root_module;  // parse failed
+
+	std::string parser_filename = filename == "-" ? "<stdin>" : filename;
+	if (!parse(root_module, text, parser_filename, parser_filename, false)) {
+		delete root_module; // parse failed
 		root_module = nullptr;
 	}
 	if (!root_module) {
-		PRINTB("Can't parse file '%s'!\n", filename.c_str());
+		PRINTB("Can't parse file '%s'!\n", parser_filename.c_str());
 		return 1;
 	}
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -194,11 +194,13 @@ endfunction()
 #
 find_package(PythonInterp 3.4 REQUIRED)
 function(add_cmdline_test TESTCMD_BASENAME)
-  cmake_parse_arguments(TESTCMD "" "EXE;SCRIPT;SUFFIX;EXPECTEDDIR" "FILES;ARGS" ${ARGN})
+  cmake_parse_arguments(TESTCMD "" "EXE;SCRIPT;SUFFIX;EXPECTEDDIR;STDIN;STDOUT" "FILES;ARGS" ${ARGN})
+
+  set(EXTRA_OPTIONS "")
 
   # If sharing results with another test, pass on this to the python script
   if (TESTCMD_EXPECTEDDIR)
-    set(EXTRA_OPTIONS -e ${TESTCMD_EXPECTEDDIR})
+    list(APPEND EXTRA_OPTIONS -e ${TESTCMD_EXPECTEDDIR})
   endif()
 
   if (TESTCMD_EXE)
@@ -206,6 +208,14 @@ function(add_cmdline_test TESTCMD_BASENAME)
   else()
     # If no executable was specified, assume it was built by us and resides here
     set(TESTCMD_EXE ${CMAKE_CURRENT_BINARY_DIR}/${TESTCMD_BASENAME})
+  endif()
+
+  if (TESTCMD_STDIN)
+    list(APPEND EXTRA_OPTIONS --stdin)
+  endif()
+
+  if (TESTCMD_STDOUT)
+    list(APPEND EXTRA_OPTIONS --stdout)
   endif()
 
   # Add tests from args
@@ -808,11 +818,17 @@ file(WRITE ${CMAKE_CURRENT_BINARY_DIR}/CTestCustom.cmake ${TMP})
 #
 
 add_cmdline_test(astdumptest EXE ${OPENSCAD_BINPATH} ARGS -o SUFFIX ast FILES ${ASTDUMPTEST_FILES})
+add_cmdline_test(astdumpstdiotest EXE ${OPENSCAD_BINPATH} ARGS --export-format ast -o SUFFIX ast STDOUT true STDIN true EXPECTEDDIR astdumptest FILES
+                                  ${CMAKE_CURRENT_SOURCE_DIR}/../testdata/scad/misc/allexpressions.scad)
+
+
 add_cmdline_test(csgtermtest EXE ${OPENSCAD_BINPATH} ARGS -o SUFFIX term FILES
                              ${CMAKE_CURRENT_SOURCE_DIR}/../testdata/scad/misc/allexpressions.scad
                              ${CMAKE_CURRENT_SOURCE_DIR}/../testdata/scad/misc/allfunctions.scad
                              ${CMAKE_CURRENT_SOURCE_DIR}/../testdata/scad/misc/allmodules.scad)
 add_cmdline_test(echotest EXE ${OPENSCAD_BINPATH} ARGS -o SUFFIX echo FILES ${ECHO_FILES})
+add_cmdline_test(echostdiotest EXE ${OPENSCAD_BINPATH} ARGS --export-format echo -o SUFFIX echo STDOUT true STDIN true EXPECTEDDIR echotest FILES
+                               ${CMAKE_CURRENT_SOURCE_DIR}/../testdata/scad/misc/echo-tests.scad)
 add_cmdline_test(echotest EXE ${OPENSCAD_BINPATH} ARGS --check-parameter-ranges=on -o SUFFIX echo FILES ${CMAKE_CURRENT_SOURCE_DIR}/../testdata/scad/misc/builtin-invalid-range-test.scad)
 
 # generate a very large scad file which we would rather not commit to the source tree
@@ -832,6 +848,9 @@ add_custom_target(svg_viewbox_tests ALL
 add_cmdline_test(dumptest EXE ${OPENSCAD_BINPATH} ARGS -o SUFFIX csg FILES ${DUMPTEST_FILES})
 add_cmdline_test(dumptest-examples EXE ${OPENSCAD_BINPATH} ARGS -o SUFFIX csg FILES ${EXAMPLE_FILES})
 add_cmdline_test(cgalpngtest EXE ${OPENSCAD_BINPATH} ARGS --render -o SUFFIX png FILES ${CGALPNGTEST_FILES})
+list(SUBLIST CGALPNGTEST_FILES 0 1 CGALPNGSTDIOTEST_FILES)
+add_cmdline_test(cgalpngstdiotest EXE ${OPENSCAD_BINPATH} ARGS --export-format png --render -o SUFFIX png STDIN true STDOUT true EXPECTEDDIR cgalpngtest FILES
+                                   ${CGALPNGSTDIOTEST_FILES})
 add_cmdline_test(opencsgtest EXE ${OPENSCAD_BINPATH} ARGS -o SUFFIX png FILES ${OPENCSGTEST_FILES})
 add_cmdline_test(csgpngtest EXE ${PYTHON_EXECUTABLE} SCRIPT ${CMAKE_CURRENT_SOURCE_DIR}/export_import_pngtest.py ARGS --openscad=${OPENSCAD_BINPATH} --format=csg --render EXPECTEDDIR cgalpngtest SUFFIX png FILES ${CGALPNGTEST_FILES})
 add_cmdline_test(throwntogethertest EXE ${OPENSCAD_BINPATH} ARGS --preview=throwntogether -o SUFFIX png FILES ${THROWNTOGETHERTEST_FILES})

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -847,7 +847,9 @@ add_custom_target(svg_viewbox_tests ALL
 
 add_cmdline_test(dumptest EXE ${OPENSCAD_BINPATH} ARGS -o SUFFIX csg FILES ${DUMPTEST_FILES})
 add_cmdline_test(dumptest-examples EXE ${OPENSCAD_BINPATH} ARGS -o SUFFIX csg FILES ${EXAMPLE_FILES})
-add_cmdline_test(cgalpngtest EXE ${OPENSCAD_BINPATH} ARGS --render -o SUFFIX png FILES ${CGALPNGTEST_FILES})
+if (WIN32)
+  add_cmdline_test(cgalpngtest EXE ${OPENSCAD_BINPATH} ARGS --render -o SUFFIX png FILES ${CGALPNGTEST_FILES})
+endif()
 list(SUBLIST CGALPNGTEST_FILES 0 1 CGALPNGSTDIOTEST_FILES)
 add_cmdline_test(cgalpngstdiotest EXE ${OPENSCAD_BINPATH} ARGS --export-format png --render -o SUFFIX png STDIN true STDOUT true EXPECTEDDIR cgalpngtest FILES
                                    ${CGALPNGSTDIOTEST_FILES})

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -847,12 +847,12 @@ add_custom_target(svg_viewbox_tests ALL
 
 add_cmdline_test(dumptest EXE ${OPENSCAD_BINPATH} ARGS -o SUFFIX csg FILES ${DUMPTEST_FILES})
 add_cmdline_test(dumptest-examples EXE ${OPENSCAD_BINPATH} ARGS -o SUFFIX csg FILES ${EXAMPLE_FILES})
-if (WIN32)
-  add_cmdline_test(cgalpngtest EXE ${OPENSCAD_BINPATH} ARGS --render -o SUFFIX png FILES ${CGALPNGTEST_FILES})
-endif()
-list(SUBLIST CGALPNGTEST_FILES 0 1 CGALPNGSTDIOTEST_FILES)
-add_cmdline_test(cgalpngstdiotest EXE ${OPENSCAD_BINPATH} ARGS --export-format png --render -o SUFFIX png STDIN true STDOUT true EXPECTEDDIR cgalpngtest FILES
+add_cmdline_test(cgalpngtest EXE ${OPENSCAD_BINPATH} ARGS --render -o SUFFIX png FILES ${CGALPNGTEST_FILES})
+if (NOT WIN32)
+  list(SUBLIST CGALPNGTEST_FILES 0 1 CGALPNGSTDIOTEST_FILES)
+  add_cmdline_test(cgalpngstdiotest EXE ${OPENSCAD_BINPATH} ARGS --export-format png --render -o SUFFIX png STDIN true STDOUT true EXPECTEDDIR cgalpngtest FILES
                                    ${CGALPNGSTDIOTEST_FILES})
+endif()
 add_cmdline_test(opencsgtest EXE ${OPENSCAD_BINPATH} ARGS -o SUFFIX png FILES ${OPENCSGTEST_FILES})
 add_cmdline_test(csgpngtest EXE ${PYTHON_EXECUTABLE} SCRIPT ${CMAKE_CURRENT_SOURCE_DIR}/export_import_pngtest.py ARGS --openscad=${OPENSCAD_BINPATH} --format=csg --render EXPECTEDDIR cgalpngtest SUFFIX png FILES ${CGALPNGTEST_FILES})
 add_cmdline_test(throwntogethertest EXE ${OPENSCAD_BINPATH} ARGS --preview=throwntogether -o SUFFIX png FILES ${THROWNTOGETHERTEST_FILES})

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -818,7 +818,7 @@ file(WRITE ${CMAKE_CURRENT_BINARY_DIR}/CTestCustom.cmake ${TMP})
 #
 
 add_cmdline_test(astdumptest EXE ${OPENSCAD_BINPATH} ARGS -o SUFFIX ast FILES ${ASTDUMPTEST_FILES})
-add_cmdline_test(astdumpstdiotest EXE ${OPENSCAD_BINPATH} ARGS --export-format ast -o SUFFIX ast STDOUT true STDIN true EXPECTEDDIR astdumptest FILES
+add_cmdline_test(astdumpstdiotest EXE ${OPENSCAD_BINPATH} ARGS --enable=function-literals --export-format ast -o SUFFIX ast STDOUT true STDIN true EXPECTEDDIR astdumptest FILES
                                   ${CMAKE_CURRENT_SOURCE_DIR}/../testdata/scad/misc/allexpressions.scad)
 
 

--- a/tests/test_cmdline_tool.py
+++ b/tests/test_cmdline_tool.py
@@ -223,7 +223,7 @@ def post_process_3mf(filename):
     with open(filename, 'wb') as xml_file:
         xml_file.write(xml_content.encode('utf-8'))
 
-def run_test(testname, cmd, args):
+def run_test(testname, cmd, args, redirect_stdin=False, redirect_stdout=False):
     cmdname = os.path.split(options.cmd)[1]
 
     if options.generate: 
@@ -243,9 +243,19 @@ def run_test(testname, cmd, args):
     outputname = os.path.normpath(outputname)
 
     outfile = open(outputname, "wb")
+    if redirect_stdin:
+        infile = open(args[0], "rb")
+    else:
+        infile = None
+
+    if redirect_stdin:
+        if not args[0].endswith('.scad'):
+            print("Error, expecting to replace input file with '-' to run a stdin test but first arg was not a .scad file")
+            return None
+        args[0] = "-"
 
     try:
-        cmdline = [cmd] + args + [outputname]
+        cmdline = [cmd] + args + ['-' if redirect_stdout else outputname]
         sys.stderr.flush()
         print('run_test() cmdline:', ' '.join(cmdline))
         fontdir = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "testdata/ttf"))
@@ -253,14 +263,17 @@ def run_test(testname, cmd, args):
         fontenv["OPENSCAD_FONT_PATH"] = fontdir
         print('using font directory:', fontdir)
         sys.stdout.flush()
-        proc = subprocess.Popen(cmdline, env = fontenv, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+        stdin = infile if redirect_stdin else None
+        stdout = outfile if redirect_stdout else subprocess.PIPE
+        proc = subprocess.Popen(cmdline, env=fontenv, stdin=stdin, stdout=stdout, stderr=subprocess.PIPE)
         comresult = proc.communicate()
-        stdouttext, errtext = comresult[0].decode('utf-8'),comresult[1].decode('utf-8')
-        if errtext != None and len(errtext) > 0:
-            print("stderr output: " + errtext, file=sys.stderr)
-        if stdouttext != None and len(stdouttext) > 0:
-            print("stdout output: " + stdouttext, file=sys.stderr)
+        if comresult[1]:
+            print("stderr output: " + comresult[1].decode('utf-8'), file=sys.stderr)
+        if comresult[0]:
+            print("stdout output: " + comresult[0].decode('utf-8'), file=sys.stderr)
         outfile.close()
+        if infile is not None:
+            infile.close()
         if proc.returncode != 0:
             print("Error: %s failed with return code %d" % (cmdname, proc.returncode), file=sys.stderr)
             return None
@@ -287,12 +300,14 @@ def usage():
     print("  -t, --test=<name>        Specify test name instead of deducting it from the argument (defaults to basename <exe>)", file=sys.stderr)
     print("  -f, --file=<name>        Specify test file instead of deducting it from the argument (default to basename <first arg>)", file=sys.stderr)
     print("  -c, --convexec=<name>    Path to ImageMagick 'convert' executable", file=sys.stderr)
+    print("      --stdin              Pipe input file to <cmdline-tool> by stdin, replacing input file name with '-' when calling <cmdline-tool>", file=sys.stderr)
+    print("      --stdout             Pipe output of <cmdline-tool> to output file, replacing output file name with '-' when calling <cmdline-tool>", file=sys.stderr)
 
 if __name__ == '__main__':
     # Handle command-line arguments
     try:
         debug('args:'+str(sys.argv))
-        opts, args = getopt.getopt(sys.argv[1:], "gs:e:c:t:f:m", ["generate", "convexec=", "suffix=", "expected_dir=", "test=", "file=", "comparator="])
+        opts, args = getopt.getopt(sys.argv[1:], "gs:e:c:t:f:m", ["generate", "convexec=", "suffix=", "expected_dir=", "test=", "file=", "comparator=", "stdin", "stdout"])
         debug('getopt args:'+str(sys.argv))
     except (getopt.GetoptError) as err:
         usage()
@@ -304,6 +319,8 @@ if __name__ == '__main__':
     options.generate = False
     options.suffix = "txt"
     options.comparator = ""
+    options.stdin = False
+    options.stdout = False
 
     for o, a in opts:
         if o in ("-g", "--generate"): options.generate = True
@@ -320,6 +337,10 @@ if __name__ == '__main__':
             options.comparison_exec = os.path.normpath( a )
         elif o in ("-m", "--comparator"):
             options.comparator = a
+        elif o == "--stdin" :
+            options.stdin = True
+        elif o == "--stdout" :
+            options.stdout = True
 
     # <cmdline-tool> and <argument>
     if len(args) < 2:
@@ -354,7 +375,7 @@ if __name__ == '__main__':
     # Verify test environment
     verification = verify_test(options.testname, options.cmd)
 
-    resultfile = run_test(options.testname, options.cmd, args[1:])
+    resultfile = run_test(options.testname, options.cmd, args[1:], options.stdin, options.stdout)
     if not resultfile: exit(1)
     if options.suffix == "3mf": post_process_3mf(resultfile)
     if not verification or not compare_with_expected(resultfile): exit(1)


### PR DESCRIPTION
These change allow reading and writing from/to stdin and stdout.

I couldn't figure out a nice way to rewrite `EchoStream` so it uses a conditional on every handle of `output`. Unless I'm missing something, it doesn't need to be a subclass of `ofstream`.

Things I'm unsure about:

1. Windows; does stdout on windows care about binary?
2. The parser takes in the filename and I'm guessing uses it to report errors. When reading from stdin, should the name displayed for reporting get changed to something else than `-`? I think other tools use something like `<stdin>`.
3. Updating the help text. Is there more than one place to document this?

Relevant issues:
#615 #616