### PR TITLE
Windows CI: Only output test report and log

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -42,6 +42,5 @@ jobs:
         with:
           name: Test Result Report (Windows)
           path: |
-            build/tests/output/
             build/tests/Testing/Temporary/*_report.html
             build/tests/Testing/Temporary/LastTest.log


### PR DESCRIPTION
..the individual test output is too large to upload