### PR TITLE
Add file bounds check to comment parser, issue #4043

### DIFF
--- a/src/comment.cc
+++ b/src/comment.cc
@@ -92,7 +92,7 @@ static std::string getComment(const std::string &fulltext, int line)
 	}
 
 	int end = start + 1;
-	while (fulltext[end] != '\n') end++;
+	while (end < fulltext.size() && fulltext[end] != '\n') end++;
 
 	std::string comment = fulltext.substr(start, end - start);
 


### PR DESCRIPTION
This is a security fix, mitigating an out-of-bounds read as outlined in issue #4043 