### PR TITLE
Default convexity to 10.

### DIFF
--- a/src/cgaladv.cc
+++ b/src/cgaladv.cc
@@ -42,6 +42,7 @@ static AbstractNode* builtin_minkowski(const ModuleInstantiation *inst, Argument
 	
 	Parameters parameters = Parameters::parse(std::move(arguments), inst->location(), {"convexity"});
 	node->convexity = static_cast<int>(parameters["convexity"].toDouble());
+    if (node->convexity <= 0) node->convexity = DEFAULT_CONVEXITY;
 
 	return children.instantiate(node);
 }
@@ -62,6 +63,7 @@ static AbstractNode* builtin_resize(const ModuleInstantiation *inst, Arguments a
 
 	Parameters parameters = Parameters::parse(std::move(arguments), inst->location(), {"newsize", "auto", "convexity"});
 	node->convexity = static_cast<int>(parameters["convexity"].toDouble());
+    if (node->convexity <= 0) node->convexity = DEFAULT_CONVEXITY;
 	node->newsize << 0,0,0;
 	if ( parameters["newsize"].type() == Value::Type::VECTOR ) {
 		const auto &vs = parameters["newsize"].toVector();

--- a/src/import.cc
+++ b/src/import.cc
@@ -112,9 +112,9 @@ static AbstractNode* do_import(const ModuleInstantiation *inst, Arguments argume
 			node->layername = "";
 		}
 	}
-	node->convexity = (int)parameters["convexity"].toDouble();
 
-	if (node->convexity <= 0) node->convexity = 1;
+	node->convexity = static_cast<int>(parameters["convexity"].toDouble());
+    if (node->convexity <= 0) node->convexity = DEFAULT_CONVEXITY;
 
 	const auto &origin = parameters["origin"];
 	node->origin_x = node->origin_y = 0;

--- a/src/node.h
+++ b/src/node.h
@@ -138,3 +138,7 @@ public:
 
 std::ostream &operator<<(std::ostream &stream, const AbstractNode &node);
 AbstractNode *find_root_tag(AbstractNode *node, const Location **nextLocation = nullptr);
+
+#define DEFAULT_CONVEXITY 10
+#define QUOTE(x__) # x__
+#define QUOTED(x__) QUOTE(x__)

--- a/src/primitives.cc
+++ b/src/primitives.cc
@@ -516,7 +516,7 @@ public:
 	
 	std::vector<point3d> points;
 	std::vector<std::vector<size_t>> faces;
-	int convexity = 1;
+	int convexity;
 };
 
 std::string PolyhedronNode::toString() const
@@ -635,8 +635,8 @@ static AbstractNode* builtin_polyhedron(const ModuleInstantiation *inst, Argumen
 		faceIndex++;
 	}
 
-	node->convexity = (int)parameters["convexity"].toDouble();
-	if (node->convexity < 1) node->convexity = 1;
+	node->convexity = static_cast<int>(parameters["convexity"].toDouble());
+    if (node->convexity <= 0) node->convexity = DEFAULT_CONVEXITY;
 
 	return node;
 }
@@ -802,7 +802,7 @@ public:
 	
 	std::vector<point2d> points;
 	std::vector<std::vector<size_t>> paths;
-	int convexity = 1;
+	int convexity;
 };
 
 std::string PolygonNode::toString() const
@@ -931,8 +931,8 @@ static AbstractNode* builtin_polygon(const ModuleInstantiation *inst, Arguments 
 		return node;
 	}
 
-	node->convexity = (int)parameters["convexity"].toDouble();
-	if (node->convexity < 1) node->convexity = 1;
+	node->convexity = static_cast<int>(parameters["convexity"].toDouble());
+    if (node->convexity <= 0) node->convexity = DEFAULT_CONVEXITY;
 
 	return node;
 }

