### PR TITLE
Secure docs downloader

### DIFF
--- a/resources/docs/docs_downloader.py
+++ b/resources/docs/docs_downloader.py
@@ -1,20 +1,23 @@
-import urllib.request
-import shutil,os
+import os
+import shutil
 import socket
+import urllib.request
 
 url = 'https://files.openscad.org/documentation/'
 url_zip = 'https://files.openscad.org/documentation/manual.zip'
 url_pdf = ['https://files.openscad.org/documentation/manual/OpenSCAD_User_Manual.pdf', 'https://files.openscad.org/documentation/manual/The_OpenSCAD_Language.pdf']
 
-docs_dir = os.path.join( os.getcwd(), 'openscad_docs')
-pdfs_dir = os.path.join( os.getcwd(), 'openscad_docs_pdf')
+docs_dir = os.path.join(os.getcwd(), 'openscad_docs')
+pdfs_dir = os.path.join(os.getcwd(), 'openscad_docs_pdf')
 
 dns_server = "one.one.one.one"
-def is_connected(hostname):
-    '''
+
+
+def is_connected(hostname) -> bool:
+    """
     This function checks if an active internet connection
     is available and returns a Boolean value.
-    '''
+    """
     try:
         host = socket.gethostbyname(hostname)
         s = socket.create_connection((host, 80), 10)
@@ -24,21 +27,23 @@ def is_connected(hostname):
         pass
     return False
 
+
 # The following downloads the documentation from
 # https://files.openscad.org/documentation/
 # if is_connected() returns True
-if (is_connected(dns_server)):
-    if not os.path.exists(pdfs_dir): os.makedirs(pdfs_dir)
+if is_connected(dns_server):
+    if not os.path.exists(pdfs_dir):
+        os.makedirs(pdfs_dir)
     print(f'Downloading : {url_zip}')
     file_name = url_zip.split('/')[-1]
-    urllib.request.urlretrieve(url_zip , file_name)
+    urllib.request.urlretrieve(url_zip, file_name)
     shutil.unpack_archive(file_name, docs_dir, 'zip')
     os.remove(file_name)
 
     for pdf in url_pdf:
         print(f'Downloading : {pdf}')
         file_name = pdf.split('/')[-1]
-        file_name = os.path.join( pdfs_dir , file_name )
-        urllib.request.urlretrieve(pdf , file_name)
+        file_name = os.path.join(pdfs_dir, file_name)
+        urllib.request.urlretrieve(pdf, file_name)
 else:
     print('Not connected to the Internet, Skipping download of User Manual.')

--- a/resources/docs/docs_downloader.py
+++ b/resources/docs/docs_downloader.py
@@ -2,9 +2,9 @@ import urllib.request
 import shutil,os
 import socket
 
-url = 'http://files.openscad.org/documentation/'
-url_zip = 'http://files.openscad.org/documentation/manual.zip'
-url_pdf = ['http://files.openscad.org/documentation/manual/OpenSCAD_User_Manual.pdf','http://files.openscad.org/documentation/manual/The_OpenSCAD_Language.pdf']
+url = 'https://files.openscad.org/documentation/'
+url_zip = 'https://files.openscad.org/documentation/manual.zip'
+url_pdf = ['https://files.openscad.org/documentation/manual/OpenSCAD_User_Manual.pdf', 'https://files.openscad.org/documentation/manual/The_OpenSCAD_Language.pdf']
 
 docs_dir = os.path.join( os.getcwd(), 'openscad_docs')
 pdfs_dir = os.path.join( os.getcwd(), 'openscad_docs_pdf')
@@ -25,7 +25,7 @@ def is_connected(hostname):
     return False
 
 # The following downloads the documentation from
-# http://files.openscad.org/documentation/ 
+# https://files.openscad.org/documentation/
 # if is_connected() returns True
 if (is_connected(dns_server)):
     if not os.path.exists(pdfs_dir): os.makedirs(pdfs_dir)


### PR DESCRIPTION
Downloader script should use secure https connection to files.openscad.org to avoid possible man in the middle attacks.

If reformatting the code is undesirable. Simply cherry-pick only the according commit.