### PR TITLE
Update macOS deployment target for QT 5.15.2 upgrade

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,7 +22,7 @@ if(POLICY CMP0072)
   cmake_policy(SET CMP0072 NEW)
 endif()
 
-set(CMAKE_OSX_DEPLOYMENT_TARGET "10.9" CACHE STRING "Minimum OS X deployment version")
+set(CMAKE_OSX_DEPLOYMENT_TARGET "10.13" CACHE STRING "Minimum OS X deployment version")
 
 project(openscad)
 


### PR DESCRIPTION
This updates the previously forgotten macOS deployment target value.

Re-issuing this separately because I closed #3784. For details, see #3775.