### PR TITLE
Minor build system fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@
 *~
 *.tar*
 *.new
+*.bak
 out.*
 Makefile
 Makefile.Debug

--- a/cmake/Modules/FindGLIB2.cmake
+++ b/cmake/Modules/FindGLIB2.cmake
@@ -48,8 +48,9 @@ foreach(GLIB2_LIB ${GLIB2_LIBRARY_NAMES})
                PATHS ${GLIB2_LIBRARY_DIRS}
                PATHS ${GLIB2_LIBDIR}
                NO_DEFAULT_PATH)
-#  message(STATUS "TMP: ${TMP}")
-  list(APPEND GLIB2_LIBRARIES "${TMP}")
+  if(TMP)
+    list(APPEND GLIB2_LIBRARIES "${TMP}")
+  endif()
 endforeach()
 message(STATUS "GLIB2_LIBRARIES:")
 foreach(glib2libdir ${GLIB2_LIBRARIES})

--- a/scripts/macosx-build-dependencies.sh
+++ b/scripts/macosx-build-dependencies.sh
@@ -385,6 +385,8 @@ build_sparkle()
 {
 # Binary install:
   version=$1
+
+  echo "Installing sparkle" $version "..."
   cd $BASEDIR/src
   rm -rf Sparkle-$version
   if [ ! -f Sparkle-$version.tar.xz ]; then

--- a/scripts/macosx-build-dependencies.sh
+++ b/scripts/macosx-build-dependencies.sh
@@ -197,8 +197,8 @@ build_qscintilla()
   version=$1
   echo "Building QScintilla" $version "..."
   cd $BASEDIR/src
+  rm -rf QScintilla_src-$version
   QSCINTILLA_FILENAME="QScintilla_src-$version.tar.gz"
-  rm -rf "${QSCINTILLA_FILENAME}"
   if [ ! -f "${QSCINTILLA_FILENAME}" ]; then
       curl -LO https://www.riverbankcomputing.com/static/Downloads/QScintilla/$version/"${QSCINTILLA_FILENAME}"
   fi

--- a/scripts/setenv-macos.sh
+++ b/scripts/setenv-macos.sh
@@ -3,6 +3,9 @@ export PKG_CONFIG_PATH=$OPENSCAD_LIBRARIES/lib/pkgconfig
 export DYLD_LIBRARY_PATH=$OPENSCAD_LIBRARIES/lib
 export DYLD_FRAMEWORK_PATH=$OPENSCAD_LIBRARIES/lib
 
+if [ ! $OPENSCADDIR ]; then
+    OPENSCADDIR=$PWD
+fi
 if [ ! $DEPLOYDIR ]; then
     DEPLOYDIR=$OPENSCADDIR/build
 fi
@@ -11,10 +14,10 @@ fi
 export PATH=$OPENSCAD_LIBRARIES/bin:$PATH
 unset QMAKESPEC
 
-# ccache:
-export PATH=/opt/local/libexec/ccache:$PATH
-export CCACHE_BASEDIR=$PWD/..
-
 if [ ! -e $DEPLOYDIR ]; then
   mkdir -p $DEPLOYDIR
 fi
+
+echo OPENSCADDIR=$OPENSCADDIR
+echo DEPLOYDIR=$DEPLOYDIR
+echo OPENSCAD_LIBRARIES=$OPENSCAD_LIBRARIES

--- a/scripts/translation-make.sh
+++ b/scripts/translation-make.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-# Script for use from qmake to generate the translation
+# Script for use from the build system to generate the translation
 # related files.
 #
 

--- a/scripts/translation-update.sh
+++ b/scripts/translation-update.sh
@@ -116,8 +116,8 @@ updatemo()
   echo "using suffix '$SUFFIX'"
  fi
  cp -f ./icons/openscad.desktop.in ./icons/openscad.desktop
- sed -i -e "s,@@openscad@@,openscad${SUFFIX}," ./icons/openscad.desktop
- sed -i -e "s,</id>,${SUFFIX}\\0,; s/openscad.desktop/openscad${SUFFIX}.desktop/; s/openscad.png/openscad${SUFFIX}.png/" ./openscad.appdata.xml
+ sed -i.bak -e "s,@@openscad@@,openscad${SUFFIX}," ./icons/openscad.desktop
+ sed -i.bak -e "s,</id>,${SUFFIX}\\0,; s/openscad.desktop/openscad${SUFFIX}.desktop/; s/openscad.png/openscad${SUFFIX}.png/" ./openscad.appdata.xml
 }
 
 GETTEXT_PATH=""


### PR DESCRIPTION
Mostly for macOS:
* Removing libxml2, as it comes with macOS
* QScintilla wasn't properly cleaned before build, potentially leaving caches from old build. This caused the build to break after a compiler update.
* Removed qmake-specific comments
* `scripts/setenv-macos.sh` can now be used interactively, for manual builds.
* Fixed `sed` invocation causing a couple of stray `-e` backup files.
* GLIB2 may use built-in libs, don't limit lib searches to our install dirs