### PR TITLE
Fix errorLog float misreading parameterDock state

### DIFF
--- a/src/mainwin.cc
+++ b/src/mainwin.cc
@@ -2835,7 +2835,7 @@ void MainWindow::on_parameterDock_visibilityChanged(bool)
 
 void MainWindow::on_errorLogDock_visibilityChanged(bool)
 {
-    errorLogTopLevelChanged(parameterDock->isFloating());
+    errorLogTopLevelChanged(errorLogDock->isFloating());
 }
 
 void MainWindow::changedTopLevelEditor(bool topLevel)


### PR DESCRIPTION
A detached Error Log refuses to reattach if the Customizer is also detached, due to a typo, fixed here.