### PR TITLE
don't show autocomplete in strings (fixes #3563)

### DIFF
--- a/src/scadapi.cc
+++ b/src/scadapi.cc
@@ -19,6 +19,26 @@ ScadApi::~ScadApi()
 
 void ScadApi::updateAutoCompletionList(const QStringList &context, QStringList &list)
 {
+    //first see if we are in a string literal. if so, don't allow auto comlete
+    bool lastWasEscape=false;
+    bool inString=false;
+    int line, col;
+    qsci->getCursorPosition(&line, &col);
+    auto sLine = qsci->text(line);  //get the current line of text
+    QByteArray ba = sLine.toLocal8Bit();
+    const char *c_str = ba.data();
+    const char *p = c_str;
+    while (col-- > 0) {
+        if (*p == '\\')
+            lastWasEscape = true;   //next character will be literal handle \"
+        else if (lastWasEscape)
+            lastWasEscape = false;
+        else if (*p == '"')        //string toggle
+            inString = !inString;
+        p++;
+    }
+    if (inString) return;  //we are in string literal, don't return autocomplete list
+    //not in string literal, proceed as normal
 	const QString c = context.last();
 	for (int a = 0; a < funcs.size(); ++a) {
 		const ApiFunc &func = funcs.at(a);

--- a/src/scadapi.cc
+++ b/src/scadapi.cc
@@ -17,8 +17,6 @@ ScadApi::~ScadApi()
 {
 }
 
-int inString=false;
-
 void ScadApi::updateAutoCompletionList(const QStringList &context, QStringList &list)
 {
     //first see if we are in a string literal. if so, don't allow auto comlete

--- a/src/scadapi.cc
+++ b/src/scadapi.cc
@@ -24,18 +24,16 @@ void ScadApi::updateAutoCompletionList(const QStringList &context, QStringList &
     bool inString=false;
     int line, col;
     qsci->getCursorPosition(&line, &col);
-    auto sLine = qsci->text(line);  //get the current line of text
-    QByteArray ba = sLine.toLocal8Bit();
-    const char *c_str = ba.data();
-    const char *p = c_str;
+    std::u32string sLine = qsci->text(line).toStdU32String();
+    int dx = 0;
     while (col-- > 0) {
-        if (*p == '\\')
+        const char32_t ch = sLine.at(dx++);
+        if (ch == '\\')
             lastWasEscape = true;   //next character will be literal handle \"
         else if (lastWasEscape)
             lastWasEscape = false;
-        else if (*p == '"')        //string toggle
+        else if (ch == '"')        //string toggle
             inString = !inString;
-        p++;
     }
     if (inString) return;  //we are in string literal, don't return autocomplete list
     //not in string literal, proceed as normal


### PR DESCRIPTION
Autocomplete will be disabled inside string literals. When the editor wants to show an auto complete this code will scan the current line up to the cursor position using '"' characters to determine if the user is in a string literal. 

This will fail on the second and subsequent lines of a multi-line string literal. To fix that would require a lot more scanning of the current text.

