### PR TITLE
Add support for lib3MF v2.0 API

### DIFF
--- a/cmake/Modules/FindLib3MF.cmake
+++ b/cmake/Modules/FindLib3MF.cmake
@@ -15,9 +15,26 @@ message(STATUS "Searching for lib3mf.")
 # We still fall back to the rest of detection code here.
 # Travis CI Ubuntu Trusty environment has some issue with pkg-config
 # not finding the version.
-pkg_check_modules(LIB3MF lib3MF>=1.8.1)
-if (LIB3MF_VERSION)
+pkg_check_modules(LIB3MF lib3MF)
+
+# default to uppercase for 1.0 library name
+set(LIB3MF_LIB "3MF")
+
+# some distribution packages are missing version information for 2.0
+if (LIB3MF_VERSION STREQUAL "" AND LIB3MF_FOUND)
+  if (EXISTS "/usr/include/lib3mf" AND EXISTS "/usr/include/lib3mf/lib3mf_implicit.hpp")
+    set(LIB3MF_VERSION "2.0.0")
+  endif()
+endif()
+
+if (LIB3MF_VERSION VERSION_GREATER_EQUAL 1.8.1)
   message("lib3MF ${LIB3MF_VERSION} found: ${LIB3MF_INCLUDE_DIRS}")
+endif()
+
+if (LIB3MF_VERSION VERSION_GREATER_EQUAL 2.0.0)
+  set(LIB3MF_API_2)
+  set(LIB3MF_LIB "3mf")
+  add_definitions(-DLIB3MF_API_2)
 endif()
 
 if (NOT $ENV{OPENSCAD_LIBRARIES} STREQUAL "")
@@ -46,7 +63,7 @@ if ("${LIB3MF_LIBDIR}" STREQUAL "")
 endif()
 
 if (NOT ${LIB3MF_LIBDIR} STREQUAL "")
-  set(LIB3MF_LIBRARIES "-L${LIB3MF_LIBDIR}" "-l3MF -lzip -lz")
+  set(LIB3MF_LIBRARIES "-L${LIB3MF_LIBDIR}" "-l${LIB3MF_LIB} -lzip -lz")
   set(LIB3MF_CFLAGS "-D__GCC -DENABLE_LIB3MF")
   set(LIB3MF_FOUND TRUE)
   message(STATUS "Found lib3mf in ${LIB3MF_LIBDIR}.")

--- a/features/lib3mf.prf
+++ b/features/lib3mf.prf
@@ -14,15 +14,9 @@ isEmpty(LIB3MF_LIBPATH) {
   LIB3MF_LIBPATH = $$(LIB3MF_LIBPATH)
 }
 
