### PR TITLE
Fix deprecated use of <mimetypes> in appdata

### DIFF
--- a/openscad.appdata.xml.in
+++ b/openscad.appdata.xml.in
@@ -21,9 +21,9 @@
     <p>OpenSCAD is not an interactive modeller. Instead it is something like a 3D-compiler that reads in a script file that describes the object and renders the 3D model from this script file. This gives you (the designer) full control over the modelling process and enables you to easily change any step in the modelling process or make designs that are defined by configurable parameters.</p>
     <p>OpenSCAD provides two main modelling techniques: First there is constructive solid geometry (aka CSG) and second there is extrusion of 2D outlines. As data exchange format for this 2D outlines Autocad DXF files are used. In addition to 2D paths for extrusion it is also possible to read design parameters from DXF files. Besides DXF files OpenSCAD can read and create 3D models in the STL and OFF file formats.</p>
   </description>
-  <mimetypes>
-    <mimetype>application/x-openscad</mimetype>
-  </mimetypes>
+  <provides>
+    <mediatype>application/x-openscad</mediatype>
+  </provides>
   <developer_name>The OpenSCAD Developers</developer_name>
   <screenshots>
     <screenshot type="default">


### PR DESCRIPTION
Use of &lt;mimetypes&gt; is deprecated in appdata [1]. Replace it by the now
recommended &lt;provides&gt; => &lt;mediatype&gt;.

Motivated by a warning shown for package openscad  in the Debian infrastructure [2].

[1] https://www.freedesktop.org/software/appstream/docs/chap-Metadata.html#tag-mimetypes
[2] https://appstream.debian.org/sid/main/issues/openscad.html
