### PR TITLE
[fast-csg] Support for upcoming CGAL remeshing

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -65,6 +65,7 @@ if(APPLE)
 endif()
 
 option(ENABLE_TESTS "Run testsuite after building." ON)
+option(ENABLE_CGAL_REMESHING "Enable usage of CGAL's branch-experimental remeshing (https://github.com/CGAL/cgal/pull/5461)" OFF)
 set(SUFFIX "" CACHE STRING "Installation suffix for binary (e.g. 'nightly')")
 set(STACKSIZE 8388608 CACHE STRING "Stack size (default is 8MB)")
 
@@ -303,6 +304,9 @@ target_compile_definitions(OpenSCAD PRIVATE ENABLE_CGAL)
 # on bad geometry input.
 target_compile_definitions(OpenSCAD PRIVATE CGAL_DEBUG)
 target_compile_definitions(OpenSCAD PRIVATE CGAL_USE_GMPXX)
+if(ENABLE_CGAL_REMESHING)
+  target_compile_definitions(OpenSCAD PRIVATE ENABLE_CGAL_REMESHING)
+endif()
 if(TARGET CGAL::CGAL)
   list(APPEND COMMON_LIBRARIES CGAL::CGAL CGAL::CGAL_Core)
   message(STATUS "CGAL: Using target CGAL::CGAL CGAL::CGAL_Core")
