### PR TITLE
improve svg arc rendering to use logic closer to circles with $fn, $fs, $fa

### DIFF
--- a/src/DrawingCallback.cc
+++ b/src/DrawingCallback.cc
@@ -102,6 +102,7 @@ void DrawingCallback::line_to(const Vector2d &to)
 // Quadric Bezier curve
 void DrawingCallback::curve_to(const Vector2d &c1, const Vector2d &to)
 {
+    // NOTE - this could be done better using a chord length iteration (uniform in space) to implement $fa (lot of work, little gain)
 	for (unsigned long idx = 1; idx <= fn; ++idx) {
 		const double a = idx * (1.0 / (double)fn);
 		add_vertex(pen * pow(1-a, 2) + 
@@ -114,6 +115,7 @@ void DrawingCallback::curve_to(const Vector2d &c1, const Vector2d &to)
 // Cubic Bezier curve
 void DrawingCallback::curve_to(const Vector2d &c1, const Vector2d &c2, const Vector2d &to)
 {
+    // NOTE - this could be done better using a chord length iteration (uniform in space) to implement $fa (lot of work, little gain)
 	for (unsigned long idx = 1; idx <= fn; ++idx) {
 		const double a = idx * (1.0 / (double)fn);
 		add_vertex(pen * pow(1-a, 3) + 

--- a/src/libsvg/path.cc
+++ b/src/libsvg/path.cc
@@ -147,7 +147,7 @@ path::arc_to(path_t& path, double x1, double y1, double rx, double ry, double x2
 	
     double rmax = fmax( rx, ry );
 	unsigned long fn = Calc::get_fragments_from_r(rmax, fValues->fn, fValues->fs, fValues->fa);
-    fn = (unsigned long) ceil( fn * fabs(delta) / 360.0 );  // beause we are implementing a section of an ellipse, not the full ellipse
+    fn = (unsigned long) ceil( fn * fabs(delta) / 360.0 );  // beause we are creating a section of an ellipse, not the full ellipse
 	int steps = (std::fabs(delta) * 10.0 / 180) + 4;
     if (steps < fn)     // use the maximum of calculated steps and user specified steps
         steps = fn;
@@ -165,6 +165,7 @@ path::arc_to(path_t& path, double x1, double y1, double rx, double ry, double x2
 void
 path::curve_to(path_t& path, double x, double y, double cx1, double cy1, double x2, double y2, void *context)
 {
+    // NOTE - this could be done better using a chord length iteration (uniform in space) to implement $fa (lot of work, little gain)
 	const fnContext *fValues = reinterpret_cast<const fnContext *> (context);
 	unsigned long fn = CalcFn( fValues->fn, 20 ); // preserve the old minimum
 	for (unsigned long idx = 1; idx <= fn; ++idx) {
@@ -178,6 +179,7 @@ path::curve_to(path_t& path, double x, double y, double cx1, double cy1, double 
 void
 path::curve_to(path_t& path, double x, double y, double cx1, double cy1, double cx2, double cy2, double x2, double y2, void *context)
 {
+    // NOTE - this could be done better using a chord length iteration (uniform in space) to implement $fa (lot of work, little gain)
 	const fnContext *fValues = reinterpret_cast<const fnContext *> (context);
 	unsigned long fn = CalcFn( fValues->fn, 20 ); // preserve the old minimum
 	for (unsigned long idx = 1; idx <= fn; ++idx) {

--- a/src/libsvg/path.cc
+++ b/src/libsvg/path.cc
@@ -36,6 +36,7 @@
 
 #include "path.h"
 #include "degree_trig.h"
+#include "calc.h"
 
 namespace libsvg {
 
@@ -144,7 +145,9 @@ path::arc_to(path_t& path, double x1, double y1, double rx, double ry, double x2
 		delta -= 360;
 	}
 	
-	unsigned long fn = CalcFn( fValues->fn, 20 ); // preserve the old minimum
+    double rmax = fmax( rx, ry );
+	unsigned long fn = Calc::get_fragments_from_r(rmax, fValues->fn, fValues->fs, fValues->fa);
+    fn = (unsigned long) ceil( fn * fabs(delta) / 360.0 );  // beause we are implementing a section of an ellipse, not the full ellipse
 	int steps = (std::fabs(delta) * 10.0 / 180) + 4;
     if (steps < fn)     // use the maximum of calculated steps and user specified steps
         steps = fn;


### PR DESCRIPTION
Improve SVG arc rendering to use logic closer to circles with $fn, $fs, $fa
Add comments about bezier rendering that could use $fs, $fa if we moved to a chord/arc length instead of parameter subdivision. 