### PR TITLE
Convert remaining instance of applyUnion3D in import_3mf.cc

### DIFF
--- a/src/import_3mf.cc
+++ b/src/import_3mf.cc
@@ -369,18 +369,21 @@ Geometry *import_3mf(const std::string& filename, const Location& loc)
   } else if (meshes.empty()) {
     return first_mesh;
   } else {
-    PolySet *p = new PolySet(3);
+    PolySet *p = nullptr;
 #ifdef ENABLE_CGAL
     Geometry::Geometries children;
     children.push_back(std::make_pair(std::shared_ptr<const AbstractNode>(),  shared_ptr<const Geometry>(first_mesh)));
     for (polysets_t::iterator it = meshes.begin(); it != meshes.end(); ++it) {
       children.push_back(std::make_pair(std::shared_ptr<const AbstractNode>(),  shared_ptr<const Geometry>(*it)));
     }
-    CGAL_Nef_polyhedron *N = CGALUtils::applyUnion3D(children.begin(), children.end());
-
-    CGALUtils::createPolySetFromNefPolyhedron3(*N->p3, *p);
-    delete N;
-#endif
+    if (auto ps = CGALUtils::getGeometryAsPolySet(CGALUtils::applyUnion3D(children.begin(), children.end()))) {
+      p = new PolySet(*ps);
+    } else {
+      p = new PolySet(3);
+    }
+#else
+    p = new PolySet(3);
+#endif // ifdef ENABLE_CGAL
     return p;
   }
 }


### PR DESCRIPTION
I wasn't able to build against lib3mf 2.2.0 because of this error:

```src/import_3mf.cc: In function ‘Geometry* import_3mf(const string&, const Location&)’:
src/import_3mf.cc:379:53: error: cannot convert >‘std::shared_ptr<const Geometry>’ to ‘CGAL_Nef_polyhedron*’ in initialization
379 |     CGAL_Nef_polyhedron *N = CGALUtils::applyUnion3D(children.begin(), children.end());
    |                              ~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    |                                                     |
    |                                                     std::shared_ptr<const Geometry>
```

I was able to fix it with this patch, and I think potentially this instance of the `applyUnion3D` call was missed in this commit: https://github.com/openscad/openscad/commit/3b822d59a3355415aabe72a64a77520392304db4