### PR TITLE
Set keyboard shortcut for "reset translation" as Ctrl+Shift+0 (fixes #3488).

### DIFF
--- a/src/MainWindow.ui
+++ b/src/MainWindow.ui
@@ -1254,6 +1254,9 @@
    <property name="text">
     <string>Ce&amp;nter</string>
    </property>
+   <property name="shortcut">
+    <string>Ctrl+Shift+0</string>
+   </property>
   </action>
   <action name="viewActionPerspective">
    <property name="checkable">
@@ -1569,7 +1572,6 @@
     <string>Hide Customizer</string>
    </property>
   </action>
-
   <action name="fileActionExportPDF">
    <property name="icon">
     <iconset resource="../openscad.qrc">
@@ -1579,7 +1581,6 @@
     <string>Export as PDF...</string>
    </property>
   </action>
-  
   <action name="viewActionHide3DViewToolBar">
    <property name="checkable">
     <bool>true</bool>

--- a/src/mainwin.cc
+++ b/src/mainwin.cc
@@ -262,8 +262,6 @@ MainWindow::MainWindow(const QStringList &filenames)
 	this->anim_dumping = false;
 	this->anim_dump_start_step = 0;
 
-	editActionZoomTextIn->setShortcuts(QList<QKeySequence>() << editActionZoomTextIn->shortcuts() << QKeySequence("CTRL+="));
-
 	this->qglview->statusLabel = new QLabel(this);
 	this->qglview->statusLabel->setMinimumWidth(100);
 	statusBar()->addWidget(this->qglview->statusLabel);
@@ -3074,11 +3072,9 @@ void MainWindow::closeEvent(QCloseEvent *event)
 			delete this->tempFile;
 			this->tempFile = nullptr;
 		}
-		this->editorDock->disableSettingsUpdate();
-		this->consoleDock->disableSettingsUpdate();
-		this->parameterDock->disableSettingsUpdate();
-		this->errorLogDock->disableSettingsUpdate();
-
+		for (auto dock : findChildren<Dock *>()) {
+			dock->disableSettingsUpdate();
+		}
 		event->accept();
 	} else {
 		event->ignore();


### PR DESCRIPTION
This removes the special case for editActionZoomTextIn which had defined an additional Ctrl+= shortcut as this collides with the new one and did not seem to work anyway (at least collides on German keyboard where = is Shift+0).