### PR TITLE
Add warnings when child module instantiations are present on builtin modules that do not support them.

### DIFF
--- a/src/control.cc
+++ b/src/control.cc
@@ -66,6 +66,11 @@ static AbstractNode* builtin_child(const ModuleInstantiation *inst, const std::s
 {
 	LOG(message_group::Deprecated,Location::NONE,"","child() will be removed in future releases. Use children() instead.");
 	
+	if (!inst->scope.moduleInstantiations.empty()) {
+		LOG(message_group::Warning,inst->location(),context->documentRoot(),
+			"module %1$s() does not support child modules",inst->name());
+	}
+	
 	Arguments arguments{inst->arguments, context};
 	const Children* children = context->user_module_children();
 	if (!children) {
@@ -87,6 +92,11 @@ static AbstractNode* builtin_child(const ModuleInstantiation *inst, const std::s
 
 static AbstractNode* builtin_children(const ModuleInstantiation *inst, const std::shared_ptr<Context>& context)
 {
+	if (!inst->scope.moduleInstantiations.empty()) {
+		LOG(message_group::Warning,inst->location(),context->documentRoot(),
+			"module %1$s() does not support child modules",inst->name());
+	}
+	
 	Arguments arguments{inst->arguments, context};
 	const Children* children = context->user_module_children();
 	if (!children) {

--- a/src/import.cc
+++ b/src/import.cc
@@ -58,6 +58,11 @@ extern Geometry * import_3mf(const std::string &, const Location &loc);
 
 static AbstractNode* do_import(const ModuleInstantiation *inst, Arguments arguments, Children children, ImportType type)
 {
+	if (!children.empty()) {
+		LOG(message_group::Warning,inst->location(),arguments.documentRoot(),
+			"module %1$s() does not support child modules",inst->name());
+	}
+
 	Parameters parameters = Parameters::parse(std::move(arguments), inst->location(),
 		{"file", "layer", "convexity", "origin", "scale"},
 		{"width", "height", "filename", "layername", "center", "dpi"}

--- a/src/linearextrude.cc
+++ b/src/linearextrude.cc
@@ -126,6 +126,9 @@ static AbstractNode* builtin_linear_extrude(const ModuleInstantiation *inst, Arg
 
 	if (node->filename.empty()) {
 		children.instantiate(node);
+	} else if (!children.empty()) {
+		LOG(message_group::Warning,inst->location(),parameters.documentRoot(),
+			"module %1$s() does not support child modules when importing a file",inst->name());
 	}
 
 	return node;

--- a/src/rotateextrude.cc
+++ b/src/rotateextrude.cc
@@ -84,7 +84,11 @@ static AbstractNode* builtin_rotate_extrude(const ModuleInstantiation *inst, Arg
 
 	if (node->filename.empty()) {
 		children.instantiate(node);
+	} else if (!children.empty()) {
+		LOG(message_group::Warning,inst->location(),parameters.documentRoot(),
+			"module %1$s() does not support child modules when importing a file",inst->name());
 	}
+
 
 	return node;
 }

--- a/src/surface.cc
+++ b/src/surface.cc
@@ -77,6 +77,11 @@ private:
 
 static AbstractNode* builtin_surface(const ModuleInstantiation *inst, Arguments arguments, Children children)
 {
+	if (!children.empty()) {
+		LOG(message_group::Warning,inst->location(),arguments.documentRoot(),
+			"module %1$s() does not support child modules",inst->name());
+	}
+
 	auto node = new SurfaceNode(inst);
 
 	Parameters parameters = Parameters::parse(std::move(arguments), inst->location(), {"file", "center", "convexity"}, {"invert"});

--- a/src/text.cc
+++ b/src/text.cc
@@ -41,6 +41,11 @@ using namespace boost::assign; // bring 'operator+=()' into scope
 
 static AbstractNode* builtin_text(const ModuleInstantiation *inst, Arguments arguments, Children children)
 {
+	if (!children.empty()) {
+		LOG(message_group::Warning,inst->location(),arguments.documentRoot(),
+			"module %1$s() does not support child modules",inst->name());
+	}
+
 	auto node = new TextNode(inst);
 
 	Parameters parameters = Parameters::parse(std::move(arguments), inst->location(),

--- a/testdata/scad/misc/leaf-module-warnings.scad
+++ b/testdata/scad/misc/leaf-module-warnings.scad
@@ -1,0 +1,19 @@
+module noop() {}
+
+module children_test() {
+	children() noop();
+}
+children_test() noop();
+
+module child_test() {
+	child() noop();
+}
+child_test() noop();
+
+import("../../dxf/circle.dxf") noop();
+linear_extrude(height = 100, file = "../../dxf-circle.dxf") noop();
+rotate_extrude(height = 100, file = "../../dxf-circle.dxf") noop();
+
+surface("../../image/smiley.png") noop();
+
+text("Hello World!", 26, font = "Liberation Sans:style=Regular") noop();

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -474,6 +474,7 @@ list(APPEND ECHO_FILES ${FUNCTION_FILES} ${MISC_FILES} ${REDEFINITION_FILES}
             ${CMAKE_CURRENT_SOURCE_DIR}/../testdata/scad/misc/operators-tests.scad
             ${CMAKE_CURRENT_SOURCE_DIR}/../testdata/scad/misc/expression-precedence.scad
             ${CMAKE_CURRENT_SOURCE_DIR}/../testdata/scad/misc/builtins-calling-vec3vec2.scad
+            ${CMAKE_CURRENT_SOURCE_DIR}/../testdata/scad/misc/leaf-module-warnings.scad
             ${CMAKE_CURRENT_SOURCE_DIR}/../testdata/scad/issues/issue1472.scad
             ${CMAKE_CURRENT_SOURCE_DIR}/../testdata/scad/misc/empty-stl.scad
             ${CMAKE_CURRENT_SOURCE_DIR}/../testdata/scad/issues/issue1516.scad

--- a/tests/regression/echotest/children-warnings-tests-expected.echo
+++ b/tests/regression/echotest/children-warnings-tests-expected.echo
@@ -1,4 +1,5 @@
 DEPRECATED: child() will be removed in future releases. Use children() instead.
+WARNING: module child() does not support child modules in file children-warnings-tests.scad, line 1
 WARNING: Children index (5) out of bounds (1 children) in file children-warnings-tests.scad, line 4
 WARNING: Children index (5) out of bounds (2 children) in file children-warnings-tests.scad, line 4
 WARNING: Bad range parameter for children: too many elements (10001) in file children-warnings-tests.scad, line 15

--- a/tests/regression/echotest/leaf-module-warnings-expected.echo
+++ b/tests/regression/echotest/leaf-module-warnings-expected.echo
@@ -1,0 +1,11 @@
+WARNING: module children() does not support child modules in file leaf-module-warnings.scad, line 4
+DEPRECATED: child() will be removed in future releases. Use children() instead.
+WARNING: module child() does not support child modules in file leaf-module-warnings.scad, line 9
+WARNING: module import() does not support child modules in file leaf-module-warnings.scad, line 13
+DEPRECATED: Support for reading files in linear_extrude will be removed in future releases. Use a child import() instead.
+WARNING: module linear_extrude() does not support child modules when importing a file in file leaf-module-warnings.scad, line 14
+WARNING: variable height not specified as parameter in file leaf-module-warnings.scad, line 15
+DEPRECATED: Support for reading files in rotate_extrude will be removed in future releases. Use a child import() instead.
+WARNING: module rotate_extrude() does not support child modules when importing a file in file leaf-module-warnings.scad, line 15
+WARNING: module surface() does not support child modules in file leaf-module-warnings.scad, line 17
+WARNING: module text() does not support child modules in file leaf-module-warnings.scad, line 19


### PR DESCRIPTION
Add warnings when child module instantiations are present on builtin modules that do not support them.

Fixes #596.