### PR TITLE
Add summary output.

### DIFF
--- a/src/CGALCache.cc
+++ b/src/CGALCache.cc
@@ -27,6 +27,16 @@ bool CGALCache::insert(const std::string &id, const shared_ptr<const CGAL_Nef_po
 	return inserted;
 }
 
+size_t CGALCache::size() const
+{
+	return cache.size();
+}
+
+size_t CGALCache::totalCost() const
+{
+	return cache.totalCost();
+}
+
 size_t CGALCache::maxSizeMB() const
 {
 	return this->cache.maxCost()/(1024*1024);

--- a/src/CGALCache.h
+++ b/src/CGALCache.h
@@ -15,6 +15,8 @@ public:
 	bool contains(const std::string &id) const { return this->cache.contains(id); }
 	shared_ptr<const class CGAL_Nef_polyhedron> get(const std::string &id) const;
 	bool insert(const std::string &id, const shared_ptr<const CGAL_Nef_polyhedron> &N);
+	size_t size() const;
+	size_t totalCost() const;
 	size_t maxSizeMB() const;
 	void setMaxSizeMB(size_t limit);
 	void clear();

--- a/src/CGAL_Nef_polyhedron.cc
+++ b/src/CGAL_Nef_polyhedron.cc
@@ -68,6 +68,19 @@ bool CGAL_Nef_polyhedron::isEmpty() const
 	return !this->p3 || this->p3->is_empty();
 }
 
