### PR TITLE
allow SVG import to use $fn, $fs, $fa

### DIFF
--- a/src/import.cc
+++ b/src/import.cc
@@ -191,7 +191,7 @@ const Geometry *ImportNode::createGeometry() const
 		break;
 	}
 	case ImportType::SVG: {
-		g = import_svg(this->filename, this->dpi, this->center, loc);
+		g = import_svg(this->fn, this->fs, this->fa, this->filename, this->dpi, this->center, loc);
  		break;
 	}
 	case ImportType::DXF: {

--- a/src/import.h
+++ b/src/import.h
@@ -5,7 +5,7 @@
 
 class PolySet *import_stl(const std::string &filename, const Location &loc);
 PolySet *import_off(const std::string &filename, const Location &loc);
-class Polygon2d *import_svg(const std::string &filename, const double dpi, const bool center, const Location &loc);
+class Polygon2d *import_svg(double fn, double fs, double fa, const std::string &filename, const double dpi, const bool center, const Location &loc);
 #ifdef ENABLE_CGAL
 class CGAL_Nef_polyhedron *import_nef3(const std::string &filename, const Location &loc);
 #endif

--- a/src/import_svg.cc
+++ b/src/import_svg.cc
@@ -80,10 +80,14 @@ double calc_alignment(const libsvg::align_t alignment, double page_mm, double sc
 
 }
 
-Polygon2d *import_svg(const std::string &filename, const double dpi, const bool center, const Location &loc)
+
+Polygon2d *import_svg(double fn, double fs, double fa,
+                    const std::string &filename, const double dpi, const bool center, const Location &loc)
 {
 	try {
-		const auto shapes = libsvg::libsvg_read_file(filename.c_str());
+        fnContext scadContext(fn, fs, fa);
+        
+		const auto shapes = libsvg::libsvg_read_file(filename.c_str(), (void *) &scadContext );
 
 		double width_mm = 0.0;
 		double height_mm = 0.0;

--- a/src/libsvg/circle.cc
+++ b/src/libsvg/circle.cc
@@ -37,15 +37,15 @@ circle::~circle()
 }
 
 void
-circle::set_attrs(attr_map_t& attrs)
+circle::set_attrs(attr_map_t& attrs, void *context)
 {
-	shape::set_attrs(attrs);
+	shape::set_attrs(attrs,context);
 	this->x = parse_double(attrs["cx"]);
 	this->y = parse_double(attrs["cy"]);
 	this->r = parse_double(attrs["r"]);
 	
 	path_t path;
-	draw_ellipse(path, get_x(), get_y(), get_radius(), get_radius());
+	draw_ellipse(path, get_x(), get_y(), get_radius(), get_radius(), context);
 	path_list.push_back(path);
 }
 

--- a/src/libsvg/circle.h
+++ b/src/libsvg/circle.h
@@ -38,7 +38,7 @@ public:
 
     double get_radius() const { return r; }
 
-    void set_attrs(attr_map_t& attrs) override;
+    void set_attrs(attr_map_t& attrs, void *context) override;
     const std::string dump() const override;
     const std::string& get_name() const override { return circle::name; };
 

--- a/src/libsvg/data.cc
+++ b/src/libsvg/data.cc
@@ -37,9 +37,9 @@ data::~data()
 }
 
 void
-data::set_attrs(attr_map_t& attrs)
+data::set_attrs(attr_map_t& attrs, void *context)
 {
-	shape::set_attrs(attrs);
+	shape::set_attrs(attrs, context);
 	this->text = attrs["text"];
 }
 

--- a/src/libsvg/data.h
+++ b/src/libsvg/data.h
@@ -38,7 +38,7 @@ public:
 
     const std::string& get_text() const { return text; }
 
-    void set_attrs(attr_map_t& attrs) override;
+    void set_attrs(attr_map_t& attrs, void *context) override;
     const std::string dump() const override;
     const std::string& get_name() const override { return data::name; };
     

--- a/src/libsvg/ellipse.cc
+++ b/src/libsvg/ellipse.cc
@@ -40,16 +40,16 @@ ellipse::~ellipse()
 }
 
 void
-ellipse::set_attrs(attr_map_t& attrs)
+ellipse::set_attrs(attr_map_t& attrs, void *context)
 {
-	shape::set_attrs(attrs);
+	shape::set_attrs(attrs,context);
 	this->x = parse_double(attrs["cx"]);
 	this->y = parse_double(attrs["cy"]);
 	this->rx = parse_double(attrs["rx"]);
 	this->ry = parse_double(attrs["ry"]);
 
 	path_t path;
-	draw_ellipse(path, get_x(), get_y(), get_radius_x(), get_radius_y());
+	draw_ellipse(path, get_x(), get_y(), get_radius_x(), get_radius_y(), context);
 	path_list.push_back(path);
 }
 

