### PR TITLE
dxf export as polylines

### DIFF
--- a/src/export_dxf.cc
+++ b/src/export_dxf.cc
@@ -30,347 +30,224 @@
 #include "dxfdata.h"
 
 /*!
-	Saves the current Polygon2d as DXF to the given absolute filename.
+    Saves the current Polygon2d as DXF to the given absolute filename.
  */
 
 void export_dxf_header(std::ostream &output,double xMin,double yMin,double xMax,double yMax) {
-	
-	// https://dxfwrite.readthedocs.io/en/latest/headervars.html
-	// http://paulbourke.net/dataformats/dxf/min3d.html
+    
+    // https://dxfwrite.readthedocs.io/en/latest/headervars.html
+    // http://paulbourke.net/dataformats/dxf/min3d.html
 
-	// based on: https://github.com/mozman/ezdxf/tree/master/examples_dxf
-	// Minimal_DXF_AC1009.dxf - not working in Adobe Illustrator
-	// Minimal_DXF_AC1006.dxf - not working with LibreCAD (due to 3DFACE?)
+    // based on: https://github.com/mozman/ezdxf/tree/master/examples_dxf
+    // Minimal_DXF_AC1009.dxf - not working in Adobe Illustrator
+    // Minimal_DXF_AC1006.dxf - not working with LibreCAD (due to 3DFACE?)
 
-	// tested to work on:
-	// - InkScape 1.0.0
-	// - LibreCAD
-	// - Adobe Illustrator
-	// - https://sharecad.org
-	// - generic cutters
+    // tested to work on:
+    // - InkScape 1.0.0
+    // - LibreCAD
+    // - Adobe Illustrator
+    // - https://sharecad.org
+    // - generic cutters
 
-	output
-		<< "999\n" << "DXF from OpenSCAD\n";
+    output
+        << "999\n" << "DXF from OpenSCAD\n";
 
-	//
-	// SECTION 1
-	//
+    //
+    // SECTION 1
+    //
 
-	/* --- START ---
-	0
-	SECTION
-	2
-	HEADER
-	9
-	$ACADVER
-	1
-	AC1006
-	9
-	$INSBASE
-	10
-	0.0
-	20
-	0.0
-	30
-	0.0
-	*/
+    /* --- START --- */
 
-	output
-		<< "  0\n" << "SECTION\n"
-		<< "  2\n" << "HEADER\n"
-		<< "  9\n" << "$ACADVER\n"
-		<< "  1\n" << "AC1006\n"
-		<< "  9\n" << "$INSBASE\n" // for 3D only?
-		<< " 10\n" << "0.0\n"
-		<< " 20\n" << "0.0\n"
-		<< " 30\n" << "0.0\n"
-		;
+    output
+        << "  0\n" << "SECTION\n"
+        << "  2\n" << "HEADER\n"
+        << "  9\n" << "$ACADVER\n"
+        << "  1\n" << "AC1006\n"
+        << "  9\n" << "$INSBASE\n"
+        << " 10\n" << "0.0\n"
+        << " 20\n" << "0.0\n"
+        << " 30\n" << "0.0\n"
+        ;
 
-	/* --- LIMITS ---
-	9
-	$EXTMIN
-	10
-	0.0
-	20
-	0.0
-	9
-	$EXTMAX
-	10
-	1000.0
-	20
-	1000.0
-	9
-	$LINMIN
-	10
-	0.0
-	20
-	0.0
-	9
-	$LINMAX
-	10
-	1000.0
-	20
-	1000.0
-	0
-	ENDSEC
-	*/
+    /* --- LIMITS --- */
 
-	// might not be necessary to set the actual limits
-	// but some apps might rely on it
+    output
+        << "  9\n" << "$EXTMIN\n"
+        << " 10\n" << xMin << "\n"
+        << " 20\n" << yMin << "\n"
+        << "  9\n" << "$EXTMAX\n"
+        << " 10\n" << xMax << "\n"
+        << " 20\n" << yMax << "\n";
 
-	output
-		<< "  9\n" << "$EXTMIN\n"
-		<< " 10\n" << xMin << "\n"
-		<< " 20\n" << yMin << "\n"
-		<< "  9\n" << "$EXTMAX\n"
-		<< " 10\n" << xMax << "\n"
-		<< " 20\n" << yMax << "\n";
+    output
+        << "  9\n" << "$LINMIN\n"
+        << " 10\n" << xMin << "\n"
+        << " 20\n" << yMin << "\n"
+        << "  9\n" << "$LINMAX\n"
+        << " 10\n" << xMax << "\n"
+        << " 20\n" << yMax << "\n";
 
-	output
-		<< "  9\n" << "$LINMIN\n"
-		<< " 10\n" << xMin << "\n"
-		<< " 20\n" << yMin << "\n"
-		<< "  9\n" << "$LINMAX\n"
-		<< " 10\n" << xMax << "\n"
-		<< " 20\n" << yMax << "\n";
+    output 
+        << "  0\n" << "ENDSEC\n";
 
-	output 
-		<< "  0\n" << "ENDSEC\n";
+    //
+    // SECTION 2
+    //
 
-	//
-	// SECTION 2
-	//
+    output
+        << "  0\n" << "SECTION\n";
+    
+    output
+        << "  2\n" << "TABLES\n";
 
-	output
-		<< "  0\n" << "SECTION\n";
-	
-	output
-		<< "  2\n" << "TABLES\n";
+    /* --- LINETYPE --- */
 
-	/* --- LINETYPE ---
-	0
-	SECTION
-	2
-	TABLES
-	0
-	TABLE
-	2
-	LTYPE
-	70
-	1
-	0
-	LTYPE
-	2
-	CONTINUOUS
-	70
-	64
-	3
-	Solid line
-	72
-	65
-	73
-	0
-	40
-	0.000000
-	0
-	ENDTAB
-	*/
+    output
+        << "  0\n" << "TABLE\n"
+        << "  2\n" << "LTYPE\n"
+        << " 70\n" << "1\n"
 
-	output
-		<< "  0\n" << "TABLE\n"
-		<< "  2\n" << "LTYPE\n"
-		<< " 70\n" << "1\n"
+        << "  0\n" << "LTYPE\n"
+        << "  2\n" << "CONTINUOUS\n" // linetype name
+        << " 70\n" << "64\n"
+        << "  3\n" << "Solid line\n" // descriptive text
+        << " 72\n" << "65\n"         // always 65
+        << " 73\n" << "0\n"          // number of linetype elements
+        << " 40\n" << "0.000000\n"   // total pattern length
 
-		<< "  0\n" << "LTYPE\n"
-		<< "  2\n" << "CONTINUOUS\n"
-		<< " 70\n" << "64\n"
-		<< "  3\n" << "Solid line\n"
-		<< " 72\n" << "65\n"
-		<< " 73\n" << "0\n"
-		<< " 40\n" << "0.000000\n"
+        << "  0\n" << "ENDTAB\n";
 
-		<< "  0\n" << "ENDTAB\n";
+    /* --- LAYERS --- */
 
-	/* --- LAYERS ---
-	0
-	TABLE
-	2
-	LAYER
-	70
-	6
-	0
-	LAYER
-	2
-	1
-	70
-	64
-	62
-	7
-	6
-	CONTINUOUS
-	0
-	LAYER
-	2
-	2
-	70
-	64
-	62
-	7
-	6
-	CONTINUOUS
-	0
-	ENDTAB
-	*/
+    output
+        << "  0\n" << "TABLE\n"
+        << "  2\n" << "LAYER\n"
+        << " 70\n" << "6\n"
 
-	output
-		<< "  0\n" << "TABLE\n"
-		<< "  2\n" << "LAYER\n"
-		<< " 70\n" << "6\n"
+        << "  0\n" << "LAYER\n"
+        << "  2\n" << "0\n"           // layer name
+        << " 70\n" << "64\n"
+        << " 62\n" << "7\n"           // color
+        << "  6\n" << "CONTINUOUS\n"
 
-		<< "  0\n" << "LAYER\n"
-		<< "  2\n" << "0\n"           // layer name
-		<< " 70\n" << "64\n"
-		<< " 62\n" << "7\n"           // color
-		<< "  6\n" << "CONTINUOUS\n"
+        << "  0\n" << "ENDTAB\n";
 
-		<< "  0\n" << "ENDTAB\n";
+    /* --- STYLE --- */
 
-	/* --- STYLE ---
-	0
-	TABLE
-	2
-	STYLE
-	70
-	0
-	0
-	ENDTAB
-	0
-	ENDSEC
-	*/
+    output
+        << "  0\n" << "TABLE\n"
+        << "  2\n" << "STYLE\n"
+        << " 70\n" << "0\n"
+        << "  0\n" << "ENDTAB\n";
 
-	output
-		<< "  0\n" << "TABLE\n"
-		<< "  2\n" << "STYLE\n"
-		<< " 70\n" << "0\n"
-		<< "  0\n" << "ENDTAB\n";
+    output
+        << "  0\n" << "ENDSEC\n";
 
-	output
-		<< "  0\n" << "ENDSEC\n";
+    //
+    // SECTION 3
+    //
 
-	//
-	// SECTION 3
-	//
-
-	/* --- BLOCKS ---
-	0
-	SECTION
-	2
-	BLOCKS
-	0
-	ENDSEC
-	*/
-
-	output
-		<< "  0\n" << "SECTION\n"
-		<< "  2\n" << "BLOCKS\n"
-		<< "  0\n" << "ENDSEC\n";
+    output
+        << "  0\n" << "SECTION\n"
+        << "  2\n" << "BLOCKS\n"
+        << "  0\n" << "ENDSEC\n";
 
 }
 
 void export_dxf(const Polygon2d &poly, std::ostream &output)
 {
-	setlocale(LC_NUMERIC, "C"); // Ensure radix is . (not ,) in output
+    setlocale(LC_NUMERIC, "C"); // Ensure radix is . (not ,) in output
 
-	// find limits
-	double xMin, yMin, xMax, yMax;
-	xMin = yMin = std::numeric_limits<double>::max(),
-	xMax = yMax = std::numeric_limits<double>::min();
-	for(const auto &o : poly.outlines()) {
-		for (unsigned int i=0; i<o.vertices.size(); ++i) {
-			const Vector2d &p = o.vertices[i];
-			if ( xMin > p[0] ) xMin = p[0];
-			if ( xMax < p[0] ) xMax = p[0];
-			if ( yMin > p[1] ) yMin = p[1];
-			if ( yMax < p[1] ) yMax = p[1];
-		}
-	}
+    // find limits
+    double xMin, yMin, xMax, yMax;
+    xMin = yMin = std::numeric_limits<double>::max(),
+    xMax = yMax = std::numeric_limits<double>::min();
+    for(const auto &o : poly.outlines()) {
+        for (unsigned int i=0; i<o.vertices.size(); ++i) {
+            const Vector2d &p = o.vertices[i];
+            if ( xMin > p[0] ) xMin = p[0];
+            if ( xMax < p[0] ) xMax = p[0];
+            if ( yMin > p[1] ) yMin = p[1];
+            if ( yMax < p[1] ) yMax = p[1];
+        }
+    }
 
-	export_dxf_header(output,xMin,yMin,xMax,yMax);
+    export_dxf_header(output,xMin,yMin,xMax,yMax);
 
-	// REFERENCE:
-	// DXF (AutoCAD Drawing Interchange Format) Family, ASCII variant
-	//    https://www.loc.gov/preservation/digital/formats/fdd/fdd000446.shtml#specs
-	// About the DXF Format (DXF)
-	//    https://help.autodesk.com/view/ACD/2017/ENU/?guid=GUID-235B22E0-A567-4CF6-92D3-38A2306D73F3
+    // REFERENCE:
+    // DXF (AutoCAD Drawing Interchange Format) Family, ASCII variant
+    //    https://www.loc.gov/preservation/digital/formats/fdd/fdd000446.shtml#specs
+    // About the DXF Format (DXF)
+    //    https://help.autodesk.com/view/ACD/2017/ENU/?guid=GUID-235B22E0-A567-4CF6-92D3-38A2306D73F3
     // About ASCII DXF Files
-	//    https://help.autodesk.com/view/ACD/2017/ENU/?guid=GUID-20172853-157D-4024-8E64-32F3BD64F883
-	// DXF Format
-	//    https://documentation.help/AutoCAD-DXF/WSfacf1429558a55de185c428100849a0ab7-5f35.htm
+    //    https://help.autodesk.com/view/ACD/2017/ENU/?guid=GUID-20172853-157D-4024-8E64-32F3BD64F883
+    // DXF Format
+    //    https://documentation.help/AutoCAD-DXF/WSfacf1429558a55de185c428100849a0ab7-5f35.htm
 
-	output  << "  0\n" << "SECTION\n"
-			<< "  2\n" << "ENTITIES\n";
+    output  << "  0\n" << "SECTION\n"
+            << "  2\n" << "ENTITIES\n";
 
-	for(const auto &o : poly.outlines()) {
-		switch( o.vertices.size() ) {
-		case 1: {
-			// POINT: just in case it's supported in the future
-			const Vector2d &p = o.vertices[0];
-			output  << "  0\n" << "POINT\n"
-					<< "100\n" << "AcDbEntity\n"
-					<< "  8\n" << "0\n" 		// layer 0
-					<< "100\n" << "AcDbPoint\n"
-					<< " 10\n" << p[0] << "\n"  // x
-					<< " 20\n" << p[1] << "\n"; // y
-			} break;
-		case 2: {
-			// LINE: just in case it's supported in the future
-			// The [X1 Y1 X2 Y2] order is the most common and can be parsed linearly.
-			// Some libraries, like the python libraries dxfgrabber and ezdxf, cannot open [X1 X2 Y1 Y2] order.
-			const Vector2d &p1 = o.vertices[0];
-			const Vector2d &p2 = o.vertices[1];
-			output  << "  0\n" << "LINE\n"
-					<< "100\n" << "AcDbEntity\n"
-					<< "  8\n" << "0\n" 		 // layer 0
-					<< "100\n" << "AcDbLine\n"
-					<< " 10\n" << p1[0] << "\n"  // x1
-					<< " 20\n" << p1[1] << "\n"  // y1
-					<< " 11\n" << p2[0] << "\n"  // x2
-					<< " 21\n" << p2[1] << "\n"; // y2
-			} break;
-		default:
-			// LWPOLYLINE
-			output  << "  0\n" << "LWPOLYLINE\n"
-					<< "100\n" << "AcDbEntity\n"
-					<< "  8\n" << "0\n" 		            // layer 0
-					<< "100\n" << "AcDbPolyline\n"
-					<< " 90\n" << o.vertices.size() << "\n" // number of vertices
-					<< " 70\n" << "1\n";                    // closed = 1
-			for (unsigned int i=0; i<o.vertices.size(); ++i) {
-				const Vector2d &p = o.vertices[i];
-				output  << " 10\n" << p[0] << "\n"
-						<< " 20\n" << p[1] << "\n";
-			}
-			break;
-		}
-	}
+    for(const auto &o : poly.outlines()) {
+        switch( o.vertices.size() ) {
+        case 1: {
+            // POINT: just in case it's supported in the future
+            const Vector2d &p = o.vertices[0];
+            output  << "  0\n" << "POINT\n"
+                    << "100\n" << "AcDbEntity\n"
+                    << "  8\n" << "0\n" 		// layer 0
+                    << "100\n" << "AcDbPoint\n"
+                    << " 10\n" << p[0] << "\n"  // x
+                    << " 20\n" << p[1] << "\n"; // y
+            } break;
+        case 2: {
+            // LINE: just in case it's supported in the future
+            // The [X1 Y1 X2 Y2] order is the most common and can be parsed linearly.
+            // Some libraries, like the python libraries dxfgrabber and ezdxf, cannot open [X1 X2 Y1 Y2] order.
+            const Vector2d &p1 = o.vertices[0];
+            const Vector2d &p2 = o.vertices[1];
+            output  << "  0\n" << "LINE\n"
+                    << "100\n" << "AcDbEntity\n"
+                    << "  8\n" << "0\n" 		 // layer 0
+                    << "100\n" << "AcDbLine\n"
+                    << " 10\n" << p1[0] << "\n"  // x1
+                    << " 20\n" << p1[1] << "\n"  // y1
+                    << " 11\n" << p2[0] << "\n"  // x2
+                    << " 21\n" << p2[1] << "\n"; // y2
+            } break;
+        default:
+            // LWPOLYLINE
+            output	<< "  0\n" << "LWPOLYLINE\n"
+                    << "100\n" << "AcDbEntity\n"
+                    << "  8\n" << "0\n" 		            // layer 0
+                    << "100\n" << "AcDbPolyline\n"
+                    << " 90\n" << o.vertices.size() << "\n" // number of vertices
+                    << " 70\n" << "1\n";                    // closed = 1
+            for (unsigned int i=0; i<o.vertices.size(); ++i) {
+                const Vector2d &p = o.vertices[i];
+                output  << " 10\n" << p[0] << "\n"
+                        << " 20\n" << p[1] << "\n";
+            }
+            break;
+        }
+    }
 
-	output << "  0\n" << "ENDSEC\n";
-	output << "  0\n" << "EOF\n";
+    output << "  0\n" << "ENDSEC\n";
+    output << "  0\n" << "EOF\n";
 
-	setlocale(LC_NUMERIC, ""); // set default locale
+    setlocale(LC_NUMERIC, ""); // set default locale
 }
 
 void export_dxf(const shared_ptr<const Geometry> &geom, std::ostream &output)
 {
-	if (const auto geomlist = dynamic_pointer_cast<const GeometryList>(geom)) {
-		for(const auto &item : geomlist->getChildren()) {
-			export_dxf(item.second, output);
-		}
-	} else if (dynamic_pointer_cast<const PolySet>(geom)) {
-		assert(false && "Unsupported file format");
-	} else if (const auto poly = dynamic_pointer_cast<const Polygon2d>(geom)) {
-		export_dxf(*poly, output);
-	} else {
-		assert(false && "Export as DXF for this geometry type is not supported");
-	}
+    if (const auto geomlist = dynamic_pointer_cast<const GeometryList>(geom)) {
+        for(const auto &item : geomlist->getChildren()) {
+            export_dxf(item.second, output);
+        }
+    } else if (dynamic_pointer_cast<const PolySet>(geom)) {
+        assert(false && "Unsupported file format");
+    } else if (const auto poly = dynamic_pointer_cast<const Polygon2d>(geom)) {
+        export_dxf(*poly, output);
+    } else {
+        assert(false && "Export as DXF for this geometry type is not supported");
+    }
 }