+BoundingBox CGAL_Nef_polyhedron::getBoundingBox() const
+{
+	if (isEmpty()) {
+		return BoundingBox();
+	}
+	auto bb = CGALUtils::boundingBox(*this->p3).bbox();
+
+	BoundingBox result;
+	result.extend(Vector3d(bb.xmin(), bb.ymin(), bb.zmin()));
+	result.extend(Vector3d(bb.xmax(), bb.ymax(), bb.zmax()));
+	return result;
+}
+
 void CGAL_Nef_polyhedron::resize(const Vector3d &newsize,
                                  const Eigen::Matrix<bool,3,1> &autosize)
 {

--- a/src/CGAL_Nef_polyhedron.h
+++ b/src/CGAL_Nef_polyhedron.h
@@ -17,7 +17,7 @@ public:
 
 	size_t memsize() const override;
 	// FIXME: Implement, but we probably want a high-resolution BBox..
-	BoundingBox getBoundingBox() const override { assert(false && "not implemented"); return BoundingBox(); }
+	BoundingBox getBoundingBox() const override;
 	std::string dump() const override;
 	unsigned int getDimension() const override { return 3; }
 	// Empty means it is a geometric node which has zero area/volume

--- a/src/GeometryCache.cc
+++ b/src/GeometryCache.cc
@@ -34,6 +34,16 @@ bool GeometryCache::insert(const std::string &id, const shared_ptr<const Geometr
 	return inserted;
 }
 
+size_t GeometryCache::size() const
+{
+	return cache.size();
+}
+
+size_t GeometryCache::totalCost() const
+{
+	return cache.totalCost();
+}
+
 size_t GeometryCache::maxSizeMB() const
 {
 	return this->cache.maxCost()/(1024*1024);

--- a/src/GeometryCache.h
+++ b/src/GeometryCache.h
@@ -14,6 +14,8 @@ public:
 	bool contains(const std::string &id) const { return this->cache.contains(id); }
 	shared_ptr<const class Geometry> get(const std::string &id) const;
 	bool insert(const std::string &id, const shared_ptr<const Geometry> &geom);
+	size_t size() const;
+	size_t totalCost() const;
 	size_t maxSizeMB() const;
 	void setMaxSizeMB(size_t limit);
 	void clear() { cache.clear(); }

--- a/src/MainWindow.cc
+++ b/src/MainWindow.cc
@@ -2130,7 +2130,7 @@ void MainWindow::actionRenderDone(shared_ptr<const Geometry> root_geom)
 {
 	progress_report_fin();
 	if (root_geom) {
-		renderStatistic.printAll(root_geom);
+		renderStatistic.printAll(root_geom, qglview->cam);
 		LOG(message_group::None,Location::NONE,"","Rendering finished.");
 
 		this->root_geom = root_geom;

--- a/src/MainWindow.cc
+++ b/src/MainWindow.cc
@@ -2130,7 +2130,17 @@ void MainWindow::actionRenderDone(shared_ptr<const Geometry> root_geom)
 {
 	progress_report_fin();
 	if (root_geom) {
-		renderStatistic.printAll(root_geom, qglview->cam);
+		std::vector<std::string> options;
+		if (Settings::Settings::summaryCamera.value()) {
+			options.push_back(RenderStatistic::CAMERA);
+		}
+		if (Settings::Settings::summaryArea.value()) {
+			options.push_back(RenderStatistic::AREA);
+		}
+		if (Settings::Settings::summaryBoundingBox.value()) {
+			options.push_back(RenderStatistic::BOUNDING_BOX);
+		}
+		renderStatistic.printAll(root_geom, qglview->cam, options);
 		LOG(message_group::None,Location::NONE,"","Rendering finished.");
 
 		this->root_geom = root_geom;

--- a/src/MainWindow.h
+++ b/src/MainWindow.h
@@ -20,6 +20,7 @@
 #include "input/InputDriver.h"
 #include "Editor.h"
 #include "TabManager.h"
+#include "RenderStatistic.h"
 #include <memory>
 
 #ifdef STATIC_QT_SVG_PLUGIN
@@ -47,7 +48,7 @@ public:
 
 	QTimer *autoReloadTimer;
 	QTimer *waitAfterReloadTimer;
-	QTime renderingTime;
+	RenderStatistic renderStatistic;
 
 	SourceFile *root_file;      // Result of parsing
 	SourceFile *parsed_file;		// Last parse for include list

--- a/src/Polygon2d-CGAL.cc
+++ b/src/Polygon2d-CGAL.cc
@@ -87,6 +87,26 @@ mark_domains(CDT &cdt)
 
 }
 
+double Polygon2d::area() const
+{
+	const PolySet *p = tessellate();
+	if (p == nullptr) {
+		return 0;
+	}
+
+	double area = 0.0;
+	for (const auto& poly : p->polygons) {
+		const auto& v1 = poly[0];
+		const auto& v2 = poly[1];
+		const auto& v3 = poly[2];
+		area += 0.5 * (
+					v1.x() * (v2.y() - v3.y())
+				+ v2.x() * (v3.y() - v1.y())
+				+ v3.x() * (v1.y() - v2.y()));
+	}
+	return area;
+}
+
 /*!
 	Triangulates this polygon2d and returns a 2D-in-3D PolySet.
 */

--- a/src/Polygon2d.h
+++ b/src/Polygon2d.h
@@ -34,6 +34,7 @@ public:
 	};
 	void addOutline(Outline2d outline) { this->theoutlines.push_back(std::move(outline)); }
 	class PolySet *tessellate() const;
+	double area() const;
 
 	typedef std::vector<Outline2d> Outlines2d;
 	const Outlines2d &outlines() const { return theoutlines; }

--- a/src/Preferences.cc
+++ b/src/Preferences.cc
@@ -689,6 +689,24 @@ void Preferences::on_useAsciiSTLCheckBox_toggled(bool checked)
 	writeSettings();
 }
 
+void Preferences::on_checkBoxSummaryCamera_toggled(bool checked)
+{
+	Settings::Settings::summaryCamera.setValue(checked);
+	writeSettings();
+}
+
+void Preferences::on_checkBoxSummaryArea_toggled(bool checked)
+{
+	Settings::Settings::summaryArea.setValue(checked);
+	writeSettings();
+}
+
+void Preferences::on_checkBoxSummaryBoundingBox_toggled(bool checked)
+{
+	Settings::Settings::summaryBoundingBox.setValue(checked);
+	writeSettings();
+}
+
 void Preferences::on_enableHidapiTraceCheckBox_toggled(bool checked)
 {
 	Settings::Settings::inputEnableDriverHIDAPILog.setValue(checked);
@@ -930,6 +948,11 @@ void Preferences::updateGUI()
 	BlockSignals<QCheckBox *>(this->enableParameterCheckBox)->setChecked(getValue("advanced/enableParameterCheck").toBool());
 	BlockSignals<QCheckBox *>(this->enableRangeCheckBox)->setChecked(getValue("advanced/enableParameterRangeCheck").toBool());
 	BlockSignals<QCheckBox *>(this->useAsciiSTLCheckBox)->setChecked(Settings::Settings::exportUseAsciiSTL.value());
+
+	BlockSignals<QCheckBox *>(this->checkBoxSummaryCamera)->setChecked(Settings::Settings::summaryCamera.value());
+	BlockSignals<QCheckBox *>(this->checkBoxSummaryArea)->setChecked(Settings::Settings::summaryArea.value());
+	BlockSignals<QCheckBox *>(this->checkBoxSummaryBoundingBox)->setChecked(Settings::Settings::summaryBoundingBox.value());
+
 	BlockSignals<QCheckBox *>(this->enableHidapiTraceCheckBox)->setChecked(Settings::Settings::inputEnableDriverHIDAPILog.value());
 	BlockSignals<QCheckBox *>(this->checkBoxEnableAutocomplete)->setChecked(getValue("editor/enableAutocomplete").toBool());
 	BlockSignals<QLineEdit *>(this->lineEditCharacterThreshold)->setText(getValue("editor/characterThreshold").toString());

--- a/src/Preferences.h
+++ b/src/Preferences.h
@@ -52,6 +52,9 @@ public slots:
 	void on_enableParameterCheckBox_toggled(bool);
 	void on_enableRangeCheckBox_toggled(bool);
 	void on_useAsciiSTLCheckBox_toggled(bool);
+	void on_checkBoxSummaryCamera_toggled(bool);
+	void on_checkBoxSummaryArea_toggled(bool);
+	void on_checkBoxSummaryBoundingBox_toggled(bool);
 	void on_enableHidapiTraceCheckBox_toggled(bool);
 	void on_checkBoxShowWarningsIn3dView_toggled(bool);
 	void on_checkBoxMouseCentricZoom_toggled(bool);

--- a/src/Preferences.ui
+++ b/src/Preferences.ui
@@ -2050,6 +2050,36 @@
              </widget>
             </item>
             <item>
+             <widget class="QGroupBox" name="groupBox_Summary">
+              <property name="title">
+               <string>Render Summary</string>
+              </property>
+              <layout class="QVBoxLayout" name="verticalLayout_Summary">
+               <item>
+                <widget class="QCheckBox" name="checkBoxSummaryCamera">
+                 <property name="text">
+                  <string>Camera</string>
+                 </property>
+                </widget>
+               </item>
+               <item>
+                <widget class="QCheckBox" name="checkBoxSummaryBoundingBox">
+                 <property name="text">
+                  <string>Bounding Box</string>
+                 </property>
+                </widget>
+               </item>
+               <item>
+                <widget class="QCheckBox" name="checkBoxSummaryArea">
+                 <property name="text">
+                  <string>Measurements: Area</string>
+                 </property>
+                </widget>
+               </item>
+              </layout>
+             </widget>
+            </item>
+            <item>
              <spacer name="verticalSpacer">
               <property name="orientation">
                <enum>Qt::Vertical</enum>

--- a/src/RenderStatistic.cc
+++ b/src/RenderStatistic.cc
@@ -47,6 +47,7 @@ struct StatisticVisitor: public GeometryVisitor
 	constexpr static auto CAMERA = "camera";
 	constexpr static auto GEOMETRY = "geometry";
 	constexpr static auto BOUNDING_BOX = "bounding-box";
+	constexpr static auto AREA = "area";
 
 	StatisticVisitor(const std::vector<std::string>& options)
 		: all(std::find(options.begin(), options.end(), "all") != options.end())
@@ -204,6 +205,10 @@ void LogVisitor::visit(const Polygon2d& poly)
 		LOG(message_group::None,Location::NONE,"","Bounding box:");
 		LOG(message_group::None,Location::NONE,"","   Min: %1$.2f, %2$.2f", bb.min().x(), bb.min().y());
 		LOG(message_group::None,Location::NONE,"","   Max: %1$.2f, %2$.2f", bb.max().x(), bb.max().y());
+	}
+	if (is_enabled(AREA)) {
+		LOG(message_group::None,Location::NONE,"","Measurements:");
+		LOG(message_group::None,Location::NONE,"","   Area: %1$.2f", poly.area());
 	}
 }
 

--- a/src/RenderStatistic.cc
+++ b/src/RenderStatistic.cc
@@ -36,6 +36,22 @@
 #include "RenderStatistic.h"
 
 
+RenderStatistic::RenderStatistic() : begin(std::chrono::steady_clock::now())
+{
+}
+
+void RenderStatistic::start()
+{
+	begin = std::chrono::steady_clock::now();
+}
+
+std::chrono::milliseconds RenderStatistic::ms()
+{
+	const std::chrono::steady_clock::time_point end{std::chrono::steady_clock::now()};
+	const std::chrono::milliseconds ms{std::chrono::duration_cast<std::chrono::milliseconds>(end-begin)};
+	return ms;
+}
+
 void RenderStatistic::printCacheStatistic()
 {
   GeometryCache::instance()->print();
@@ -44,13 +60,24 @@ void RenderStatistic::printCacheStatistic()
 #endif
 }
 
-void RenderStatistic::printRenderingTime(std::chrono::milliseconds ms)
+void RenderStatistic::printRenderingTime()
 {
+	const std::chrono::steady_clock::time_point end{std::chrono::steady_clock::now()};
+	const std::chrono::milliseconds ms{std::chrono::duration_cast<std::chrono::milliseconds>(end-begin)};
   LOG(message_group::None,Location::NONE,"","Total rendering time: %1$d:%2$02d:%3$02d.%4$03d",
     (ms.count() /1000/60/60     ),
     (ms.count() /1000/60 % 60   ),
     (ms.count() /1000    % 60   ),
     (ms.count()          % 1000 ));
+}
+
+void RenderStatistic::printAll(const shared_ptr<const Geometry> geom)
+{
+	printCacheStatistic();
+	printRenderingTime();
+	if (geom && !geom->isEmpty()) {
+		print(*geom);
+	}
 }
 
 void RenderStatistic::print(const Geometry &geom)

--- a/src/RenderStatistic.cc
+++ b/src/RenderStatistic.cc
@@ -23,6 +23,8 @@
  *
  */
 
+#include <json.hpp>
+
 #include "printutils.h"
 #include "GeometryCache.h"
 #include "CGALCache.h"
@@ -34,7 +36,52 @@
 #endif // ENABLE_CGAL
 
 #include "RenderStatistic.h"
+#include "parameter/parameterobject.h"
 
+struct StatisticVisitor: public GeometryVisitor
+{
+	virtual void printCamera(const Camera& camera) = 0;
+	virtual void printCacheStatistic() = 0;
+	virtual void printRenderingTime(std::chrono::milliseconds) = 0;
+	virtual void finish() = 0;
+};
+
+struct LogVisitor: public StatisticVisitor
+{
+  void visit(const class GeometryList &node) override;
+  void visit(const class PolySet &node) override;
+  void visit(const class Polygon2d &node) override;
+#ifdef ENABLE_CGAL
+  void visit(const class CGAL_Nef_polyhedron &node) override;
+#endif // ENABLE_CGAL
+	void printCamera(const Camera& camera) override;
+	void printCacheStatistic() override;
+	void printRenderingTime(std::chrono::milliseconds) override;
+	void finish() override;
+};
+
+struct StreamVisitor: public StatisticVisitor
+{
+	StreamVisitor(std::ostream &stream) : stream(stream) {}
+	StreamVisitor(const std::string& filename) : fstream(filename), stream(fstream)	{}
+	~StreamVisitor() {
+		if (fstream.is_open()) fstream.close();
+	}
+  void visit(const class GeometryList &node) override;
+  void visit(const class PolySet &node) override;
+  void visit(const class Polygon2d &node) override;
+#ifdef ENABLE_CGAL
+  void visit(const class CGAL_Nef_polyhedron &node) override;
+#endif // ENABLE_CGAL
+	void printCamera(const Camera& camera) override;
+	void printCacheStatistic() override;
+	void printRenderingTime(std::chrono::milliseconds) override;
+	void finish() override;
+private:
+	nlohmann::json json;
+	std::ofstream fstream;
+	std::ostream &stream;
+};
 
 RenderStatistic::RenderStatistic() : begin(std::chrono::steady_clock::now())
 {
@@ -54,65 +101,73 @@ std::chrono::milliseconds RenderStatistic::ms()
 
 void RenderStatistic::printCacheStatistic()
 {
-  GeometryCache::instance()->print();
-#ifdef ENABLE_CGAL
-  CGALCache::instance()->print();
-#endif
+	LogVisitor visitor;
+	visitor.printCacheStatistic();
 }
 
 void RenderStatistic::printRenderingTime()
 {
-	const std::chrono::steady_clock::time_point end{std::chrono::steady_clock::now()};
-	const std::chrono::milliseconds ms{std::chrono::duration_cast<std::chrono::milliseconds>(end-begin)};
-  LOG(message_group::None,Location::NONE,"","Total rendering time: %1$d:%2$02d:%3$02d.%4$03d",
-    (ms.count() /1000/60/60     ),
-    (ms.count() /1000/60 % 60   ),
-    (ms.count() /1000    % 60   ),
-    (ms.count()          % 1000 ));
+	LogVisitor visitor;
+	visitor.printRenderingTime(ms());
 }
 
-void RenderStatistic::printAll(const shared_ptr<const Geometry> geom)
+template <typename F>
+static void run_if_enabled(const bool default_on, const std::vector<std::string>& options, const std::string& name, F f)
 {
-	printCacheStatistic();
-	printRenderingTime();
-	if (geom && !geom->isEmpty()) {
-		print(*geom);
+	const bool enabled = default_on || std::find(options.begin(), options.end(), "all") != options.end();
+	if (enabled || std::find(options.begin(), options.end(), name) != options.end()) {
+		f();
 	}
 }
 
-void RenderStatistic::print(const Geometry &geom)
+void RenderStatistic::printAll(const shared_ptr<const Geometry> geom, const Camera& camera, const std::vector<std::string>& options, const std::string& filename)
 {
-  geom.accept(*this);
+	bool is_log = false;
+	std::unique_ptr<StatisticVisitor> visitor;
+	if (filename.empty()) {
+		is_log = true;
+		visitor = std::make_unique<LogVisitor>();
+	} else if (filename == "-") {
+		visitor = std::make_unique<StreamVisitor>(std::cout);
+	} else {
+		visitor = std::make_unique<StreamVisitor>(filename);
+	}
+
+	run_if_enabled(is_log, options, "cache", [&visitor]{ visitor->printCacheStatistic(); });
+	run_if_enabled(is_log, options, "time", [&visitor,this]{ visitor->printRenderingTime(ms()); });
+	run_if_enabled(is_log, options, "geometry", [&visitor, &geom]{ if (geom && !geom->isEmpty()) { geom->accept(*visitor); } });
+	run_if_enabled(false,  options, "camera", [&visitor, &camera]{ visitor->printCamera(camera); });
+	visitor->finish();
 }
 
-void RenderStatistic::visit(const GeometryList& geomlist)
+void LogVisitor::visit(const GeometryList& geomlist)
 {
-	LOG(message_group::None,Location::NONE,"","   Top level object is a list of objects:");
+	LOG(message_group::None,Location::NONE,"","Top level object is a list of objects:");
 	LOG(message_group::None,Location::NONE,"","   Objects:    %1$d",
 	geomlist.getChildren().size());
 }
 
-void RenderStatistic::visit(const PolySet& ps)
+void LogVisitor::visit(const PolySet& ps)
 {
 	assert(ps.getDimension() == 3);
-	LOG(message_group::None,Location::NONE,"","   Top level object is a 3D object:");
+	LOG(message_group::None,Location::NONE,"","Top level object is a 3D object:");
 	LOG(message_group::None,Location::NONE,"","   Facets:     %1$6d",
 	ps.numFacets());
 }
 
-void RenderStatistic::visit(const Polygon2d& poly)
+void LogVisitor::visit(const Polygon2d& poly)
 {
-	LOG(message_group::None,Location::NONE,"","   Top level object is a 2D object:");
+	LOG(message_group::None,Location::NONE,"","Top level object is a 2D object:");
 	LOG(message_group::None,Location::NONE,"","   Contours:   %1$6d",
 	poly.outlines().size());
 }
 
 #ifdef ENABLE_CGAL
-void RenderStatistic::visit(const CGAL_Nef_polyhedron& Nef)
+void LogVisitor::visit(const CGAL_Nef_polyhedron& Nef)
 {
   if (Nef.getDimension() == 3) {
     bool simple = Nef.p3->is_simple();
-    LOG(message_group::None,Location::NONE,"","   Top level object is a 3D object:");
+    LOG(message_group::None,Location::NONE,"","Top level object is a 3D object:");
     LOG(message_group::None,Location::NONE,"","   Simple:     %6s",(simple ? "yes" : "no"));
     LOG(message_group::None,Location::NONE,"","   Vertices:   %1$6d",Nef.p3->number_of_vertices());
     LOG(message_group::None,Location::NONE,"","   Halfedges:  %1$6d",Nef.p3->number_of_halfedges());
@@ -126,3 +181,144 @@ void RenderStatistic::visit(const CGAL_Nef_polyhedron& Nef)
   }
 }
 #endif // ENABLE_CGAL
+
+void LogVisitor::printCamera(const Camera& camera)
+{
+	LOG(message_group::None,Location::NONE,"","Camera:");
+	LOG(message_group::None,Location::NONE,"","   Translation: %1$.2f, %2$.2f, %3$.2f", camera.getVpt().x(), camera.getVpt().y(), camera.getVpt().z());
+	LOG(message_group::None,Location::NONE,"","   Rotation:    %1$.2f, %2$.2f, %3$.2f", camera.getVpr().x(), camera.getVpr().y(), camera.getVpr().z());
+	LOG(message_group::None,Location::NONE,"","   Distance:    %1$.2f", camera.zoomValue());
+	LOG(message_group::None,Location::NONE,"","   FOV:         %1$.2f", camera.fovValue());
+}
+
+void LogVisitor::printCacheStatistic()
+{
+  GeometryCache::instance()->print();
+#ifdef ENABLE_CGAL
+  CGALCache::instance()->print();
+#endif
+}
+
+void LogVisitor::printRenderingTime(const std::chrono::milliseconds ms)
+{
+  LOG(message_group::None,Location::NONE,"","Total rendering time: %1$d:%2$02d:%3$02d.%4$03d",
+    (ms.count() /1000/60/60     ),
+    (ms.count() /1000/60 % 60   ),
+    (ms.count() /1000    % 60   ),
+    (ms.count()          % 1000 ));
+}
+
+void LogVisitor::finish()
+{
+}
+
+template <typename G>
+static nlohmann::json getBoundingBox3(G geometry)
+{
+	const auto& bb = geometry.getBoundingBox();
+	const std::array<double, 3> min = { bb.min().x(), bb.min().y(), bb.min().z() };
+	const std::array<double, 3> max = { bb.max().x(), bb.max().y(), bb.max().z() };
+	nlohmann::json bbJson;
+	bbJson["min"] = min;
+	bbJson["max"] = max;
+	return bbJson;
+}
+
+void StreamVisitor::visit(const GeometryList& geomlist)
+{
+}
+
+void StreamVisitor::visit(const PolySet& ps)
+{
+	assert(ps.getDimension() == 3);
+	nlohmann::json geometryJson;
+	geometryJson["dimensions"] = 3;
+	geometryJson["convex"] = ps.is_convex();
+	geometryJson["facets"] = ps.numFacets();
+	geometryJson["bounding_box"] = getBoundingBox3(ps);
+	json["geometry"] = geometryJson;
+}
+
+void StreamVisitor::visit(const Polygon2d& poly)
+{
+	const auto& bb = poly.getBoundingBox();
+	const std::array<double, 2> min = { bb.min().x(), bb.min().y() };
+	const std::array<double, 2> max = { bb.max().x(), bb.max().y() };
+	nlohmann::json bbJson;
+	bbJson["min"] = min;
+	bbJson["max"] = max;
+	nlohmann::json geometryJson;
+	geometryJson["dimensions"] = 2;
+	geometryJson["convex"] = poly.is_convex();
+	geometryJson["contours"] = poly.outlines().size();
+	geometryJson["bounding_box"] = bbJson;
+	json["geometry"] = geometryJson;
+}
+
+#ifdef ENABLE_CGAL
+void StreamVisitor::visit(const CGAL_Nef_polyhedron& nef)
+{
+	nlohmann::json geometryJson;
+	geometryJson["dimensions"] = 3;
+	geometryJson["simple"] = nef.p3->is_simple();
+	geometryJson["vertices"] = nef.p3->number_of_vertices();
+	geometryJson["edges"] = nef.p3->number_of_edges();
+	geometryJson["facets"] = nef.p3->number_of_facets();
+	geometryJson["volumes"] = nef.p3->number_of_volumes();
+	geometryJson["bounding_box"] = getBoundingBox3(nef);
+	json["geometry"] = geometryJson;
+}
+#endif // ENABLE_CGAL
+
+void StreamVisitor::printCamera(const Camera& camera)
+{
+	const std::array<double, 3> translation = { camera.getVpt().x(), camera.getVpt().y(), camera.getVpt().z() };
+	const std::array<double, 3> rotation = { camera.getVpr().x(), camera.getVpr().y(), camera.getVpr().z() };
+	nlohmann::json cameraJson;
+	cameraJson["translation"] = translation;
+	cameraJson["rotation"] = rotation;
+	cameraJson["distance"] = camera.zoomValue();
+	cameraJson["fov"] = camera.fovValue();
+	json["camera"] = cameraJson;
+}
+
+template <typename C>
+static nlohmann::json getCache(C cache)
+{
+	nlohmann::json cacheJson;
+	cacheJson["entries"] = cache->size();
+	cacheJson["bytes"] = cache->totalCost();
+	cacheJson["max_size"] = cache->maxSizeMB() * 1024 * 1024;
+	return cacheJson;
+}
+
+void StreamVisitor::printCacheStatistic()
+{
+	nlohmann::json cacheJson;
+	cacheJson["geometry_cache"] = getCache(GeometryCache::instance());
+#ifdef ENABLE_CGAL
+	cacheJson["cgal_cache"] = getCache(CGALCache::instance());
+#endif // ENABLE_CGAL
+	json["cache"] = cacheJson;
+}
+
+void StreamVisitor::printRenderingTime(const std::chrono::milliseconds ms)
+{
+	nlohmann::json timeJson;
+	timeJson["time"] = (boost::format("%1$d:%2$02d:%3$02d.%4$03d")
+					% (ms.count() / 1000 / 60 / 60)
+					% (ms.count() / 1000 / 60 % 60)
+					% (ms.count() / 1000 % 60)
+					% (ms.count() % 1000)).str();
+	timeJson["total"] = ms.count();
+	timeJson["milliseconds"] = ms.count() % 1000;
+	timeJson["seconds"] = ms.count() / 1000 % 60;
+	timeJson["minutes"] = ms.count() / 1000 / 60 % 60;
+	timeJson["hours"] = ms.count() / 1000 / 60 / 60;
+	json["time"] = timeJson;
+}
+
+void StreamVisitor::finish()
+{
+	stream << json;
+}

--- a/src/RenderStatistic.h
+++ b/src/RenderStatistic.h
@@ -38,21 +38,36 @@ class RenderStatistic: protected GeometryVisitor
 {
 public:
   /**
-   * Construct a statistic printer for the given geometry
+   * Construct a statistic printer for the given geometry with current
+   * time as start time.
    */
-  RenderStatistic() {};
-  
+  RenderStatistic();
+
+  /**
+   * Set start time when reusing a RenderStatistic instance.
+   */
+  void start();
+
+  /**
+   * Return render time in milliseconds.
+   */
+  std::chrono::milliseconds ms();
+
+  /**
+   * Print all available statistic information.
+   */
+  void printAll(const shared_ptr<const Geometry> geom);
+
   /**
    * Print some statistic on cache usage. Namely, stats on the @ref GeometryCache
    * and @ref CGALCache (if enabled).
    */
-  static void printCacheStatistic();
+  void printCacheStatistic();
   
   /**
    * Format and print time elapsed by rendering.
-   * @arg time elapsed by rendering in seconds
    */
-  static void printRenderingTime(std::chrono::milliseconds ms);
+  void printRenderingTime();
   
   /**
    * Actually print the statistic based on the given Geometry
@@ -67,6 +82,9 @@ protected:
 #ifdef ENABLE_CGAL
   void visit(const class CGAL_Nef_polyhedron &node) override;
 #endif // ENABLE_CGAL
+
+private:
+  std::chrono::steady_clock::time_point begin;
 };
 
 #endif // RENDERSTATISTIC_H

--- a/src/RenderStatistic.h
+++ b/src/RenderStatistic.h
@@ -23,18 +23,17 @@
  *
  */
 
-#ifndef RENDERSTATISTIC_H
-#define RENDERSTATISTIC_H
-
-#include "Geometry.h"
+#pragma once
 
 #include <chrono>
+#include "Camera.h"
+#include "Geometry.h"
 
 /**
  * An utility class to collect and print rendering statistics for the given
  * geometry
  */
-class RenderStatistic: protected GeometryVisitor
+class RenderStatistic
 {
 public:
   /**
@@ -54,37 +53,21 @@ public:
   std::chrono::milliseconds ms();
 
   /**
-   * Print all available statistic information.
-   */
-  void printAll(const shared_ptr<const Geometry> geom);
-
-  /**
    * Print some statistic on cache usage. Namely, stats on the @ref GeometryCache
    * and @ref CGALCache (if enabled).
    */
   void printCacheStatistic();
-  
+
   /**
    * Format and print time elapsed by rendering.
    */
   void printRenderingTime();
   
   /**
-   * Actually print the statistic based on the given Geometry
-   * @arg geom A Geometry-derived object statistic for which we should print.
+   * Print all available statistic information.
    */
-  void print(const Geometry &geom);
-  
-protected:
-  void visit(const class GeometryList &node) override;
-  void visit(const class PolySet &node) override;
-  void visit(const class Polygon2d &node) override;
-#ifdef ENABLE_CGAL
-  void visit(const class CGAL_Nef_polyhedron &node) override;
-#endif // ENABLE_CGAL
+  void printAll(const shared_ptr<const Geometry> geom, const Camera& camera, const std::vector<std::string>& options = {}, const std::string& filename = {});
 
 private:
   std::chrono::steady_clock::time_point begin;
 };
-
-#endif // RENDERSTATISTIC_H

--- a/src/RenderStatistic.h
+++ b/src/RenderStatistic.h
@@ -36,6 +36,13 @@
 class RenderStatistic
 {
 public:
+  constexpr static auto CACHE = "cache";
+  constexpr static auto TIME = "time";
+  constexpr static auto CAMERA = "camera";
+  constexpr static auto GEOMETRY = "geometry";
+  constexpr static auto BOUNDING_BOX = "bounding-box";
+  constexpr static auto AREA = "area";
+
   /**
    * Construct a statistic printer for the given geometry with current
    * time as start time.

--- a/src/Settings.cc
+++ b/src/Settings.cc
@@ -124,6 +124,10 @@ SettingsEntryString Settings::octoPrintSlicerProfileDesc("printing", "octoPrintS
 
 SettingsEntryBool Settings::exportUseAsciiSTL("export", "useAsciiSTL", false);
 
+SettingsEntryBool Settings::summaryCamera("summary", "camera", false);
+SettingsEntryBool Settings::summaryArea("summary", "measurementArea", false);
+SettingsEntryBool Settings::summaryBoundingBox("summary", "boundingBox", false);
+
 SettingsEntryBool   Settings::inputEnableDriverHIDAPI("input", "enableDriverHIDAPI", false);
 SettingsEntryBool   Settings::inputEnableDriverHIDAPILog("input", "enableDriverHIDAPILog", false);
 SettingsEntryBool   Settings::inputEnableDriverSPNAV("input", "enableDriverSPNAV", false);

--- a/src/Settings.h
+++ b/src/Settings.h
@@ -187,6 +187,10 @@ public:
 
 	static SettingsEntryBool   exportUseAsciiSTL;
 
+	static SettingsEntryBool   summaryCamera;
+	static SettingsEntryBool   summaryArea;
+	static SettingsEntryBool   summaryBoundingBox;
+
 	static SettingsEntryBool   inputEnableDriverHIDAPI;
 	static SettingsEntryBool   inputEnableDriverHIDAPILog;
 	static SettingsEntryBool   inputEnableDriverSPNAV;

--- a/src/export.h
+++ b/src/export.h
@@ -117,8 +117,8 @@ struct ViewOptions {
 
 class OffscreenView;
 
-std::unique_ptr<OffscreenView> prepare_preview(Tree &tree, const ViewOptions& options, Camera camera);
-bool export_png(const shared_ptr<const class Geometry> &root_geom, const ViewOptions& options, Camera camera, std::ostream &output);
+std::unique_ptr<OffscreenView> prepare_preview(Tree &tree, const ViewOptions& options, Camera& camera);
+bool export_png(const shared_ptr<const class Geometry> &root_geom, const ViewOptions& options, Camera& camera, std::ostream &output);
 bool export_png(const OffscreenView &glview, std::ostream &output);
 bool export_param(SourceFile *root, const fs::path& path, std::ostream &output);
 

--- a/src/export_png.cc
+++ b/src/export_png.cc
@@ -17,7 +17,7 @@ static void setupCamera(Camera &cam, const BoundingBox &bbox)
 	if (cam.viewall) cam.viewAll(bbox);
 }
 
-bool export_png(const shared_ptr<const Geometry> &root_geom, const ViewOptions& options, Camera camera, std::ostream &output)
+bool export_png(const shared_ptr<const Geometry> &root_geom, const ViewOptions& options, Camera& camera, std::ostream &output)
 {
 	PRINTD("export_png geom");
 	OffscreenView *glview;
@@ -51,7 +51,7 @@ bool export_png(const shared_ptr<const Geometry> &root_geom, const ViewOptions& 
 #endif
 #include "ThrownTogetherRenderer.h"
 
-std::unique_ptr<OffscreenView> prepare_preview(Tree &tree, const ViewOptions& options, Camera camera)
+std::unique_ptr<OffscreenView> prepare_preview(Tree &tree, const ViewOptions& options, Camera& camera)
 {
 	PRINTD("prepare_preview_common");
 	CsgInfo csgInfo = CsgInfo();

--- a/src/input/QGamepadInputDriver.h
+++ b/src/input/QGamepadInputDriver.h
@@ -38,7 +38,7 @@ public:
     void run() override;
     bool open() override;
     void close() override;
-    bool isOpen() const;
+    bool isOpen() const override;
 
     const std::string & get_name() const override;
     std::string get_info() const override;

--- a/src/openscad.cc
+++ b/src/openscad.cc
@@ -981,8 +981,8 @@ int main(int argc, char **argv)
 		("view", po::value<CommaSeparatedVector>(), ("=view options: " + boost::join(viewOptions.names(), " | ")).c_str())
 		("projection", po::value<string>(), "=(o)rtho or (p)erspective when exporting png")
 		("csglimit", po::value<unsigned int>(), "=n -stop rendering at n CSG elements when exporting png")
-    ("summary", po::value<vector<string>>(), "enable additional render summary and statistics: camera | bounding-box")
-    ("summary-file", po::value<string>(), "output summary information in JSON format to the given file")
+    ("summary", po::value<vector<string>>(), "enable additional render summary and statistics: all | cache | time | camera | geometry | bounding-box | area")
+    ("summary-file", po::value<string>(), "output summary information in JSON format to the given file, using '-' outputs to stdout")
 		("colorscheme", po::value<string>(), ("=colorscheme: " +
 		                                      join(ColorMap::inst()->colorSchemeNames(), " | ",
 		                                           [](const std::string& colorScheme) {

--- a/src/openscad.cc
+++ b/src/openscad.cc
@@ -330,6 +330,8 @@ struct CommandLine
 	const Camera& camera;
 	const boost::optional<FileFormat> export_format;
 	unsigned animate_frames;
+	const std::vector<std::string> summaryOptions;
+	const std::string summaryFile;
 };
 
 struct RenderVariables
@@ -573,8 +575,6 @@ int do_export(const CommandLine &cmd, const RenderVariables& render_variables, F
 			}
 		}
 
-		renderStatistic.printAll(root_geom);
-
         if( curFormat == FileFormat::ASCIISTL ||
             curFormat == FileFormat::STL ||
             curFormat == FileFormat::OFF ||
@@ -603,9 +603,12 @@ int do_export(const CommandLine &cmd, const RenderVariables& render_variables, F
 					success = export_png(*glview, stream);
 			}
 			}, std::ios::out | std::ios::binary);
-			return (success && wrote) ? 0 : 1;
+			if (!success || !wrote) {
+				return 1;
+			}
 		}
 
+		renderStatistic.printAll(root_geom, camera, cmd.summaryOptions, cmd.summaryFile);
 #else
 		LOG(message_group::None,Location::NONE,"","OpenSCAD has been compiled without CGAL support!\n");
 		return 1;
@@ -978,6 +981,8 @@ int main(int argc, char **argv)
 		("view", po::value<CommaSeparatedVector>(), ("=view options: " + boost::join(viewOptions.names(), " | ")).c_str())
 		("projection", po::value<string>(), "=(o)rtho or (p)erspective when exporting png")
 		("csglimit", po::value<unsigned int>(), "=n -stop rendering at n CSG elements when exporting png")
+    ("summary", po::value<vector<string>>(), "enable additional render summary and statistics: camera | bounding-box")
+    ("summary-file", po::value<string>(), "output summary information in JSON format to the given file")
 		("colorscheme", po::value<string>(), ("=colorscheme: " +
 		                                      join(ColorMap::inst()->colorSchemeNames(), " | ",
 		                                           [](const std::string& colorScheme) {
@@ -1184,7 +1189,22 @@ int main(int argc, char **argv)
 					const std::string input_file = is_stdin ? "<stdin>" : inputFiles[0];
 					const bool is_stdout = filename == "-";
 					const std::string output_file = is_stdout ? "<stdout>" : filename;
-					const CommandLine cmd{is_stdin, input_file, is_stdout, output_file, deps_output_file, original_path, parameterFile, parameterSet, viewOptions, camera, export_format, animate_frames};
+					const CommandLine cmd{
+						is_stdin,
+						input_file,
+						is_stdout,
+						output_file,
+						deps_output_file,
+						original_path,
+						parameterFile,
+						parameterSet,
+						viewOptions,
+						camera,
+						export_format,
+						animate_frames,
+						vm.count("summary") ? vm["summary"].as<std::vector<std::string>>() : std::vector<std::string>{},
+						vm.count("summary-file") ? vm["summary-file"].as<std::string>() : ""
+					};
 					rc |= cmdline(cmd);
 				}
 			}

--- a/src/openscad.cc
+++ b/src/openscad.cc
@@ -543,7 +543,7 @@ int do_export(const CommandLine &cmd, const RenderVariables& render_variables, F
 #ifdef ENABLE_CGAL
 
 		// start measuring render time
-		std::chrono::steady_clock::time_point begin = std::chrono::steady_clock::now();
+		RenderStatistic renderStatistic;
 		GeometryEvaluator geomevaluator(tree);
 		unique_ptr<OffscreenView> glview;
 		shared_ptr<const Geometry> root_geom;
@@ -573,12 +573,7 @@ int do_export(const CommandLine &cmd, const RenderVariables& render_variables, F
 			}
 		}
 
-		std::chrono::steady_clock::time_point end = std::chrono::steady_clock::now();
-		RenderStatistic::printCacheStatistic();
-		RenderStatistic::printRenderingTime( std::chrono::duration_cast<std::chrono::milliseconds>(end-begin) );
-		if (root_geom && !root_geom->isEmpty()) {
-			RenderStatistic().print(*root_geom);
-		}
+		renderStatistic.printAll(root_geom);
 
         if( curFormat == FileFormat::ASCIISTL ||
             curFormat == FileFormat::STL ||

--- a/tests/data/python/gen_svg_viewbox_tests-template.py
+++ b/tests/data/python/gen_svg_viewbox_tests-template.py
@@ -32,6 +32,5 @@ for p in params:
     svg_preserveAspectRatio = "preserveAspectRatio=\"{}\"".format(aspectParam)
     out = svg.replace('__VIEWBOX__', svg_viewBox).replace('__PRESERVE_ASPECT_RATIO__', svg_preserveAspectRatio)
     outfile = sys.argv[1] + "/viewbox_{}x{}_{}.svg".format(width, height, aspectFile)
-    print(outfile)
     with open(outfile, "w") as f:
         f.write(out)


### PR DESCRIPTION
Draft for extended summary output, first intended to support #3827 but should be also able to cover #433 eventually.

New command line arguments:
`--summary all|camera|cache|time|geometry|bounding-box`
`--summary-file filename|-`

If `--summary-file` is given, information is exported in JSON format, using `-` it will be sent to `stdout`.

Example for just the camera data:
`echo 'sphere(5);cube(10);' | ./openscad --summary camera --summary-file - -o /tmp/x.png - --render | jq`
```
{
  "camera": {
    "distance": 66.16001403043475,
    "fov": 22.5,
    "rotation": [ 55, 0, 25 ],
    "translation": [ 2.548037052154541, 2.548037052154541, 2.548037052154541 ]
  }
}
```
Output with `all`:
```
{
  "cache": {
    "cgal_cache": {
      "bytes": 276376,
      "entries": 1,
      "max_size": 104857600
    },
    "geometry_cache": {
      "bytes": 17776,
      "entries": 2,
      "max_size": 104857600
    }
  },
  "camera": {
    "distance": 66.16001403043475,
    "fov": 22.5,
    "rotation": [ 55, 0, 25 ],
    "translation": [ 2.548037052154541, 2.548037052154541, 2.548037052154541 ]
  },
  "geometry": {
    "bounding_box": {
      "max": [ 10, 10, 10 ],
      "min": [ -4.903925895690918, -4.903925895690918, -4.903925895690918 ],
      "size": [ 14.903925895690918, 14.903925895690918, 14.903925895690918 ]
    },
    "dimensions": 3,
    "edges": 319,
    "facets": 192,
    "simple": true,
    "vertices": 129,
    "volumes": 2
  },
  "time": {
    "hours": 0,
    "milliseconds": 425,
    "minutes": 0,
    "seconds": 0,
    "time": "0:00:00.425",
    "total": 425
  }
}
```