### PR TITLE
Only trade AbstractNodes in shared pointers

### DIFF
--- a/src/CSGTreeEvaluator.cc
+++ b/src/CSGTreeEvaluator.cc
@@ -157,7 +157,7 @@ Response CSGTreeEvaluator::visit(State& state, const class ListNode& node)
       if (node.modinst->isBackground()) state.setBackground(true);
     }
     if (state.isPostfix()) {
-      for (auto chnode : this->visitedchildren[node.index()]) {
+      for (auto &chnode : this->visitedchildren[node.index()]) {
         addToParent(state, *chnode);
       }
     }

--- a/src/CSGTreeEvaluator.cc
+++ b/src/CSGTreeEvaluator.cc
@@ -157,7 +157,7 @@ Response CSGTreeEvaluator::visit(State& state, const class ListNode& node)
       if (node.modinst->isBackground()) state.setBackground(true);
     }
     if (state.isPostfix()) {
-      for (const AbstractNode *chnode : this->visitedchildren[node.index()]) {
+      for (auto chnode : this->visitedchildren[node.index()]) {
         addToParent(state, *chnode);
       }
     }
@@ -297,6 +297,6 @@ void CSGTreeEvaluator::addToParent(const State& state, const AbstractNode& node)
 {
   this->visitedchildren.erase(node.index());
   if (state.parent()) {
-    this->visitedchildren[state.parent()->index()].push_back(&node);
+    this->visitedchildren[state.parent()->index()].push_back(node.shared_from_this());
   }
 }

--- a/src/CSGTreeEvaluator.h
+++ b/src/CSGTreeEvaluator.h
@@ -47,7 +47,7 @@ private:
                                                     const AbstractNode& node);
   void applyBackgroundAndHighlight(State& state, const AbstractNode& node);
 
-  typedef std::list<const AbstractNode *> ChildList;
+  typedef std::list<std::shared_ptr<const AbstractNode>> ChildList;
   std::map<int, ChildList> visitedchildren;
 
 protected:

