### PR TITLE
handle missing file on command line

### DIFF
--- a/src/tabmanager.h
+++ b/src/tabmanager.h
@@ -22,7 +22,7 @@ public:
     void createTab(const QString &filename);
     void openTabFile(const QString &filename);
     void setTabName(const QString &filename, EditorInterface *edt = nullptr);
-    void refreshDocument();
+    bool refreshDocument();
     bool shouldClose();
     bool save(EditorInterface *edt);
     bool saveAs(EditorInterface *edt);


### PR DESCRIPTION
This patch handles the case of a file specified on the command line not able to be opened. It will leave the current tab empty with the title untitled.scad.