--- a/src/libsvg/ellipse.h
+++ b/src/libsvg/ellipse.h
@@ -40,7 +40,7 @@ public:
     double get_radius_x() const { return rx; }
     double get_radius_y() const { return ry; }
 
-    void set_attrs(attr_map_t& attrs) override;
+    void set_attrs(attr_map_t& attrs, void *context) override;
     const std::string dump() const override;
     const std::string& get_name() const override { return ellipse::name; };
 

--- a/src/libsvg/group.cc
+++ b/src/libsvg/group.cc
@@ -40,9 +40,9 @@ group::~group()
 }
 
 void
-group::set_attrs(attr_map_t& attrs)
+group::set_attrs(attr_map_t& attrs, void *context)
 {
-	shape::set_attrs(attrs);
+	shape::set_attrs(attrs, context);
 }
 
 const std::string

--- a/src/libsvg/group.h
+++ b/src/libsvg/group.h
@@ -37,7 +37,7 @@ public:
 
     bool is_container() const override { return true; }
     
-    void set_attrs(attr_map_t& attrs) override;
+    void set_attrs(attr_map_t& attrs, void *context) override;
     const std::string dump() const override;
     const std::string& get_name() const override { return group::name; };
     

--- a/src/libsvg/libsvg.h
+++ b/src/libsvg/libsvg.h
@@ -50,7 +50,7 @@ private:
 using shapes_list_t = std::vector<shared_ptr<shape>>;
 
 shapes_list_t *
-libsvg_read_file(const char *filename);
+libsvg_read_file(const char *filename, void *context);
 
 void
 libsvg_free(shapes_list_t *shapes);

--- a/src/libsvg/line.cc
+++ b/src/libsvg/line.cc
@@ -37,9 +37,9 @@ line::~line()
 }
 
 void
-line::set_attrs(attr_map_t& attrs)
+line::set_attrs(attr_map_t& attrs, void *context)
 {
-	shape::set_attrs(attrs);
+	shape::set_attrs(attrs,context);
 	this->x = parse_double(attrs["x1"]);
 	this->y = parse_double(attrs["y1"]);
 	this->x2 = parse_double(attrs["x2"]);

--- a/src/libsvg/line.h
+++ b/src/libsvg/line.h
@@ -40,7 +40,7 @@ public:
     double get_x2() const { return x2; }
     double get_y2() const { return y2; }
 
-    void set_attrs(attr_map_t& attrs) override;
+    void set_attrs(attr_map_t& attrs, void *context) override;
     const std::string dump() const override;
     const std::string& get_name() const override { return line::name; };
     

--- a/src/libsvg/path.h
+++ b/src/libsvg/path.h
@@ -40,15 +40,15 @@ private:
     }
 
     bool is_open_path(path_t& path) const;
-    void arc_to(path_t& path, double x, double y, double rx, double ry, double x2, double y2, double angle, bool large, bool sweep);
-    void curve_to(path_t& path, double x, double y, double cx1, double cy1, double x2, double y2);
-    void curve_to(path_t& path, double x, double y, double cx1, double cy1, double cx2, double cy2, double x2, double y2);
+    void arc_to(path_t& path, double x, double y, double rx, double ry, double x2, double y2, double angle, bool large, bool sweep, void *context);
+    void curve_to(path_t& path, double x, double y, double cx1, double cy1, double x2, double y2, void *context);
+    void curve_to(path_t& path, double x, double y, double cx1, double cy1, double cx2, double cy2, double x2, double y2, void *context);
 
 public:
     path();
     ~path();
 
-    void set_attrs(attr_map_t& attrs) override;
+    void set_attrs(attr_map_t& attrs, void *context) override;
     const std::string dump() const override;
     const std::string& get_name() const override { return path::name; };
     

--- a/src/libsvg/polygon.cc
+++ b/src/libsvg/polygon.cc
@@ -39,9 +39,9 @@ polygon::~polygon()
 }
 
 void
-polygon::set_attrs(attr_map_t& attrs)
+polygon::set_attrs(attr_map_t& attrs, void *context)
 {
-	shape::set_attrs(attrs);
+	shape::set_attrs(attrs, context);
 	this->points = attrs["points"];
 	
 	using tokenizer = boost::tokenizer<boost::char_separator<char> >;

--- a/src/libsvg/polygon.h
+++ b/src/libsvg/polygon.h
@@ -36,7 +36,7 @@ public:
     polygon();
     ~polygon();
 
-    void set_attrs(attr_map_t& attrs) override;
+    void set_attrs(attr_map_t& attrs, void *context) override;
     const std::string& get_name() const override { return polygon::name; };
 
     static const std::string name;

--- a/src/libsvg/polyline.cc
+++ b/src/libsvg/polyline.cc
@@ -39,9 +39,9 @@ polyline::~polyline()
 }
 
 void