-exists($$LIB3MF_INCLUDEPATH/Model/COM/NMR_DLLInterfaces.h) {
-  ENABLE_LIB3MF=yes
-} else {
-  LIB3MF_INCLUDEPATH =
-  LIB3MF_LIBPATH =
-}
-
 isEmpty(LIB3MF_INCLUDEPATH) {
   LIB3MF_CFLAGS = $$system("$$PKG_CONFIG --cflags lib3MF")
+  LIB3MF_INCLUDEPATH = $$system("$$PKG_CONFIG --variable=includedir lib3MF")
   !isEmpty(LIB3MF_CFLAGS) {
     ENABLE_LIB3MF=yes
   }
@@ -32,6 +26,7 @@ isEmpty(LIB3MF_INCLUDEPATH) {
 
 isEmpty(LIB3MF_LIBPATH) {
   LIB3MF_LIBS = $$system("$$PKG_CONFIG --libs lib3MF")
+  LIB3MF_LIBPATH = $$system("$$PKG_CONFIG --variable=libdir lib3MF")
   !isEmpty(LIB3MF_LIBS) {
     ENABLE_LIB3MF=yes
   }
@@ -39,11 +34,25 @@ isEmpty(LIB3MF_LIBPATH) {
   LIB3MF_LIBS = -L$$LIB3MF_LIBPATH -l3MF
 }
 
+exists($$LIB3MF_INCLUDEPATH/Model/COM/NMR_DLLInterfaces.h) {
+  ENABLE_LIB3MF=yes
+  LIB3MF_API="API 1.0"
+} else:exists($$LIB3MF_INCLUDEPATH/lib3mf_implicit.hpp) {
+  ENABLE_LIB3MF=yes
+  LIB3MF_API="API 2.0"
+  DEFINES += LIB3MF_API_2
+  LIB3MF_LIBS = -L$$LIB3MF_LIBPATH -l3mf
+} else {
+  ENABLE_LIB3MF=
+  LIB3MF_INCLUDEPATH =
+  LIB3MF_LIBPATH =
+}
+
 !isEmpty(ENABLE_LIB3MF) {
   DEFINES += ENABLE_LIB3MF
   QMAKE_CXXFLAGS += $$LIB3MF_CFLAGS
   LIBS += $$LIB3MF_LIBS
-  message("3MF Import/Export enabled")
+  message("3MF Import/Export enabled $$LIB3MF_API")
 } else {
   message("3MF Import/Export disabled")
 }

--- a/src/export_3mf.cc
+++ b/src/export_3mf.cc
@@ -30,16 +30,6 @@
 #include "printutils.h"
 
 #ifdef ENABLE_LIB3MF
-#ifdef ENABLE_CGAL
-#include <Model/COM/NMR_DLLInterfaces.h>
-#undef BOOL
-using namespace NMR;
-
-#include <algorithm>
-
-#include "CGAL_Nef_polyhedron.h"
-#include "cgal.h"
-#include "cgalutils.h"
 
 static uint32_t lib3mf_write_callback(const char *data, uint32_t bytes, std::ostream *stream)
 {
@@ -52,6 +42,19 @@ static uint32_t lib3mf_seek_callback(uint64_t pos, std::ostream *stream)
 	stream->seekp(pos);
 	return !(*stream);
 }
+
+#ifndef LIB3MF_API_2
+#include <Model/COM/NMR_DLLInterfaces.h>
+#undef BOOL
+using namespace NMR;
+
+#include <algorithm>
+
+#ifdef ENABLE_CGAL
+
+#include "CGAL_Nef_polyhedron.h"
+#include "cgal.h"
+#include "cgalutils.h"
 
 static void export_3mf_error(const std::string msg, PLib3MFModel *&model)
 {
@@ -201,6 +204,194 @@ void export_3mf(const shared_ptr<const Geometry> &geom, std::ostream &output)
 }
 
 #endif // ENABLE_CGAL
+
+#else // LIB3MF_API_2
+
+#include "lib3mf_implicit.hpp"
+
+#include <algorithm>
+
+#ifdef ENABLE_CGAL
+
+#include "CGAL_Nef_polyhedron.h"
+#include "cgal.h"
+#include "cgalutils.h"
+
+static void export_3mf_error(const std::string msg)
+{
+	LOG(message_group::Export_Error,Location::NONE,"",std::string(msg));
+}
+
+/*
+ * PolySet must be triangulated.
+ */
+static bool append_polyset(const PolySet &ps, Lib3MF::PWrapper &wrapper, Lib3MF::PModel &model)
+{
+	try {
+		auto mesh = model->AddMeshObject();
+		if (!mesh) return false;
+		mesh->SetName("OpenSCAD Model");
+
+		auto vertexFunc = [&](const std::array<double, 3>& coords) -> bool {
+			try {
+				Lib3MF::sPosition v{(Lib3MF_single)coords[0], (Lib3MF_single)coords[1], (Lib3MF_single)coords[2]};
+				mesh->AddVertex(v);
+			} catch (Lib3MF::ELib3MFException &e) {
+				export_3mf_error(e.what());
+				return false;
+			}
+			return true;
+		};
+
+		auto triangleFunc = [&](const std::array<int, 3>& indices) -> bool {
+			try {
+				Lib3MF::sTriangle t{(Lib3MF_uint32)indices[0], (Lib3MF_uint32)indices[1], (Lib3MF_uint32)indices[2]};
+				mesh->AddTriangle(t);
+			} catch (Lib3MF::ELib3MFException &e) {
+				export_3mf_error(e.what());
+				return false;
+			}
+			return true;
+		};
+
+		Export::ExportMesh exportMesh{ps};
+
+		if (!exportMesh.foreach_vertex(vertexFunc)) {
+			export_3mf_error("Can't add vertex to 3MF model.");
+			return false;
+		}
+
+		if (!exportMesh.foreach_triangle(triangleFunc)) {
+			export_3mf_error("Can't add triangle to 3MF model.");
+			return false;
+		}
+
+		Lib3MF::PBuildItem builditem;
+		try {
+			model->AddBuildItem(mesh.get(), wrapper->GetIdentityTransform());
+		} catch (Lib3MF::ELib3MFException &e) {
+			export_3mf_error(e.what());
+		}
+	} catch (Lib3MF::ELib3MFException &e) {
+		export_3mf_error(e.what());
+		return false;
+	}
+	return true;
+}
+
+static bool append_nef(const CGAL_Nef_polyhedron &root_N, Lib3MF::PWrapper &wrapper, Lib3MF::PModel &model)
+{
+	if (!root_N.p3) {
+		LOG(message_group::Export_Error,Location::NONE,"","Export failed, empty geometry.");
+		return false;
+	}
+
+	if (!root_N.p3->is_simple()) {
+		LOG(message_group::Export_Warning,Location::NONE,"","Exported object may not be a valid 2-manifold and may need repair");
+	}
+
+	PolySet ps{3};
+	const bool err = CGALUtils::createPolySetFromNefPolyhedron3(*root_N.p3, ps);
+	if (err) {
+		export_3mf_error("Error converting NEF Polyhedron.");
+		return false;
+	}
+
+	return append_polyset(ps, wrapper, model);
+}
+
+static bool append_3mf(const shared_ptr<const Geometry> &geom, Lib3MF::PWrapper &wrapper, Lib3MF::PModel &model)
+{
+	if (const auto geomlist = dynamic_pointer_cast<const GeometryList>(geom)) {
+		for (const auto &item : geomlist->getChildren()) {
+			if (!append_3mf(item.second, wrapper, model)) return false;
+		}
+	}
+	else if (const auto N = dynamic_pointer_cast<const CGAL_Nef_polyhedron>(geom)) {
+		return append_nef(*N, wrapper, model);
+	}
+	else if (const auto ps = dynamic_pointer_cast<const PolySet>(geom)) {
+		PolySet triangulated(3);
+		PolysetUtils::tessellate_faces(*ps, triangulated);
+		return append_polyset(triangulated, wrapper, model);
+	}
+	else if (dynamic_pointer_cast<const Polygon2d>(geom)) {
+		assert(false && "Unsupported file format");
+	} else {
+		assert(false && "Not implemented");
+	}
+
+	return true;
+}
+
+/*!
+    Saves the current 3D Geometry as 3MF to the given file.
+    The file must be open.
+ */
+
+void export_3mf(const shared_ptr<const Geometry> &geom, std::ostream &output)
+{
+	Lib3MF_uint32 interfaceVersionMajor, interfaceVersionMinor, interfaceVersionMicro;
+	Lib3MF::PWrapper wrapper;
+	
+	try {
+		wrapper = Lib3MF::CWrapper::loadLibrary();
+		wrapper->GetLibraryVersion(interfaceVersionMajor, interfaceVersionMinor, interfaceVersionMicro);
+		if (interfaceVersionMajor != LIB3MF_VERSION_MAJOR) {
+			LOG(message_group::Error,Location::NONE,"","Invalid 3MF library major version %1$d.%2$d.%3$d, expected %4$d.%5$d.%6$d",
+				interfaceVersionMajor,interfaceVersionMinor,interfaceVersionMicro,
+				LIB3MF_VERSION_MAJOR,LIB3MF_VERSION_MINOR,LIB3MF_VERSION_MICRO);
+			return;
+		}
+	} catch (Lib3MF::ELib3MFException &e) {
+		LOG(message_group::Export_Error,Location::NONE,"",e.what());
+		return;
+	}
+
+	if ((interfaceVersionMajor != LIB3MF_VERSION_MAJOR)) {
+		LOG(message_group::Export_Error,Location::NONE,"","Invalid 3MF library major version %1$d.%2$d.%3$d, expected %4$d.%5$d.%6$d",interfaceVersionMajor,interfaceVersionMinor,interfaceVersionMicro,LIB3MF_VERSION_MAJOR,LIB3MF_VERSION_MINOR,LIB3MF_VERSION_MICRO);
+		return;
+	}
+
+	Lib3MF::PModel model;
+	try {
+		model = wrapper->CreateModel();
+		if (!model) {
+			LOG(message_group::Export_Error,Location::NONE,"","Can't create 3MF model.");
+			return;
+		}
+	} catch (Lib3MF::ELib3MFException &e) {
+		LOG(message_group::Export_Error,Location::NONE,"",e.what());
+		return;
+	}
+	
+	if (!append_3mf(geom, wrapper, model)) {
+		return;
+	}
+
+	Lib3MF::PWriter writer;
+	try {
+		writer = model->QueryWriter("3mf");
+		if (!writer) {
+			export_3mf_error("Can't get writer for 3MF model.");
+			return;
+		}
+	} catch (Lib3MF::ELib3MFException &e) {
+		export_3mf_error("Can't get writer for 3MF model.");
+		return;
+	}
+
+	try {
+		writer->WriteToCallback((Lib3MF::WriteCallback)lib3mf_write_callback, (Lib3MF::SeekCallback)lib3mf_seek_callback, &output);
+	} catch (Lib3MF::ELib3MFException &e) {
+		LOG(message_group::Export_Error,Location::NONE,"",e.what());
+	}
+	output.flush();
+}
+
+#endif // ENABLE_CGAL
+
+#endif // LIB3MF_API_2
 
 #else // ENABLE_LIB3MF
 

--- a/src/import_3mf.cc
+++ b/src/import_3mf.cc
@@ -34,6 +34,7 @@
 #include "boost-utils.h"
 
 #ifdef ENABLE_LIB3MF
+#ifndef LIB3MF_API_2
 #include <Model/COM/NMR_DLLInterfaces.h>
 #undef BOOL
 using namespace NMR;
@@ -206,6 +207,182 @@ Geometry * import_3mf(const std::string &filename, const Location &loc)
 		return p;
 	}
 }
+
+#else // LIB3MF_API_2
+
+#include "lib3mf_implicit.hpp"
+
+/*
+ * Provided here for reference in LibraryInfo.cc which can't include
+ * both Qt and lib3mf headers due to some conflicting definitions of
+ * windows types when compiling with MinGW.
+ */
+const std::string get_lib3mf_version() {
+	Lib3MF_uint32 interfaceVersionMajor, interfaceVersionMinor, interfaceVersionMicro;
+	Lib3MF::PWrapper wrapper;
+	
+	try {
+		wrapper = Lib3MF::CWrapper::loadLibrary();
+		wrapper->GetLibraryVersion(interfaceVersionMajor, interfaceVersionMinor, interfaceVersionMicro);
+	} catch (Lib3MF::ELib3MFException &e) {
+		LOG(message_group::Export_Error,Location::NONE,"",e.what());
+	}
+
+	const OpenSCAD::library_version_number header_version{LIB3MF_VERSION_MAJOR, LIB3MF_VERSION_MINOR, LIB3MF_VERSION_MICRO};
+	const OpenSCAD::library_version_number runtime_version{interfaceVersionMajor, interfaceVersionMinor, interfaceVersionMicro};
+	return OpenSCAD::get_version_string(header_version, runtime_version);
+}
+
+#ifdef ENABLE_CGAL
+#include "cgalutils.h"
+#endif
+
+typedef std::list<std::shared_ptr<PolySet>> polysets_t;
+
+static Geometry * import_3mf_error(PolySet *mesh = nullptr, PolySet *mesh2 = nullptr)
+{
+	if (mesh) {
+		delete mesh;
+	}
+	if (mesh2) {
+		delete mesh2;
+	}
+	return new PolySet(3);
+}
+
+Geometry *import_3mf(const std::string &filename, const Location &loc)
+{
+	Lib3MF_uint32 interfaceVersionMajor, interfaceVersionMinor, interfaceVersionMicro;
+	Lib3MF::PWrapper wrapper;
+	
+	try {
+		wrapper = Lib3MF::CWrapper::loadLibrary();
+		wrapper->GetLibraryVersion(interfaceVersionMajor, interfaceVersionMinor, interfaceVersionMicro);
+		if (interfaceVersionMajor != LIB3MF_VERSION_MAJOR) {
+			LOG(message_group::Error,Location::NONE,"","Invalid 3MF library major version %1$d.%2$d.%3$d, expected %4$d.%5$d.%6$d",
+	                        interfaceVersionMajor,interfaceVersionMinor,interfaceVersionMicro,
+	                        LIB3MF_VERSION_MAJOR,LIB3MF_VERSION_MINOR,LIB3MF_VERSION_MICRO);
+			return new PolySet(3);
+		}
+	} catch (Lib3MF::ELib3MFException &e) {
+		LOG(message_group::Export_Error,Location::NONE,"",e.what());
+		return new PolySet(3);
+	}
+
+	Lib3MF::PModel model;
+	try {
+		model = wrapper->CreateModel();
+		if (!model) {
+			LOG(message_group::Error,Location::NONE,"","Could not create model");
+			return new PolySet(3);		
+		}
+	} catch (Lib3MF::ELib3MFException &e) {
+		LOG(message_group::Export_Error,Location::NONE,"",e.what());
+		return new PolySet(3);		
+	}
+
+	Lib3MF::PReader reader;
+	try {
+		reader = model->QueryReader("3mf");
+		if (!reader) {
+			LOG(message_group::Error,Location::NONE,"","Could not create 3MF reader");
+			return new PolySet(3);		
+		}
+	} catch (Lib3MF::ELib3MFException &e) {
+		LOG(message_group::Export_Error,Location::NONE,"",e.what());
+		return new PolySet(3);		
+	}
+
+	bool read_error = false;
+	try {
+		reader->ReadFromFile(filename);
+	} catch (Lib3MF::ELib3MFException &e) {
+		read_error = true;
+	}
+	if (!reader || read_error) {
+		LOG(message_group::Warning,Location::NONE,"","Could not read file '%1$s', import() at line %2$d",filename.c_str(),loc.firstLine());
+		return new PolySet(3);		
+	}
+
+	Lib3MF::PMeshObjectIterator object_it;
+	object_it = model->GetMeshObjects();
+	if (!object_it) {
+		return new PolySet(3);		
+	}
+
+	PolySet *first_mesh = 0;
+	polysets_t meshes;
+	unsigned int mesh_idx = 0;
+	bool has_next = object_it->MoveNext();
+	while (has_next) {
+		Lib3MF::PMeshObject object;
+		try {
+			object = object_it->GetCurrentMeshObject();
+			if (!object) {
+				return import_3mf_error(first_mesh);
+			}
+		} catch (Lib3MF::ELib3MFException &e) {
+			LOG(message_group::Error,Location::NONE,"",e.what());
+			return import_3mf_error(first_mesh);			
+		}
+
+		Lib3MF_uint64 vertex_count = object->GetVertexCount();
+		if (!vertex_count) {
+			return import_3mf_error(first_mesh);
+		}
+		Lib3MF_uint64 triangle_count = object->GetTriangleCount();
+		if (!triangle_count) {
+			return import_3mf_error(first_mesh);
+		}
+
+		PRINTDB("%s: mesh %d, vertex count: %lu, triangle count: %lu", filename.c_str() % mesh_idx % vertex_count % triangle_count);
+
+		PolySet *p = new PolySet(3);
+		for (Lib3MF_uint64 idx = 0; idx < triangle_count; ++idx) {
+			Lib3MF::sTriangle triangle = object->GetTriangle(idx);
+			Lib3MF::sPosition vertex1, vertex2, vertex3;
+			
+			vertex1 = object->GetVertex(triangle.m_Indices[0]);
+			vertex2 = object->GetVertex(triangle.m_Indices[1]);
+			vertex3 = object->GetVertex(triangle.m_Indices[2]);
+			
+			p->append_poly();
+			p->append_vertex(vertex1.m_Coordinates[0], vertex1.m_Coordinates[1], vertex1.m_Coordinates[2]);
+			p->append_vertex(vertex2.m_Coordinates[0], vertex2.m_Coordinates[1], vertex2.m_Coordinates[2]);
+			p->append_vertex(vertex3.m_Coordinates[0], vertex3.m_Coordinates[1], vertex3.m_Coordinates[2]);
+		}
+
+		if (first_mesh) {
+			meshes.push_back(std::shared_ptr<PolySet>(p));
+		} else {
+			first_mesh = p;
+		}
+		mesh_idx++;
+		has_next = object_it->MoveNext();
+	}
+
+	if (first_mesh == 0) {
+		return new PolySet(3);
+	} else if (meshes.empty()) {
+		return first_mesh;
+	} else {
+		PolySet *p = new PolySet(3);
+#ifdef ENABLE_CGAL
+		Geometry::Geometries children;
+		children.push_back(std::make_pair((const AbstractNode*)NULL,  shared_ptr<const Geometry>(first_mesh)));
+		for (polysets_t::iterator it = meshes.begin(); it != meshes.end(); ++it) {
+			children.push_back(std::make_pair((const AbstractNode*)NULL,  shared_ptr<const Geometry>(*it)));
+		}
+		CGAL_Nef_polyhedron *N = CGALUtils::applyUnion3D(children.begin(), children.end());
+
+		CGALUtils::createPolySetFromNefPolyhedron3(*N->p3, *p);
+		delete N;
+#endif
+		return p;
+	}
+}
+
+#endif // LIB3MF_API_2
 
 #else // ENABLE_LIB3MF
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -635,6 +635,24 @@ disable_tests(
 
 )
 
+# Disable LIB3MF tests if library was disabled in build
+if(NOT LIB3MF_FOUND)
+  # check for package again in case this is qmake build ctest
+  if(NOT MSVC)
+    pkg_check_modules(LIB3MF lib3MF)
+  endif()
+  if (NOT LIB3MF_FOUND)
+    disable_tests(
+      opencsgtest_import_3mf-tests
+      cgalpngtest_import_3mf-tests
+      csgpngtest_import_3mf-tests
+      throwntogethertest_import_3mf-tests
+      3mfpngtest_cube10
+      3mfexport_3mf-export
+    )
+  endif()
+endif()
+
 # 2D tests
 list(APPEND FILES_2D ${FEATURES_2D_FILES} ${ISSUES_2D_FILES} ${EXAMPLE_2D_FILES})
 list(APPEND ALL_2D_FILES ${FILES_2D} ${SCAD_DXF_FILES} ${SCAD_SVG_FILES})

--- a/tests/test_cmdline_tool.py
+++ b/tests/test_cmdline_tool.py
@@ -220,6 +220,8 @@ def post_process_3mf(filename):
     from zipfile import ZipFile
     xml_content = ZipFile(filename).read("3D/3dmodel.model")
     xml_content = re.sub('UUID="[^"]*"', 'UUID="XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXX"', xml_content.decode('utf-8'))
+    # add tag end whitespace for lib3mf 2.0 output files
+    xml_content = re.sub('\"/>', '\" />', xml_content)
     with open(filename, 'wb') as xml_file:
         xml_file.write(xml_content.encode('utf-8'))
 


### PR DESCRIPTION
In working #3477, needed to build lib3MF v1.8 package, and already had distribution lib3MF v2.0.

These changes keep the existing lib3MF v1.8 API export/import unchanged. Adds new code in ifdef to support lib3MF v2.0 API depending on which version is found during compile. Disable lib3MF tests if library not found.

Implements enhancement #3116