### PR TITLE
support --hardwarnings for PNG and ECHO output (#3616)

### DIFF
--- a/src/FileModule.cc
+++ b/src/FileModule.cc
@@ -195,7 +195,9 @@ AbstractNode *FileModule::instantiateWithFileContext(const std::shared_ptr<FileC
 		// FIXME: Set document path to the path of the module
 		auto instantiatednodes = this->scope.instantiateChildren(ctx);
 		node->children.insert(node->children.end(), instantiatednodes.begin(), instantiatednodes.end());
-	} catch (EvaluationException &e) {
+	} catch (HardWarningException &e) {
+            throw;
+        } catch (EvaluationException &e) {
 		// LOG(message_group::None,Location::NONE,"",e.what()); //please output the message before throwing the exception
 	}
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1068,8 +1068,8 @@ add_failing_test(stlfailedtest EXE ${PYTHON_EXECUTABLE} SCRIPT ${CMAKE_CURRENT_S
 add_failing_test(offfailedtest EXE ${PYTHON_EXECUTABLE} SCRIPT ${CMAKE_CURRENT_SOURCE_DIR}/shouldfail.py ARGS --openscad=${OPENSCAD_BINPATH} --retval=1 -o SUFFIX off FILES ${CMAKE_CURRENT_SOURCE_DIR}/../testdata/scad/misc/empty-union.scad)
 add_failing_test(parsererrors EXE ${PYTHON_EXECUTABLE} SCRIPT ${CMAKE_CURRENT_SOURCE_DIR}/shouldfail.py ARGS --openscad=${OPENSCAD_BINPATH} --retval=1 -o SUFFIX stl FILES ${FAILING_FILES})
 
-# Hardwarning Test       
-add_failing_test(hardwarnings EXE ${PYTHON_EXECUTABLE} SCRIPT ${CMAKE_CURRENT_SOURCE_DIR}/shouldfail.py ARGS --openscad=${OPENSCAD_BINPATH} --retval=1 --hardwarnings -o SUFFIX echo FILES ${CMAKE_CURRENT_SOURCE_DIR}/../testdata/scad/misc/errors-warnings.scad)
+# Hardwarning Test
+add_failing_test(hardwarnings EXE ${PYTHON_EXECUTABLE} SCRIPT ${CMAKE_CURRENT_SOURCE_DIR}/shouldfail.py ARGS --openscad=${OPENSCAD_BINPATH} --retval=1 --hardwarnings --export-format echo -o - FILES ${CMAKE_CURRENT_SOURCE_DIR}/../testdata/scad/misc/errors-warnings.scad)
 
 # Verify that test framework is paying attention to alpha channel, issue 1492
 #add_cmdline_test(openscad-colorscheme-cornfield-alphafail EXE ${OPENSCAD_BINPATH} ARGS --colorscheme=Cornfield -o SUFFIX png FILES ${CMAKE_CURRENT_SOURCE_DIR}/../examples/Basics/logo.scad)


### PR DESCRIPTION
As reported in #3616, --hardwarnings didn't always cause openscad to
exit with a non-zero error code when a warning was encountered. It did
for STL (and likely other geometry outputs) because those exports exited
with an error code if the root node was empty, but PNG and ECHO don't
check that.

I thought that relying on the geometry check seemed a little accidental,
so the fix I've made is to prevent the file context initialization from
swallowing the HardWarningsException.

I also fixed the hardwarnings test. The test passed only because it was
running the openscad executable with invalid commandline parameters.
OpenSCAD printed usage and exited with an error. The SUFFIX parameter is
not supported by the Cmake add_failing_test function, and shouldfail.py
does not automatically add a - for stdout output.