### PR TITLE
Update console text colors for dark theme

### DIFF
--- a/src/Console.cc
+++ b/src/Console.cc
@@ -93,6 +93,8 @@ void Console::update()
 	this->setMaximumBlockCount(0);
 	for (const auto &line : this->msgBuffer) {
 		QTextCharFormat charFormat;
+		if (line.group != message_group::None && line.group != message_group::Echo)
+			charFormat.setForeground(QBrush(QColor("#000000")));
 		charFormat.setBackground(QBrush(QColor(getGroupColor(line.group).c_str())));
 		if (!line.link.isEmpty()) {
 			charFormat.setAnchor(true);

--- a/src/printutils.cc
+++ b/src/printutils.cc
@@ -217,7 +217,7 @@ std::string getGroupColor(const enum message_group& group)
 	case message_group::Trace:
 		return "#d0d0ff";
 	default:
-		return "#ffffff";
+		return "transparent";
 	}
 }
 


### PR DESCRIPTION
Fixes #3645 by setting the default background color to transparent and setting the foreground to black for text that has a set background color.  

Before:
![Screenshot_20210210_203041](https://user-images.githubusercontent.com/40727284/107601561-b5b62880-6bec-11eb-97a1-3cf99e184770.png)

After:
![Screenshot_20210210_203139](https://user-images.githubusercontent.com/40727284/107601572-bbac0980-6bec-11eb-8115-272a89abe943.png)
