### PR TITLE
Improved editor call-tips (fixes #3655).

### DIFF
--- a/src/text.cc
+++ b/src/text.cc
@@ -110,6 +110,6 @@ void register_builtin_text()
 {
 	Builtins::init("text", new TextModule(),
 				{
-					"text(text = \"\", size = 10, spacing = 1, font = \"\", halign = \"left\", valign = \"baseline\", direction = \"ltr\", language = \"en\", script = \"latin\"[, $fn])",
+					"text(text = \"\", size = 10, font = \"\", halign = \"left\", valign = \"baseline\", spacing = 1, direction = \"ltr\", language = \"en\", script = \"latin\"[, $fn])",
 				});
 }

--- a/src/text.cc
+++ b/src/text.cc
@@ -110,6 +110,6 @@ void register_builtin_text()
 {
 	Builtins::init("text", new TextModule(),
 				{
-					"text(string, size = 10, string, halign = \"left\", valign = \"baseline\", spacing = 1, direction = \"ltr\", language = \"en\", script = \"latin\"[, $fn])",
+					"text(text = \"\", size = 10, spacing = 1, font = \"\", halign = \"left\", valign = \"baseline\", direction = \"ltr\", language = \"en\", script = \"latin\"[, $fn])",
 				});
 }


### PR DESCRIPTION
In text() call-tip, removed duplicate `string`, added `text=""` and `font=""`
changed the position of `spacing = 1` to match similar code in other files.