### PR TITLE
Remove loop causing EXC_BAD_ACCESS on QApplication::quit()

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,7 +22,7 @@ if(POLICY CMP0072)
   cmake_policy(SET CMP0072 NEW)
 endif()
 
-set(CMAKE_OSX_DEPLOYMENT_TARGET "10.9" CACHE STRING "Minimum OS X deployment version")
+set(CMAKE_OSX_DEPLOYMENT_TARGET "10.13" CACHE STRING "Minimum OS X deployment version")
 
 project(openscad)
 

--- a/src/openscad.cc
+++ b/src/openscad.cc
@@ -424,7 +424,7 @@ int cmdline(const CommandLine& cmd)
 
 	RenderVariables render_variables;
 	render_variables.preview = canPreview(export_format) ? (cmd.viewOptions.renderer == RenderType::OPENCSG || cmd.viewOptions.renderer == RenderType::THROWNTOGETHER) : false;
-	
+
 	if (cmd.animate_frames == 0) {
 		render_variables.time = 0;
 		return do_export(cmd, render_variables, export_format, root_file);
@@ -445,7 +445,7 @@ int cmdline(const CommandLine& cmd)
 			string frame_str = frame_file.generic_string();
 
 			LOG(message_group::None, Location::NONE, "", "Exporting %1$s...", cmd.filename);
-			
+
 			CommandLine frame_cmd = cmd;
 			frame_cmd.output_file = frame_str;
 
@@ -853,9 +853,7 @@ int gui(vector<string> &inputFiles, const fs::path &original_path, int argc, cha
 #endif
 
 	InputDriverManager::instance()->init();
-	int rc = app.exec();
-	for (auto &mainw : scadApp->windowManager.getWindows()) delete mainw;
-	return rc;
+	return app.exec();
 }
 #else // OPENSCAD_QTGUI
 bool QtUseGUI() { return false; }
@@ -924,7 +922,7 @@ int main(int argc, char **argv)
 #else
 	PlatformUtils::registerApplicationPath(fs::absolute(boost::filesystem::path(argv[0]).parent_path()).generic_string());
 #endif
-	
+
 #ifdef Q_OS_MAC
 	bool isGuiLaunched = getenv("GUI_LAUNCHED") != nullptr;
 	auto nslog = [](const Message &msg, void *userdata) { CocoaUtils::nslog(msg.msg, userdata); };
@@ -1027,7 +1025,7 @@ int main(int argc, char **argv)
 	if (vm.count("hardwarnings")) {
 		OpenSCAD::hardwarnings = true;
 	}
-	
+
 	std::map<std::string, bool*> flags;
 	flags.insert(std::make_pair("check-parameters",&OpenSCAD::parameterCheck));
 	flags.insert(std::make_pair("check-parameter-ranges",&OpenSCAD::rangeCheck));
@@ -1042,7 +1040,7 @@ int main(int argc, char **argv)
 			}
 		}
 	}
-	
+
 	if (vm.count("help")) help(argv[0], desc);
 	if (vm.count("version")) version();
 	if (vm.count("info")) arg_info = true;
@@ -1120,7 +1118,7 @@ int main(int argc, char **argv)
 		}
 		parameterSet = vm["P"].as<string>().c_str();
 	}
-	
+
 	vector<string> inputFiles;
 	if (vm.count("input-file"))	{
 		inputFiles = vm["input-file"].as<vector<string>>();


### PR DESCRIPTION
Looks like I found the reason for the crash reported in #3775. It happens as soon as something calls `QApplication::quit()`, which is done by the `Cmd+Q` command and also by the menu entry "Quit". 
It happens in [`src/openscad.cc` in line 857](https://github.com/openscad/openscad/blob/176ea07abba6f5f8fb5a130143f23b397416c789/src/openscad.cc#L857). The loop iterates through all main windows and frees their memory. On macOS, I get an EXC_BAD_ACCESS on requesting the vector of all main windows.
![openscad_mac_crash](https://user-images.githubusercontent.com/21987613/119279219-9175d900-bc2a-11eb-8d43-fbf576172d2b.png)
I think this loop is rather useless, because `MainWindow` has the attribute `Qt::WA_DeleteOnClose` set [(file mainwin.cc, line 272)](https://github.com/openscad/openscad/blob/176ea07abba6f5f8fb5a130143f23b397416c789/src/mainwin.cc#L272), which makes their close routine call `delete` automatically.
I did some tests on Manjaro Linux with gdb and Qt 5.15.2, and it is throwing a segmentation fault at the same call if I'm closing OpenSCAD via the menu -> quit or `Ctrl+Q` (see screenshot). So, my suggestion is simple: remove it.
![openscad_linux_crash](https://user-images.githubusercontent.com/21987613/119279214-891d9e00-bc2a-11eb-963c-f8834912100b.png)

If anyone thinks this is not the right solution, I'd be happy to hear their suggestion!