@@ -718,6 +722,7 @@ set(CGAL_SOURCES
   src/cgalutils-orient.cc
   src/cgalutils-polyhedron.cc
   src/cgalutils-project.cc
+  src/cgalutils-repair.cc
   src/cgalutils-tess.cc
   src/cgalutils-triangulate.cc
   src/export_nef.cc

--- a/src/CGALHybridPolyhedron.cc
+++ b/src/CGALHybridPolyhedron.cc
@@ -5,6 +5,7 @@
 #include "hash.h"
 #include <CGAL/Surface_mesh.h>
 #include <CGAL/boost/graph/helpers.h>
+#include <CGAL/Polygon_mesh_processing/corefinement.h>
 #include <fstream>
 #include <sstream>
 #include <stdio.h>
@@ -16,6 +17,13 @@
 void cleanupMesh(CGALHybridPolyhedron::mesh_t& mesh, bool is_corefinement_result)
 {
   mesh.collect_garbage();
+
+#ifdef ENABLE_CGAL_REMESHING
+  if (is_corefinement_result) {
+    CGALUtils::remeshPlanarPatches(mesh);
+  }
+#endif // CGAL_REMESHING_AVAILABLE
+
 #if FAST_CSG_KERNEL_IS_LAZY
   // If exact corefinement callbacks are enabled, no need to make numbers exact here again.
   auto make_exact = 

--- a/src/CGALHybridPolyhedron.cc
+++ b/src/CGALHybridPolyhedron.cc
@@ -19,7 +19,7 @@ void cleanupMesh(CGALHybridPolyhedron::mesh_t& mesh, bool is_corefinement_result
   mesh.collect_garbage();
 
 #ifdef ENABLE_CGAL_REMESHING
-  if (is_corefinement_result) {
+  if (is_corefinement_result && Feature::ExperimentalFastCsgRemesh.is_enabled()) {
     CGALUtils::remeshPlanarPatches(mesh);
   }
 #endif // CGAL_REMESHING_AVAILABLE

--- a/src/cgalutils-mesh.cc
+++ b/src/cgalutils-mesh.cc
@@ -125,6 +125,13 @@ template void convertNefPolyhedronToTriangleMesh(const CGAL::Nef_polyhedron_3<CG
 void cleanupMesh(CGAL::Surface_mesh<CGAL::Point_3<CGAL_HybridKernel3>>& mesh, bool is_corefinement_result)
 {
   mesh.collect_garbage();
+
+#ifdef ENABLE_CGAL_REMESHING
+  if (is_corefinement_result && Feature::ExperimentalFastCsgRemesh.is_enabled()) {
+    CGALUtils::remeshPlanarPatches(mesh);
+  }
+#endif // ENABLE_CGAL_REMESHING
+
 #if FAST_CSG_KERNEL_IS_LAZY
   // If exact corefinement callbacks are enabled, no need to make numbers exact here again.
   auto make_exact =

--- a/src/cgalutils-repair.cc
+++ b/src/cgalutils-repair.cc
@@ -1,0 +1,21 @@
+// Portions of this file are Copyright 2021 Google LLC, and licensed under GPL2+. See COPYING.
+#include <CGAL/Exact_predicates_exact_constructions_kernel.h>
+#ifdef ENABLE_CGAL_REMESHING
+#include <CGAL/Polygon_mesh_processing/remesh_planar_patches.h>
+#endif
+#include <CGAL/Surface_mesh.h>
+
+namespace CGALUtils {
+
+#ifdef ENABLE_CGAL_REMESHING
+template <typename M>
+bool remeshPlanarPatches(M &mesh)
+{
+  CGAL::Polygon_mesh_processing::remesh_planar_patches(mesh);
+}
+
+template bool remeshPlanarPatches(CGAL::Surface_mesh<CGAL::Point_3<CGAL::Epeck>> &mesh);
+#endif
+
+} // namespace CGALUtils
+

--- a/src/cgalutils.h
+++ b/src/cgalutils.h
@@ -137,6 +137,10 @@ template <typename K>
 bool corefineAndComputeIntersection(CGAL::Surface_mesh<CGAL::Point_3<K>>& lhs, CGAL::Surface_mesh<CGAL::Point_3<K>>& rhs, CGAL::Surface_mesh<CGAL::Point_3<K>>& out);
 template <typename K>
 bool corefineAndComputeDifference(CGAL::Surface_mesh<CGAL::Point_3<K>>& lhs, CGAL::Surface_mesh<CGAL::Point_3<K>>& rhs, CGAL::Surface_mesh<CGAL::Point_3<K>>& out);
+#ifdef ENABLE_CGAL_REMESHING
+template <typename M>
+bool remeshPlanarPatches(M &mesh);
+#endif
 
 template <typename K>
 void convertNefPolyhedronToTriangleMesh(const CGAL::Nef_polyhedron_3<K>& nef, CGAL::Surface_mesh<CGAL::Point_3<K>>& mesh);

--- a/src/feature.cc
+++ b/src/feature.cc
@@ -37,6 +37,9 @@ const Feature Feature::ExperimentalFastCsgDebugCorefinement("fast-csg-debug-core
 const Feature Feature::ExperimentalFastCsgExact("fast-csg-exact", "Force lazy numbers to exact after each CSG operation.");
 const Feature Feature::ExperimentalFastCsgExactCorefinementCallback("fast-csg-exact-callbacks", "Same as fast-csg-exact but even forces exact numbers inside corefinement callbacks rather than at the end of each operation.");
 #endif // FAST_CSG_KERNEL_IS_LAZY
+#ifdef ENABLE_CGAL_REMESHING
+const Feature Feature::ExperimentalFastCsgRemesh("fast-csg-remesh", "Simplify meshes after each corefinement operation. HIGHLY RECOMMENDED esp for models that are hanging.");
+#endif // ENABLE_CGAL_REMESHING
 const Feature Feature::ExperimentalRoof("roof", "Enable <code>roof</code>");
 const Feature Feature::ExperimentalInputDriverDBus("input-driver-dbus", "Enable DBus input drivers (requires restart)");
 const Feature Feature::ExperimentalLazyUnion("lazy-union", "Enable lazy unions.");

--- a/src/feature.h
+++ b/src/feature.h
@@ -18,6 +18,7 @@ public:
   static const Feature ExperimentalFastCsgTrustCorefinement;
   static const Feature ExperimentalFastCsgDebugCorefinement;
   static const Feature ExperimentalFastCsgExact;
+  static const Feature ExperimentalFastCsgRemesh;
   static const Feature ExperimentalFastCsgExactCorefinementCallback;
   static const Feature ExperimentalRoof;
   static const Feature ExperimentalInputDriverDBus;


### PR DESCRIPTION
**Edit: https://github.com/openscad/openscad/pull/4117 (custom remeshing) might be a better option if it graduates**

Using https://github.com/CGAL/cgal/pull/5461 (`remesh_planar_patches` planned for CGAL 5.5) fixes performance issues caused by the worst-case increases of facets during corefinements.

The following files go from astronomically slow w/ `fast-csg` to 4-5x faster than the baseline:
- [pushpull handle cutout](https://pastebin.com/i8BFB0tY) (extracted from [markmaker/PushPullFeeder](https://github.com/markmaker/PushPullFeeder) reported [here](https://twitter.com/braincode/status/1491547378435854338))
- @t-paul's minkowski-based [cookie cutter](https://forum.openscad.org/Minkowski-Sum-and-Cookie-Cutter-td20733.html) 

The fix was originally suggested by @sloriot (author of both corefinement functions & that remesh PR) in https://github.com/openscad/openscad/pull/3641#issuecomment-781038017

Here are [instructions to build locally](https://gist.github.com/ochafik/28bde2491d1f8cc0992a51c8e6f25716) with both this PR and the CGAL one it depends on.