### PR TITLE
Add GUI Console font to Preferences.

### DIFF
--- a/src/Console.cc
+++ b/src/Console.cc
@@ -83,6 +83,10 @@ void Console::addHtml(const QString& html)
 	this->setTextCursor(this->appendCursor);
 }
 
+void Console::setFont(const QString &fontFamily, uint ptSize) {
+	this->document()->setDefaultFont(QFont(fontFamily, ptSize));
+}
+
 void Console::update()
 {
 	// Faster to ignore block count until group of messages are done inserting.

--- a/src/Console.h
+++ b/src/Console.h
@@ -81,5 +81,6 @@ public slots:
 	void actionClearConsole_triggered();
 	void actionSaveAs_triggered();
 	void hyperlinkClicked(const QString& loc);
+	void setFont(const QString &fontFamily, uint ptSize);
 	void update();
 };

--- a/src/Preferences.h
+++ b/src/Preferences.h
@@ -57,6 +57,8 @@ public slots:
 	void on_checkBoxMouseCentricZoom_toggled(bool);
 	void on_timeThresholdOnRenderCompleteSoundEdit_textChanged(const QString &);
 	void on_consoleMaxLinesEdit_textChanged(const QString &);
+	void on_consoleFontChooser_activated(const QString &);
+	void on_consoleFontSize_currentIndexChanged(const QString &);
 	void on_checkBoxEnableAutocomplete_toggled(bool);
 	void on_lineEditCharacterThreshold_textChanged(const QString &);
   //
@@ -104,6 +106,7 @@ signals:
 	void updateUndockMode(bool undockMode) const;
 	void updateReorderMode(bool undockMode) const;
 	void fontChanged(const QString &family, uint size) const;
+	void consoleFontChanged(const QString &family, uint size) const;
 	void colorSchemeChanged(const QString &scheme) const;
 	void openCSGSettingsChanged() const;
 	void syntaxHighlightChanged(const QString &s) const;

--- a/src/Preferences.ui
+++ b/src/Preferences.ui
@@ -1662,7 +1662,14 @@
                   </widget>
                  </item>
                  <item>
-                  <widget class="QLineEdit" name="opencsgLimitEdit"/>
+                  <widget class="QLineEdit" name="opencsgLimitEdit">
+                   <property name="sizePolicy">
+                    <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+                     <horstretch>0</horstretch>
+                     <verstretch>0</verstretch>
+                    </sizepolicy>
+                   </property>
+                  </widget>
                  </item>
                  <item>
                   <widget class="QLabel" name="label_8">
@@ -1670,6 +1677,19 @@
                     <string>elements</string>
                    </property>
                   </widget>
+                 </item>
+                 <item>
+                  <spacer name="horizontalSpacer_39">
+                   <property name="orientation">
+                    <enum>Qt::Horizontal</enum>
+                   </property>
+                   <property name="sizeHint" stdset="0">
+                    <size>
+                     <width>40</width>
+                     <height>20</height>
+                    </size>
+                   </property>
+                  </spacer>
                  </item>
                 </layout>
                </item>
@@ -1699,7 +1719,14 @@
                   </widget>
                  </item>
                  <item>
-                  <widget class="QLineEdit" name="cgalCacheSizeMBEdit"/>
+                  <widget class="QLineEdit" name="cgalCacheSizeMBEdit">
+                   <property name="sizePolicy">
+                    <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+                     <horstretch>0</horstretch>
+                     <verstretch>0</verstretch>
+                    </sizepolicy>
+                   </property>
+                  </widget>
                  </item>
                  <item>
                   <widget class="QLabel" name="label_2">
@@ -1707,6 +1734,19 @@
                     <string>MB</string>
                    </property>
                   </widget>
+                 </item>
+                 <item>
+                  <spacer name="horizontalSpacer_37">
+                   <property name="orientation">
+                    <enum>Qt::Horizontal</enum>
+                   </property>
+                   <property name="sizeHint" stdset="0">
+                    <size>
+                     <width>40</width>
+                     <height>20</height>
+                    </size>
+                   </property>
+                  </spacer>
                  </item>
                 </layout>
                </item>
@@ -1723,7 +1763,14 @@
                   </widget>
                  </item>
                  <item>
-                  <widget class="QLineEdit" name="polysetCacheSizeMBEdit"/>
+                  <widget class="QLineEdit" name="polysetCacheSizeMBEdit">
+                   <property name="sizePolicy">
+                    <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+                     <horstretch>0</horstretch>
+                     <verstretch>0</verstretch>
+                    </sizepolicy>
+                   </property>
+                  </widget>
                  </item>
                  <item>
                   <widget class="QLabel" name="label_6">
@@ -1731,6 +1778,19 @@
                     <string>MB</string>
                    </property>
                   </widget>
