### PR TITLE
Fix export_import_pngtest.py for relative source path

### DIFF
--- a/tests/export_import_pngtest.py
+++ b/tests/export_import_pngtest.py
@@ -86,7 +86,7 @@ inputbasename,inputsuffix = os.path.splitext(inputfilename)
 
 if args.format == 'csg':
         # Must export to same folder for include/use/import to work
-        exportfile = inputfile + '.' + args.format
+        exportfile = os.path.abspath(inputfile + '.' + args.format)
 else:
         exportfile = os.path.join(outputdir, inputfilename)
         if args.format != inputsuffix[1:]: exportfile += '.' + args.format


### PR DESCRIPTION
This patch fixes a bunch of testsuite failures in the Debian packaging. The
packaging uses the testsuite in a different way from normal upstream build
(eg. running it outside of the build directory for autopkgtests), which
triggered this issue.

I do not think this patch is critical to get into the release, I'll just
carry the one-line patch in the packaging along with a few other patches. So
no need to do an RC6 just for this, for sure.
 
Use an absolute destination path for .csg output. This is necessary to
put the destination file in the correct place when the source path is
a relative path.

When outputting .csg, openscad interprets the destination path
relative to the parent directory of the source file, not relative to
the current directory when the program was started. This means that
something like `openscad a/b/c.scad -o a/b/c.csg` will try to write
a/b/a/b/c.csg, not a/b/c.csg as was expected by
export_import_pngtest.py.

Signed-off-by: Kristian Nielsen <knielsen@knielsen-hq.org>