### PR TITLE
Call CGAL::set_error_behaviour(CGAL::THROW_EXCEPTION) only once from main.

### DIFF
--- a/src/GeometryEvaluator.cc
+++ b/src/GeometryEvaluator.cc
@@ -109,8 +109,6 @@ bool GeometryEvaluator::isValidDim(const Geometry::GeometryItem &item, unsigned 
 
 GeometryEvaluator::ResultObject GeometryEvaluator::applyToChildren(const AbstractNode &node, OpenSCADOperator op)
 {
-	CGALUtils::CGALErrorBehaviour behaviour{CGAL::THROW_EXCEPTION};
-
 	unsigned int dim = 0;
 	for(const auto &item : this->visitedchildren[node.index()]) {
 		if (!isValidDim(item, dim)) break;
@@ -202,7 +200,6 @@ Polygon2d *GeometryEvaluator::applyHull2D(const AbstractNode &node)
 	if (points.size() > 0) {
 		// Apply hull
 		std::list<CGALPoint2> result;
-		CGAL::Failure_behaviour old_behaviour = CGAL::set_error_behaviour(CGAL::THROW_EXCEPTION);
 		try {
 			CGAL::convex_hull_2(points.begin(), points.end(), std::back_inserter(result));
 			// Construct Polygon2d
@@ -214,8 +211,7 @@ Polygon2d *GeometryEvaluator::applyHull2D(const AbstractNode &node)
 		}
 		catch (const CGAL::Failure_exception &e) {
 			LOG(message_group::Warning,Location::NONE,"","GeometryEvaluator::applyHull2D() during CGAL::convex_hull_2(): %1$s",e.what());
-}
-		CGAL::set_error_behaviour(old_behaviour);
+		}
 	}
 	return geometry;
 }

--- a/src/Polygon2d-CGAL.cc
+++ b/src/Polygon2d-CGAL.cc
@@ -97,7 +97,6 @@ PolySet *Polygon2d::tessellate() const
 
 	Polygon2DCGAL::CDT cdt; // Uses a constrained Delaunay triangulator.
 
-	CGAL::Failure_behaviour old_behaviour = CGAL::set_error_behaviour(CGAL::THROW_EXCEPTION);
 	try {
 
 	// Adds all vertices, and add all contours as constraints.
@@ -116,10 +115,8 @@ PolySet *Polygon2d::tessellate() const
   }
 	catch (const CGAL::Precondition_exception &e) {
 		LOG(message_group::None,Location::NONE,"","CGAL error in Polygon2d::tesselate(): %1$s",e.what());
-		CGAL::set_error_behaviour(old_behaviour);
 		return nullptr;
 	}
-	CGAL::set_error_behaviour(old_behaviour);
   
 	// To extract triangles which is part of our polygon, we need to filter away
 	// triangles inside holes.

--- a/src/cgalutils-applyops.cc
+++ b/src/cgalutils-applyops.cc
@@ -79,7 +79,6 @@ namespace CGALUtils {
 	CGAL_Nef_polyhedron *applyOperator3D(const Geometry::Geometries &children, OpenSCADOperator op)
 	{
 		CGAL_Nef_polyhedron *N = nullptr;
-		CGAL::Failure_behaviour old_behaviour = CGAL::set_error_behaviour(CGAL::THROW_EXCEPTION);
 
 		assert(op != OpenSCADOperator::UNION && "use applyUnion3D() instead of applyOperator3D()");
 		bool foundFirst = false;
@@ -135,7 +134,6 @@ namespace CGALUtils {
 			LOG(message_group::Error,Location::NONE,"","CGAL error in CGALUtils::applyBinaryOperator %1$s: %2$s",opstr,e.what());
 
 		}
-		CGAL::set_error_behaviour(old_behaviour);
 		return N;
 	}
 
@@ -230,7 +228,6 @@ namespace CGALUtils {
 		// Apply hull
 		bool success = false;
 		if (points.size() >= 4) {
-			CGAL::Failure_behaviour old_behaviour = CGAL::set_error_behaviour(CGAL::THROW_EXCEPTION);
 			try {
 				CGAL::Polyhedron_3<K> r;
 				CGAL::convex_hull_3(points.begin(), points.end(), r);
@@ -243,7 +240,6 @@ namespace CGALUtils {
 			catch (const CGAL::Failure_exception &e) {
 				LOG(message_group::Error,Location::NONE,"","CGAL error in applyHull(): %1$s",e.what());
 			}
-			CGAL::set_error_behaviour(old_behaviour);
 		}
 		return success;
 	}
@@ -254,7 +250,6 @@ namespace CGALUtils {
 	*/
 	Geometry const * applyMinkowski(const Geometry::Geometries &children)
 	{
-		CGAL::Failure_behaviour old_behaviour = CGAL::set_error_behaviour(CGAL::THROW_EXCEPTION);
 		CGAL::Timer t,t_tot;
 		assert(children.size() >= 2);
 		Geometry::Geometries::const_iterator it = children.begin();
@@ -444,7 +439,6 @@ namespace CGALUtils {
 			t_tot.stop();
 			PRINTDB("Minkowski: Total execution time %f s", t_tot.time());
 			t_tot.reset();
-			CGAL::set_error_behaviour(old_behaviour);
 			return operands[0];
 		}
 		catch (...) {
@@ -452,7 +446,6 @@ namespace CGALUtils {
 			PRINTD("Minkowski: Falling back to Nef Minkowski");
 
 			CGAL_Nef_polyhedron *N = applyOperator3D(children, OpenSCADOperator::MINKOWSKI);
-			CGAL::set_error_behaviour(old_behaviour);
 			return N;
 		}
 	}

--- a/src/cgalutils-polyhedron.cc
+++ b/src/cgalutils-polyhedron.cc
@@ -249,7 +249,6 @@ namespace CGALUtils {
 	bool createPolyhedronFromPolySet(const PolySet &ps, Polyhedron &p)
 	{
 		bool err = false;
-		CGAL::Failure_behaviour old_behaviour = CGAL::set_error_behaviour(CGAL::THROW_EXCEPTION);
 		try {
 			CGAL_Build_PolySet<Polyhedron> builder(ps);
 			p.delegate(builder);
@@ -258,7 +257,6 @@ namespace CGALUtils {
 			LOG(message_group::Error, Location::NONE, "", "CGAL error in CGALUtils::createPolyhedronFromPolySet: %1$s", e.what());
 			err = true;
 		}
-		CGAL::set_error_behaviour(old_behaviour);
 		return err;
 	}
 

--- a/src/cgalutils-project.cc
+++ b/src/cgalutils-project.cc
@@ -18,8 +18,8 @@
 #include <CGAL/normal_vector_newell_3.h>
 #include <CGAL/Handle_hash_function.h>
 
-#include <CGAL/config.h> 
-#include <CGAL/version.h> 
+#include <CGAL/config.h>
+#include <CGAL/version.h>
 
 #include <CGAL/convex_hull_3.h>
 #pragma pop_macro("NDEBUG")
@@ -185,7 +185,6 @@ namespace CGALUtils {
 
 		CGAL_Nef_polyhedron newN;
 		if (cut) {
-			CGAL::Failure_behaviour old_behaviour = CGAL::set_error_behaviour(CGAL::THROW_EXCEPTION);
 			try {
 				CGAL_Nef_polyhedron3::Plane_3 xy_plane = CGAL_Nef_polyhedron3::Plane_3(0,0,1,0);
 				newN.p3.reset(new CGAL_Nef_polyhedron3(N.p3->intersection(xy_plane, CGAL_Nef_polyhedron3::PLANE_ONLY)));
@@ -214,7 +213,6 @@ namespace CGALUtils {
 			}
 				
 			if (!newN.p3 || newN.p3->is_empty()) {
-				CGAL::set_error_behaviour(old_behaviour);
 				LOG(message_group::Warning,Location::NONE,"","Projection() failed.");
 				return poly;
 			}
@@ -241,7 +239,6 @@ namespace CGALUtils {
 			}
 			PRINTD("</svg>");
 				
-			CGAL::set_error_behaviour(old_behaviour);
 		}
 		// In projection mode all the triangles are projected manually into the XY plane
 		else {

--- a/src/cgalutils.cc
+++ b/src/cgalutils.cc
@@ -19,8 +19,8 @@
 #include <CGAL/normal_vector_newell_3.h>
 #include <CGAL/Handle_hash_function.h>
 
-#include <CGAL/config.h> 
-#include <CGAL/version.h> 
+#include <CGAL/config.h>
+#include <CGAL/version.h>
 
 #include <CGAL/convex_hull_3.h>
 #pragma pop_macro("NDEBUG")
@@ -69,7 +69,6 @@ static CGAL_Nef_polyhedron *createNefPolyhedronFromPolySet(const PolySet &ps)
 
 	CGAL_Nef_polyhedron3 *N = nullptr;
 	auto plane_error = false;
-	CGAL::Failure_behaviour old_behaviour = CGAL::set_error_behaviour(CGAL::THROW_EXCEPTION);
 	try {
 		CGAL_Polyhedron P;
 		auto err = CGALUtils::createPolyhedronFromPolySet(psq, P);
@@ -107,7 +106,6 @@ static CGAL_Nef_polyhedron *createNefPolyhedronFromPolySet(const PolySet &ps)
 		catch (const CGAL::Assertion_exception &e) {
 			LOG(message_group::Error,Location::NONE,"","Alternate construction failed. CGAL error in CGAL_Nef_polyhedron3(): %1$s",e.what());
 		}
-	CGAL::set_error_behaviour(old_behaviour);
 	return new CGAL_Nef_polyhedron(N);
 }
 

--- a/src/cgalutils.h
+++ b/src/cgalutils.h
@@ -23,18 +23,6 @@ namespace /* anonymous */ {
 
 namespace CGALUtils {
 
-	class CGALErrorBehaviour {
-	public:
-		CGALErrorBehaviour(CGAL::Failure_behaviour behaviour) {
-			old_behaviour = CGAL::set_error_behaviour(behaviour);
-		}
-		~CGALErrorBehaviour() {
-			CGAL::set_error_behaviour(old_behaviour);
-		}
-	private:
-		CGAL::Failure_behaviour old_behaviour;
-	};
-
 	bool applyHull(const Geometry::Geometries &children, PolySet &P);
 	CGAL_Nef_polyhedron *applyOperator3D(const Geometry::Geometries &children, OpenSCADOperator op);
 	CGAL_Nef_polyhedron *applyUnion3D(Geometry::Geometries::iterator chbegin, Geometry::Geometries::iterator chend);

--- a/src/export_amf.cc
+++ b/src/export_amf.cc
@@ -55,7 +55,6 @@ static void append_amf(const CGAL_Nef_polyhedron &root_N, std::ostream &output)
 		LOG(message_group::Export_Warning,Location::NONE,"","Export failed, the object isn't a valid 2-manifold.");
 		return;
 	}
-	CGAL::Failure_behaviour old_behaviour = CGAL::set_error_behaviour(CGAL::THROW_EXCEPTION);
 	try {
 		CGAL_Polyhedron P;
 		root_N.p3->convert_to_polyhedron(P);
@@ -145,7 +144,6 @@ static void append_amf(const CGAL_Nef_polyhedron &root_N, std::ostream &output)
 	} catch (CGAL::Assertion_exception& e) {
 		LOG(message_group::Export_Error,Location::NONE,"","CGAL error in CGAL_Nef_polyhedron3::convert_to_polyhedron(): %1$s",e.what());
 	}
-	CGAL::set_error_behaviour(old_behaviour);
 }
 
 static void append_amf(const shared_ptr<const Geometry> &geom, std::ostream &output)

--- a/src/import_nef.cc
+++ b/src/import_nef.cc
@@ -22,9 +22,8 @@ CGAL_Nef_polyhedron *import_nef3(const std::string &filename, const Location &lo
 		LOG(message_group::Warning,Location::NONE,"","Can't open import file '%1$s', import() at line %2$d",filename,loc.firstLine());
 		return N;
 	}
-	
+
 	std::string msg="";
-	CGAL::Failure_behaviour old_behaviour = CGAL::set_error_behaviour(CGAL::THROW_EXCEPTION);
 	try {
 		auto nef = make_shared<CGAL_Nef_polyhedron3>();
 		f >> *nef;
@@ -34,7 +33,6 @@ CGAL_Nef_polyhedron *import_nef3(const std::string &filename, const Location &lo
 		LOG(message_group::None,Location::NONE,"",e.what());
 		N = new CGAL_Nef_polyhedron;
 	}
-	CGAL::set_error_behaviour(old_behaviour);
 	return N;
 }
 #endif

--- a/src/openscad.cc
+++ b/src/openscad.cc
@@ -934,9 +934,8 @@ int main(int argc, char **argv)
 #endif
 
 #ifdef ENABLE_CGAL
-	// Causes CGAL errors to abort directly instead of throwing exceptions
-	// (which we don't catch). This gives us stack traces without rerunning in gdb.
-	CGAL::set_error_behaviour(CGAL::ABORT);
+	// Always throw exceptions from CGAL, so we can catch instead of crashing on bad geometry.
+	CGAL::set_error_behaviour(CGAL::THROW_EXCEPTION);
 #endif
 	Builtins::instance()->initialize();
 

--- a/src/polyset-utils-old.cc
+++ b/src/polyset-utils-old.cc
@@ -144,7 +144,6 @@ namespace PolysetUtils {
 	bool triangulate_polygon( const PolySet::Polygon &pgon, std::vector<PolySet::Polygon> &triangles, projection_t projection )
 	{
 		bool err = false;
-		CGAL::Failure_behaviour old_behaviour = CGAL::set_error_behaviour(CGAL::THROW_EXCEPTION);
 		try {
 			CDT cdt;
 			std::vector<Vertex_handle> vhandles;
@@ -199,7 +198,6 @@ namespace PolysetUtils {
 			LOG(message_group::None,Location::NONE,"","CGAL error in triangulate_polygon(): %1$s",e.what());
 			err = true;
 		}
-		CGAL::set_error_behaviour(old_behaviour);
 		return err;
 	}
 


### PR DESCRIPTION
edit: I had originally tried removing `#pragma push_macro("NDEBUG")` etc, in addition to the error behavior change, but had to revert those changes.
It appeared to work fine on my local machine at the time that I created the PR, but I guess I just hadn't properly cleaned the build.