+                 </item>
+                 <item>
+                  <spacer name="horizontalSpacer_38">
+                   <property name="orientation">
+                    <enum>Qt::Horizontal</enum>
+                   </property>
+                   <property name="sizeHint" stdset="0">
+                    <size>
+                     <width>40</width>
+                     <height>20</height>
+                    </size>
+                   </property>
+                  </spacer>
                  </item>
                 </layout>
                </item>
@@ -1803,7 +1863,7 @@
                   <number>0</number>
                  </property>
                  <property name="rightMargin">
-                  <number>30</number>
+                  <number>0</number>
                  </property>
                  <property name="bottomMargin">
                   <number>0</number>
@@ -1816,7 +1876,14 @@
                   </widget>
                  </item>
                  <item>
-                  <widget class="QLineEdit" name="timeThresholdOnRenderCompleteSoundEdit"/>
+                  <widget class="QLineEdit" name="timeThresholdOnRenderCompleteSoundEdit">
+                   <property name="sizePolicy">
+                    <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+                     <horstretch>0</horstretch>
+                     <verstretch>0</verstretch>
+                    </sizepolicy>
+                   </property>
+                  </widget>
                  </item>
                  <item>
                   <widget class="QLabel" name="secLabel">
@@ -1824,6 +1891,19 @@
                     <string>sec</string>
                    </property>
                   </widget>
+                 </item>
+                 <item>
+                  <spacer name="horizontalSpacer_40">
+                   <property name="orientation">
+                    <enum>Qt::Horizontal</enum>
+                   </property>
+                   <property name="sizeHint" stdset="0">
+                    <size>
+                     <width>40</width>
+                     <height>20</height>
+                    </size>
+                   </property>
+                  </spacer>
                  </item>
                 </layout>
                </item>
@@ -1846,7 +1926,14 @@
                   </widget>
                  </item>
                  <item>
-                  <widget class="QLineEdit" name="consoleMaxLinesEdit"/>
+                  <widget class="QLineEdit" name="consoleMaxLinesEdit">
+                   <property name="sizePolicy">
+                    <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+                     <horstretch>0</horstretch>
+                     <verstretch>0</verstretch>
+                    </sizepolicy>
+                   </property>
+                  </widget>
                  </item>
                  <item>
                   <widget class="QLabel" name="consoleUnlimitedLabel">
@@ -1854,6 +1941,69 @@
                     <string>(0 for unlimited)</string>
                    </property>
                   </widget>
+                 </item>
+                 <item>
+                  <spacer name="horizontalSpacer_41">
+                   <property name="orientation">
+                    <enum>Qt::Horizontal</enum>
+                   </property>
+                   <property name="sizeHint" stdset="0">
+                    <size>
+                     <width>40</width>
+                     <height>20</height>
+                    </size>
+                   </property>
+                  </spacer>
+                 </item>
+                </layout>
+               </item>
+               <item>
+                <layout class="QHBoxLayout" name="horizontalLayout_consoleFont" stretch="0,0,0,0">
+                 <property name="spacing">
+                  <number>6</number>
+                 </property>
+                 <item>
+                  <widget class="QLabel" name="label_consoleFont">
+                   <property name="text">
+                    <string>Font</string>
+                   </property>
+                   <property name="scaledContents">
+                    <bool>true</bool>
+                   </property>
+                   <property name="alignment">
+                    <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
+                   </property>
+                  </widget>
+                 </item>
+                 <item>
+                  <widget class="QFontComboBox" name="consoleFontChooser">
+                   <property name="consoleCurrentFont" stdset="0">
+                    <font>
+                     <family>DejaVu Sans</family>
+                     <pointsize>12</pointsize>
+                    </font>
+                   </property>
+                  </widget>
+                 </item>
+                 <item>
+                  <widget class="QComboBox" name="consoleFontSize">
+                   <property name="editable">
+                    <bool>true</bool>
+                   </property>
+                  </widget>
+                 </item>
+                 <item>
+                  <spacer name="horizontalSpacer_35">
+                   <property name="orientation">
+                    <enum>Qt::Horizontal</enum>
+                   </property>
+                   <property name="sizeHint" stdset="0">
+                    <size>
+                     <width>40</width>
+                     <height>20</height>
+                    </size>
+                   </property>
+                  </spacer>
                  </item>
                 </layout>
                </item>


### PR DESCRIPTION
Also changed appearance of some other preferences on advanced tab, to not stretch fill the entire width.

BEFORE:
![Screenshot from 2021-01-19 07-40-03](https://user-images.githubusercontent.com/252233/105042374-c7f7d900-5a29-11eb-8990-10a4ba32e35b.png)

AFTER:
![Screenshot from 2021-01-19 07-39-10](https://user-images.githubusercontent.com/252233/105042389-cd552380-5a29-11eb-985b-02543a892610.png)
