### PR TITLE
Add safety to line lookups in DXF import (fixes #4037)

### DIFF
--- a/src/dxfdata.cc
+++ b/src/dxfdata.cc
@@ -441,6 +441,11 @@ DxfData::DxfData(double fn, double fs, double fa,
 				auto lv = grid.data(this->points[lines[idx].idx[j]][0], this->points[lines[idx].idx[j]][1]);
 				for (size_t ki = 0; ki < lv.size(); ++ki) {
 					int k = lv.at(ki);
+                    if (k < 0 || k >= lines.size()) {
+                        LOG(message_group::Warning,Location::NONE,"",
+                            "Bad DXF line index in %1$s.",QuotedString(boostfs_uncomplete(filename, fs::current_path()).generic_string()));
+                        continue;
+                    }
 					if (k == idx || lines[k].disabled) continue;
 					goto next_open_path_j;
 				}
@@ -466,13 +471,20 @@ DxfData::DxfData(double fn, double fs, double fa,
 			auto lv = grid.data(ref_point[0], ref_point[1]);
 			for (size_t ki = 0; ki < lv.size(); ++ki) {
 				int k = lv.at(ki);
+                if (k < 0 || k >= lines.size()) {
+                    LOG(message_group::Warning,Location::NONE,"",
+                        "Bad DXF line index in %1$s.",QuotedString(boostfs_uncomplete(filename, fs::current_path()).generic_string()));
+                    continue;
+                }
 				if (lines[k].disabled) continue;
-				if (grid.eq(ref_point[0], ref_point[1], this->points[lines[k].idx[0]][0], this->points[lines[k].idx[0]][1])) {
+                auto idk0 = lines[k].idx[0];    // make it easier to read and debug
+                auto idk1 = lines[k].idx[1];
+				if (grid.eq(ref_point[0], ref_point[1], this->points[idk0][0], this->points[idk0][1])) {
 					current_line = k;
 					current_point = 0;
 					goto found_next_line_in_open_path;
 				}
-				if (grid.eq(ref_point[0], ref_point[1], this->points[lines[k].idx[1]][0], this->points[lines[k].idx[1]][1])) {
+				if (grid.eq(ref_point[0], ref_point[1], this->points[idk1][0], this->points[idk1][1])) {
 					current_line = k;
 					current_point = 1;
 					goto found_next_line_in_open_path;
@@ -501,13 +513,20 @@ DxfData::DxfData(double fn, double fs, double fa,
 			auto lv = grid.data(ref_point[0], ref_point[1]);
 			for (size_t ki = 0; ki < lv.size(); ++ki) {
 				int k = lv.at(ki);
+                if (k < 0 || k >= lines.size()) {
+                    LOG(message_group::Warning,Location::NONE,"",
+                        "Bad DXF line index in %1$s.",QuotedString(boostfs_uncomplete(filename, fs::current_path()).generic_string()));
+                    continue;
+                }
 				if (lines[k].disabled) continue;
-				if (grid.eq(ref_point[0], ref_point[1], this->points[lines[k].idx[0]][0], this->points[lines[k].idx[0]][1])) {
+                auto idk0 = lines[k].idx[0];    // make it easier to read and debug
+                auto idk1 = lines[k].idx[1];
+				if (grid.eq(ref_point[0], ref_point[1], this->points[idk0][0], this->points[idk0][1])) {
 					current_line = k;
 					current_point = 0;
 					goto found_next_line_in_closed_path;
 				}
-					if (grid.eq(ref_point[0], ref_point[1], this->points[lines[k].idx[1]][0], this->points[lines[k].idx[1]][1])) {
+                if (grid.eq(ref_point[0], ref_point[1], this->points[idk1][0], this->points[idk1][1])) {
 					current_line = k;
 					current_point = 1;
 					goto found_next_line_in_closed_path;


### PR DESCRIPTION
* Add safety (test for, and continue past, bad indices)
* Report warnings about bad indices
* Add variables just to make the array indices easier to read and debug