### PR TITLE
Build most recently modified files first

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -842,6 +842,13 @@ else()
 endif()
 set(RESOURCE_FILES icons/${MACOSX_BUNDLE_ICON_FILE})
 
+if ((NOT WIN32 AND NOT DEFINED SORT_BUILD) OR SORT_BUILD)
+  # Build the last modified sources first (to fail fast during development)
+  execute_process(
+    COMMAND ../scripts/sort_cmake_filelist.sh "${Sources}"
+    OUTPUT_VARIABLE Sources)
+endif()
+
 target_sources(OpenSCAD PRIVATE ${Sources} ${RESOURCE_FILES} ${WINDOWS_RESOURCE_PATH})
 find_program(SHELL_EXE NAMES sh bash $ENV{SHELL})
 add_custom_command(TARGET OpenSCAD POST_BUILD

--- a/scripts/sort_cmake_filelist.sh
+++ b/scripts/sort_cmake_filelist.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+#
+# Sorts the CMake-style file list(s) given as arguments by most recently
+# modified first.
+#
+# Note: not using `ls -t` as it drops the folder from the output. Here we
+# preserve the file paths.
+#
+set -eu
+
+function get_timestamp() {
+  # Try Unix & BSD (Mac) syntaxes
+  stat -c%Y "$1" 2>/dev/null || stat -f%c "$1"
+}
+
+function get_timestamps() {
+	for f in "$@" ; do
+		echo "$(get_timestamp "$f") $f"
+	done
+}
+
+# Source paths are relative to the project root.
+cd $( dirname -- "${BASH_SOURCE[0]}" )/..
+
+# # - Split the input path(s) by semicolon
+# # - Prefix each of them with their epoch timestamp
+# # - Sort (numerically) by that timestamp, then drop it
+# # - Join the paths
+get_timestamps $( echo "$@" | tr ';' ' ' ) | \
+  sort -rh | \
+  sed -E 's/[^ ]+ //g' | \
+  tr '\n' ' ' | \
+  sed 's/ /;/g'


### PR DESCRIPTION
This helps fail builds fast (and can pick which files to build first by just touching them), esp. when many files need to be rebuilt (e.g. when modifying a core header often but mostly caring about the compilation of a couple of C++ files).

Disabled on Windows (forks out to bash script tested on Mac and Linux), or if -DSORT_BUILD=0 passed to cmake

Note that it all relies on make to build files in the order they're provided (modulo -j parallelism), which only POSIX make seems to guarantee (but others still seem to do).

cmake needs to be re-run to sort the files again (e.g. at each step of a git rebase, which you'd probably do anyway)