### PR TITLE
Implement variable clipper scale for wider range of effective precision.

### DIFF
--- a/src/GeometryEvaluator.h
+++ b/src/GeometryEvaluator.h
@@ -71,6 +71,9 @@ private:
 	Polygon2d *applyToChildren2D(const AbstractNode &node, OpenSCADOperator op);
 	ResultObject applyToChildren3D(const AbstractNode &node, OpenSCADOperator op);
 	ResultObject applyToChildren(const AbstractNode &node, OpenSCADOperator op);
+	shared_ptr<const Geometry> projectionCut(const ProjectionNode &node);
+	shared_ptr<const Geometry> projectionNoCut(const ProjectionNode &node);
+
 	void addToParent(const State &state, const AbstractNode &node, const shared_ptr<const Geometry> &geom);
 	Response lazyEvaluateRootNode(State &state, const AbstractNode& node);
 

--- a/src/Polygon2d.cc
+++ b/src/Polygon2d.cc
@@ -1,6 +1,15 @@
 #include "Polygon2d.h"
 #include "printutils.h"
 
+
+BoundingBox Outline2d::getBoundingBox() const {
+	BoundingBox bbox;
+	for (const auto &v : this->vertices) {
+		bbox.extend(Vector3d(v[0], v[1], 0));
+	}
+	return bbox;
+}
+
 /*!
 	Class for holding 2D geometry.
 	
@@ -30,9 +39,7 @@ BoundingBox Polygon2d::getBoundingBox() const
 {
 	BoundingBox bbox;
 	for (const auto &o : this->outlines()) {
-		for (const auto &v : o.vertices) {
-			bbox.extend(Vector3d(v[0], v[1], 0));
-		}
+		bbox.extend(o.getBoundingBox());
 	}
 	return bbox;
 }

--- a/src/Polygon2d.h
+++ b/src/Polygon2d.h
@@ -13,6 +13,7 @@ struct Outline2d {
 	Outline2d() : positive(true) {}
 	VectorOfVector2d vertices;
 	bool positive;
+	BoundingBox getBoundingBox() const;
 };
 
 class Polygon2d : public Geometry

--- a/src/clipper-utils.h
+++ b/src/clipper-utils.h
@@ -5,18 +5,20 @@
 
 namespace ClipperUtils {
 
-	static const unsigned int CLIPPER_SCALE = 1 << 16;
+	template <typename T>
+	struct AutoScaled {
+		AutoScaled(T&& geom, BoundingBox b) : geometry(std::move(geom)), bounds(std::move(b)) {}
+		T geometry;
+		BoundingBox bounds;
+	};
 
-	ClipperLib::Path fromOutline2d(const Outline2d &poly, bool keep_orientation);
-	ClipperLib::Paths fromPolygon2d(const Polygon2d &poly);
-	ClipperLib::PolyTree sanitize(const ClipperLib::Paths &paths);
+	int getScalePow2(const BoundingBox& bounds);
+	ClipperLib::Paths fromPolygon2d(const Polygon2d &poly, int pow2);
 	Polygon2d *sanitize(const Polygon2d &poly);
-	Polygon2d *toPolygon2d(const ClipperLib::PolyTree &poly);
+	Polygon2d *toPolygon2d(const ClipperLib::PolyTree &poly, int pow2);
 	ClipperLib::Paths process(const ClipperLib::Paths &polygons, 
-														ClipperLib::ClipType, ClipperLib::PolyFillType);
+	                          ClipperLib::ClipType, ClipperLib::PolyFillType);
 	Polygon2d *applyOffset(const Polygon2d& poly, double offset, ClipperLib::JoinType joinType, double miter_limit, double arc_tolerance);
 	Polygon2d *applyMinkowski(const std::vector<const Polygon2d*> &polygons);
 	Polygon2d *apply(const std::vector<const Polygon2d*> &polygons, ClipperLib::ClipType);
-	Polygon2d *apply(const std::vector<ClipperLib::Paths> &pathsvector, ClipperLib::ClipType);
-
 };

--- a/src/offsetnode.h
+++ b/src/offsetnode.h
@@ -12,8 +12,8 @@ public:
 	std::string toString() const override;
 	std::string name() const override { return "offset"; }
 
-        bool chamfer;
+	bool chamfer;
 	double fn, fs, fa, delta;
-        double miter_limit; // currently fixed high value to disable chamfers with jtMiter
-        ClipperLib::JoinType join_type;
+	double miter_limit; // currently fixed high value to disable chamfers with jtMiter
+	ClipperLib::JoinType join_type;
 };


### PR DESCRIPTION
The Clipper library used for 2D operations represents vertex coordinates internally with `signed long long` integers (should be 64bit on most if not all supported architectures).

To convert double precision values into integers we have been scaling those doubles by a constant `CLIPPER_SCALE = 1 << 16;` before coercing into integral types.  This can leave a lot of imprecision on the lower end of the scale.

This PR replaces the static with an adaptive scale, which tries to maximize the usable bits of integer precision, depending on the scale of the geometry involved.

Here is a short example I used to show the differences between this nightly and this PR:
```
scalepow2 = -10;

$fn = 100;
d = 2^scalepow2;
linear_extrude(d/10) offset(r=d/10) difference() {
  circle(d=d);
  translate([d/2,0,0]) circle(d=d);
}
```

![nightly_test](https://user-images.githubusercontent.com/252233/120095401-75bb7880-c0eb-11eb-9e13-790651150175.png)

![PR_test](https://user-images.githubusercontent.com/252233/120095403-76540f00-c0eb-11eb-978b-36511aa0bd39.png)

With these changes, `scalepow2` can be set down to `-16` before some noticeable geometry rounding starts to happen.  It should be capable of much more precision than that, but I think the PolySet Grid snapping starts to become the limiting factor rather than clipper's precision.
