### PR TITLE
Add $export_suffix

### DIFF
--- a/src/MainWindow.h
+++ b/src/MainWindow.h
@@ -64,6 +64,7 @@ public:
 #endif
 	class ThrownTogetherRenderer *thrownTogetherRenderer;
 
+  QString custom_export_suffix;
 	QString last_compiled_doc;
 
 	QAction *actionRecentFile[UIUtils::maxRecentFiles];


### PR DESCRIPTION
This will allow you to add a special suffix that will be the default export
name.

For example, for mypart.scad, if you set $export_suffix to "top-part", the
default STL export name will be "mypart-top-part.scad".

See https://github.com/openscad/openscad/issues/3404 