### PR TITLE
Fix uncaught exception from boost::fs

### DIFF
--- a/src/openscad.cc
+++ b/src/openscad.cc
@@ -463,9 +463,6 @@ int do_export(const CommandLine &cmd, Tree &tree, Camera& camera, ContextHandle<
 {
 	const std::string filename_str = fs::path(cmd.output_file).generic_string();
 
-	auto fpath = fs::absolute(fs::path(cmd.filename));
-	auto fparent = fpath.parent_path();
-
   unique_ptr<OffscreenView> glview;
 	ModuleInstantiation root_inst("group");
 	ContextHandle<FileContext> filectx{Context::create<FileContext>(top_ctx.ctx)};
@@ -485,6 +482,8 @@ int do_export(const CommandLine &cmd, Tree &tree, Camera& camera, ContextHandle<
 		LOG(message_group::Warning,*nextLocation,top_ctx->documentPath(),"More than one Root Modifier (!)");
 	}
 	fs::current_path(cmd.original_path);
+	auto fpath = fs::absolute(fs::path(cmd.filename));
+	auto fparent = fpath.parent_path();
 
 	if (cmd.deps_output_file) {
 		fs::current_path(cmd.original_path);


### PR DESCRIPTION
The do_export() function wants to switch to the parent directory of
the .scad source file for .ast and .csg output. But the path to that
directory is computed at the wrong place, when a different directory
is the current one. This causes failure when the source file is
specified by relative path.

Fixes #3579

Signed-off-by: Kristian Nielsen <knielsen@knielsen-hq.org>