### PR TITLE
show message in console when caches are flushed  (fixes #3540)

### DIFF
--- a/src/mainwin.cc
+++ b/src/mainwin.cc
@@ -2561,6 +2561,9 @@ void MainWindow::actionFlushCaches()
 	dxf_dim_cache.clear();
 	dxf_cross_cache.clear();
 	ModuleCache::instance()->clear();
+    
+    setCurrentOutput();
+    LOG(message_group::None,Location::NONE,"","Caches Flushed");
 }
 
 void MainWindow::viewModeActionsUncheck()


### PR DESCRIPTION
I didn't do anything with the timestamp portion of the issue. If you want that added maybe you could create a separate issue for that alone.

I just display "Caches Flushed" in the console when the Design->Flush Caches menu option is selected.
