### PR TITLE
macOS dependencies: Update glib to 2.71

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -120,7 +120,7 @@ jobs:
           name: Install Homebrew packages
           command: |
             brew update
-            brew install automake libtool cmake pkg-config wget
+            brew install automake libtool cmake pkg-config wget meson
       - restore_cache:
           keys:
             # CircleCI library caching. If we ever need invalidate the cache (e.g. to remove any old files 

--- a/.github/workflows/macos-release.yml
+++ b/.github/workflows/macos-release.yml
@@ -21,7 +21,7 @@ jobs:
     - name: Install Homebrew packages
       run: |
         brew update
-        brew install automake
+        brew install automake meson
     - name: Cache Libraries
       id: cache-libraries
       uses: actions/cache@v2

--- a/.github/workflows/macos-snapshot.yml
+++ b/.github/workflows/macos-snapshot.yml
@@ -21,7 +21,7 @@ jobs:
     - name: Install Homebrew packages
       run: |
         brew update
-        brew install automake
+        brew install automake meson
     - name: Cache Libraries
       id: cache-libraries
       uses: actions/cache@v2

--- a/scripts/macosx-build-dependencies.sh
+++ b/scripts/macosx-build-dependencies.sh
@@ -102,7 +102,8 @@ check_version_file()
     if [ -f $versionfile ]; then
 	if [ -z "$2" ]; then
 	    return 0
-	elif [[ $(cat $versionfile) == $2 ]]; then
+	else
+	    [[ $(cat $versionfile) == $2 ]]
 	    return $?
 	fi
     else

--- a/scripts/macosx-build-dependencies.sh
+++ b/scripts/macosx-build-dependencies.sh
@@ -46,7 +46,7 @@ PACKAGES=(
     "fontconfig 2.13.1"
     "hidapi 0.11.0"
     "lib3mf 1.8.1"
-    "glib2 2.70.2"
+    "glib2 2.71.0"
     "pixman 0.40.0"
     "cairo 1.16.0"
     "cgal 5.3"
@@ -569,12 +569,9 @@ build_glib2()
   tar xJf "glib-$version.tar.xz"
   cd "glib-$version"
 
-  CFLAGS="-I$DEPLOYDIR/include -mmacosx-version-min=$MAC_OSX_VERSION_MIN" LDFLAGS="-Wl,-rpath,$DEPLOYDIR/lib -L$DEPLOYDIR/lib -mmacosx-version-min=$MAC_OSX_VERSION_MIN" meson setup --prefix $PWD/../../install --force-fallback-for libpcre -Dgtk_doc=false -Dman=false -Ddtrace=false -Dtests=false build
+  CFLAGS="-I$DEPLOYDIR/include -mmacosx-version-min=$MAC_OSX_VERSION_MIN" LDFLAGS="-Wl,-rpath,$DEPLOYDIR/lib -L$DEPLOYDIR/lib -mmacosx-version-min=$MAC_OSX_VERSION_MIN" meson setup --prefix $DEPLOYDIR --force-fallback-for libpcre -Dgtk_doc=false -Dman=false -Ddtrace=false -Dtests=false build
   meson compile -C build
   meson install -C build
-#  ./configure --disable-gtk-doc --disable-man --without-pcre --prefix="$DEPLOYDIR" CFLAGS="-I$DEPLOYDIR/include -mmacosx-version-min=$MAC_OSX_VERSION_MIN" LDFLAGS="-Wl,-rpath,$DEPLOYDIR/lib -L$DEPLOYDIR/lib -mmacosx-version-min=$MAC_OSX_VERSION_MIN"
-#  make -j$NUMCPU
-#  make install
   install_name_tool -id @rpath/libglib-2.0.dylib $DEPLOYDIR/lib/libglib-2.0.dylib
   echo $version > $DEPLOYDIR/share/macosx-build-dependencies/glib2.version
 }

--- a/scripts/macosx-build-dependencies.sh
+++ b/scripts/macosx-build-dependencies.sh
@@ -569,7 +569,7 @@ build_glib2()
   tar xJf "glib-$version.tar.xz"
   cd "glib-$version"
 
