### PR TITLE
Bring back ECHO: prefix for stderr output.

### DIFF
--- a/src/openscad.cc
+++ b/src/openscad.cc
@@ -103,8 +103,7 @@ public:
 	}
 	static void output(const Message& msgObj, void *userdata) {
 		auto stream = static_cast<Echostream*>(userdata);
-		const std::string loc = msgObj.loc.isNone() ? "" : " " + msgObj.loc.toRelativeString(msgObj.docPath);
-		*stream << getGroupName(msgObj.group) << ": " << msgObj.msg << loc << "\n";
+		*stream << msgObj.str() << "\n";
 	}
 
 	~Echostream() {

--- a/src/printutils.h
+++ b/src/printutils.h
@@ -47,6 +47,12 @@ struct Message {
 	Message(const std::string& msg, const Location& loc, const std::string& docPath, const message_group& group)
 	: msg(msg), loc(loc), docPath(docPath), group(group)
 	{ }
+
+	std::string str() const {
+		const auto g = group == message_group::None ? "" : getGroupName(group) + ": ";
+		const auto l = loc.isNone() ? "" : " " + loc.toRelativeString(docPath);
+		return g + msg + l;
+	}
 };
 
 typedef void (OutputHandlerFunc)(const Message &msg,void *userdata);

--- a/tests/regression/echotest/errors-warnings-expected.echo
+++ b/tests/regression/echotest/errors-warnings-expected.echo
@@ -25,7 +25,7 @@ WARNING: Cylinder parameters ambiguous in file errors-warnings.scad, line 35
 WARNING: color() expects numbers between 0.0 and 1.0. Value of -1.0 is out of range in file errors-warnings.scad, line 42
 WARNING: color() expects numbers between 0.0 and 1.0. Value of 2.0 is out of range in file errors-warnings.scad, line 42
 WARNING: Unable to parse color "notaname" in file errors-warnings.scad, line 43
-WARNING: Please see https://en.wikipedia.org/wiki/Web_colors
+Please see https://en.wikipedia.org/wiki/Web_colors
 WARNING: Ignoring unknown module 'box' in file errors-warnings.scad, line 44
 WARNING: $fs too small - clamping to 0.010000 in file errors-warnings.scad, line 46
 WARNING: $fa too small - clamping to 0.010000 in file errors-warnings.scad, line 47

--- a/tests/regression/echotest/errors-warnings-included-expected.echo
+++ b/tests/regression/echotest/errors-warnings-included-expected.echo
@@ -26,7 +26,7 @@ WARNING: Cylinder parameters ambiguous in file errors-warnings.scad, line 35
 WARNING: color() expects numbers between 0.0 and 1.0. Value of -1.0 is out of range in file errors-warnings.scad, line 42
 WARNING: color() expects numbers between 0.0 and 1.0. Value of 2.0 is out of range in file errors-warnings.scad, line 42
 WARNING: Unable to parse color "notaname" in file errors-warnings.scad, line 43
-WARNING: Please see https://en.wikipedia.org/wiki/Web_colors
+Please see https://en.wikipedia.org/wiki/Web_colors
 WARNING: Ignoring unknown module 'box' in file errors-warnings.scad, line 44
 WARNING: $fs too small - clamping to 0.010000 in file errors-warnings.scad, line 46
 WARNING: $fa too small - clamping to 0.010000 in file errors-warnings.scad, line 47


### PR DESCRIPTION
Fixes  #3451.