### PR TITLE
add status to context accounting, fixes #3871

### DIFF
--- a/src/context-mm.cc
+++ b/src/context-mm.cc
@@ -357,6 +357,8 @@ ContextMemoryManager::~ContextMemoryManager()
 void ContextMemoryManager::addContext(std::shared_ptr<Context> context)
 {
 	heapSizeAccounting.addContext();
+    context->setAccountingAdded(); // avoiding bad accounting when an exception threw in constructor  issue #3871
+    
 	/*
 	 * If we are holding the last copy to this context, no point in invoking
 	 * the garbage collection machinery, we can just let context get destroyed

--- a/src/context.cc
+++ b/src/context.cc
@@ -49,7 +49,8 @@ Context::Context(const std::shared_ptr<const Context>& parent):
 Context::~Context()
 {
 	clear();
-	session()->contextMemoryManager().releaseContext();
+    if (accountingAdded) // avoiding bad accounting where exception threw in constructor  issue #3871
+        session()->contextMemoryManager().releaseContext();
 }
 
 const Children* Context::user_module_children() const

--- a/src/context.h
+++ b/src/context.h
@@ -91,9 +91,13 @@ public:
 	const std::shared_ptr<const Context> &getParent() const { return this->parent; }
 	// This modifies the semantics of the context in an error-prone way. Use with caution.
 	void setParent(const std::shared_ptr<const Context>& parent) { this->parent = parent; }
+ 
+    void setAccountingAdded() { accountingAdded = true; }
 
 protected:
 	std::shared_ptr<const Context> parent;
+ 
+    bool accountingAdded = false; // avoiding bad accounting when exception threw in constructor  issue #3871
 
 public:
 #ifdef DEBUG


### PR DESCRIPTION
Only subtract from accounting if we added to accounting in the first place, avoiding crash/assert due to subtracting too many counts from the heapSizeAccounting.
Fixes #3871