### PR TITLE
More macOS build fixes

### DIFF
--- a/patches/uuid-1.6.2.patch
+++ b/patches/uuid-1.6.2.patch
@@ -1,6 +1,6 @@
-diff -u uuid-1.6.2/Makefile.in uuid-1.6.2.new/Makefile.in
---- uuid-1.6.2/Makefile.in	2008-03-08 13:31:40.000000000 -0500
-+++ uuid-1.6.2.new/Makefile.in	2019-02-17 18:35:51.000000000 -0500
+diff -u uuid-1.6.2-orig/Makefile.in uuid-1.6.2/Makefile.in
+--- uuid-1.6.2-orig/Makefile.in	2008-03-08 13:31:40.000000000 -0500
++++ uuid-1.6.2/Makefile.in	2022-01-02 21:59:36.000000000 -0500
 @@ -112,7 +112,7 @@
  	@$(LIBTOOL) --mode=compile $(CXX) $(CPPFLAGS) $(CXXFLAGS) -c $<
  
@@ -10,3 +10,12 @@ diff -u uuid-1.6.2/Makefile.in uuid-1.6.2.new/Makefile.in
  	    -version-info `$(SHTOOL) version -l c -d libtool $(S)/uuid_vers.h`
  
  $(DCE_NAME): $(DCE_OBJS)
+@@ -231,7 +231,7 @@
+ 	$(SHTOOL) mkdir -f -p -m 755 $(DESTDIR)$(mandir)/man1
+ 	$(SHTOOL) install -c -m 755 uuid-config $(DESTDIR)$(bindir)/
+ 	$(SHTOOL) install -c -m 644 $(S)/uuid-config.1 $(DESTDIR)$(mandir)/man1/
+-	$(SHTOOL) install -c -m 644 $(S)/uuid.pc $(DESTDIR)$(libdir)/pkgconfig/
++	$(SHTOOL) install -c -m 644 uuid.pc $(DESTDIR)$(libdir)/pkgconfig/
+ 	$(SHTOOL) install -c -m 644 uuid.h $(DESTDIR)$(includedir)/
+ 	-@if [ ".$(WITH_DCE)" = .yes ]; then \
+ 	    echo "$(SHTOOL) install -c -m 644 $(S)/uuid_dce.h $(DESTDIR)$(includedir)/"; \

--- a/scripts/macosx-build-dependencies.sh
+++ b/scripts/macosx-build-dependencies.sh
@@ -244,7 +244,7 @@ build_gmp()
   tar xjf gmp-$version.tar.bz2
   cd gmp-$version
   # Note: We're building against the core2 CPU profile as that's the minimum required hardware for running OS X 10.9
-  ./configure --prefix=$DEPLOYDIR CFLAGS="--target=$ARCH-apple-macos13.0" LDFLAGS="-arch $ARCH" --enable-cxx --build=$ARCH-apple-darwin --host=$ARCH-apple-darwin17.0.0
+  ./configure --prefix=$DEPLOYDIR CFLAGS="-arch $ARCH -mmacos-version-min=$MAC_OSX_VERSION_MIN" LDFLAGS="-arch $ARCH -mmacos-version-min=$MAC_OSX_VERSION_MIN" --enable-cxx --build=$ARCH-apple-darwin --host=$ARCH-apple-darwin17.0.0
   make -j"$NUMCPU" install
 
   install_name_tool -id @rpath/libgmp.dylib $DEPLOYDIR/lib/libgmp.dylib
@@ -266,7 +266,7 @@ build_mpfr()
   tar xjf mpfr-$version.tar.bz2
   cd mpfr-$version
 
-  ./configure --prefix=$DEPLOYDIR --with-gmp=$DEPLOYDIR CFLAGS="--target=$ARCH-apple-macos13.0" LDFLAGS="-arch $ARCH"
+  ./configure --prefix=$DEPLOYDIR --with-gmp=$DEPLOYDIR CFLAGS="-arch $ARCH -mmacos-version-min=$MAC_OSX_VERSION_MIN" LDFLAGS="-arch $ARCH -mmacos-version-min=$MAC_OSX_VERSION_MIN"
   make -j"$NUMCPU" install
 
   install_name_tool -id @rpath/libmpfr.dylib $DEPLOYDIR/lib/libmpfr.dylib

