### PR TITLE
WIP: Upload files to DO Space instead of droplet

### DIFF
--- a/Info.plist
+++ b/Info.plist
@@ -113,6 +113,6 @@
 	<key>SUPublicDSAKeyFile</key>
 	<string>dsa_pub.pem</string>
 	<key>SUFeedURL</key>
-	<string>https://files.openscad.org/appcast.xml</string>
+	<string>https://openscad.thisistheremix.dev/appcast.xml</string>
 </dict>
 </plist>

--- a/Info.plist.in
+++ b/Info.plist.in
@@ -103,6 +103,6 @@
 	<key>SUPublicDSAKeyFile</key>
 	<string>dsa_pub.pem</string>
 	<key>SUFeedURL</key>
-	<string>https://files.openscad.org/appcast.xml</string>
+	<string>https://openscad.thisistheremix.dev/appcast.xml</string>
 </dict>
 </plist>

--- a/appcast-snapshots.xml.in
+++ b/appcast-snapshots.xml.in
@@ -9,7 +9,7 @@
       <pubDate>@VERSIONDATE@</pubDate>
       <sparkle:releaseNotesLink>https://raw.githubusercontent.com/openscad/openscad/master/releases/2015.XX.md</sparkle:releaseNotesLink>
       <sparkle:minimumSystemVersion>10.9.0</sparkle:minimumSystemVersion>
-      <enclosure url="https://files.openscad.org/snapshots/OpenSCAD-@VERSION@.dmg"
+      <enclosure url="https://openscad.thisistheremix.dev/snapshots/OpenSCAD-@VERSION@.dmg"
                  sparkle:version="@VERSIONDATE@"
                  sparkle:shortVersionString="@VERSION@"
                  sparkle:dsaSignature="@DSASIGNATURE@"

--- a/appcast.xml.in
+++ b/appcast.xml.in
@@ -9,7 +9,7 @@
       <pubDate>@VERSIONDATE@</pubDate>
       <sparkle:releaseNotesLink>https://raw.githubusercontent.com/openscad/openscad/openscad-@VERSION@/releases/@SHORTVERSION@.md</sparkle:releaseNotesLink>
       <sparkle:minimumSystemVersion>10.9.0</sparkle:minimumSystemVersion>
-      <enclosure url="https://files.openscad.org/OpenSCAD-@VERSION@.dmg"
+      <enclosure url="https://openscad.thisistheremix.dev/OpenSCAD-@VERSION@.dmg"
                  sparkle:version="@VERSIONDATE@"
                  sparkle:shortVersionString="@VERSION@"
                  sparkle:dsaSignature="@DSASIGNATURE@"

--- a/doc/patchlevel-checklist.txt
+++ b/doc/patchlevel-checklist.txt
@@ -17,7 +17,7 @@ o git tag "openscad-$VERSION"
 o ./scripts/git-archive-all.py --prefix=openscad-$VERSION/ openscad-$VERSION.src.tar.gz
 o git push --tags
 o Upload Source package
-  $ scp openscad-$VERSION.src.tar.gz openscad@files.openscad.org:www
+  $ aws --profile openscad-files s3 cp openscad-$VERSION.src.tar.gz s3://openscad-files/
 
 o Revert VERSION and VERSIONDATE in openscad.pro scripts/publish-macosx.sh scripts/release-common.sh scripts/publish-mingw-x.sh tests/CMakeLists.txt
 

--- a/doc/release-checklist.txt
+++ b/doc/release-checklist.txt
@@ -42,7 +42,7 @@ o Sanity check; build a binary or two and manually run some tests
 o git push --tags master
 
 o Upload Source package
-  $ scp openscad-$VERSION.src.tar.gz openscad@files.openscad.org:www
+  $ aws --profile openscad-files s3 cp openscad-$VERSION.src.tar.gz s3://openscad-files/
 
 o Build binaries for all platforms and wait for upload
 
@@ -83,7 +83,7 @@ Linux:
 
     $ ./scripts/release-common.sh -> openscad-$VERSION.x86-ARCH.tar.gz
     (where ARCH will be detected and set to 32 or 64)
-    $ scp openscad-$VERSION.x86-ARCH.tar.gz openscad@files.openscad.org:www
+    $ aws --profile openscad-files s3 cp openscad-$VERSION.x86-ARCH.tar.gz s3://openscad-files/
     o Update web page with download links
 
 Windows mingw cross-build:

--- a/scripts/builder.sh
+++ b/scripts/builder.sh
@@ -50,13 +50,13 @@ init_variables()
 	#BRANCH_TO_BUILD=unstable
 	BRANCH_TO_BUILD=master
 	STARTPATH=$PWD
-	# kilobit (not kilobyte!) per second for scp upload
-	RATELIMIT=420
 	DOBUILD=1
 	DOUPLOAD=1
 	DRYRUN=
 	DOSNAPSHOT=1
 	DOLOOP=
+	AWSPROFILE=openscad-files
+	S3BUCKET=openscad-files
 	#solar day
 	LOOPSLEEP=86400
 	DATECODE=`date +"%Y.%m.%d"`
