### PR TITLE
Add timeout option for macos dependency build.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -124,7 +124,7 @@ jobs:
       - restore_cache:
           keys:
             # CircleCI library caching. If we ever need invalidate the cache (e.g. to remove any old files 
-            # from a library cache), the safest, change the MAOS_CACHE_VERSION variable to a random value at
+            # from a library cache), the safest, change the MACOS_CACHE_VERSION variable to a random value at
             # https://app.circleci.com/settings/project/github/openscad/openscad/environment-variables.
             - macos-libraries-{{ .Environment.MACOS_CACHE_VERSION }}-{{ checksum "scripts/macosx-build-dependencies.sh" }}-{{ checksum ".circleci/config.yml" }}
             # Fetch the most recently saved cache
@@ -134,7 +134,8 @@ jobs:
           command: |
             # Pick up our own Qt
             export PATH=$OPENSCAD_LIBRARIES/bin:$PATH
-            ./scripts/macosx-build-dependencies.sh -d double_conversion eigen gmp mpfr glew gettext libffi freetype ragel harfbuzz libzip libxml2 libuuid fontconfig hidapi lib3mf pixman cairo glib2 boost cgal qt5 opencsg qscintilla sparkle
+            # Limit to 30 minutes
+            ./scripts/macosx-build-dependencies.sh -l 30 -d double_conversion eigen gmp mpfr glew gettext libffi freetype ragel harfbuzz libzip libxml2 libuuid fontconfig hidapi lib3mf pixman cairo glib2 boost cgal qt5 opencsg qscintilla sparkle
       - run:
           name: Package Dependencies as an artifact
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -143,7 +143,9 @@ jobs:
             tar cz -C "$OPENSCAD_LIBRARIES" -f /tmp/out/libraries.tar.bz2 .
             shasum -a 512 /tmp/out/libraries.tar.bz2 > /tmp/out/libraries.tar.bz2.sha512
       - save_cache:
-          key: macos-libraries-{{ .Environment.MACOS_CACHE_VERSION }}-{{ checksum "scripts/macosx-build-dependencies.sh" }}-{{ checksum ".circleci/config.yml" }}
+          # Make sure to create a new cache entry, needed for incremental library builds and also
+          # preventing full cache drop after 15 days.
+          key: macos-libraries-{{ .Environment.MACOS_CACHE_VERSION }}-{{ checksum "scripts/macosx-build-dependencies.sh" }}-{{ checksum ".circleci/config.yml" }}-{{ .BuildNum }}
           paths:
             - /Users/distiller/libraries/install
       - run:

--- a/scripts/macosx-build-dependencies.sh
+++ b/scripts/macosx-build-dependencies.sh
@@ -742,7 +742,8 @@ do
   esac
 done
 
-STOP_TIME=$(( $(date +%s) / 60 + $TIME_LIMIT ))
+START_TIME=$(( $(date +%s) / 60 ))
+STOP_TIME=$(( $START_TIME + $TIME_LIMIT ))
 OPTION_PACKAGES="${@:$OPTIND}"
 
 OSX_MAJOR_VERSION=`sw_vers -productVersion | cut -d. -f1`
@@ -805,6 +806,13 @@ echo
 
 rm -f .timeout
 for package in $OPTION_PACKAGES; do
+  ELAPSED=$(( $(date +%s) / 60 - $START_TIME ))
+  echo "Elapsed build time: $ELAPSED minutes"
+  if [ "qt5" = $package -a $TIME_LIMIT -le 60 -a $ELAPSED -gt 2 ]; then
+    touch .timeout
+    echo "Timeout before building package $package"
+    exit 0
+  fi
   if [[ $ALL_PACKAGES =~ $package ]]; then
     build $package $(package_version $package)
     CURRENT_TIME=$(( $(date +%s) / 60 ))

--- a/scripts/msys2-install-dependencies.sh
+++ b/scripts/msys2-install-dependencies.sh
@@ -22,6 +22,8 @@ for pkg in \
     mingw-w64-x86_64-cairo \
     mingw-w64-x86_64-ghostscript \
     mingw-w64-x86_64-imagemagick \
+    mingw-w64-x86_64-qt5-svg \
+    mingw-w64-x86_64-qt5-multimedia \
     make \
     cmake \
     bison \


### PR DESCRIPTION
With this change we can incrementally build the cache by just running the build multiple times. The always stored cache should also ensure we are not completely losing the cache after 15 days.