-polyline::set_attrs(attr_map_t& attrs)
+polyline::set_attrs(attr_map_t& attrs, void *context)
 {
-	shape::set_attrs(attrs);
+	shape::set_attrs(attrs, context);
 	this->points = attrs["points"];
 	
 	using tokenizer = boost::tokenizer<boost::char_separator<char> >;

--- a/src/libsvg/polyline.h
+++ b/src/libsvg/polyline.h
@@ -36,7 +36,7 @@ public:
     polyline();
     ~polyline();
 
-    void set_attrs(attr_map_t& attrs) override;
+    void set_attrs(attr_map_t& attrs, void *context) override;
     const std::string& get_name() const override { return polyline::name; };
     
     static const std::string name;

--- a/src/libsvg/rect.cc
+++ b/src/libsvg/rect.cc
@@ -93,9 +93,9 @@ rect::~rect()
  * 9) perform an absolute elliptical arc operation to coordinate (x+rx,y)
  */
 void
-rect::set_attrs(attr_map_t& attrs)
+rect::set_attrs(attr_map_t& attrs, void *context)
 {
-	shape::set_attrs(attrs);
+	shape::set_attrs(attrs, context);
 	this->x = parse_double(attrs["x"]);
 	this->y = parse_double(attrs["y"]);
 	this->width = parse_double(attrs["width"]);
@@ -141,7 +141,7 @@ rect::set_attrs(attr_map_t& attrs)
 		% rx % ry % (x + rx) % y
 			);
 		attrs["d"] = path;