--- a/src/CsgInfo.h
+++ b/src/CsgInfo.h
@@ -20,7 +20,7 @@ public:
   shared_ptr<CSGProducts> background_products;
 
   bool compile_products(const Tree& tree) {
-    auto root_node = tree.root();
+    auto &root_node = tree.root();
     GeometryEvaluator geomevaluator(tree);
     CSGTreeEvaluator evaluator(tree, &geomevaluator);
     shared_ptr<CSGNode> csgRoot = evaluator.buildCSGTree(*root_node);

--- a/src/CsgInfo.h
+++ b/src/CsgInfo.h
@@ -20,7 +20,7 @@ public:
   shared_ptr<CSGProducts> background_products;
 
   bool compile_products(const Tree& tree) {
-    const AbstractNode *root_node = tree.root();
+    auto root_node = tree.root();
     GeometryEvaluator geomevaluator(tree);
     CSGTreeEvaluator evaluator(tree, &geomevaluator);
     shared_ptr<CSGNode> csgRoot = evaluator.buildCSGTree(*root_node);

--- a/src/Geometry.h
+++ b/src/Geometry.h
@@ -7,12 +7,13 @@
 #include "linalg.h"
 #include "memory.h"
 
+class AbstractNode;
 class GeometryVisitor;
 
 class Geometry
 {
 public:
-  typedef std::pair<const class AbstractNode *, shared_ptr<const Geometry>> GeometryItem;
+  typedef std::pair<std::shared_ptr<const AbstractNode>, shared_ptr<const Geometry>> GeometryItem;
   typedef std::list<GeometryItem> Geometries;
 
   Geometry() : convexity(1) {}

--- a/src/GeometryEvaluator.cc
+++ b/src/GeometryEvaluator.cc
@@ -236,7 +236,7 @@ std::vector<const class Polygon2d *> GeometryEvaluator::collectChildren2D(const 
 {
   std::vector<const Polygon2d *> children;
   for (const auto& item : this->visitedchildren[node.index()]) {
-    auto chnode = item.first;
+    auto &chnode = item.first;
     const shared_ptr<const Geometry>& chgeom = item.second;
     if (chnode->modinst->isBackground()) continue;
 
@@ -313,7 +313,7 @@ Geometry::Geometries GeometryEvaluator::collectChildren3D(const AbstractNode& no
 {
   Geometry::Geometries children;
   for (const auto& item : this->visitedchildren[node.index()]) {
-    auto chnode = item.first;
+    auto &chnode = item.first;
     const shared_ptr<const Geometry>& chgeom = item.second;
     if (chnode->modinst->isBackground()) continue;
 
@@ -438,7 +438,7 @@ Response GeometryEvaluator::visit(State& state, const ListNode& node)
       unsigned int dim = 0;
       for (const auto& item : this->visitedchildren[node.index()]) {
         if (!isValidDim(item, dim)) break;
-        auto chnode = item.first;
+        auto &chnode = item.first;
         const shared_ptr<const Geometry>& chgeom = item.second;
         addToParent(state, *chnode, chgeom);
       }
@@ -475,7 +475,7 @@ Response GeometryEvaluator::lazyEvaluateRootNode(State& state, const AbstractNod
     GeometryList::Geometries geometries;
     for (const auto& item : this->visitedchildren[node.index()]) {
       if (!isValidDim(item, dim)) break;
-      auto chnode = item.first;
+      auto &chnode = item.first;
       const shared_ptr<const Geometry>& chgeom = item.second;
       if (chnode->modinst->isBackground()) continue;
       // NB! We insert into the cache here to ensure that all children of
@@ -1342,7 +1342,7 @@ shared_ptr<const Geometry> GeometryEvaluator::projectionNoCut(const ProjectionNo
   std::vector<const Polygon2d *> tmp_geom;
   BoundingBox bounds;
   for (const auto& item : this->visitedchildren[node.index()]) {
-    auto chnode = item.first;
+    auto &chnode = item.first;
     const shared_ptr<const Geometry>& chgeom = item.second;
     if (chnode->modinst->isBackground()) continue;
 

--- a/src/GeometryEvaluator.cc
+++ b/src/GeometryEvaluator.cc
@@ -236,7 +236,7 @@ std::vector<const class Polygon2d *> GeometryEvaluator::collectChildren2D(const 
 {
   std::vector<const Polygon2d *> children;
   for (const auto& item : this->visitedchildren[node.index()]) {
-    const AbstractNode *chnode = item.first;
+    auto chnode = item.first;
     const shared_ptr<const Geometry>& chgeom = item.second;
     if (chnode->modinst->isBackground()) continue;
 
@@ -313,7 +313,7 @@ Geometry::Geometries GeometryEvaluator::collectChildren3D(const AbstractNode& no
 {
   Geometry::Geometries children;
   for (const auto& item : this->visitedchildren[node.index()]) {
-    const AbstractNode *chnode = item.first;
+    auto chnode = item.first;
     const shared_ptr<const Geometry>& chgeom = item.second;
     if (chnode->modinst->isBackground()) continue;
 
@@ -394,7 +394,7 @@ void GeometryEvaluator::addToParent(const State& state,
 {
   this->visitedchildren.erase(node.index());
   if (state.parent()) {
-    this->visitedchildren[state.parent()->index()].push_back(std::make_pair(&node, geom));
+    this->visitedchildren[state.parent()->index()].push_back(std::make_pair(node.shared_from_this(), geom));
   } else {
     // Root node
     this->root = geom;
@@ -438,7 +438,7 @@ Response GeometryEvaluator::visit(State& state, const ListNode& node)
       unsigned int dim = 0;
       for (const auto& item : this->visitedchildren[node.index()]) {
         if (!isValidDim(item, dim)) break;
-        const AbstractNode *chnode = item.first;
+        auto chnode = item.first;
         const shared_ptr<const Geometry>& chgeom = item.second;
         addToParent(state, *chnode, chgeom);
       }
@@ -475,7 +475,7 @@ Response GeometryEvaluator::lazyEvaluateRootNode(State& state, const AbstractNod
     GeometryList::Geometries geometries;
     for (const auto& item : this->visitedchildren[node.index()]) {
       if (!isValidDim(item, dim)) break;
-      const AbstractNode *chnode = item.first;
+      auto chnode = item.first;
       const shared_ptr<const Geometry>& chgeom = item.second;
       if (chnode->modinst->isBackground()) continue;
       // NB! We insert into the cache here to ensure that all children of
@@ -1342,7 +1342,7 @@ shared_ptr<const Geometry> GeometryEvaluator::projectionNoCut(const ProjectionNo
   std::vector<const Polygon2d *> tmp_geom;
   BoundingBox bounds;
   for (const auto& item : this->visitedchildren[node.index()]) {
-    const AbstractNode *chnode = item.first;
+    auto chnode = item.first;
     const shared_ptr<const Geometry>& chgeom = item.second;
     if (chnode->modinst->isBackground()) continue;
 

--- a/src/GroupModule.cc
+++ b/src/GroupModule.cc
@@ -30,10 +30,10 @@
 #include "children.h"
 #include "parameters.h"
 
-AbstractNode *builtin_group(const ModuleInstantiation *inst, Arguments arguments, Children children)
+std::shared_ptr<AbstractNode> builtin_group(const ModuleInstantiation *inst, Arguments arguments, Children children)
 {
   Parameters parameters = Parameters::parse(std::move(arguments), inst->location(), {});
-  return children.instantiate(new GroupNode(inst));
+  return children.instantiate(std::make_shared<GroupNode>(inst));
 }
 
 void register_builtin_group()

--- a/src/MainWindow.cc
+++ b/src/MainWindow.cc
@@ -2239,7 +2239,7 @@ void MainWindow::selectObject(QPoint mouse)
     // Create context menu with the backtrace
     QMenu tracemenu(this);
     std::stringstream ss;
-    for (auto step : path) {
+    for (auto &step : path) {
       // Skip certain node types
       if (step->name() == "root") {
         continue;

--- a/src/MainWindow.h
+++ b/src/MainWindow.h
@@ -28,6 +28,7 @@
 Q_IMPORT_PLUGIN(QSvgPlugin)
 #endif
 
+class AbstractNode;
 class MouseSelector;
 
 class MainWindow : public QMainWindow, public Ui::MainWindow, public InputEventHandler
@@ -52,8 +53,8 @@ public:
 
   SourceFile *root_file; // Result of parsing
   SourceFile *parsed_file; // Last parse for include list
-  AbstractNode *absolute_root_node; // Result of tree evaluation
-  AbstractNode *root_node; // Root if the root modifier (!) is used
+  std::shared_ptr<AbstractNode> absolute_root_node; // Result of tree evaluation
+  std::shared_ptr<AbstractNode> root_node; // Root if the root modifier (!) is used
   Tree tree;
   EditorInterface *activeEditor;
   TabManager *tabManager;
@@ -126,7 +127,7 @@ private:
   void compile(bool reload, bool forcedone = false);
   void compileCSG();
   bool checkEditorModified();
-  QString dumpCSGTree(AbstractNode *root);
+  QString dumpCSGTree(const std::shared_ptr<AbstractNode> &root);
 
   void loadViewSettings();
   void loadDesignSettings();
@@ -329,7 +330,7 @@ public slots:
 
 private:
   bool network_progress_func(const double permille);
-  static void report_func(const class AbstractNode *, void *vp, int mark);
+  static void report_func(const std::shared_ptr<const AbstractNode> &, void *vp, int mark);
   static bool undockMode;
   static bool reorderMode;
   static const int tabStopWidth;

--- a/src/ModuleInstantiation.cc
+++ b/src/ModuleInstantiation.cc
@@ -69,7 +69,7 @@ static void NOINLINE print_trace(const ModuleInstantiation *mod, const std::shar
   LOG(message_group::Trace, mod->location(), context->documentRoot(), "called by '%1$s'", mod->name());
 }
 
-AbstractNode *ModuleInstantiation::evaluate(const std::shared_ptr<const Context> context) const
+std::shared_ptr<AbstractNode> ModuleInstantiation::evaluate(const std::shared_ptr<const Context> context) const
 {
   boost::optional<InstantiableModule> module = context->lookup_module(this->name(), this->loc);
   if (!module) {
@@ -77,7 +77,7 @@ AbstractNode *ModuleInstantiation::evaluate(const std::shared_ptr<const Context>
   }
 
   try{
-    AbstractNode *node = module->module->instantiate(module->defining_context, this, context);
+    auto node = module->module->instantiate(module->defining_context, this, context);
     return node;
   } catch (EvaluationException& e) {
     if (e.traceDepth > 0) {

--- a/src/ModuleInstantiation.h
+++ b/src/ModuleInstantiation.h
@@ -15,7 +15,7 @@ public:
 
   virtual void print(std::ostream& stream, const std::string& indent, const bool inlined) const;
   void print(std::ostream& stream, const std::string& indent) const override { print(stream, indent, false); }
-  AbstractNode *evaluate(const std::shared_ptr<const Context> context) const;
+  std::shared_ptr<AbstractNode> evaluate(const std::shared_ptr<const Context> context) const;
 
   const std::string& name() const { return this->modname; }
   bool isBackground() const { return this->tag_background; }

--- a/src/NodeVisitor.cc
+++ b/src/NodeVisitor.cc
@@ -15,7 +15,7 @@ Response NodeVisitor::traverse(const AbstractNode& node, const State& state)
 
   // Pruned traversals mean don't traverse children
   if (response == Response::ContinueTraversal) {
-    newstate.setParent(&node);
+    newstate.setParent(node.shared_from_this());
     for (const auto& chnode : node.getChildren()) {
       response = this->traverse(*chnode, newstate);
       if (response == Response::AbortTraversal) return response; // Abort immediately

--- a/src/SourceFile.cc
+++ b/src/SourceFile.cc
@@ -170,9 +170,9 @@ time_t SourceFile::handleDependencies(bool is_root)
   return latest;
 }
 
-AbstractNode *SourceFile::instantiate(const std::shared_ptr<const Context>& context, std::shared_ptr<const FileContext> *resulting_file_context) const
+std::shared_ptr<AbstractNode> SourceFile::instantiate(const std::shared_ptr<const Context>& context, std::shared_ptr<const FileContext> *resulting_file_context) const
 {
-  auto node = new RootNode();
+  auto node = std::make_shared<RootNode>();
   try {
     ContextHandle<FileContext> file_context{Context::create<FileContext>(context, this)};
     *resulting_file_context = *file_context;

--- a/src/SourceFile.h
+++ b/src/SourceFile.h
@@ -16,7 +16,7 @@ public:
   SourceFile(const std::string& path, const std::string& filename);
   ~SourceFile();
 
-  AbstractNode *instantiate(const std::shared_ptr<const Context>& context, std::shared_ptr<const class FileContext> *resulting_file_context) const;
+  std::shared_ptr<AbstractNode> instantiate(const std::shared_ptr<const Context>& context, std::shared_ptr<const class FileContext> *resulting_file_context) const;
   void print(std::ostream& stream, const std::string& indent) const override;
 
   void setModulePath(const std::string& path) { this->path = path; }

--- a/src/Tree.cc
+++ b/src/Tree.cc
@@ -63,7 +63,7 @@ const std::string Tree::getIdString(const AbstractNode& node) const
 /*!
    Sets a new root. Will clear the existing cache.
  */
-void Tree::setRoot(const AbstractNode *root)
+void Tree::setRoot(const std::shared_ptr<const AbstractNode> &root)
 {
   this->root_node = root;
   this->nodecachemap.clear();

--- a/src/Tree.h
+++ b/src/Tree.h
@@ -12,19 +12,19 @@
 class Tree
 {
 public:
-  Tree(const AbstractNode *root = nullptr, const std::string& path = {}) : root_node(root), document_path(path) {}
+  Tree(const std::shared_ptr<const AbstractNode> &root = nullptr, const std::string& path = {}) : root_node(root), document_path(path) {}
   ~Tree();
 
-  void setRoot(const AbstractNode *root);
+  void setRoot(const std::shared_ptr<const AbstractNode> &root);
   void setDocumentPath(const std::string path);
-  const AbstractNode *root() const { return this->root_node; }
+  std::shared_ptr<const AbstractNode> root() const { return this->root_node; }
 
   const std::string getString(const AbstractNode& node, const std::string& indent) const;
   const std::string getIdString(const AbstractNode& node) const;
   const std::string getDocumentPath() const;
 
 private:
-  const AbstractNode *root_node;
+  std::shared_ptr<const AbstractNode> root_node;
   // keep a separate nodecache per tuple of NodeDumper constructor parameters
   mutable std::map<std::tuple<std::string, bool>, NodeCache> nodecachemap;
   std::string document_path;

--- a/src/Tree.h
+++ b/src/Tree.h
@@ -17,7 +17,7 @@ public:
 
   void setRoot(const std::shared_ptr<const AbstractNode> &root);
   void setDocumentPath(const std::string path);
-  std::shared_ptr<const AbstractNode> root() const { return this->root_node; }
+  const std::shared_ptr<const AbstractNode>& root() const { return this->root_node; }
 
   const std::string getString(const AbstractNode& node, const std::string& indent) const;
   const std::string getIdString(const AbstractNode& node) const;

--- a/src/UserModule.cc
+++ b/src/UserModule.cc
@@ -42,7 +42,7 @@ static void NOINLINE print_err(std::string name, const Location& loc, const std:
   LOG(message_group::Error, loc, context->documentRoot(), "Recursion detected calling module '%1$s'", name);
 }
 
-AbstractNode *UserModule::instantiate(const std::shared_ptr<const Context>& defining_context, const ModuleInstantiation *inst, const std::shared_ptr<const Context>& context) const
+std::shared_ptr<AbstractNode> UserModule::instantiate(const std::shared_ptr<const Context>& defining_context, const ModuleInstantiation *inst, const std::shared_ptr<const Context>& context) const
 {
   if (StackCheck::inst().check()) {
     print_err(inst->name(), loc, context);
@@ -63,7 +63,7 @@ AbstractNode *UserModule::instantiate(const std::shared_ptr<const Context>& defi
   PRINTDB("%s", module_context->dump());
 #endif
 
-  return this->body.instantiateModules(*module_context, new GroupNode(inst, std::string("module ") + this->name));
+  return this->body.instantiateModules(*module_context, std::make_shared<GroupNode>(inst, std::string("module ") + this->name));
 }
 
 void UserModule::print(std::ostream& stream, const std::string& indent) const

--- a/src/UserModule.h
+++ b/src/UserModule.h
@@ -30,7 +30,7 @@ public:
   UserModule(const char *name, const class Feature& feature, const Location& loc) : AbstractModule(feature), ASTNode(loc), name(name) { }
   ~UserModule() {}
 
-  AbstractNode *instantiate(const std::shared_ptr<const Context>& defining_context, const ModuleInstantiation *inst, const std::shared_ptr<const Context>& context) const override;
+  std::shared_ptr<AbstractNode> instantiate(const std::shared_ptr<const Context>& defining_context, const ModuleInstantiation *inst, const std::shared_ptr<const Context>& context) const override;
   void print(std::ostream& stream, const std::string& indent) const override;
   static const std::string& stack_element(int n) { return StaticModuleNameStack::at(n); }
   static int stack_size() { return StaticModuleNameStack::size(); }

--- a/src/cgaladv.cc
+++ b/src/cgaladv.cc
@@ -36,9 +36,9 @@
 #include <boost/assign/std/vector.hpp>
 using namespace boost::assign; // bring 'operator+=()' into scope
 
-static AbstractNode *builtin_minkowski(const ModuleInstantiation *inst, Arguments arguments, Children children)
+static std::shared_ptr<AbstractNode> builtin_minkowski(const ModuleInstantiation *inst, Arguments arguments, Children children)
 {
-  auto node = new CgaladvNode(inst, CgaladvType::MINKOWSKI);
+  auto node = std::make_shared<CgaladvNode>(inst, CgaladvType::MINKOWSKI);
 
   Parameters parameters = Parameters::parse(std::move(arguments), inst->location(), {"convexity"});
   node->convexity = static_cast<int>(parameters["convexity"].toDouble());
@@ -46,9 +46,9 @@ static AbstractNode *builtin_minkowski(const ModuleInstantiation *inst, Argument
   return children.instantiate(node);
 }
 
-static AbstractNode *builtin_hull(const ModuleInstantiation *inst, Arguments arguments, Children children)
+static std::shared_ptr<AbstractNode> builtin_hull(const ModuleInstantiation *inst, Arguments arguments, Children children)
 {
-  auto node = new CgaladvNode(inst, CgaladvType::HULL);
+  auto node = std::make_shared<CgaladvNode>(inst, CgaladvType::HULL);
 
   Parameters parameters = Parameters::parse(std::move(arguments), inst->location(), {});
   node->convexity = 0;
@@ -56,9 +56,9 @@ static AbstractNode *builtin_hull(const ModuleInstantiation *inst, Arguments arg
   return children.instantiate(node);
 }
 
-static AbstractNode *builtin_resize(const ModuleInstantiation *inst, Arguments arguments, Children children)
+static std::shared_ptr<AbstractNode> builtin_resize(const ModuleInstantiation *inst, Arguments arguments, Children children)
 {
-  auto node = new CgaladvNode(inst, CgaladvType::RESIZE);
+  auto node = std::make_shared<CgaladvNode>(inst, CgaladvType::RESIZE);
 
   Parameters parameters = Parameters::parse(std::move(arguments), inst->location(), {"newsize", "auto", "convexity"});
   node->convexity = static_cast<int>(parameters["convexity"].toDouble());

--- a/src/cgalutils-applyops-hybrid.cc
+++ b/src/cgalutils-applyops-hybrid.cc
@@ -8,7 +8,7 @@
 #include "node.h"
 #include "progress.h"
 
-Location getLocation(const AbstractNode *node)
+Location getLocation(const std::shared_ptr<const AbstractNode> &node)
 {
   return node && node->modinst ? node->modinst->location() : Location::NONE;
 }

--- a/src/cgalutils-applyops.cc
+++ b/src/cgalutils-applyops.cc
@@ -404,7 +404,7 @@ shared_ptr<const Geometry> applyMinkowski(const Geometry::Geometries& children)
         for (const auto& part : result_parts) {
           PolySet ps(3, true);
           createPolySetFromPolyhedron(part, ps);
-          fake_children.push_back(std::make_pair((const AbstractNode *)nullptr,
+          fake_children.push_back(std::make_pair(std::shared_ptr<const AbstractNode>(),
                                                  createNefPolyhedronFromGeometry(ps)));
         }
         auto N = CGALUtils::applyUnion3D(fake_children.begin(), fake_children.end());

--- a/src/children.cc
+++ b/src/children.cc
@@ -27,12 +27,12 @@
 #include "children.h"
 #include "modcontext.h"
 
-AbstractNode *Children::instantiate(AbstractNode *target) const
+std::shared_ptr<AbstractNode> Children::instantiate(const std::shared_ptr<AbstractNode> &target) const
 {
   return children_scope->instantiateModules(*scopeContext(), target);
 }
 
-AbstractNode *Children::instantiate(AbstractNode *target, const std::vector<size_t>& indices) const
+std::shared_ptr<AbstractNode> Children::instantiate(const std::shared_ptr<AbstractNode> &target, const std::vector<size_t>& indices) const
 {
   return children_scope->instantiateModules(*scopeContext(), target, indices);
 }

--- a/src/children.h
+++ b/src/children.h
@@ -17,8 +17,8 @@ public:
   Children(Children&& other) = default;
   Children& operator=(Children&& other) = default;
 
-  AbstractNode *instantiate(AbstractNode *target) const;
-  AbstractNode *instantiate(AbstractNode *target, const std::vector<size_t>& indices) const;
+  std::shared_ptr<AbstractNode> instantiate(const std::shared_ptr<AbstractNode> &target) const;
+  std::shared_ptr<AbstractNode> instantiate(const std::shared_ptr<AbstractNode> &target, const std::vector<size_t>& indices) const;
 
   bool empty() const { return !children_scope->hasChildren(); }
   size_t size() const { return children_scope->moduleInstantiations.size(); }

--- a/src/color.cc
+++ b/src/color.cc
@@ -235,9 +235,9 @@ static boost::optional<Color4f> parse_hex_color(const std::string& hex) {
   return rgba;
 }
 
-static AbstractNode *builtin_color(const ModuleInstantiation *inst, Arguments arguments, Children children)
+static std::shared_ptr<AbstractNode> builtin_color(const ModuleInstantiation *inst, Arguments arguments, Children children)
 {
-  auto node = new ColorNode(inst);
+  auto node = std::make_shared<ColorNode>(inst);
 
   Parameters parameters = Parameters::parse(std::move(arguments), inst->location(), {"c", "alpha"});
   if (parameters["c"].type() == Value::Type::VECTOR) {

--- a/src/csgops.cc
+++ b/src/csgops.cc
@@ -35,22 +35,22 @@
 #include <sstream>
 #include <assert.h>
 
-static AbstractNode *builtin_union(const ModuleInstantiation *inst, Arguments arguments, Children children)
+static std::shared_ptr<AbstractNode> builtin_union(const ModuleInstantiation *inst, Arguments arguments, Children children)
 {
   Parameters parameters = Parameters::parse(std::move(arguments), inst->location(), {});
-  return children.instantiate(new CsgOpNode(inst, OpenSCADOperator::UNION));
+  return children.instantiate(std::make_shared<CsgOpNode>(inst, OpenSCADOperator::UNION));
 }
 
-static AbstractNode *builtin_difference(const ModuleInstantiation *inst, Arguments arguments, Children children)
+static std::shared_ptr<AbstractNode> builtin_difference(const ModuleInstantiation *inst, Arguments arguments, Children children)
 {
   Parameters parameters = Parameters::parse(std::move(arguments), inst->location(), {});
-  return children.instantiate(new CsgOpNode(inst, OpenSCADOperator::DIFFERENCE));
+  return children.instantiate(std::make_shared<CsgOpNode>(inst, OpenSCADOperator::DIFFERENCE));
 }
 
-static AbstractNode *builtin_intersection(const ModuleInstantiation *inst, Arguments arguments, Children children)
+static std::shared_ptr<AbstractNode> builtin_intersection(const ModuleInstantiation *inst, Arguments arguments, Children children)
 {
   Parameters parameters = Parameters::parse(std::move(arguments), inst->location(), {});
-  return children.instantiate(new CsgOpNode(inst, OpenSCADOperator::INTERSECTION));
+  return children.instantiate(std::make_shared<CsgOpNode>(inst, OpenSCADOperator::INTERSECTION));
 }
 
 std::string CsgOpNode::toString() const

--- a/src/import.cc
+++ b/src/import.cc
@@ -56,7 +56,7 @@ using namespace boost::assign; // bring 'operator+=()' into scope
 extern PolySet *import_amf(std::string, const Location& loc);
 extern Geometry *import_3mf(const std::string&, const Location& loc);
 
-static AbstractNode *do_import(const ModuleInstantiation *inst, Arguments arguments, Children children, ImportType type)
+static std::shared_ptr<AbstractNode> do_import(const ModuleInstantiation *inst, Arguments arguments, Children children, ImportType type)
 {
   if (!children.empty()) {
     LOG(message_group::Warning, inst->location(), arguments.documentRoot(),
@@ -93,7 +93,7 @@ static AbstractNode *do_import(const ModuleInstantiation *inst, Arguments argume
     else if (ext == ".svg") actualtype = ImportType::SVG;
   }
 
-  auto node = new ImportNode(inst, actualtype);
+  auto node = std::make_shared<ImportNode>(inst, actualtype);
 
   node->fn = parameters["$fn"].toDouble();
   node->fs = parameters["$fs"].toDouble();
@@ -151,16 +151,16 @@ static AbstractNode *do_import(const ModuleInstantiation *inst, Arguments argume
   return node;
 }
 
-static AbstractNode *builtin_import(const ModuleInstantiation *inst, Arguments arguments, Children children)
+static std::shared_ptr<AbstractNode> builtin_import(const ModuleInstantiation *inst, Arguments arguments, Children children)
 { return do_import(inst, std::move(arguments), std::move(children), ImportType::UNKNOWN); }
 
-static AbstractNode *builtin_import_stl(const ModuleInstantiation *inst, Arguments arguments, Children children)
+static std::shared_ptr<AbstractNode> builtin_import_stl(const ModuleInstantiation *inst, Arguments arguments, Children children)
 { return do_import(inst, std::move(arguments), std::move(children), ImportType::STL); }
 
-static AbstractNode *builtin_import_off(const ModuleInstantiation *inst, Arguments arguments, Children children)
+static std::shared_ptr<AbstractNode> builtin_import_off(const ModuleInstantiation *inst, Arguments arguments, Children children)
 { return do_import(inst, std::move(arguments), std::move(children), ImportType::OFF); }
 
-static AbstractNode *builtin_import_dxf(const ModuleInstantiation *inst, Arguments arguments, Children children)
+static std::shared_ptr<AbstractNode> builtin_import_dxf(const ModuleInstantiation *inst, Arguments arguments, Children children)
 { return do_import(inst, std::move(arguments), std::move(children), ImportType::DXF); }
 
 

--- a/src/import_3mf.cc
+++ b/src/import_3mf.cc
@@ -195,9 +195,9 @@ Geometry *import_3mf(const std::string& filename, const Location& loc)
     PolySet *p = nullptr;
 #ifdef ENABLE_CGAL
     Geometry::Geometries children;
-    children.push_back(std::make_pair((const AbstractNode *)NULL,  shared_ptr<const Geometry>(first_mesh)));
+    children.push_back(std::make_pair(std::shared_ptr<AbstractNode>(),  shared_ptr<const Geometry>(first_mesh)));
     for (polysets_t::iterator it = meshes.begin(); it != meshes.end(); ++it) {
-      children.push_back(std::make_pair((const AbstractNode *)NULL,  shared_ptr<const Geometry>(*it)));
+      children.push_back(std::make_pair(std::shared_ptr<AbstractNode>(),  shared_ptr<const Geometry>(*it)));
     }
     if (auto ps = CGALUtils::getGeometryAsPolySet(CGALUtils::applyUnion3D(children.begin(), children.end()))) {
       p = new PolySet(*ps);
@@ -372,9 +372,9 @@ Geometry *import_3mf(const std::string& filename, const Location& loc)
     PolySet *p = new PolySet(3);
 #ifdef ENABLE_CGAL
     Geometry::Geometries children;
-    children.push_back(std::make_pair((const AbstractNode *)NULL,  shared_ptr<const Geometry>(first_mesh)));
+    children.push_back(std::make_pair(std::shared_ptr<const AbstractNode>(),  shared_ptr<const Geometry>(first_mesh)));
     for (polysets_t::iterator it = meshes.begin(); it != meshes.end(); ++it) {
-      children.push_back(std::make_pair((const AbstractNode *)NULL,  shared_ptr<const Geometry>(*it)));
+      children.push_back(std::make_pair(std::shared_ptr<const AbstractNode>(),  shared_ptr<const Geometry>(*it)));
     }
     CGAL_Nef_polyhedron *N = CGALUtils::applyUnion3D(children.begin(), children.end());
 

--- a/src/import_amf.cc
+++ b/src/import_amf.cc
@@ -269,7 +269,7 @@ PolySet *AmfImporter::read(const std::string filename)
   if (polySets.size() > 1) {
     Geometry::Geometries children;
     for (std::vector<PolySet *>::iterator it = polySets.begin(); it != polySets.end(); ++it) {
-      children.push_back(std::make_pair((const AbstractNode *)nullptr,  shared_ptr<const Geometry>(*it)));
+      children.push_back(std::make_pair(std::shared_ptr<AbstractNode>(),  shared_ptr<const Geometry>(*it)));
     }
 
     if (auto ps = CGALUtils::getGeometryAsPolySet(CGALUtils::applyUnion3D(children.begin(), children.end()))) {

--- a/src/linearextrude.cc
+++ b/src/linearextrude.cc
@@ -73,9 +73,9 @@ Parameters parse_parameters(Arguments arguments, const Location& location)
                            );
 }
 
-static AbstractNode *builtin_linear_extrude(const ModuleInstantiation *inst, Arguments arguments, Children children)
+static std::shared_ptr<AbstractNode> builtin_linear_extrude(const ModuleInstantiation *inst, Arguments arguments, Children children)
 {
-  auto node = new LinearExtrudeNode(inst);
+  auto node = std::make_shared<LinearExtrudeNode>(inst);
 
   Parameters parameters = parse_parameters(std::move(arguments), inst->location());
 

--- a/src/localscope.cc
+++ b/src/localscope.cc
@@ -54,10 +54,10 @@ void LocalScope::print(std::ostream& stream, const std::string& indent, const bo
   }
 }
 
-AbstractNode *LocalScope::instantiateModules(const std::shared_ptr<const Context>& context, AbstractNode *target) const
+std::shared_ptr<AbstractNode> LocalScope::instantiateModules(const std::shared_ptr<const Context>& context, const std::shared_ptr<AbstractNode> &target) const
 {
   for (const auto& modinst : this->moduleInstantiations) {
-    AbstractNode *node = modinst->evaluate(context);
+    auto node = modinst->evaluate(context);
     if (node) {
       target->children.push_back(node);
     }
@@ -65,11 +65,11 @@ AbstractNode *LocalScope::instantiateModules(const std::shared_ptr<const Context
   return target;
 }
 
-AbstractNode *LocalScope::instantiateModules(const std::shared_ptr<const Context>& context, AbstractNode *target, const std::vector<size_t>& indices) const
+std::shared_ptr<AbstractNode> LocalScope::instantiateModules(const std::shared_ptr<const Context>& context, const std::shared_ptr<AbstractNode> &target, const std::vector<size_t>& indices) const
 {
   for (size_t index : indices) {
     assert(index < this->moduleInstantiations.size());
-    AbstractNode *node = moduleInstantiations[index]->evaluate(context);
+    auto node = moduleInstantiations[index]->evaluate(context);
     if (node) {
       target->children.push_back(node);
     }

--- a/src/localscope.h
+++ b/src/localscope.h
@@ -12,8 +12,8 @@ class LocalScope
 public:
   size_t numElements() const { return assignments.size() + moduleInstantiations.size(); }
   void print(std::ostream& stream, const std::string& indent, const bool inlined = false) const;
-  AbstractNode *instantiateModules(const std::shared_ptr<const Context>& context, AbstractNode *target) const;
-  AbstractNode *instantiateModules(const std::shared_ptr<const Context>& context, AbstractNode *target, const std::vector<size_t>& indices) const;
+  std::shared_ptr<AbstractNode> instantiateModules(const std::shared_ptr<const Context>& context, const std::shared_ptr<AbstractNode> &target) const;
+  std::shared_ptr<AbstractNode> instantiateModules(const std::shared_ptr<const Context>& context, const std::shared_ptr<AbstractNode> &target, const std::vector<size_t>& indices) const;
   void addModuleInst(const shared_ptr<class ModuleInstantiation>& modinst);
   void addModule(const shared_ptr<class UserModule>& module);
   void addFunction(const shared_ptr<class UserFunction>& function);

--- a/src/module.cc
+++ b/src/module.cc
@@ -31,12 +31,12 @@
 #include "ModuleInstantiation.h"
 #include "value.h"
 
-BuiltinModule::BuiltinModule(AbstractNode *(*instantiate)(const class ModuleInstantiation *, const std::shared_ptr<const Context>&), const Feature *feature) :
+BuiltinModule::BuiltinModule(std::shared_ptr<AbstractNode>(*instantiate)(const class ModuleInstantiation *, const std::shared_ptr<const Context>&), const Feature *feature) :
   AbstractModule(feature),
   do_instantiate(instantiate)
 {}
 
-BuiltinModule::BuiltinModule(AbstractNode *(*instantiate)(const class ModuleInstantiation *, Arguments, Children), const Feature *feature) :
+BuiltinModule::BuiltinModule(std::shared_ptr<AbstractNode>(*instantiate)(const class ModuleInstantiation *, Arguments, Children), const Feature *feature) :
   AbstractModule(feature)
 {
   do_instantiate = [instantiate](const class ModuleInstantiation *inst, const std::shared_ptr<const Context>& context) {
@@ -44,7 +44,7 @@ BuiltinModule::BuiltinModule(AbstractNode *(*instantiate)(const class ModuleInst
     };
 }
 
-AbstractNode *BuiltinModule::instantiate(const std::shared_ptr<const Context>& defining_context, const ModuleInstantiation *inst, const std::shared_ptr<const Context>& context) const
+std::shared_ptr<AbstractNode> BuiltinModule::instantiate(const std::shared_ptr<const Context>& defining_context, const ModuleInstantiation *inst, const std::shared_ptr<const Context>& context) const
 {
   return do_instantiate(inst, context);
 }

--- a/src/module.h
+++ b/src/module.h
@@ -22,18 +22,18 @@ public:
   virtual ~AbstractModule() {}
   virtual bool is_experimental() const { return feature != nullptr; }
   virtual bool is_enabled() const { return (feature == nullptr) || feature->is_enabled(); }
-  virtual AbstractNode *instantiate(const std::shared_ptr<const Context>& defining_context, const ModuleInstantiation *inst, const std::shared_ptr<const Context>& context) const = 0;
+  virtual std::shared_ptr<AbstractNode> instantiate(const std::shared_ptr<const Context>& defining_context, const ModuleInstantiation *inst, const std::shared_ptr<const Context>& context) const = 0;
 };
 
 class BuiltinModule : public AbstractModule
 {
 public:
-  BuiltinModule(AbstractNode *(*instantiate)(const class ModuleInstantiation *, const std::shared_ptr<const Context>&), const Feature *feature = nullptr);
-  BuiltinModule(AbstractNode *(*instantiate)(const class ModuleInstantiation *, Arguments, Children), const Feature *feature = nullptr);
-  AbstractNode *instantiate(const std::shared_ptr<const Context>& defining_context, const ModuleInstantiation *inst, const std::shared_ptr<const Context>& context) const override;
+  BuiltinModule(std::shared_ptr<AbstractNode>(*instantiate)(const class ModuleInstantiation *, const std::shared_ptr<const Context>&), const Feature *feature = nullptr);
+  BuiltinModule(std::shared_ptr<AbstractNode>(*instantiate)(const class ModuleInstantiation *, Arguments, Children), const Feature *feature = nullptr);
+  std::shared_ptr<AbstractNode> instantiate(const std::shared_ptr<const Context>& defining_context, const ModuleInstantiation *inst, const std::shared_ptr<const Context>& context) const override;
 
 private:
-  std::function<AbstractNode *(const class ModuleInstantiation *, const std::shared_ptr<const class Context>&)> do_instantiate;
+  std::function<std::shared_ptr<AbstractNode> (const class ModuleInstantiation *, const std::shared_ptr<const class Context>&)> do_instantiate;
 };
 
 struct InstantiableModule

--- a/src/nodedumper.cc
+++ b/src/nodedumper.cc
@@ -79,7 +79,7 @@ Response NodeDumper::visit(State& state, const GroupNode& node)
   if (state.isPrefix()) {
     // For handling root modifier '!'
     // Check if we are processing the root of the current Tree and init cache
-    if (this->root == &node) {
+    if (this->root.get() == &node) {
       this->initCache();
     }
 
@@ -111,7 +111,7 @@ Response NodeDumper::visit(State& state, const GroupNode& node)
 
     // For handling root modifier '!'
     // Check if we are processing the root of the current Tree and finalize cache
-    if (this->root == &node) {
+    if (this->root.get() == &node) {
       this->finalizeCache();
     }
   }
@@ -129,7 +129,7 @@ Response NodeDumper::visit(State& state, const AbstractNode& node)
 
     // For handling root modifier '!'
     // Check if we are processing the root of the current Tree and init cache
-    if (this->root == &node) {
+    if (this->root.get() == &node) {
       this->initCache();
     }
 
@@ -197,7 +197,7 @@ Response NodeDumper::visit(State& state, const AbstractNode& node)
 
     // For handling root modifier '!'
     // Check if we are processing the root of the current Tree and finalize cache
-    if (this->root == &node) {
+    if (this->root.get() == &node) {
       this->finalizeCache();
     }
   }
@@ -212,7 +212,7 @@ Response NodeDumper::visit(State& state, const ListNode& node)
 {
   if (state.isPrefix()) {
     // For handling root modifier '!'
-    if (this->root == &node) {
+    if (this->root.get() == &node) {
       this->initCache();
     }
     // pass modifiers down to children via state
@@ -222,7 +222,7 @@ Response NodeDumper::visit(State& state, const ListNode& node)
   } else if (state.isPostfix()) {
     this->cache.insertEnd(node.index(), this->dumpstream.tellp());
     // For handling root modifier '!'
-    if (this->root == &node) {
+    if (this->root.get() == &node) {
       this->finalizeCache();
     }
   }

--- a/src/nodedumper.h
+++ b/src/nodedumper.h
@@ -31,7 +31,7 @@ private:
 class NodeDumper : public NodeVisitor
 {
 public:
-  NodeDumper(NodeCache& cache, const AbstractNode *root_node, const std::string& indent, bool idString) :
+  NodeDumper(NodeCache& cache, const std::shared_ptr<const AbstractNode> &root_node, const std::string& indent, bool idString) :
     cache(cache), indent(indent), idString(idString), currindent(0), root(root_node) {
     if (idString) {
       groupChecker.traverse(*root);
@@ -55,7 +55,7 @@ private:
   bool idString;
 
   int currindent;
-  const AbstractNode *root;
+  std::shared_ptr<const AbstractNode> root;
   GroupNodeChecker groupChecker;
   std::ostringstream dumpstream;
 

--- a/src/offset.cc
+++ b/src/offset.cc
@@ -43,9 +43,9 @@ using namespace boost::assign; // bring 'operator+=()' into scope
 #include <boost/filesystem.hpp>
 namespace fs = boost::filesystem;
 
-static AbstractNode *builtin_offset(const ModuleInstantiation *inst, Arguments arguments, Children children)
+static std::shared_ptr<AbstractNode> builtin_offset(const ModuleInstantiation *inst, Arguments arguments, Children children)
 {
-  auto node = new OffsetNode(inst);
+  auto node = std::make_shared<OffsetNode>(inst);
 
   Parameters parameters = Parameters::parse(std::move(arguments), inst->location(), {"r"}, {"delta", "chamfer"});
 

--- a/src/openscad.cc
+++ b/src/openscad.cc
@@ -474,7 +474,7 @@ int do_export(const CommandLine& cmd, const RenderVariables& render_variables, F
 
   AbstractNode::resetIndexCounter();
   std::shared_ptr<const FileContext> file_context;
-  AbstractNode *absolute_root_node = root_file->instantiate(*builtin_context, &file_context);
+  auto absolute_root_node = root_file->instantiate(*builtin_context, &file_context);
   Camera camera = cmd.camera;
   if (file_context) {
     camera.updateView(file_context, true);
@@ -484,7 +484,7 @@ int do_export(const CommandLine& cmd, const RenderVariables& render_variables, F
   fs::current_path(cmd.original_path);
 
   // Do we have an explicit root node (! modifier)?
-  const AbstractNode *root_node;
+  std::shared_ptr<const AbstractNode> root_node;
   const Location *nextLocation = nullptr;
   if (!(root_node = find_root_tag(absolute_root_node, &nextLocation))) {
     root_node = absolute_root_node;
@@ -611,7 +611,6 @@ int do_export(const CommandLine& cmd, const RenderVariables& render_variables, F
 #endif // ifdef ENABLE_CGAL
 
   }
-  delete root_node;
   return 0;
 }
 

--- a/src/primitives.cc
+++ b/src/primitives.cc
@@ -198,9 +198,9 @@ const Geometry *CubeNode::createGeometry() const
   return p;
 }
 
-static AbstractNode *builtin_cube(const ModuleInstantiation *inst, Arguments arguments, Children children)
+static std::shared_ptr<AbstractNode> builtin_cube(const ModuleInstantiation *inst, Arguments arguments, Children children)
 {
-  auto node = new CubeNode(inst);
+  auto node = std::make_shared<CubeNode>(inst);
 
   if (!children.empty()) {
     LOG(message_group::Warning, inst->location(), arguments.documentRoot(),
@@ -329,9 +329,9 @@ sphere_next_r2:
   return p;
 }
 
-static AbstractNode *builtin_sphere(const ModuleInstantiation *inst, Arguments arguments, Children children)
+static std::shared_ptr<AbstractNode> builtin_sphere(const ModuleInstantiation *inst, Arguments arguments, Children children)
 {
-  auto node = new SphereNode(inst);
+  auto node = std::make_shared<SphereNode>(inst);
 
   if (!children.empty()) {
     LOG(message_group::Warning, inst->location(), arguments.documentRoot(),
@@ -449,9 +449,9 @@ const Geometry *CylinderNode::createGeometry() const
   return p;
 }
 
-static AbstractNode *builtin_cylinder(const ModuleInstantiation *inst, Arguments arguments, Children children)
+static std::shared_ptr<AbstractNode> builtin_cylinder(const ModuleInstantiation *inst, Arguments arguments, Children children)
 {
-  auto node = new CylinderNode(inst);
+  auto node = std::make_shared<CylinderNode>(inst);
 
   if (!children.empty()) {
     LOG(message_group::Warning, inst->location(), arguments.documentRoot(),
@@ -571,9 +571,9 @@ const Geometry *PolyhedronNode::createGeometry() const
   return p;
 }
 
-static AbstractNode *builtin_polyhedron(const ModuleInstantiation *inst, Arguments arguments, Children children)
+static std::shared_ptr<AbstractNode> builtin_polyhedron(const ModuleInstantiation *inst, Arguments arguments, Children children)
 {
-  auto node = new PolyhedronNode(inst);
+  auto node = std::make_shared<PolyhedronNode>(inst);
 
   if (!children.empty()) {
     LOG(message_group::Warning, inst->location(), arguments.documentRoot(),
@@ -689,9 +689,9 @@ const Geometry *SquareNode::createGeometry() const
   return p;
 }
 
-static AbstractNode *builtin_square(const ModuleInstantiation *inst, Arguments arguments, Children children)
+static std::shared_ptr<AbstractNode> builtin_square(const ModuleInstantiation *inst, Arguments arguments, Children children)
 {
-  auto node = new SquareNode(inst);
+  auto node = std::make_shared<SquareNode>(inst);
 
   if (!children.empty()) {
     LOG(message_group::Warning, inst->location(), arguments.documentRoot(),
@@ -768,9 +768,9 @@ const Geometry *CircleNode::createGeometry() const
   return p;
 }
 
-static AbstractNode *builtin_circle(const ModuleInstantiation *inst, Arguments arguments, Children children)
+static std::shared_ptr<AbstractNode> builtin_circle(const ModuleInstantiation *inst, Arguments arguments, Children children)
 {
-  auto node = new CircleNode(inst);
+  auto node = std::make_shared<CircleNode>(inst);
 
   if (!children.empty()) {
     LOG(message_group::Warning, inst->location(), arguments.documentRoot(),
@@ -876,9 +876,9 @@ const Geometry *PolygonNode::createGeometry() const
   return p;
 }
 
-static AbstractNode *builtin_polygon(const ModuleInstantiation *inst, Arguments arguments, Children children)
+static std::shared_ptr<AbstractNode> builtin_polygon(const ModuleInstantiation *inst, Arguments arguments, Children children)
 {
-  auto node = new PolygonNode(inst);
+  auto node = std::make_shared<PolygonNode>(inst);
 
   if (!children.empty()) {
     LOG(message_group::Warning, inst->location(), arguments.documentRoot(),

--- a/src/progress.cc
+++ b/src/progress.cc
@@ -3,10 +3,10 @@
 
 int progress_report_count;
 int _progress_mark;
-void (*progress_report_f)(const class AbstractNode *, void *, int);
+void (*progress_report_f)(const std::shared_ptr<const AbstractNode> &, void *, int);
 void *progress_report_userdata;
 
-void progress_report_prep(AbstractNode *root, void (*f)(const class AbstractNode *node, void *userdata, int mark), void *userdata)
+void progress_report_prep(const std::shared_ptr<AbstractNode> &root, void (*f)(const std::shared_ptr<const AbstractNode> &node, void *userdata, int mark), void *userdata)
 {
   progress_report_count = 0;
   progress_report_f = f;
@@ -21,7 +21,7 @@ void progress_report_fin()
   progress_report_userdata = nullptr;
 }
 
-void progress_update(const AbstractNode *node, int mark)
+void progress_update(const std::shared_ptr<const AbstractNode> &node, int mark)
 {
   if (progress_report_f) {
     _progress_mark = mark;
@@ -31,5 +31,5 @@ void progress_update(const AbstractNode *node, int mark)
 
 void progress_tick()
 {
-  if (progress_report_f) progress_report_f(nullptr, progress_report_userdata, ++_progress_mark);
+  if (progress_report_f) progress_report_f(std::shared_ptr<const AbstractNode>(), progress_report_userdata, ++_progress_mark);
 }

--- a/src/progress.h
+++ b/src/progress.h
@@ -1,14 +1,18 @@
 #pragma once
 
+#include <memory>
+
+class AbstractNode;
+
 // Reset to 0 in _prep() and increased for each Node instance in progress_prepare()
 extern int progress_report_count;
 
-extern void (*progress_report_f)(const class AbstractNode *, void *, int);
+extern void (*progress_report_f)(const std::shared_ptr<const AbstractNode> &, void *, int);
 extern void *progress_report_userdata;
 
-void progress_report_prep(AbstractNode *root, void (*f)(const class AbstractNode *node, void *userdata, int mark), void *userdata);
+void progress_report_prep(const std::shared_ptr<AbstractNode> &root, void (*f)(const std::shared_ptr<const AbstractNode> &node, void *userdata, int mark), void *userdata);
 void progress_report_fin();
-void progress_update(const AbstractNode *node, int mark);
+void progress_update(const std::shared_ptr<const AbstractNode> &node, int mark);
 // CGALUtils::applyUnion3D may process nodes out of order, so allow for an increment instead of tracking exact node
 void progress_tick();
 

--- a/src/projection.cc
+++ b/src/projection.cc
@@ -36,9 +36,9 @@
 #include <boost/assign/std/vector.hpp>
 using namespace boost::assign; // bring 'operator+=()' into scope
 
-static AbstractNode *builtin_projection(const ModuleInstantiation *inst, Arguments arguments, Children children)
+static std::shared_ptr<AbstractNode> builtin_projection(const ModuleInstantiation *inst, Arguments arguments, Children children)
 {
-  auto node = new ProjectionNode(inst);
+  auto node = std::make_shared<ProjectionNode>(inst);
 
   Parameters parameters = Parameters::parse(std::move(arguments), inst->location(), {"cut"}, {"convexity"});
   node->convexity = static_cast<int>(parameters["convexity"].toDouble());

--- a/src/render.cc
+++ b/src/render.cc
@@ -36,9 +36,9 @@
 #include <boost/assign/std/vector.hpp>
 using namespace boost::assign; // bring 'operator+=()' into scope
 
-static AbstractNode *builtin_render(const ModuleInstantiation *inst, Arguments arguments, Children children)
+static std::shared_ptr<AbstractNode> builtin_render(const ModuleInstantiation *inst, Arguments arguments, Children children)
 {
-  auto node = new RenderNode(inst);
+  auto node = std::make_shared<RenderNode>(inst);
 
   Parameters parameters = Parameters::parse(std::move(arguments), inst->location(), {"convexity"});
   if (parameters["convexity"].type() == Value::Type::NUMBER) {

--- a/src/roof.cc
+++ b/src/roof.cc
@@ -11,9 +11,9 @@
 #include "children.h"
 #include "roofnode.h"
 
-static AbstractNode *builtin_roof(const ModuleInstantiation *inst, Arguments arguments, Children children)
+static std::shared_ptr<AbstractNode> builtin_roof(const ModuleInstantiation *inst, Arguments arguments, Children children)
 {
-  auto node = new RoofNode(inst);
+  auto node = std::make_shared<RoofNode>(inst);
 
   Parameters parameters = Parameters::parse(std::move(arguments), inst->location(),
                                             {"method"},

--- a/src/rotateextrude.cc
+++ b/src/rotateextrude.cc
@@ -42,9 +42,9 @@ using namespace boost::assign; // bring 'operator+=()' into scope
 #include <boost/filesystem.hpp>
 namespace fs = boost::filesystem;
 
-static AbstractNode *builtin_rotate_extrude(const ModuleInstantiation *inst, Arguments arguments, Children children)
+static std::shared_ptr<AbstractNode> builtin_rotate_extrude(const ModuleInstantiation *inst, Arguments arguments, Children children)
 {
-  auto node = new RotateExtrudeNode(inst);
+  auto node = std::make_shared<RotateExtrudeNode>(inst);
 
   Parameters parameters = Parameters::parse(std::move(arguments), inst->location(),
                                             {"file", "layer", "origin", "scale"},

--- a/src/state.h
+++ b/src/state.h
@@ -8,7 +8,7 @@
 class State
 {
 public:
-  State(const class AbstractNode *parent)
+  State(const std::shared_ptr<const AbstractNode> &parent)
     : flags(NONE), parentnode(parent), numchildren(0) {
     this->matrix_ = Transform3d::Identity();
     this->color_.fill(-1.0f);
@@ -20,7 +20,7 @@ public:
   void setHighlight(bool on) { FLAG(this->flags, HIGHLIGHT, on); }
   void setBackground(bool on) { FLAG(this->flags, BACKGROUND, on); }
   void setNumChildren(unsigned int numc) { this->numchildren = numc; }
-  void setParent(const AbstractNode *parent) { this->parentnode = parent; }
+  void setParent(const std::shared_ptr<const AbstractNode> &parent) { this->parentnode = parent; }
   void setMatrix(const Transform3d& m) { this->matrix_ = m; }
   void setColor(const Color4f& c) { this->color_ = c; }
   void setPreferNef(bool on) { FLAG(this->flags, PREFERNEF, on); }
@@ -31,7 +31,7 @@ public:
   bool isHighlight() const { return this->flags & HIGHLIGHT; }
   bool isBackground() const { return this->flags & BACKGROUND; }
   unsigned int numChildren() const { return this->numchildren; }
-  const AbstractNode *parent() const { return this->parentnode; }
+  std::shared_ptr<const AbstractNode> parent() const { return this->parentnode; }
   const Transform3d& matrix() const { return this->matrix_; }
   const Color4f& color() const { return this->color_; }
 
@@ -46,7 +46,7 @@ private:
   };
 
   unsigned int flags;
-  const AbstractNode *parentnode;
+  std::shared_ptr<const AbstractNode> parentnode;
   unsigned int numchildren;
 
   // Transformation matrix and color. FIXME: Generalize such state variables?

--- a/src/surface.cc
+++ b/src/surface.cc
@@ -99,14 +99,14 @@ private:
   img_data_t read_png_or_dat(std::string filename) const;
 };
 
-static AbstractNode *builtin_surface(const ModuleInstantiation *inst, Arguments arguments, Children children)
+static std::shared_ptr<AbstractNode> builtin_surface(const ModuleInstantiation *inst, Arguments arguments, Children children)
 {
   if (!children.empty()) {
     LOG(message_group::Warning, inst->location(), arguments.documentRoot(),
         "module %1$s() does not support child modules", inst->name());
   }
 
-  auto node = new SurfaceNode(inst);
+  auto node = std::make_shared<SurfaceNode>(inst);
 
   Parameters parameters = Parameters::parse(std::move(arguments), inst->location(), {"file", "center", "convexity"}, {"invert"});
 

--- a/src/text.cc
+++ b/src/text.cc
@@ -38,14 +38,14 @@
 #include <boost/assign/std/vector.hpp>
 using namespace boost::assign; // bring 'operator+=()' into scope
 
-static AbstractNode *builtin_text(const ModuleInstantiation *inst, Arguments arguments, Children children)
+static std::shared_ptr<AbstractNode> builtin_text(const ModuleInstantiation *inst, Arguments arguments, Children children)
 {
   if (!children.empty()) {
     LOG(message_group::Warning, inst->location(), arguments.documentRoot(),
         "module %1$s() does not support child modules", inst->name());
   }
 
-  auto node = new TextNode(inst);
+  auto node = std::make_shared<TextNode>(inst);
 
   Parameters parameters = Parameters::parse(std::move(arguments), inst->location(),
                                             {"text", "size", "font"},

--- a/src/transform.cc
+++ b/src/transform.cc
@@ -48,9 +48,9 @@ enum class transform_type_e {
   MULTMATRIX
 };
 
-AbstractNode *builtin_scale(const ModuleInstantiation *inst, Arguments arguments, Children children)
+std::shared_ptr<AbstractNode> builtin_scale(const ModuleInstantiation *inst, Arguments arguments, Children children)
 {
-  auto node = new TransformNode(inst, "scale");
+  auto node = std::make_shared<TransformNode>(inst, "scale");
 
   Parameters parameters = Parameters::parse(std::move(arguments), inst->location(), {"v"});
 
@@ -73,9 +73,9 @@ AbstractNode *builtin_scale(const ModuleInstantiation *inst, Arguments arguments
   return children.instantiate(node);
 }
 
-AbstractNode *builtin_rotate(const ModuleInstantiation *inst, Arguments arguments, Children children)
+std::shared_ptr<AbstractNode> builtin_rotate(const ModuleInstantiation *inst, Arguments arguments, Children children)
 {
-  auto node = new TransformNode(inst, "rotate");
+  auto node = std::make_shared<TransformNode>(inst, "rotate");
 
   Parameters parameters = Parameters::parse(std::move(arguments), inst->location(), {"a", "v"});
 
@@ -152,9 +152,9 @@ AbstractNode *builtin_rotate(const ModuleInstantiation *inst, Arguments argument
   return children.instantiate(node);
 }
 
-AbstractNode *builtin_mirror(const ModuleInstantiation *inst, Arguments arguments, Children children)
+std::shared_ptr<AbstractNode> builtin_mirror(const ModuleInstantiation *inst, Arguments arguments, Children children)
 {
-  auto node = new TransformNode(inst, "mirror");
+  auto node = std::make_shared<TransformNode>(inst, "mirror");
 
   Parameters parameters = Parameters::parse(std::move(arguments), inst->location(), {"v"});
 
@@ -183,9 +183,9 @@ AbstractNode *builtin_mirror(const ModuleInstantiation *inst, Arguments argument
   return children.instantiate(node);
 }
 
-AbstractNode *builtin_translate(const ModuleInstantiation *inst, Arguments arguments, Children children)
+std::shared_ptr<AbstractNode> builtin_translate(const ModuleInstantiation *inst, Arguments arguments, Children children)
 {
-  auto node = new TransformNode(inst, "translate");
+  auto node = std::make_shared<TransformNode>(inst, "translate");
 
   Parameters parameters = Parameters::parse(std::move(arguments), inst->location(), {"v"});
 
@@ -201,9 +201,9 @@ AbstractNode *builtin_translate(const ModuleInstantiation *inst, Arguments argum
   return children.instantiate(node);
 }
 
-AbstractNode *builtin_multmatrix(const ModuleInstantiation *inst, Arguments arguments, Children children)
+std::shared_ptr<AbstractNode> builtin_multmatrix(const ModuleInstantiation *inst, Arguments arguments, Children children)
 {
-  auto node = new TransformNode(inst, "multmatrix");
+  auto node = std::make_shared<TransformNode>(inst, "multmatrix");
 
   Parameters parameters = Parameters::parse(std::move(arguments), inst->location(), {"m"});
 


### PR DESCRIPTION
This is a mostly mechanical refactoring meant to make it easier to transform the AST (stuff like https://github.com/openscad/openscad/pull/3637)

- No more naked AbstractNode pointers anywhere (nor explicit deletions).
- AbstractNode extends std::enable_shared_from_this for the occasion (so it can find itself and so visitors who only have a reference to it can also play the shared_ptr game).
- Threw a few autos in the mix.