### PR TITLE
Fix various typos

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -79,7 +79,7 @@
 * Raise error when export folder does not exist (fixes #432)
 * Fixes for linear_extrude with scale and/or twist
 * Avoid undefined behavior for `convexity' parameter to linear_extrude
-* Fix echo() formating error (fixes #2950)
+* Fix echo() formatting error (fixes #2950)
 * Fix search order for use<>
 * Fix large text (fixes #3262)
 * Fix initial editor focus (fixes #3471)

--- a/releases/2021.01.md
+++ b/releases/2021.01.md
@@ -76,7 +76,7 @@
 * Raise error when export folder does not exist (fixes #432)
 * Fixes for linear_extrude with scale and/or twist
 * Avoid undefined behavior for `convexity' parameter to linear_extrude
-* Fix echo() formating error (fixes #2950)
+* Fix echo() formatting error (fixes #2950)
 * Fix search order for use<>
 * Fix large text (fixes #3262)
 * Fix initial editor focus (fixes #3471)

--- a/scripts/LogicLib.nsh
+++ b/scripts/LogicLib.nsh
@@ -716,7 +716,7 @@
     !verbose ${LOGICLIB_VERBOSITY}
     !insertmacro _PushLogic
     !insertmacro _PushScope Switch ${_Logic}              ; Keep a separate stack for switch data
-    !insertmacro _PushScope Break _LogicLib_Label_${LOGICLIB_COUNTER}            ; Get a lable for beyond the end of the switch
+    !insertmacro _PushScope Break _LogicLib_Label_${LOGICLIB_COUNTER}            ; Get a label for beyond the end of the switch
     !insertmacro _IncreaseCounter
     !define ${_Switch}Var `${_a}`                         ; Remember the left hand side of the comparison
     !tempfile ${_Switch}Tmp                               ; Create a temporary file

--- a/src/ScintillaEditor.cc
+++ b/src/ScintillaEditor.cc
@@ -23,7 +23,7 @@ namespace fs=boost::filesystem;
 
 const QString ScintillaEditor::cursorPlaceHolder = "^~^";
 
-// In setCursorPosition, how many lines should be visible above and below the curser
+// In setCursorPosition, how many lines should be visible above and below the cursor
 const int setCursorPositionVisibleLines = 3;
 
 

--- a/src/VertexArray.h
+++ b/src/VertexArray.h
@@ -148,7 +148,7 @@ private:
 	std::vector<T> data_;
 };
 
-// Storeage and access class for multiple AttributeData that make up one vertex.
+// Storage and access class for multiple AttributeData that make up one vertex.
 class VertexData
 {
 public:

--- a/src/input/AxisConfigWidget.cc
+++ b/src/input/AxisConfigWidget.cc
@@ -54,7 +54,7 @@ void AxisConfigWidget::AxesChanged(int nr, double val) const{
 	//QProgressBar generates the shown string from the format string.
 	//By setting a format string without a place holder,
 	//we can set arbitrary text, like a custom formatted double.
-	//(Note: QProgressBar internally works on int, so has no formating for double values)
+	//(Note: QProgressBar internally works on int, so has no formatting for double values)
 	//(Note: The text of a QProgressBar can not be set directly)
 	QString s =  QString::number(val, 'f', 2 );
 	progressBar->setFormat(s); 

--- a/src/renderer.cc
+++ b/src/renderer.cc
@@ -72,7 +72,7 @@ Renderer::Renderer() : colorscheme(nullptr)
 		int loglen;
 		char logbuffer[1000];
 		glGetShaderInfoLog(fs, sizeof(logbuffer), &loglen, logbuffer);
-		PRINTDB("OpenGL Program Compile Fragement Shader Error:\n%s", logbuffer);
+		PRINTDB("OpenGL Program Compile Fragment Shader Error:\n%s", logbuffer);
 		return;
 	}
 

--- a/src/roof_ss.cc
+++ b/src/roof_ss.cc
@@ -111,7 +111,7 @@ PolySet *straight_skeleton_roof(const Polygon2d &poly)
 					RAISE_ROOF_EXCEPTION("A non-simple face in straight skeleton, likely cause is cgal issue #5177");
 				}
 
-				// do convex partition if necesary
+				// do convex partition if necessary
 				std::vector<CGAL_PT::Polygon_2> facets;
 				CGAL::approx_convex_partition_2(face.vertices_begin(), face.vertices_end(),
 						std::back_inserter(facets));

--- a/src/value.cc
+++ b/src/value.cc
@@ -78,7 +78,7 @@ inline int trimTrailingZeroesHelper(char *buffer, const int pos, char *currentpo
 
   int cont = TRIM_TRAILINGZEROES_CONTINUE;
 
-  //we have exhaused all positions from end to start
+  //we have exhausted all positions from end to start
   if(currentpos <= buffer)
     return TRIM_TRAILINGZEROES_DONE;
 


### PR DESCRIPTION
Found via `codespell -q 3 -S *.po,./src/ext -L childs,nd,synopsys,tesselate,tesselation,tesselator,vie`