@@ -90,8 +90,9 @@ init_variables()
 	export DATECODE
 	export DOSNAPSHOT
 	export DOLOOP
+	export AWSPROFILE
+	export S3BUCKET
 	export LOOPSLEEP
-	export RATELIMIT
 	export DATECODE
 }
 
@@ -246,15 +247,15 @@ upload_win_common()
 	opts="$opts -p openscad"
 	opts="$opts -u $username"
 	opts="$opts $filename"
-	remotepath=www/
+	remotepath=/
 	if [ $DOSNAPSHOT ]; then
-		remotepath=www/snapshots/
+		remotepath=snapshots/
 	fi
 	if [ $DRYRUN ]; then
-		echo dry run, not uploading to files.openscad.org
-		echo scp -v -l $RATELIMIT $filename openscad@files.openscad.org:$remotepath
+		echo dry run, not uploading to openscad.thisistheremix.dev
+		echo aws --profile $AWSPROFILE s3 cp $filename s3://$S3BUCKET/$remotepath
 	else
-		scp -v -l $RATELIMIT $filename openscad@files.openscad.org:$remotepath
+		aws --profile $AWSPROFILE s3 cp $filename s3://$S3BUCKET/$remotepath
 	fi
 }
 
@@ -354,10 +355,10 @@ update_win_www_download_links()
 	cd openscad.github.com
 	cd inc
 	echo `pwd`
-	# BASEURL='https://openscad.googlecode.com/files/'
-	BASEURL='http://files.openscad.org/'
+	# BASEURL='https://openscad.thisistheremix.dev/files/'
+	BASEURL='https://openscad.thisistheremix.dev/'
 	if [ $DOSNAPSHOT ]; then
-		BASEURL='http://files.openscad.org/snapshots/'
+		BASEURL='https://openscad.thisistheremix.dev/snapshots/'
 	fi
 
 	mv win_snapshot_links.js win_snapshot_links.js.backup

--- a/scripts/coverity.sh
+++ b/scripts/coverity.sh
@@ -1,10 +1,11 @@
 #!/bin/bash
 
-UPLOAD_DIR=coverity
-UPLOAD_HOST=openscad@files.openscad.org
+UPLOAD_DIR=dev/coverity
+UPLOAD_PROFILE=openscad-files
+UPLOAD_BUCKET=openscad-files
 UPLOAD_FILENAME="coverity-${TRAVIS_BUILD_NUMBER}-scm-log.txt"
 COVERITY_LOG=/home/travis/build/openscad/openscad/cov-int/scm_log.txt
 
 if [ -f "$COVERITY_LOG" ]; then
-	scp "${COVERITY_LOG}" "${UPLOAD_HOST}:${UPLOAD_DIR}/${UPLOAD_FILENAME}"
+	aws --profile $UPLOAD_PROFILE s3 cp "${COVERITY_LOG}" "s3://${UPLOAD_BUCKET}/${UPLOAD_DIR}/${UPLOAD_FILENAME}"
 fi

--- a/scripts/migrate-from-droplet-to-spaces.sh
+++ b/scripts/migrate-from-droplet-to-spaces.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+
+# Run this on files.openscad.or
+
+PROFILE=openscad-files
+BUCKET=openscad-files
+
+aws --profile $PROFILE s3 cp ~/www/ s3://$BUCKET --recursive

--- a/scripts/publish-macosx.sh
+++ b/scripts/publish-macosx.sh
@@ -25,7 +25,7 @@ update_www_download_links()
     webdir=../openscad.github.com
     # FIXME: release vs. snapshot
     incfile=inc/mac_snapshot_links.js
-    BASEURL='http://files.openscad.org/snapshots'
+    BASEURL='http://openscad.thisistheremix.dev/snapshots'
     DATECODE=`date +"%Y.%m.%d"`
     
     if [ -f $webdir/$incfile ]; then
@@ -57,6 +57,15 @@ if test -z "$VERSION"; then
   SNAPSHOT=snapshot
 fi
 SHORTVERSION=${VERSION%%-*}
