### PR TITLE
Skip incomplete faces in polyhedron builtin

### DIFF
--- a/src/primitives.cc
+++ b/src/primitives.cc
@@ -630,7 +630,9 @@ static AbstractNode* builtin_polyhedron(const ModuleInstantiation *inst, Argumen
 				}
 				pointIndexIndex++;
 			}
-			node->faces.push_back(std::move(face));
+			if (face.size() >= 3) {
+				node->faces.push_back(std::move(face));
+			}
 		}
 		faceIndex++;
 	}

--- a/tests/regression/dumptest/polyhedron-tests-expected.csg
+++ b/tests/regression/dumptest/polyhedron-tests-expected.csg
@@ -26,5 +26,5 @@ multmatrix([[1, 0, 0, 0], [0, 1, 0, 2], [0, 0, 1, 0], [0, 0, 0, 1]]) {
 polyhedron(points = [], faces = [], convexity = 1);
 polyhedron(points = [[0, 0, 0], [1, 1, 1]], faces = [], convexity = 1);
 polyhedron(points = [], faces = [], convexity = 1);
-polyhedron(points = [[0, 0, 0]], faces = [[0]], convexity = 1);
+polyhedron(points = [[0, 0, 0]], faces = [], convexity = 1);
 


### PR DESCRIPTION
This is to avoid crashing upcoming mesh-based code in fast-csg (https://github.com/openscad/openscad/pull/3641) with files like tests/data/scad/3D/features/polyhedron-tests.scad
