### PR TITLE
bring back doubleclick to center

### DIFF
--- a/src/QGLView.cc
+++ b/src/QGLView.cc
@@ -203,7 +203,7 @@ void QGLView::mousePressEvent(QMouseEvent *event)
 }
 
 void QGLView::mouseDoubleClickEvent (QMouseEvent *event) {
-
+	this->makeCurrent();
 	setupCamera();
 
 	int viewport[4];
@@ -223,6 +223,11 @@ void QGLView::mouseDoubleClickEvent (QMouseEvent *event) {
 	glReadPixels(x, y, 1, 1, GL_DEPTH_COMPONENT, GL_FLOAT, &z);
 	auto glError = glGetError();
 	if (glError != GL_NO_ERROR) {
+		if (statusLabel) {
+			auto status = QString("Center View: OpenGL Error reading Pixel: %s")
+				.arg(QString::fromLocal8Bit((const char *)gluErrorString(glError)));
+			statusLabel->setText(status);
+		}
 		return;
 	}
 


### PR DESCRIPTION
Bring back double click to center, which occasionally did not work - problem was the Framebuffer was not current. 

closes #2466 (superseeded, simpler solution)
closes  #1787 (once and for all!)