### PR TITLE
Make scad-mode derive from c-mode

### DIFF
--- a/contrib/scad-mode.el
+++ b/contrib/scad-mode.el
@@ -50,6 +50,14 @@
 
 (require 'cc-mode)
 
+(eval-when-compile
+  (require 'cc-langs)
+  (require 'cc-fonts)
+  (require 'cl))
+
+(eval-and-compile
+  (c-add-language 'scad-mode 'c-mode))
+
 (defcustom scad-command
   '"openscad"
   "Path to openscad executable"
@@ -181,9 +189,15 @@
           scad-keywords scad-functions scad-modules)
   "List of known words for completion.")
 
+(defcustom scad-mode-disable-c-mode-hook t
+  "When set to `T', do not run hooks of parent mode (`c-mode')."
+  :group 'scad-mode
+  :tag "SCAD Mode Disable C Mode Hook"
+  :type 'boolean)
+
 (put 'scad-mode 'c-mode-prefix "scad-")
 ;;;###autoload
-(define-derived-mode scad-mode prog-mode "SCAD"
+(define-derived-mode scad-mode c-mode "SCAD"
   "Major mode for editing OpenSCAD code.
 
 To see what version of CC Mode you are running, enter `\\[c-version]'.
@@ -195,11 +209,14 @@ Key bindings:
 \\{scad-mode-map}"
   (add-hook 'completion-at-point-functions
             'scad-completion-at-point nil 'local)
-  (c-initialize-cc-mode)
+  (when scad-mode-disable-c-mode-hook
+    (setq-local c-mode-hook nil))
+  (c-initialize-cc-mode t)
   ;; (setq local-abbrev-table scad-mode-abbrev-table
   ;; 	abbrev-mode t)
   (use-local-map scad-mode-map)
   (c-set-offset (quote cpp-macro) 0 nil)
+  (c-init-language-vars scad-mode)
   (c-basic-common-init 'scad-mode (or scad-indent-style "k&r"))
   (c-font-lock-init)
   (c-run-mode-hooks 'c-mode-common-hook 'scad-mode-hook)


### PR DESCRIPTION
When extending directly from `prog-mode`, it seems there are some edge cases that cause font-lock to hang until you interrupt with `C-g`, as discussed in #2996 

Deriving from `c-mode` fixes the problem. By default, such derived modes call `c-mode-hook` during initialization, but it's not really desirable for scad-mode, so we disable this hook (unless the user overrides this by customizing `scad-mode-disable-c-mode-hook`).

Fixes #2969
