### PR TITLE
Change: use secure connection to files.openscad.org

### DIFF
--- a/scripts/builder.sh
+++ b/scripts/builder.sh
@@ -355,9 +355,9 @@ update_win_www_download_links()
 	cd inc
 	echo `pwd`
 	# BASEURL='https://openscad.googlecode.com/files/'
-	BASEURL='http://files.openscad.org/'
+	BASEURL='https://files.openscad.org/'
 	if [ $DOSNAPSHOT ]; then
-		BASEURL='http://files.openscad.org/snapshots/'
+		BASEURL='https://files.openscad.org/snapshots/'
 	fi
 
 	mv win_snapshot_links.js win_snapshot_links.js.backup

--- a/scripts/travis-ci-before-install-linux.sh
+++ b/scripts/travis-ci-before-install-linux.sh
@@ -32,7 +32,7 @@ fi
 
 echo "Selected distribution: $DIST"
 
-wget -qO - http://files.openscad.org/OBS-Repository-Key.pub | sudo apt-key add -
+wget -qO - https://files.openscad.org/OBS-Repository-Key.pub | sudo apt-key add -
 echo yes | sudo add-apt-repository "deb $LIB3MF_REPO ./"
 echo yes | sudo add-apt-repository "deb $LIBCGAL_REPO ./"
 sudo apt-get update -qq


### PR DESCRIPTION
Build script should use secure https connection to files.openscad.org to avoid possible man in the middle attacks.