### PR TITLE
Resolve build warnings

### DIFF
--- a/src/Preferences.ui
+++ b/src/Preferences.ui
@@ -2080,7 +2080,7 @@
              </widget>
             </item>
             <item>
-             <spacer name="verticalSpacer">
+             <spacer name="verticalSpacer_1">
               <property name="orientation">
                <enum>Qt::Vertical</enum>
               </property>
@@ -2109,7 +2109,7 @@
              </widget>
             </item>
             <item>
-             <spacer name="verticalSpacer">
+             <spacer name="verticalSpacer_4">
               <property name="orientation">
                <enum>Qt::Vertical</enum>
               </property>
@@ -2126,7 +2126,7 @@
               <property name="title">
                <string>Debugging</string>
               </property>
-              <layout class="QVBoxLayout" name="verticalLayout_16">
+              <layout class="QVBoxLayout" name="verticalLayout_17">
                <item>
                 <widget class="QCheckBox" name="enableHidapiTraceCheckBox">
                  <property name="text">

--- a/src/handle_dep.cc
+++ b/src/handle_dep.cc
@@ -21,7 +21,24 @@ void handle_dep(const std::string &filename)
     dependencies.insert(dep);
 
     if (make_command && !fs::exists(filepath)) {
-        system(STR(make_command << " '" << boost::regex_replace(filename, boost::regex("'"), "'\\''") << "'").c_str()); // FIXME: Handle error
+        // This should only happen from command-line execution.
+        // If changed, add an alternate error-reporting process.
+        auto cmd = STR(make_command << " '" << boost::regex_replace(filename, boost::regex("'"), "'\\''") << "'");
+        int res = system(cmd.c_str());
+        if (res == -1) {
+            perror("ERROR: system(make_cmd) failed");
+        }
+        else if (WIFEXITED(res)) {
+            int cmd_res = WEXITSTATUS(res);
+            if (cmd_res != 0) {
+                std::cerr << "ERROR: " << cmd.c_str() << ": Exit status "
+                    << cmd_res << std::endl;
+            }
+        }
+        else {
+            std::cerr << "ERROR: " << cmd.c_str()
+                << ": Process terminated abnormally!" << std::endl;
+        }
     }
 }
 

--- a/src/handle_dep.cc
+++ b/src/handle_dep.cc
@@ -13,31 +13,31 @@ const char *make_command = nullptr;
 
 void handle_dep(const std::string &filename)
 {
-	fs::path filepath(filename);
-	std::string dep = boost::regex_replace(filepath.generic_string(), boost::regex("\\ "), "\\\\ ");
-	if (dependencies.find(dep) != dependencies.end()) {
-		return; // included and used files are very likely to be added many times by the parser
-	}
-	dependencies.insert(dep);
+    fs::path filepath(filename);
+    std::string dep = boost::regex_replace(filepath.generic_string(), boost::regex("\\ "), "\\\\ ");
+    if (dependencies.find(dep) != dependencies.end()) {
+        return; // included and used files are very likely to be added many times by the parser
+    }
+    dependencies.insert(dep);
 
-	if (make_command && !fs::exists(filepath)) {
-		system(STR(make_command << " '" << boost::regex_replace(filename, boost::regex("'"), "'\\''") << "'").c_str()); // FIXME: Handle error
-	}
+    if (make_command && !fs::exists(filepath)) {
+        system(STR(make_command << " '" << boost::regex_replace(filename, boost::regex("'"), "'\\''") << "'").c_str()); // FIXME: Handle error
+    }
 }
 
 bool write_deps(const std::string &filename, const std::string &output_file)
 {
-	FILE *fp = fopen(filename.c_str(), "wt");
-	if (!fp) {
-		fprintf(stderr, "Can't open dependencies file `%s' for writing!\n", filename.c_str());
-		return false;
-	}
-	fprintf(fp, "%s:", output_file.c_str());
+    FILE *fp = fopen(filename.c_str(), "wt");
+    if (!fp) {
+        fprintf(stderr, "Can't open dependencies file `%s' for writing!\n", filename.c_str());
+        return false;
+    }
+    fprintf(fp, "%s:", output_file.c_str());
 
-	for(const auto &str : dependencies) {
-		fprintf(fp, " \\\n\t%s", str.c_str());
-	}
-	fprintf(fp, "\n");
-	fclose(fp);
-	return true;
+    for(const auto &str : dependencies) {
+        fprintf(fp, " \\\n\t%s", str.c_str());
+    }
+    fprintf(fp, "\n");
+    fclose(fp);
+    return true;
 }


### PR DESCRIPTION
This PR resolves every warning I'm seeing in the build process, except for the shift/reduce warnings in the comment parser for customizer settings.  (This is because I can't find any complete test cases or specification for the expected behavior of that part, meaning I cannot properly evaluate attempted edits to this.  So resolving that goes to later work.)

This resolves a non-substantive UI warning, and makes a substantive improvement to the processing of the command-line -m make_cmd, adding in proper error reporting for failures of the resulting system() call.