-  CFLAGS="-I$DEPLOYDIR/include -mmacosx-version-min=$MAC_OSX_VERSION_MIN" LDFLAGS="-Wl,-rpath,$DEPLOYDIR/lib -L$DEPLOYDIR/lib -mmacosx-version-min=$MAC_OSX_VERSION_MIN" meson setup --prefix $PWD/../../install --force-fallback-for libpcre -Dgtk_doc=false -Dman=false -Ddtrace=false build
+  CFLAGS="-I$DEPLOYDIR/include -mmacosx-version-min=$MAC_OSX_VERSION_MIN" LDFLAGS="-Wl,-rpath,$DEPLOYDIR/lib -L$DEPLOYDIR/lib -mmacosx-version-min=$MAC_OSX_VERSION_MIN" meson setup --prefix $PWD/../../install --force-fallback-for libpcre -Dgtk_doc=false -Dman=false -Ddtrace=false -Dtests=false build
   meson compile -C build
   meson install -C build
 #  ./configure --disable-gtk-doc --disable-man --without-pcre --prefix="$DEPLOYDIR" CFLAGS="-I$DEPLOYDIR/include -mmacosx-version-min=$MAC_OSX_VERSION_MIN" LDFLAGS="-Wl,-rpath,$DEPLOYDIR/lib -L$DEPLOYDIR/lib -mmacosx-version-min=$MAC_OSX_VERSION_MIN"

--- a/scripts/macosx-build-dependencies.sh
+++ b/scripts/macosx-build-dependencies.sh
@@ -11,7 +11,7 @@
 #  -f   Force build even if package is installed
 #  -v   Verbose
 #
-# Prerequisites: automake, libtool, cmake, pkg-config, wget
+# Prerequisites: automake, libtool, cmake, pkg-config, wget, meson
 #
 
 set -e
@@ -46,7 +46,7 @@ PACKAGES=(
     "fontconfig 2.13.1"
     "hidapi 0.11.0"
     "lib3mf 1.8.1"
-    "glib2 2.56.3"
+    "glib2 2.70.2"
     "pixman 0.40.0"
     "cairo 1.16.0"
     "cgal 5.3"
@@ -569,9 +569,12 @@ build_glib2()
   tar xJf "glib-$version.tar.xz"
   cd "glib-$version"
 
-  ./configure --disable-gtk-doc --disable-man --without-pcre --prefix="$DEPLOYDIR" CFLAGS="-I$DEPLOYDIR/include -mmacosx-version-min=$MAC_OSX_VERSION_MIN" LDFLAGS="-Wl,-rpath,$DEPLOYDIR/lib -L$DEPLOYDIR/lib -mmacosx-version-min=$MAC_OSX_VERSION_MIN"
-  make -j$NUMCPU
-  make install
+  CFLAGS="-I$DEPLOYDIR/include -mmacosx-version-min=$MAC_OSX_VERSION_MIN" LDFLAGS="-Wl,-rpath,$DEPLOYDIR/lib -L$DEPLOYDIR/lib -mmacosx-version-min=$MAC_OSX_VERSION_MIN" meson setup --prefix $PWD/../../install --force-fallback-for libpcre -Dgtk_doc=false -Dman=false -Ddtrace=false build
+  meson compile -C build
+  meson install -C build
+#  ./configure --disable-gtk-doc --disable-man --without-pcre --prefix="$DEPLOYDIR" CFLAGS="-I$DEPLOYDIR/include -mmacosx-version-min=$MAC_OSX_VERSION_MIN" LDFLAGS="-Wl,-rpath,$DEPLOYDIR/lib -L$DEPLOYDIR/lib -mmacosx-version-min=$MAC_OSX_VERSION_MIN"
+#  make -j$NUMCPU
+#  make install
   install_name_tool -id @rpath/libglib-2.0.dylib $DEPLOYDIR/lib/libglib-2.0.dylib
   echo $version > $DEPLOYDIR/share/macosx-build-dependencies/glib2.version
 }


### PR DESCRIPTION
Glib has deprecated the old build system in favour of meson. In preparation for x86_64/arm64 cross builds, we need to bite the bullet and get this updated.