### PR TITLE
[#3420] disable autocomplete on hide - pt.2

### DIFF
--- a/src/mainwin.cc
+++ b/src/mainwin.cc
@@ -2867,6 +2867,9 @@ void MainWindow::hideEditor()
 		}
 		e->qsci->setAutoCompletionSource(QsciScintilla::AcsNone);
 		e->qsci->setCallTipsStyle(QsciScintilla::CallTipsNone);
+		if (e->qsci->isCallTipActive()) {
+		 	e->cancelCallTip();
+		}
 		editorDock->close();
 	}else {
 		e->qsci->setReadOnly(false);

--- a/src/mainwin.cc
+++ b/src/mainwin.cc
@@ -2866,10 +2866,12 @@ void MainWindow::hideEditor()
 			e->qsci->cancelList();
 		}
 		e->qsci->setAutoCompletionSource(QsciScintilla::AcsNone);
+		e->qsci->setCallTipsStyle(QsciScintilla::CallTipsNone);
 		editorDock->close();
 	}else {
 		e->qsci->setReadOnly(false);
 		e->qsci->setAutoCompletionSource(QsciScintilla::AcsAPIs);
+		e->qsci->setCallTipsStyle(QsciScintilla::CallTipsContext);
 		editorDock->show();
 	}
 }

--- a/src/mainwin.cc
+++ b/src/mainwin.cc
@@ -2865,9 +2865,11 @@ void MainWindow::hideEditor()
 		if (e->qsci->isListActive()) {
 			e->qsci->cancelList();
 		}
+		e->qsci->setAutoCompletionSource(QsciScintilla::AcsNone);
 		editorDock->close();
 	}else {
 		e->qsci->setReadOnly(false);
+		e->qsci->setAutoCompletionSource(QsciScintilla::AcsAPIs);
 		editorDock->show();
 	}
 }

--- a/src/scintillaeditor.cpp
+++ b/src/scintillaeditor.cpp
@@ -1319,3 +1319,8 @@ void ScintillaEditor::jumpToNextError()
 {
 	findMarker(1, 0, [this](int line){ return qsci->markerFindNext(line, 1 << errMarkerNumber); });
 }
+
+void ScintillaEditor::cancelCallTip()
+{
+	qsci->SendScintilla(QsciScintilla::SCI_CALLTIPCANCEL);
+}

--- a/src/scintillaeditor.h
+++ b/src/scintillaeditor.h
@@ -64,6 +64,7 @@ public:
 	QPoint mapToGlobal(const QPoint &) override;
 
 	void setCursorPosition(int line, int col) override;
+	void cancelCallTip();
 
 private:
 	void getRange(int *lineFrom, int *lineTo);


### PR DESCRIPTION
I hadn't thought to test additional text input after setting the editor to read only, thought that would already block everything, my bad. Thanks for the comments and sorry for the delay!

Second PR addressing: https://github.com/openscad/openscad/issues/3420
First PR: https://github.com/openscad/openscad/pull/3423

- 7ab7624 fixes https://github.com/openscad/openscad/pull/3423#issuecomment-684084541
- 8d5e046  fixes https://github.com/openscad/openscad/pull/3423#issuecomment-684124142
- f92e0e1 fixes another issue I was encountering where the active call tip wasn't disappearing after hiding the editor 