### PR TITLE
RFC: mouse selector with ctrl+click

### DIFF
--- a/src/QGLView.cc
+++ b/src/QGLView.cc
@@ -298,7 +298,8 @@ void QGLView::mouseReleaseEvent(QMouseEvent *event)
   mouse_drag_active = false;
   releaseMouse();
 
-  if (!mouse_drag_moved) {
+  if (!mouse_drag_moved
+      && (event->button() == Qt::RightButton)) {
     QPoint point = event->pos();
     //point.setY(this->height() - point.y());
     emit doSelectObject(point);
@@ -351,7 +352,7 @@ void QGLView::zoomCursor(int x, int y, int zoom)
   const auto old_dist = cam.zoomValue();
   this->cam.zoom(zoom, true);
   const auto dist = cam.zoomValue();
-  const auto ratio = old_dist / dist - 1.0; 
+  const auto ratio = old_dist / dist - 1.0;
   // screen coordinates from -1 to 1
   const auto screen_x = 2.0 * (x + 0.5) / this->cam.pixel_width - 1.0;
   const auto screen_y = 1.0 - 2.0 * (y + 0.5) / this->cam.pixel_height;


### PR DESCRIPTION
This will change the selection-Click to **CTRL + Click**. (The modification is 1 line of code - this here should be a discussion about the "correct" UX!)

**Benefits**

* No possible confusion with double click to center object (talking to you @nophead :smiley: )
* This allows for a "Selection-Mode" while Ctrl is pressed in future work, for example to select vertices, edges and faces for measurements.
* has roughly the same meaning in source code, when ctrl + clicking on `include`d/`use`d files

**Downsides**

* I think Apple handles Ctrl + Click not always as ctrl + click, did not find good ressources on that (Maybe @kintel can help out here or suggest a "apple-feel" way to do this.)
* The feature is not as prominent as before, and users might miss it


@t-paul This has to be resolved for the next RC, as it will be nearly impossible to change later.