-		path::set_attrs(attrs);
+		path::set_attrs(attrs, context);
 	} else {
 		path_t path;
 		path.push_back(Eigen::Vector3d(get_x(), get_y(), 0));

--- a/src/libsvg/rect.h
+++ b/src/libsvg/rect.h
@@ -45,7 +45,7 @@ public:
     double get_rx() const { return rx; }
     double get_ry() const { return ry; }
     
-    void set_attrs(attr_map_t& attrs) override;
+    void set_attrs(attr_map_t& attrs, void *context) override;
     const std::string dump() const override;
     const std::string& get_name() const override { return rect::name; };
     

--- a/src/libsvg/shape.cc
+++ b/src/libsvg/shape.cc
@@ -23,6 +23,7 @@
  * THE SOFTWARE.
  */
 #include <stdio.h>
+#include <math.h>
 #include <string>
 #include <vector>
 
@@ -47,6 +48,7 @@
 
 #include "transformation.h"
 #include "degree_trig.h"
+#include "calc.h"
 
 namespace libsvg {
 
@@ -93,7 +95,7 @@ shape::create_from_name(const char *name)
 }
 
 void
-shape::set_attrs(attr_map_t& attrs)
+shape::set_attrs(attr_map_t& attrs, void *context)
 {
 	this->id = attrs["id"];
 	this->transform = attrs["transform"];
@@ -285,8 +287,11 @@ shape::offset_path(path_list_t& path_list, path_t& path, double stroke_width, Cl
 }
 
 void
-shape::draw_ellipse(path_t& path, double x, double y, double rx, double ry) {
-	unsigned long fn = 40;
+shape::draw_ellipse(path_t& path, double x, double y, double rx, double ry, void *context) {
+	const fnContext *fValues = reinterpret_cast<const fnContext *> (context);
+    double rmax = fmax( rx, ry );
+	unsigned long fn = Calc::get_fragments_from_r(rmax, fValues->fn, fValues->fs, fValues->fa);
+    if (fn < 40) fn = 40;       // preserve the old minimum value
 	for (unsigned long idx = 1; idx <= fn; ++idx) {
 		const double a = idx * 360.0 / fn;
 		const double xx = rx * sin_degrees(a) + x;

--- a/src/libsvg/shape.h
+++ b/src/libsvg/shape.h
@@ -37,6 +37,20 @@
 #include "util.h"
 #include "ext/polyclipping/clipper.hpp"
 
+
+// ccox - I don't like putting this here, but the svg library code did not plan ahead for app customization.
+// And this is one of the few sensible places to put it without adding new header files.
+typedef struct fnContext {
+public:
+    fnContext( double fNN, double fSS, double fAA ) : fn(fNN), fs(fSS), fa(fAA) {}
+
+public:
+    double fn;
+    double fs;
+    double fa;
+} fnContext;
+
+
 namespace libsvg {
 
 using path_t = std::vector<Eigen::Vector3d>;
@@ -63,7 +77,7 @@ protected:
     ClipperLib::EndType get_stroke_linecap() const;
     ClipperLib::JoinType get_stroke_linejoin() const;
     const std::string get_style(std::string name) const;
-    void draw_ellipse(path_t& path, double x, double y, double rx, double ry);
+    void draw_ellipse(path_t& path, double x, double y, double rx, double ry, void *context);
     void offset_path(path_list_t& path_list, path_t& path, double stroke_width, ClipperLib::EndType stroke_linecap);
     void collect_transform_matrices(std::vector<Eigen::Matrix3d>& matrices, shape *s);
 
@@ -87,7 +101,7 @@ public:
     virtual void apply_transform();
 
     virtual const std::string& get_name() const = 0;
-    virtual void set_attrs(attr_map_t& attrs);
+    virtual void set_attrs(attr_map_t& attrs, void *context);
     virtual const std::string dump() const { return ""; }
 
     static shape * create_from_name(const char *name);

--- a/src/libsvg/svgpage.cc
+++ b/src/libsvg/svgpage.cc
@@ -40,7 +40,7 @@ svgpage::~svgpage()
 }
 
 void
-svgpage::set_attrs(attr_map_t& attrs)
+svgpage::set_attrs(attr_map_t& attrs, void *context)
 {
 	this->x = 0;
 	this->y = 0;

--- a/src/libsvg/svgpage.h
+++ b/src/libsvg/svgpage.h
@@ -45,7 +45,7 @@ public:
 	const alignment_t& get_alignment() const { return alignment; }
     bool is_container() const override { return true; }
     
-    void set_attrs(attr_map_t& attrs) override;
+    void set_attrs(attr_map_t& attrs, void *context) override;
     const std::string dump() const override;
     const std::string& get_name() const override { return svgpage::name; };
     

--- a/src/libsvg/text.cc
+++ b/src/libsvg/text.cc
@@ -37,9 +37,9 @@ text::~text()
 }
 
 void
-text::set_attrs(attr_map_t& attrs)
+text::set_attrs(attr_map_t& attrs, void *context)
 {
-	shape::set_attrs(attrs);
+	shape::set_attrs(attrs,context);
 	this->x = parse_double(attrs["x"]);
 	this->y = parse_double(attrs["y"]);
 	this->dx = parse_double(attrs["dx"]);

--- a/src/libsvg/text.h
+++ b/src/libsvg/text.h
@@ -50,7 +50,7 @@ public:
     const std::string& get_font_family() const { return font_family; }
     int get_font_size() const { return font_size; }
 
-    void set_attrs(attr_map_t& attrs) override;
+    void set_attrs(attr_map_t& attrs, void *context) override;
     const std::string dump() const override;
     const std::string& get_name() const override { return text::name; };
     

--- a/src/libsvg/tspan.cc
+++ b/src/libsvg/tspan.cc
@@ -37,9 +37,9 @@ tspan::~tspan()
 }
 
 void
-tspan::set_attrs(attr_map_t& attrs)
+tspan::set_attrs(attr_map_t& attrs, void *context)
 {
-	shape::set_attrs(attrs);
+	shape::set_attrs(attrs,context);
 	this->x = parse_double(attrs["x"]);
 	this->y = parse_double(attrs["y"]);
 	this->dx = parse_double(attrs["dx"]);

--- a/src/libsvg/tspan.h
+++ b/src/libsvg/tspan.h
@@ -50,7 +50,7 @@ public:
     const std::string& get_font_family() const { return font_family; }
     int get_font_size() const { return font_size; }
 
-    void set_attrs(attr_map_t& attrs) override;
+    void set_attrs(attr_map_t& attrs, void *context) override;
     const std::string dump() const override;
     const std::string& get_name() const override { return tspan::name; };
     

--- a/src/libsvg/use.cc
+++ b/src/libsvg/use.cc
@@ -40,9 +40,9 @@ use::~use()
 }
 
 void
-use::set_attrs(attr_map_t& attrs)
+use::set_attrs(attr_map_t& attrs, void *context)
 {
-	shape::set_attrs(attrs);
+	shape::set_attrs(attrs, context);
 	this->x = parse_double(attrs["x"]);
 	this->y = parse_double(attrs["y"]);
 

--- a/src/libsvg/use.h
+++ b/src/libsvg/use.h
@@ -42,7 +42,7 @@ public:
 
 	bool is_container() const override { return false; }
 
-	void set_attrs(attr_map_t& attrs) override;
+	void set_attrs(attr_map_t& attrs, void *context) override;
 	const std::string dump() const override;
 	const std::string& get_name() const override { return use::name; };
 


### PR DESCRIPTION
Allow SVG import to use $fn,$fs,$fa - with an opaque context added to the parser so the values can reach the polygon generation code.  Use the best estimates for ellipses (max radius, all 3 parameters), circles (all 3 parameters), curves (just obey $fn), and arcs (just obey $fn) - while preserving previous minimum defined steps.
This is in response to a user request that came across the IRC channel on Dec 3, 2021.