### PR TITLE
Fix test path for uploads from github CMake builds.

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -33,7 +33,7 @@ jobs:
       if: ${{ always() }}
       with:
         name: Test Result Report (${{ matrix.os }})
-        path: tests/Testing/Temporary/*_report.html
+        path: b/tests/Testing/Temporary/*_report.html
     - name: Upload Code Coverage Report
       uses: actions/upload-artifact@v2
       with:


### PR DESCRIPTION
Just noticed the uploads were failing due to recent slight path change.