### PR TITLE
[#3420] disable editor when hidden

### DIFF
--- a/src/mainwin.cc
+++ b/src/mainwin.cc
@@ -2857,6 +2857,9 @@ void MainWindow::hideEditor()
 	auto e = (ScintillaEditor *) this->activeEditor;
 	if (viewActionHideEditor->isChecked()) {
 		e->qsci->setReadOnly(true);
+		if (e->qsci->isListActive()) {
+			e->qsci->cancelList();
+		}
 		editorDock->close();
 	}else {
 		e->qsci->setReadOnly(false);

--- a/src/mainwin.cc
+++ b/src/mainwin.cc
@@ -48,6 +48,7 @@
 #include "FontListDialog.h"
 #include "LibraryInfoDialog.h"
 #include "RenderStatistic.h"
+#include "scintillaeditor.h"
 #ifdef ENABLE_OPENCSG
 #include "CSGTreeEvaluator.h"
 #include "OpenCSGRenderer.h"
@@ -2853,9 +2854,12 @@ void MainWindow::hide3DViewToolbar()
 
 void MainWindow::hideEditor()
 {
+	auto e = (ScintillaEditor *) this->activeEditor;
 	if (viewActionHideEditor->isChecked()) {
+		e->qsci->setReadOnly(true);
 		editorDock->close();
 	}else {
+		e->qsci->setReadOnly(false);
 		editorDock->show();
 	}
 }

--- a/src/mainwin.cc
+++ b/src/mainwin.cc
@@ -2856,6 +2856,11 @@ void MainWindow::hideEditor()
 {
 	auto e = (ScintillaEditor *) this->activeEditor;
 	if (viewActionHideEditor->isChecked()) {
+		// Workaround manually disabling interactions with editor by setting it
+		// to read-only when not being shown.  This is an upstream bug from Qt
+		// (tracking ticket: https://bugreports.qt.io/browse/QTBUG-82939) and
+		// may eventually get resolved at which point this bit and the stuff in
+		// the else should be removed. Currently known to affect 5.14.1 and 5.15.0
 		e->qsci->setReadOnly(true);
 		if (e->qsci->isListActive()) {
 			e->qsci->cancelList();


### PR DESCRIPTION
Addresses https://github.com/openscad/openscad/issues/3420

- Setting the active editor to read only when hidden 94cc6b4 
- If an autocomplete is being shown, cancel it 2b470a0 