--- a/src/export_dxf.cc
+++ b/src/export_dxf.cc
@@ -39,8 +39,15 @@ void export_dxf_header(std::ostream &output,double xMin,double yMin,double xMax,
 	// http://paulbourke.net/dataformats/dxf/min3d.html
 
 	// based on: https://github.com/mozman/ezdxf/tree/master/examples_dxf
-	// note: Minimal_DXF_AC1009.dxf - does not work in Adobe Illustrator
-	// Minimal_DXF_AC1006.dxf - with some changes, as is, it's not compatible with LibreCAD
+	// Minimal_DXF_AC1009.dxf - not working in Adobe Illustrator
+	// Minimal_DXF_AC1006.dxf - not working with LibreCAD (due to 3DFACE?)
+
+	// tested to work on:
+	// - InkScape 1.0.0
+	// - LibreCAD
+	// - Adobe Illustrator
+	// - https://sharecad.org
+	// - generic cutters
 
 	output
 		<< "999\n" << "DXF from OpenSCAD\n";

--- a/src/export_dxf.cc
+++ b/src/export_dxf.cc
@@ -32,18 +32,273 @@
 /*!
 	Saves the current Polygon2d as DXF to the given absolute filename.
  */
+
+void export_dxf_header(std::ostream &output,double xMin,double yMin,double xMax,double yMax) {
+	
+	// based on: https://github.com/mozman/ezdxf/tree/master/examples_dxf
+	// note: Minimal_DXF_AC1009.dxf - does not work in Adobe Illustrator
+	// Minimal_DXF_AC1006.dxf
+
+	output
+		<< "999\n" << "DXF from OpenSCAD\n";
+
+	//
+	// SECTION 1
+	//
+
+	/* --- START ---
+	0
+	SECTION
+	2
+	HEADER
+	9
+	$ACADVER
+	1
+	AC1006
+	9
+	$INSBASE
+	10
+	0.0
+	20
+	0.0
+	30
+	0.0
+	*/
+
+	output
+		<< "  0\n" << "SECTION\n"
+		<< "  2\n" << "HEADER\n"
+		<< "  9\n" << "$ACADVER\n"
+		<< "  1\n" << "AC1006\n"
+		<< "  9\n" << "$INSBASE\n"
+		<< " 10\n" << "0.0\n"
+		<< " 20\n" << "0.0\n"
+		<< " 30\n" << "0.0\n";
+
+	/* --- LIMITS ---
+	9
+	$EXTMIN
+	10
+	0.0
+	20
+	0.0
+	9
+	$EXTMAX
+	10
+	1000.0
+	20
+	1000.0
+	9
+	$LINMIN
+	10
+	0.0
+	20
+	0.0
+	9
+	$LINMAX
+	10
+	1000.0
+	20
+	1000.0
+	0
+	ENDSEC
+	*/
+
+	// might not be necessary to set the actual limits
+	// but some apps might rely on it
+	output
+		<< "  9\n" << "$EXTMIN\n"
+		<< " 10\n" << xMin << "\n"
+		<< " 20\n" << yMin << "\n"
+		<< "  9\n" << "$EXTMAX\n"
+		<< " 10\n" << xMax << "\n"
+		<< " 20\n" << yMax << "\n";
+
+	output
+		<< "  9\n" << "$LINMIN\n"
+		<< " 10\n" << xMin << "\n"
+		<< " 20\n" << yMin << "\n"
+		<< "  9\n" << "$LINMAX\n"
+		<< " 10\n" << xMax << "\n"
+		<< " 20\n" << yMax << "\n";
+
+	output 
+		<< "  0\n" << "ENDSEC\n";
+
+	//
+	// SECTION 2
+	//
+
+	output
+		<< "  0\n" << "SECTION\n";
+
+	output
+		<< "  2\n" << "TABLES\n";
+
+	/* --- LINETYPE ---
+	0
+	SECTION
+	2
+	TABLES
+	0
+	TABLE
+	2
+	LTYPE
+	70
+	1
+	0
+	LTYPE
+	2
+	CONTINUOUS
+	70
+	64
+	3
+	Solid line
+	72
+	65
+	73
+	0
+	40
+	0.000000
+	0
+	ENDTAB
+	*/
+
+	output
+		<< "  0\n" << "TABLE\n"
+		<< "  2\n" << "LTYPE\n"
+		<< " 70\n" << "1\n"
+
+		<< "  0\n" << "LTYPE\n"
+		<< "  2\n" << "CONTINUOUS\n"
+		<< " 70\n" << "64\n"
+		<< "  3\n" << "Solid line\n"
+		<< " 72\n" << "65\n"
+		<< " 73\n" << "0\n"
+		<< " 40\n" << "0.000000\n"
+
+		<< "  0\n" << "ENDTAB\n";
+
+	/* --- LAYERS ---
+	0
+	TABLE
+	2
+	LAYER
+	70
+	6
+	0
+	LAYER
+	2
+	1
+	70
+	64
+	62
+	7
+	6
+	CONTINUOUS
+	0
+	LAYER
+	2
+	2
+	70
+	64
+	62
+	7
+	6
+	CONTINUOUS
+	0
+	ENDTAB
+	*/
+
+	output
+		<< "  0\n" << "TABLE\n"
+		<< "  2\n" << "LAYER\n"
+		<< " 70\n" << "6\n"
+
+		<< "  0\n" << "LAYER\n"
+		<< "  2\n" << "1\n"
+		<< " 70\n" << "64\n"
+		<< " 62\n" << "7\n"
+		<< "  6\n" << "CONTINUOUS\n"
+
+		<< "  0\n" << "LAYER\n"
+		<< "  2\n" << "2\n"
+		<< " 70\n" << "64\n"
+		<< " 62\n" << "7\n"
+		<< "  6\n" << "CONTINUOUS\n"
+
+		<< "  0\n" << "ENDTAB\n";
+
+	/* --- STYLE ---
+	0
+	TABLE
+	2
+	STYLE
+	70
+	0
+	0
+	ENDTAB
+	0
+	ENDSEC
+	*/
+
+	output
+		<< "  0\n" << "TABLE\n"
+		<< "  2\n" << "STYLE\n"
+		<< " 70\n" << "0\n"
+		<< "  0\n" << "ENDTAB\n";
+
+	output
+		<< "  0\n" << "ENDSEC\n";
+
+	//
+	// SECTION 3
+	//
+
+	/* --- BLOCKS ---
+	0
+	SECTION
+	2
+	BLOCKS
+	0
+	ENDSEC
+	*/
+
+	output
+		<< "  0\n" << "SECTION\n"
+		<< "  2\n" << "BLOCKS\n"
+		<< "  0\n" << "ENDSEC\n";
+
+}
+
 void export_dxf(const Polygon2d &poly, std::ostream &output)
 {
 	setlocale(LC_NUMERIC, "C"); // Ensure radix is . (not ,) in output
 
-	// Some importers needs a BLOCKS section to be present
-	// e.g. Inkscape 1.1 still needs it 
-	output  << "  0\n" << "SECTION\n"
-			<< "  2\n" << "BLOCKS\n"
-			<< "  0\n" << "ENDSEC\n";
+	// find limits
+	double xMin, yMin, xMax, yMax;
+	xMin = yMin = std::numeric_limits<double>::max(),
+	xMax = yMax = std::numeric_limits<double>::min();
+	for(const auto &o : poly.outlines()) {
+		for (unsigned int i=0; i<o.vertices.size(); ++i) {
+			const Vector2d &p = o.vertices[i];
+			if ( xMin > p[0] ) xMin = p[0];
+			if ( xMax < p[0] ) xMax = p[0];
+			if ( yMin > p[1] ) yMin = p[1];
+			if ( yMax < p[1] ) yMax = p[1];
+		}
+	}
 
-	output  << "  0\n" << "SECTION\n"
-			<< "  2\n" << "ENTITIES\n";
+	export_dxf_header(output,xMin,yMin,xMax,yMax);
+
+	// --- TO BE DELETED ---
+	// // Some importers needs a BLOCKS section to be present
+	// // e.g. Inkscape 1.1 still needs it 
+	// // output  << "  0\n" << "SECTIONxxx\n"
+	// // 		<< "  2\n" << "BLOCKS\n"
+	// // 		<< "  0\n" << "ENDSEC\n";
+	// output  << "  0\n" << "SECTION\n"
+	// 		<< "  2\n" << "ENTITIES\n";
 
 	// ENTITIES:
     // https://help.autodesk.com/view/ACD/2017/ENU/?guid=GUID-3610039E-27D1-4E23-B6D3-7E60B22BB5BD
@@ -59,10 +314,10 @@ void export_dxf(const Polygon2d &poly, std::ostream &output)
 			const Vector2d &p = o.vertices[0];
 			output  << "  0\n" << "POINT\n"
 					<< "100\n" << "AcDbEntity\n"
-					<< "  8\n" << "0\n" 		// layer 0
+					<< "  8\n" << "1\n" 		// layer 1
 					<< "100\n" << "AcDbPoint\n"
 					<< " 10\n" << p[0] << "\n"  // x
-					<< " 20\n" << p[1] << "\n"; // y					
+					<< " 20\n" << p[1] << "\n"; // y
 			} break;
 		case 2: {
 			// LINE: just in case it's supported in the future
@@ -74,12 +329,12 @@ void export_dxf(const Polygon2d &poly, std::ostream &output)
 			const Vector2d &p2 = o.vertices[1];
 			output  << "  0\n" << "LINE\n"
 					<< "100\n" << "AcDbEntity\n"
-					<< "  8\n" << "0\n" 		 // layer 0
+					<< "  8\n" << "1\n" 		 // layer 1
 					<< "100\n" << "AcDbLine\n"
 					<< " 10\n" << p1[0] << "\n"  // x1
 					<< " 20\n" << p1[1] << "\n"  // y1
 					<< " 11\n" << p2[0] << "\n"  // x2
-					<< " 21\n" << p2[1] << "\n"; // y2				
+					<< " 21\n" << p2[1] << "\n"; // y2
 			} break;
 		default:
 			// LWPOLYLINE
@@ -87,10 +342,10 @@ void export_dxf(const Polygon2d &poly, std::ostream &output)
             // https://documentation.help/AutoCAD-DXF/WS1a9193826455f5ff18cb41610ec0a2e719-79fc.htm
 			output  << "  0\n" << "LWPOLYLINE\n"
 					<< "100\n" << "AcDbEntity\n"
-					<< "  8\n" << "0\n" 		            // layer 0
+					<< "  8\n" << "1\n" 		            // layer 1
 					<< "100\n" << "AcDbPolyline\n"
 					<< " 90\n" << o.vertices.size() << "\n" // number of vertices
-					<< " 70\n" << "1\n";                    // closed = 1					
+					<< " 70\n" << "1\n";                    // closed = 1
 			for (unsigned int i=0; i<o.vertices.size(); ++i) {
 				const Vector2d &p = o.vertices[i];
 				output  << " 10\n" << p[0] << "\n"
@@ -99,6 +354,7 @@ void export_dxf(const Polygon2d &poly, std::ostream &output)
 			break;
 		}
 
+		// --- TO BE DELETED ---
 		// each segment as separate line
 		// for (unsigned int i=0; i<o.vertices.size(); ++i) {
 		// 	const Vector2d &p1 = o.vertices[i];
@@ -116,6 +372,7 @@ void export_dxf(const Polygon2d &poly, std::ostream &output)
 
 	output << "  0\n" << "ENDSEC\n";
 
+	// --- TO BE DELETED ---
 	// Some importers (e.g. Inkscape) needs an OBJECTS section with a DICTIONARY entry.
 	// as of Inkscape 1.0, not needed anymore
 	// output


### PR DESCRIPTION
dxf export converted to polyline, so each island comes out as single entity when imported.
Most users would probably need it to be as such, after all what's the use of 100's of separate line 
segments for a circular path.
Removed extra dxf sections for inkscape compatibility as it is not needed anymore.

Tested in inkscape and https://sharecad.org/# only.
If this is acceptable will do more test on other apps.