### PR TITLE
Fix segfault on exit

### DIFF
--- a/src/openscad.cc
+++ b/src/openscad.cc
@@ -854,8 +854,8 @@ int gui(vector<string> &inputFiles, const fs::path &original_path, int argc, cha
 
 	InputDriverManager::instance()->init();
 	int rc = app.exec();
-  const auto &windows = scadApp->windowManager.getWindows();
-  while (!windows.empty()) delete *windows.begin();
+	const auto &windows = scadApp->windowManager.getWindows();
+	while (!windows.empty()) delete *windows.begin();
 	return rc;
 }
 #else // OPENSCAD_QTGUI

--- a/src/openscad.cc
+++ b/src/openscad.cc
@@ -854,7 +854,8 @@ int gui(vector<string> &inputFiles, const fs::path &original_path, int argc, cha
 
 	InputDriverManager::instance()->init();
 	int rc = app.exec();
-	for (auto &mainw : scadApp->windowManager.getWindows()) delete mainw;
+  const auto &windows = scadApp->windowManager.getWindows();
+  while (!windows.empty()) delete *windows.begin();
 	return rc;
 }
 #else // OPENSCAD_QTGUI


### PR DESCRIPTION
This is the new version of #3784. For details, see the comments of this merge request.

Thanks to @icecream95 for proposing this fix in #3837. The new solution checks if there are some windows left and deletes them, rather than just exit as my old solution did.

Because this issue also happens outside of macOS, I decided to point the merge request to 'master' rather than 'qt5-upgrade-macos'.