### PR TITLE
Fix styling of tab bar on macOS 11

### DIFF
--- a/patches/qt5/qt-5.15.2-macos-tabbar.patch
+++ b/patches/qt5/qt-5.15.2-macos-tabbar.patch
@@ -1,0 +1,75 @@
+--- a/qtbase/src/plugins/styles/mac/qmacstyle_mac.mm	2020-10-27 09:02:11.000000000 +0100
++++ b/qtbase/src/plugins/styles/mac/qmacstyle_mac.mm	2021-05-26 00:55:31.000000000 +0200
+@@ -3870,6 +3870,7 @@
+             const auto cs = d->effectiveAquaSizeConstrain(opt, w);
+             // Extra hacks to get the proper pressed appreance when not selected or selected and inactive
+             const bool needsInactiveHack = (!isActive && isSelected);
++            const bool isBigSurOrAbove = QOperatingSystemVersion::current() >= QOperatingSystemVersion::MacOSBigSur;
+             const auto ct = !needsInactiveHack && (isSelected || tp == QStyleOptionTab::OnlyOneTab) ?
+                     QMacStylePrivate::Button_PushButton :
+                     QMacStylePrivate::Button_PopupButton;
+@@ -3878,6 +3879,11 @@
+             auto *pb = static_cast<NSButton *>(d->cocoaControl(cw));
+ 
+             auto vOffset = isPopupButton ? 1 : 2;
++            if (isBigSurOrAbove) {
++                // Make it 1, otherwise, offset is very visible compared
++                // to selected tab (which is not a popup button).
++                vOffset = 0;
++            }
+             if (tabDirection == QMacStylePrivate::East)
+                 vOffset -= 1;
+             const auto outerAdjust = isPopupButton ? 1 : 4;
+@@ -3894,9 +3900,19 @@
+                     frameRect = frameRect.adjusted(-innerAdjust, 0, outerAdjust, 0);
+                 else
+                     frameRect = frameRect.adjusted(-outerAdjust, 0, innerAdjust, 0);
++                if (isSelected && isBigSurOrAbove) {
++                    // 1 pixed of 'roundness' is still visible on the right
++                    // (the left is OK, it's rounded).
++                    frameRect = frameRect.adjusted(0, 0, 1, 0);
++                }
+                 break;
+             case QStyleOptionTab::Middle:
+                 frameRect = frameRect.adjusted(-innerAdjust, 0, innerAdjust, 0);
++                if (isSelected && isBigSurOrAbove) {
++                    // 1 pixel of 'roundness' is still visible on both
++                    // sides - left and right.
++                    frameRect = frameRect.adjusted(-1, 0, 1, 0);
++                }
+                 break;
+             case QStyleOptionTab::End:
+                 // Pressed state hack: tweak adjustments in preparation for flip below
+@@ -3904,6 +3920,10 @@
+                     frameRect = frameRect.adjusted(-innerAdjust, 0, outerAdjust, 0);
+                 else
+                     frameRect = frameRect.adjusted(-outerAdjust, 0, innerAdjust, 0);
++                if (isSelected && isBigSurOrAbove) {
++                    // 1 pixel of 'roundness' is still visible on the left.
++                    frameRect = frameRect.adjusted(-1, 0, 0, 0);
++                }
+                 break;
+             case QStyleOptionTab::OnlyOneTab:
+                 frameRect = frameRect.adjusted(-outerAdjust, 0, outerAdjust, 0);
+@@ -3951,7 +3971,10 @@
+                 NSPopUpArrowPosition oldPosition = NSPopUpArrowAtCenter;
+                 NSPopUpButtonCell *pbCell = nil;
+                 auto rAdjusted = r;
+-                if (isPopupButton && tp == QStyleOptionTab::OnlyOneTab) {
++                if (isPopupButton && (tp == QStyleOptionTab::OnlyOneTab || isBigSurOrAbove)) {
++                    // Note: starting from macOS BigSur NSPopupButton has this
++                    // arrow 'button' in a different place and it became
++                    // quite visible 'in between' inactive tabs.
+                     pbCell = static_cast<NSPopUpButtonCell *>(pb.cell);
+                     oldPosition = pbCell.arrowPosition;
+                     pbCell.arrowPosition = NSPopUpNoArrow;
+@@ -3959,6 +3982,9 @@
+                         // NSPopUpButton in this state is smaller.
+                         rAdjusted.origin.x -= 3;
+                         rAdjusted.size.width += 6;
++                        if (isBigSurOrAbove && tp == QStyleOptionTab::End) {
++                            rAdjusted.origin.x -= 2;
++                        }
+                     }
+                 }
+ 

--- a/scripts/macosx-build-dependencies.sh
+++ b/scripts/macosx-build-dependencies.sh
@@ -170,6 +170,7 @@ build_qt5()
   fi
   tar xzf qt-everywhere-src-$version.tar.xz
   cd qt-everywhere-src-$version
+  patch -p1 < $OPENSCADDIR/patches/qt5/qt-5.15.2-macos-tabbar.patch
   ./configure -prefix $DEPLOYDIR -release -opensource -confirm-license \
 		-nomake examples -nomake tests \
 		-no-xcb -no-glib -no-harfbuzz -no-sql-db2 -no-sql-ibase -no-sql-mysql -no-sql-oci -no-sql-odbc \


### PR DESCRIPTION
This fixes the ugly-looking tab bar on macOS 11 (Big Sur), mentioned in #3775.

The fix is an improved modified backport of the official fix for [QTBUG-86513](https://bugreports.qt.io/browse/QTBUG-86513). It is only required for the time OpenSCAD stays on Qt 5, as the bug is fixed in Qt 6.

Before:
<img width="570" alt="tabbar_before" src="https://user-images.githubusercontent.com/21987613/119583553-244b7a80-bdc7-11eb-8328-ee393bf26662.png">

After:
<img width="570" alt="tabbar_after" src="https://user-images.githubusercontent.com/21987613/119583566-2b728880-bdc7-11eb-80f1-f8bc6f184a34.png">