--- a/src/projection.cc
+++ b/src/projection.cc
@@ -42,6 +42,7 @@ static AbstractNode* builtin_projection(const ModuleInstantiation *inst, Argumen
 
 	Parameters parameters = Parameters::parse(std::move(arguments), inst->location(), {"cut"}, {"convexity"});
 	node->convexity = static_cast<int>(parameters["convexity"].toDouble());
+    if (node->convexity <= 0) node->convexity = DEFAULT_CONVEXITY;
 	if (parameters["cut"].type() == Value::Type::BOOL) {
 		node->cut_mode = parameters["cut"].toBool();
 	}

--- a/src/render.cc
+++ b/src/render.cc
@@ -41,9 +41,8 @@ static AbstractNode* builtin_render(const ModuleInstantiation *inst, Arguments a
 	auto node = new RenderNode(inst);
 
 	Parameters parameters = Parameters::parse(std::move(arguments), inst->location(), {"convexity"});
-	if (parameters["convexity"].type() == Value::Type::NUMBER) {
-		node->convexity = static_cast<int>(parameters["convexity"].toDouble());
-	}
+	node->convexity = static_cast<int>(parameters["convexity"].toDouble());
+    if (node->convexity <= 0) node->convexity = DEFAULT_CONVEXITY;
 
 	return children.instantiate(node);
 }
@@ -57,6 +56,6 @@ void register_builtin_render()
 {
 	Builtins::init("render", new BuiltinModule(builtin_render),
 				{
-					"render(convexity = 1)",
+					"render(convexity = " QUOTED(DEFAULT_CONVEXITY) ")",
 				});
 }

--- a/src/rendernode.h
+++ b/src/rendernode.h
@@ -7,7 +7,7 @@ class RenderNode : public AbstractNode
 {
 public:
 	VISITABLE();
-	RenderNode(const ModuleInstantiation *mi) : AbstractNode(mi), convexity(1) { }
+	RenderNode(const ModuleInstantiation *mi) : AbstractNode(mi) { }
 	std::string toString() const override;
 	std::string name() const override { return "render"; }
 

--- a/src/rotateextrude.cc
+++ b/src/rotateextrude.cc
@@ -64,6 +64,7 @@ static AbstractNode* builtin_rotate_extrude(const ModuleInstantiation *inst, Arg
 
 	node->layername = parameters["layer"].isUndefined() ? "" : parameters["layer"].toString();
 	node->convexity = static_cast<int>(parameters["convexity"].toDouble());
+    if (node->convexity <= 0) node->convexity = DEFAULT_CONVEXITY;
 	bool originOk = parameters["origin"].getVec2(node->origin_x, node->origin_y);
 	originOk &= std::isfinite(node->origin_x) && std::isfinite(node->origin_y);
 	if (parameters["origin"].isDefined() && !originOk){
@@ -72,9 +73,6 @@ static AbstractNode* builtin_rotate_extrude(const ModuleInstantiation *inst, Arg
 	node->scale = parameters["scale"].toDouble();
 	node->angle = 360;
 	parameters["angle"].getFiniteDouble(node->angle);
-
-	if (node->convexity <= 0)
-		node->convexity = 2;
 
 	if (node->scale <= 0)
 		node->scale = 1;
@@ -122,6 +120,7 @@ void register_builtin_dxf_rotate_extrude()
 
 	Builtins::init("rotate_extrude", new BuiltinModule(builtin_rotate_extrude),
 				{
-					"rotate_extrude(angle = 360, convexity = 2)",
+					"rotate_extrude(angle = 360, convexity = "
+                    QUOTED(DEFAULT_CONVEXITY) ")",
 				});
 }

--- a/src/surface.cc
+++ b/src/surface.cc
@@ -58,7 +58,7 @@ class SurfaceNode : public LeafNode
 {
 public:
 	VISITABLE();
-	SurfaceNode(const ModuleInstantiation *mi) : LeafNode(mi), center(false), invert(false), convexity(1) { }
+	SurfaceNode(const ModuleInstantiation *mi) : LeafNode(mi), center(false), invert(false) { }
 	std::string toString() const override;
 	std::string name() const override { return "surface"; }
 
@@ -95,9 +95,8 @@ static AbstractNode* builtin_surface(const ModuleInstantiation *inst, Arguments 
 		node->center = parameters["center"].toBool();
 	}
 
-	if (parameters["convexity"].type() == Value::Type::NUMBER) {
-		node->convexity = static_cast<int>(parameters["convexity"].toDouble());
-	}
+	node->convexity = static_cast<int>(parameters["convexity"].toDouble());
+    if (node->convexity <= 0) node->convexity = DEFAULT_CONVEXITY;
 
 	if (parameters["invert"].type() == Value::Type::BOOL) {
 		node->invert = parameters["invert"].toBool();
@@ -310,6 +309,7 @@ std::string SurfaceNode::toString() const
 	stream << this->name() << "(file = " << this->filename
 		<< ", center = " << (this->center ? "true" : "false")
 		<< ", invert = " << (this->invert ? "true" : "false")
+		<< ", convexity = " << this->convexity
 				 << ", " "timestamp = " << (fs::exists(path) ? fs::last_write_time(path) : 0)
 				 << ")";
 


### PR DESCRIPTION
Also, in linear extrude, allow "h" as an alias for "height".

This is pretty straightforward, but I'd like to discuss a little.  In particular, I'm wondering about adding a $convexity so that those who are nostalgic for rendering artifacts can easily globally set $convexity=1.

Questions:

Is there a better place for the definitions of DEFAULT_CONVEXITY and QUOTE/QUOTED?  (Note that QUOTE/QUOTED are defined in several other places; it would be nice to commonize them.)

If adding $convexity, and even if not, it'd be nice to commonize the "get convexity parameter and default it to DEFAULT_CONVEXITY" pattern.  Is there a good place to put such a helper function?

The sample I happened to pick to standardize on uses `static_cast<int>`, but as far as I can tell a simple `(int)` would work too.  Is there a reason to prefer one over the other?