+
+
+if test -z "$AWSPROFILE"; then
+  AWS_PROFILE="openscad-files"
+fi
+if test -z "$S3BUCKET"; then
+  S3_BUCKET="openscad-files"
+fi
+
 
 # Turn off ccache, just for safety
 PATH=${PATH//\/opt\/local\/libexec\/ccache:}
@@ -101,19 +110,19 @@ fi
 
 echo "Uploading..."
 if [[ $VERSION == $VERSIONDATE ]]; then
-  scp OpenSCAD-$VERSION.dmg openscad@files.openscad.org:www/snapshots
+  aws --profile $AWSPROFILE s3 cp OpenSCAD-$VERSION.dmg s3://$S3BUCKET/snapshots/
 else
-  scp OpenSCAD-$VERSION.dmg openscad@files.openscad.org:www
+  aws --profile $AWSPROFILE s3 cp OpenSCAD-$VERSION.dmg s3://$S3BUCKET/
 fi
 if [[ $? != 0 ]]; then
   exit 1
 fi
-scp $APPCASTFILE openscad@files.openscad.org:www/
+aws --profile $AWSPROFILE s3 cp $APPCASTFILE s3://$S3BUCKET/
 if [[ $? != 0 ]]; then
   exit 1
 fi
 if [[ $VERSION == $VERSIONDATE ]]; then
-  scp $APPCASTFILE openscad@files.openscad.org:www/appcast-snapshots.xml
+  aws --profile $AWSPROFILE s3 cp $APPCASTFILE s3://$S3BUCKET/appcast-snapshots.xml
   if [[ $? != 0 ]]; then
     exit 1
   fi

--- a/scripts/travis-ci-before-install-linux.sh
+++ b/scripts/travis-ci-before-install-linux.sh
@@ -32,7 +32,7 @@ fi
 
 echo "Selected distribution: $DIST"
 
-wget -qO - http://files.openscad.org/OBS-Repository-Key.pub | sudo apt-key add -
+wget -qO - http://openscad.thisistheremix.dev/OBS-Repository-Key.pub | sudo apt-key add -
 echo yes | sudo add-apt-repository "deb $LIB3MF_REPO ./"
 echo yes | sudo add-apt-repository "deb $LIBCGAL_REPO ./"
 sudo apt-get update -qq

--- a/scripts/update-snapshots.sh
+++ b/scripts/update-snapshots.sh
@@ -15,7 +15,7 @@ do
 	FILE="$(ls -t ${NAME[$n]} | head -n 1)"
         DATE="$(echo "$FILE" | cut -b 1-19)"
 	SIZE="$((($(stat --format=%s "$FILE") / 1024 + 512) / 1024)) MB"
-	echo "setSnapshotFileInfo('${KEY[$n]}', '$DATE', '$SIZE', 'https://files.openscad.org/snapshots/$FILE');" >> "${OUT[$n]}".tmp
+	echo "setSnapshotFileInfo('${KEY[$n]}', '$DATE', '$SIZE', 'https://openscad.thisistheremix.dev/snapshots/$FILE');" >> "${OUT[$n]}".tmp
 done
 
 for o in ${OUT[*]}

--- a/src/PrintService.cc
+++ b/src/PrintService.cc
@@ -62,7 +62,7 @@ PrintService * PrintService::inst()
 
 void PrintService::init()
 {
-	auto networkRequest = NetworkRequest<void>{QUrl{"https://files.openscad.org/print-service.json"}, { 200 }, 30};
+	auto networkRequest = NetworkRequest<void>{QUrl{"https://openscad.thisistheremix.dev/print-service.json"}, { 200 }, 30};
 	return networkRequest.execute(
 			[](QNetworkRequest& request) {
 				request.setHeader(QNetworkRequest::ContentTypeHeader, "application/json");

--- a/src/SparkleAutoUpdater.mm
+++ b/src/SparkleAutoUpdater.mm
@@ -76,7 +76,7 @@ QString SparkleAutoUpdater::lastUpdateCheckDate()
 
 void SparkleAutoUpdater::updateFeed()
 {
-  NSString *urlstring = [NSString stringWithFormat:@"https://files.openscad.org/appcast%@.xml", enableSnapshots() ? @"-snapshots" : @""];
+  NSString *urlstring = [NSString stringWithFormat:@"https://openscad.thisistheremix.dev/appcast%@.xml", enableSnapshots() ? @"-snapshots" : @""];
   [d->updater setFeedURL:[NSURL URLWithString:urlstring]];
   NSString *userAgent = [NSString stringWithFormat:@"OpenSCAD %s %s", TOSTRING(OPENSCAD_VERSION), PlatformUtils::sysinfo(false).c_str()];
   [d->updater setUserAgentString: userAgent];


### PR DESCRIPTION
Hey hey,

Many moons ago, DigitalOcean introduced an S3-compatible product. Currently, this project uploads build artifacts (.dmg files, etc., ) to a DigitalOcean droplet (that I'm hosting) running nginx and taking uploads via scp, but I think Spaces is a better fit for this problem.

I set up a space for this and pointed a domain I own to point to it as a CDN. Unfortunately, I think I need to own the DNS in order to make a subdomain for openscad.org work, but I think openscad.thisistheremix.dev will be OK. Happy to use a different domain, as long as I can make my DigitalOcean account control the TLD.

In order to use this new process, you'll need an AWS style access key ID and secret key. I can hand those out to whoever. I don't have keys to files.openscad.org anymore, but am happy to use that machine to transfer working creds for that bucket given that someone can upload my current machine's pubkey. Let me know.

I haven't considered data migrations at all, because I don't know the scope of what would need to be moved and because I don't have keys to files.openscad.org to actually do the migration with. If I can get access, I can write the script to do the migration and make it happen.

Aside from all of that, what this needs now is testing. I'm trying to test the MacOS release process locally, since that's the machine I happen to be on, but the others will need their levers pulled as well.