--- a/scripts/macosx-build-dependencies.sh
+++ b/scripts/macosx-build-dependencies.sh
@@ -35,7 +35,7 @@ PACKAGES=(
     "mpfr 4.0.2"
     "glew 2.1.0"
     "gettext 0.21"
-    "libffi 3.4.2"
+    "libffi REMOVE"
     "freetype 2.9.1"
     "ragel 6.10"
     "harfbuzz 2.3.1"
@@ -100,8 +100,11 @@ check_version_file()
 {
     versionfile="$DEPLOYDIR/share/macosx-build-dependencies/$1.version"
     if [ -f $versionfile ]; then
-	[[ $(cat $versionfile) == $2 ]]
-	return $?
+	if [ -z "$2" ]; then
+	    return 0
+	elif [[ $(cat $versionfile) == $2 ]]; then
+	    return $?
+	fi
     else
 	return 1
     fi
@@ -517,23 +520,10 @@ build_fontconfig()
   echo $version > $DEPLOYDIR/share/macosx-build-dependencies/fontconfig.version
 }
 
-build_libffi()
+remove_libffi()
 {
-  version="$1"
-
-  echo "Building libffi $version..."
-  cd "$BASEDIR"/src
-  rm -rf "libffi-$version"
-  if [ ! -f "libffi-$version.tar.gz" ]; then
-    curl --insecure -LO "https://github.com/libffi/libffi/releases/download/v$version/libffi-$version.tar.gz"
-  fi
-  tar xzf "libffi-$version.tar.gz"
-  cd "libffi-$version"
-  ./configure --prefix="$DEPLOYDIR"
-  make -j$NUMCPU
-  make install
-  install_name_tool -id @rpath/libffi.dylib $DEPLOYDIR/lib/libffi.dylib
-  echo $version > $DEPLOYDIR/share/macosx-build-dependencies/libffi.version
+  echo "Removing libffi..."
+  find $DEPLOYDIR -type f -name "ffi*" -o -name "libffi*" -exec rm -f {} \;
 }
 
 build_gettext()

--- a/scripts/macosx-build-dependencies.sh
+++ b/scripts/macosx-build-dependencies.sh
@@ -334,7 +334,7 @@ build_glew()
   tar xzf glew-$version.tgz
   cd glew-$version
   mkdir -p $DEPLOYDIR/lib/pkgconfig
-  make GLEW_DEST=$DEPLOYDIR CFLAGS.EXTRA="-no-cpp-precomp -dynamic -fno-common -mmacosx-version-min=$MAC_OSX_VERSION_MIN -arch $ARCH" LDFLAGS.EXTRA="-install_name @rpath/libGLEW.dylib -mmacosx-version-min=$MAC_OSX_VERSION_MIN -arch $ARCH" POPT="-Os" STRIP= install
+  make GLEW_PREFIX=$DEPLOYDIR GLEW_DEST=$DEPLOYDIR CFLAGS.EXTRA="-no-cpp-precomp -dynamic -fno-common -mmacosx-version-min=$MAC_OSX_VERSION_MIN -arch $ARCH" LDFLAGS.EXTRA="-install_name @rpath/libGLEW.dylib -mmacosx-version-min=$MAC_OSX_VERSION_MIN -arch $ARCH" POPT="-Os" STRIP= install
   echo $version > $DEPLOYDIR/share/macosx-build-dependencies/glew.version
 }
 

--- a/scripts/macosx-build-dependencies.sh
+++ b/scripts/macosx-build-dependencies.sh
@@ -685,7 +685,7 @@ build_cairo()
         --enable-xlib=no --enable-xlib-xrender=no --enable-xcb=no \
         --enable-xlib-xcb=no --enable-xcb-shm=no --enable-win32=no \
         --enable-win32-font=no --enable-png=no --enable-ps=no \
-        --enable-svg=no
+        --enable-svg=no --enable-gobject=no
   make -j"$NUMCPU" install
   otool -L $DEPLOYDIR/lib/libcairo.dylib
   install_name_tool -id @rpath/libcairo.dylib $DEPLOYDIR/lib/libcairo.dylib

--- a/scripts/macosx-build-dependencies.sh
+++ b/scripts/macosx-build-dependencies.sh
@@ -477,7 +477,7 @@ build_libzip()
 remove_libxml2()
 {
   echo "Removing libxml2..."
-  find $DEPLOYDIR -name "*libxml*" -exec rm -rf {} \;
+  find $DEPLOYDIR -name "*libxml*" -prune -exec rm -rf {} \;
 }
 
 build_libuuid()

--- a/scripts/macosx-build-dependencies.sh
+++ b/scripts/macosx-build-dependencies.sh
@@ -37,7 +37,7 @@ PACKAGES=(
     "gettext 0.21"
     "libffi REMOVE"
     "freetype 2.9.1"
-    "ragel 6.10"
+    "ragel REMOVE"
     "harfbuzz 2.3.1"
     "libzip 1.8.0"
     "libxml2 REMOVE"
@@ -576,22 +576,10 @@ build_glib2()
   echo $version > $DEPLOYDIR/share/macosx-build-dependencies/glib2.version
 }
 
-build_ragel()
+remove_ragel()
 {
-  version=$1
-
-  echo "Building ragel $version..."
-  cd "$BASEDIR"/src
-  rm -rf "ragel-$version"
-  if [ ! -f "ragel-$version.tar.gz" ]; then
-    curl --insecure -LO "http://www.colm.net/files/ragel/ragel-$version.tar.gz"
-  fi
-  tar xzf "ragel-$version.tar.gz"
-  cd "ragel-$version"
-  ./configure --prefix="$DEPLOYDIR"
-  make -j$NUMCPU
-  make install
-  echo $version > $DEPLOYDIR/share/macosx-build-dependencies/ragel.version
+  echo "Removing ragel..."
+  find $DEPLOYDIR -type f -name "ragel*" -exec rm -f {} \;
 }
 
 build_harfbuzz()

--- a/scripts/macosx-build-dependencies.sh
+++ b/scripts/macosx-build-dependencies.sh
@@ -30,7 +30,8 @@ OPTION_FORCE=0
 
 PACKAGES=(
     "double_conversion 3.1.5"
-    "eigen 3.3.7"
+    "boost 1.74.0"
+    "eigen 3.4.0"
     "gmp 6.2.1"
     "mpfr 4.0.2"
     "glew 2.1.0"
@@ -46,7 +47,6 @@ PACKAGES=(
     "hidapi 0.11.0"
     "lib3mf 1.8.1"
     "glib2 2.56.3"
-    "boost 1.74.0"
     "pixman 0.40.0"
     "cairo 1.16.0"
     "cgal 5.3"


### PR DESCRIPTION
* Removed custom `libffi`; it comes with macOS
* Removed custom `ragel`; harfbuzz now ships with ragel-generated files
* Removing libxml2 could cause the script to fail, added `-prune` argument to `find`
* use `-arch` and `-mmacos-version-min` instead of `--target` arguments to `configure` for gmp and mpfr.
* The GLEW pkg-config file had the wrong prefix, added GLEW_PREFIX
* uuid.pc is now correctly installed