### PR TITLE
[fast-csg] Port minkowski to the hybrid fast-csg world

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -707,6 +707,7 @@ set(CGAL_SOURCES
   src/cgalutils.cc
   src/cgalutils-applyops.cc
   src/cgalutils-applyops-hybrid.cc
+  src/cgalutils-applyops-hybrid-minkowski.cc
   src/cgalutils-closed.cc
   src/cgalutils-convex.cc
   src/cgalutils-corefine.cc

--- a/src/CGALHybridPolyhedron.cc
+++ b/src/CGALHybridPolyhedron.cc
@@ -169,7 +169,7 @@ bool CGALHybridPolyhedron::canCorefineWith(const CGALHybridPolyhedron& other) co
   if (Feature::ExperimentalFastCsgTrustCorefinement.is_enabled()) {
     return true;
   }
-  const char* reasonWontCorefine = nullptr;
+  const char *reasonWontCorefine = nullptr;
   if (sharesAnyVertexWith(other)) {
     reasonWontCorefine = "operands share some vertices";
   } else if (!isManifold() || !other.isManifold()) {
@@ -308,7 +308,7 @@ bool CGALHybridPolyhedron::meshBinOp(
       rhsOut << opName << " " << opNumber << " rhs.off";
       lhsDebugDumpFile = lhsOut.str();
       rhsDebugDumpFile = rhsOut.str();
-      
+
       std::ofstream(lhsDebugDumpFile) << lhs;
       std::ofstream(rhsDebugDumpFile) << rhs;
     }

--- a/src/CGALHybridPolyhedron.cc
+++ b/src/CGALHybridPolyhedron.cc
@@ -9,30 +9,6 @@
 #include <sstream>
 #include <stdio.h>
 
-/**
- * Will force lazy coordinates to be exact to avoid subsequent performance issues
- * (only if the kernel is lazy), and will also collect the mesh's garbage if applicable.
- */
-void cleanupMesh(CGALHybridPolyhedron::mesh_t& mesh, bool is_corefinement_result)
-{
-  mesh.collect_garbage();
-#if FAST_CSG_KERNEL_IS_LAZY
-  // If exact corefinement callbacks are enabled, no need to make numbers exact here again.
-  auto make_exact = 
-    Feature::ExperimentalFastCsgExactCorefinementCallback.is_enabled()
-      ? !is_corefinement_result
-      : Feature::ExperimentalFastCsgExact.is_enabled();
-
-  if (make_exact) {
-    for (auto v : mesh.vertices()) {
-      auto &pt = mesh.point(v);
-      CGAL::exact(pt.x());
-      CGAL::exact(pt.y());
-      CGAL::exact(pt.z());
-    }
-  }
-#endif // FAST_CSG_KERNEL_IS_LAZY
-}
 
 CGALHybridPolyhedron::CGALHybridPolyhedron(const shared_ptr<nef_polyhedron_t>& nef)
 {
@@ -112,6 +88,7 @@ bool CGALHybridPolyhedron::isManifold() const
 {
   if (auto mesh = getMesh()) {
     // Note: haven't tried mesh->is_valid() but it could be too expensive.
+    // TODO: use is_valid_polygon_mesh and remember
     return CGAL::is_closed(*mesh);
   } else if (auto nef = getNefPolyhedron()) {
     return nef->is_simple();
@@ -225,7 +202,7 @@ void CGALHybridPolyhedron::transform(const Transform3d& mat)
 
     if (auto mesh = getMesh()) {
       CGALUtils::transform(*mesh, mat);
-      cleanupMesh(*mesh, /* is_corefinement_result */ false);
+      CGALUtils::cleanupMesh(*mesh, /* is_corefinement_result */ false);
     } else if (auto nef = getNefPolyhedron()) {
       CGALUtils::transform(*nef, mat);
     } else {
@@ -337,7 +314,7 @@ bool CGALHybridPolyhedron::meshBinOp(
     }
 
     if ((success = operation(lhs, rhs, lhs))) {
-      cleanupMesh(lhs, /* is_corefinement_result */ true);
+      CGALUtils::cleanupMesh(lhs, /* is_corefinement_result */ true);
 
       if (Feature::ExperimentalFastCsgDebugCorefinement.is_enabled()) {
         remove(lhsDebugDumpFile.c_str());
@@ -390,7 +367,7 @@ CGALHybridPolyhedron::mesh_t& CGALHybridPolyhedron::convertToMesh()
   } else if (auto nef = getNefPolyhedron()) {
     auto mesh = make_shared<mesh_t>();
     CGALUtils::convertNefPolyhedronToTriangleMesh(*nef, *mesh);
-    cleanupMesh(*mesh, /* is_corefinement_result */ false);
+    CGALUtils::cleanupMesh(*mesh, /* is_corefinement_result */ false);
     data = mesh;
     return *mesh;
   } else {

--- a/src/CGALHybridPolyhedron.cc
+++ b/src/CGALHybridPolyhedron.cc
@@ -45,16 +45,16 @@ CGALHybridPolyhedron::CGALHybridPolyhedron()
   data = make_shared<CGALHybridPolyhedron::mesh_t>();
 }
 
-CGALHybridPolyhedron::nef_polyhedron_t *CGALHybridPolyhedron::getNefPolyhedron() const
+std::shared_ptr<CGALHybridPolyhedron::nef_polyhedron_t> CGALHybridPolyhedron::getNefPolyhedron() const
 {
   auto pp = boost::get<shared_ptr<nef_polyhedron_t>>(&data);
-  return pp ? pp->get() : nullptr;
+  return pp ? *pp : nullptr;
 }
 
-CGALHybridPolyhedron::mesh_t *CGALHybridPolyhedron::getMesh() const
+std::shared_ptr<CGALHybridPolyhedron::mesh_t> CGALHybridPolyhedron::getMesh() const
 {
   auto pp = boost::get<shared_ptr<mesh_t>>(&data);
-  return pp ? pp->get() : nullptr;
+  return pp ? *pp : nullptr;
 }
 
 bool CGALHybridPolyhedron::isEmpty() const

--- a/src/CGALHybridPolyhedron.h
+++ b/src/CGALHybridPolyhedron.h
@@ -17,6 +17,9 @@ class Surface_mesh;
 namespace CGALUtils {
 std::shared_ptr<CGAL_Nef_polyhedron> createNefPolyhedronFromHybrid(
   const CGALHybridPolyhedron& hybrid);
+
+std::shared_ptr<const Geometry> applyMinkowskiHybrid(
+  const Geometry::Geometries& children);
 } // namespace CGALUtils
 
 /*! A mutable polyhedron backed by a CGAL::Surface_mesh and fast Polygon Mesh
@@ -84,6 +87,9 @@ private:
   // of polyhedra of two different kernels, which instantiates huge amounts of templates.
   friend std::shared_ptr<CGAL_Nef_polyhedron> CGALUtils::createNefPolyhedronFromHybrid(
     const CGALHybridPolyhedron& hybrid);
+
+  friend std::shared_ptr<const Geometry> CGALUtils::applyMinkowskiHybrid(
+    const Geometry::Geometries& children);
 
   /*! Runs a binary operation that operates on nef polyhedra, stores the result in
    * the first one and potentially mutates (e.g. corefines) the second. */

--- a/src/CGALHybridPolyhedron.h
+++ b/src/CGALHybridPolyhedron.h
@@ -117,10 +117,10 @@ private:
 
   /*! Returns the mesh if that's what's in the current data, or else nullptr.
    * Do NOT make this public. */
-  mesh_t *getMesh() const;
+  std::shared_ptr<mesh_t> getMesh() const;
   /*! Returns the nef polyhedron if that's what's in the current data, or else nullptr.
    * Do NOT make this public. */
-  nef_polyhedron_t *getNefPolyhedron() const;
+  std::shared_ptr<nef_polyhedron_t> getNefPolyhedron() const;
 
   bbox_t getExactBoundingBox() const;
 

--- a/src/cgalutils-applyops-hybrid-minkowski.cc
+++ b/src/cgalutils-applyops-hybrid-minkowski.cc
@@ -1,0 +1,261 @@
+// this file is split into many separate cgalutils* files
+// in order to workaround gcc 4.9.1 crashing on systems with only 2GB of RAM
+
+#ifdef ENABLE_CGAL
+
+#include "cgal.h"
+#include "cgalutils.h"
+#include "polyset.h"
+#include "printutils.h"
+#include "progress.h"
+#include "Polygon2d.h"
+#include "polyset-utils.h"
+#include "grid.h"
+#include "CGALHybridPolyhedron.h"
+#include "node.h"
+
+#include <CGAL/Exact_predicates_inexact_constructions_kernel.h>
+#include <CGAL/normal_vector_newell_3.h>
+#include <CGAL/Handle_hash_function.h>
+#include <CGAL/Surface_mesh.h>
+
+#include <CGAL/config.h>
+#include <CGAL/version.h>
+
+#include <CGAL/convex_hull_3.h>
+
+#include "memory.h"
+#include "svg.h"
+#include "Reindexer.h"
+#include "GeometryUtils.h"
+
+#include <map>
+#include <queue>
+#include <unordered_set>
+
+namespace CGALUtils {
+
+/*!
+   children cannot contain nullptr objects
+ */
+shared_ptr<const Geometry> applyMinkowskiHybrid(const Geometry::Geometries& children)
+{
+  // TODO: use Surface_mesh everywhere!!!
+  typedef CGAL::Epick Hull_kernel;
+  typedef CGAL::Polyhedron_3<CGAL_HybridKernel3> Hybrid_Polyhedron;
+  typedef CGAL::Polyhedron_3<Hull_kernel>        Hull_Polyhedron;
+  typedef CGAL::Nef_polyhedron_3<CGAL_HybridKernel3> Hybrid_Nef;
+
+  CGAL::Timer t, t_tot;
+  assert(children.size() >= 2);
+  Geometry::Geometries::const_iterator it = children.begin();
+  t_tot.start();
+  shared_ptr<const Geometry> operands[2] = {it->second, shared_ptr<const Geometry>()};
+  try {
+    while (++it != children.end()) {
+      operands[1] = it->second;
+
+      std::list<shared_ptr<Hybrid_Polyhedron>> P[2];
+      std::list<shared_ptr<Hull_Polyhedron>> result_parts;
+
+      for (size_t i = 0; i < 2; ++i) {
+        auto poly = make_shared<Hybrid_Polyhedron>();
+
+        auto ps = dynamic_pointer_cast<const PolySet>(operands[i]);
+        auto hybrid = CGALUtils::getHybridPolyhedronFromGeometry(operands[i]);
+        if (!hybrid) throw 0;
+
+        if (ps) CGALUtils::createPolyhedronFromPolySet(*ps, *poly);
+        else if (auto nef = hybrid->getNefPolyhedron()) {
+          if (nef->is_simple()) CGALUtils::convertNefToPolyhedron(*nef, *poly);
+          else throw 0;
+        }  
+        else if (auto mesh = hybrid->getMesh()) {
+          if (CGAL::is_valid_polygon_mesh(*mesh)) CGAL::copy_face_graph(*mesh, *poly);
+          else throw 0;
+        }  
+        else throw 0;
+
+        if ((ps && ps->is_convex()) ||
+            (!ps && CGALUtils::is_weakly_convex(*poly))) {
+          PRINTDB("Minkowski: child %d is convex and %s", i % (ps?"PolySet":"Hybrid"));
+          P[i].push_back(poly);
+        } else {
+          PRINTDB("Minkowski: child %d is nonconvex, decomposing...", i);
+          shared_ptr<Hybrid_Nef> decomposed_nef;
+
+          if (auto mesh = hybrid->getMesh()) {
+            decomposed_nef = make_shared<Hybrid_Nef>(*mesh);
+          } else if (auto nef = hybrid->getNefPolyhedron()) {
+            decomposed_nef = make_shared<Hybrid_Nef>(*nef);
+          }
+
+          t.start();
+          CGAL::convex_decomposition_3(*decomposed_nef);
+
+          // the first volume is the outer volume, which ignored in the decomposition
+          Hybrid_Nef::Volume_const_iterator ci = ++decomposed_nef->volumes_begin();
+          for (; ci != decomposed_nef->volumes_end(); ++ci) {
+            if (ci->mark()) {
+              auto poly = make_shared<Hybrid_Polyhedron>();
+              decomposed_nef->convert_inner_shell_to_polyhedron(ci->shells_begin(), *poly);
+              P[i].push_back(poly);
+            }
+          }
+
+          PRINTDB("Minkowski: decomposed into %d convex parts", P[i].size());
+          t.stop();
+          PRINTDB("Minkowski: decomposition took %f s", t.time());
+        }
+      }
+
+      std::vector<Hull_kernel::Point_3> points[2];
+      std::vector<Hull_kernel::Point_3> minkowski_points;
+
+      CGAL::Cartesian_converter<CGAL_HybridKernel3, Hull_kernel> conv;
+
+      for (size_t i = 0; i < P[0].size(); ++i) {
+        for (size_t j = 0; j < P[1].size(); ++j) {
+          t.start();
+          points[0].clear();
+          points[1].clear();
+
+          for (int k = 0; k < 2; ++k) {
+            auto it = P[k].begin();
+            std::advance(it, k == 0?i:j);
+
+            auto& poly = *it;
+            points[k].reserve(poly->size_of_vertices());
+
+            for (auto pi = poly->vertices_begin(); pi != poly->vertices_end(); ++pi) {
+              Hybrid_Polyhedron::Point_3 const& p = pi->point();
+              points[k].push_back(conv(p));
+            }
+          }
+
+          minkowski_points.clear();
+          minkowski_points.reserve(points[0].size() * points[1].size());
+          for (size_t i = 0; i < points[0].size(); ++i) {
+            for (size_t j = 0; j < points[1].size(); ++j) {
+              minkowski_points.push_back(points[0][i] + (points[1][j] - CGAL::ORIGIN));
+            }
+          }
+
+          if (minkowski_points.size() <= 3) {
+            t.stop();
+            continue;
+          }
+
+          auto result = make_shared<Hull_Polyhedron>();
+          t.stop();
+          PRINTDB("Minkowski: Point cloud creation (%d ⨉ %d -> %d) took %f ms", points[0].size() % points[1].size() % minkowski_points.size() % (t.time() * 1000));
+          t.reset();
+
+          t.start();
+
+          CGAL::convex_hull_3(minkowski_points.begin(), minkowski_points.end(), *result);
+
+          std::vector<Hull_kernel::Point_3> strict_points;
+          strict_points.reserve(minkowski_points.size());
+
+          for (auto i = result->vertices_begin(); i != result->vertices_end(); ++i) {
+            auto& p = i->point();
+
+            auto h = i->halfedge();
+            auto e = h;
+            bool collinear = false;
+            bool coplanar = true;
+
+            do {
+              auto& q = h->opposite()->vertex()->point();
+              if (coplanar && !CGAL::coplanar(p, q,
+                                              h->next_on_vertex()->opposite()->vertex()->point(),
+                                              h->next_on_vertex()->next_on_vertex()->opposite()->vertex()->point())) {
+                coplanar = false;
+              }
+
+
+              for (auto j = h->next_on_vertex();
+                   j != h && !collinear && !coplanar;
+                   j = j->next_on_vertex()) {
+
+                auto& r = j->opposite()->vertex()->point();
+                if (CGAL::collinear(p, q, r)) {
+                  collinear = true;
+                }
+              }
+
+              h = h->next_on_vertex();
+            } while (h != e && !collinear);
+
+            if (!collinear && !coplanar) strict_points.push_back(p);
+          }
+
+          result->clear();
+          CGAL::convex_hull_3(strict_points.begin(), strict_points.end(), *result);
+
+
+          t.stop();
+          PRINTDB("Minkowski: Computing convex hull took %f s", t.time());
+          t.reset();
+
+          result_parts.push_back(result);
+        }
+      }
+
+      if (it != std::next(children.begin())) operands[0].reset();
+
+      auto partToGeom = [&](auto &poly) -> shared_ptr<const Geometry> {
+        auto mesh = make_shared<CGALHybridPolyhedron::mesh_t>();
+        CGAL::copy_face_graph(*poly, *mesh);
+        CGALUtils::triangulateFaces(*mesh);
+        return make_shared<CGALHybridPolyhedron>(mesh);
+      };
+
+      if (result_parts.size() == 1) {
+        operands[0] = partToGeom(*result_parts.begin());
+      } else if (!result_parts.empty()) {
+        t.start();
+        PRINTDB("Minkowski: Computing union of %d parts", result_parts.size());
+        Geometry::Geometries fake_children;
+        for (const auto& part : result_parts) {
+          fake_children.push_back(std::make_pair(std::shared_ptr<const AbstractNode>(),
+                                                 partToGeom(part)));
+        }
+        auto N = CGALUtils::applyUnion3D(fake_children.begin(), fake_children.end());
+        // FIXME: This should really never throw.
+        // Assert once we figured out what went wrong with issue #1069?
+        if (!N) throw 0;
+        t.stop();
+        PRINTDB("Minkowski: Union done: %f s", t.time());
+        t.reset();
+        operands[0] = N;
+      } else {
+        operands[0] = shared_ptr<const Geometry>(new CGAL_Nef_polyhedron());
+      }
+    }
+
+    t_tot.stop();
+    PRINTDB("Minkowski: Total execution time %f s", t_tot.time());
+    t_tot.reset();
+    return operands[0];
+  } catch (const std::exception& e) {
+    LOG(message_group::Warning, Location::NONE, "",
+        "[fast-csg] Minkowski failed with error, falling back to Nef operation: %1$s\n", e.what());
+
+    auto N = shared_ptr<const Geometry>(applyOperator3D(children, OpenSCADOperator::MINKOWSKI));
+    return N;
+  }
+}
+}  // namespace CGALUtils
+
+
+#endif // ENABLE_CGAL
+
+
+
+
+
+
+
+

--- a/src/cgalutils-applyops-hybrid-minkowski.cc
+++ b/src/cgalutils-applyops-hybrid-minkowski.cc
@@ -43,7 +43,7 @@ shared_ptr<const Geometry> applyMinkowskiHybrid(const Geometry::Geometries& chil
   // TODO: use Surface_mesh everywhere!!!
   typedef CGAL::Epick Hull_kernel;
   typedef CGAL::Polyhedron_3<CGAL_HybridKernel3> Hybrid_Polyhedron;
-  typedef CGAL::Polyhedron_3<Hull_kernel>        Hull_Polyhedron;
+  typedef CGAL::Polyhedron_3<Hull_kernel> Hull_Polyhedron;
   typedef CGAL::Nef_polyhedron_3<CGAL_HybridKernel3> Hybrid_Nef;
 
   CGAL::Timer t, t_tot;
@@ -69,12 +69,10 @@ shared_ptr<const Geometry> applyMinkowskiHybrid(const Geometry::Geometries& chil
         else if (auto nef = hybrid->getNefPolyhedron()) {
           if (nef->is_simple()) CGALUtils::convertNefToPolyhedron(*nef, *poly);
           else throw 0;
-        }  
-        else if (auto mesh = hybrid->getMesh()) {
+        } else if (auto mesh = hybrid->getMesh())   {
           if (CGAL::is_valid_polygon_mesh(*mesh)) CGAL::copy_face_graph(*mesh, *poly);
           else throw 0;
-        }  
-        else throw 0;
+        } else throw 0;
 
         if ((ps && ps->is_convex()) ||
             (!ps && CGALUtils::is_weakly_convex(*poly))) {
@@ -205,12 +203,12 @@ shared_ptr<const Geometry> applyMinkowskiHybrid(const Geometry::Geometries& chil
 
       if (it != std::next(children.begin())) operands[0].reset();
 
-      auto partToGeom = [&](auto &poly) -> shared_ptr<const Geometry> {
-        auto mesh = make_shared<CGALHybridPolyhedron::mesh_t>();
-        CGAL::copy_face_graph(*poly, *mesh);
-        CGALUtils::triangulateFaces(*mesh);
-        return make_shared<CGALHybridPolyhedron>(mesh);
-      };
+      auto partToGeom = [&](auto& poly) -> shared_ptr<const Geometry> {
+          auto mesh = make_shared<CGALHybridPolyhedron::mesh_t>();
+          CGAL::copy_face_graph(*poly, *mesh);
+          CGALUtils::triangulateFaces(*mesh);
+          return make_shared<CGALHybridPolyhedron>(mesh);
+        };
 
       if (result_parts.size() == 1) {
         operands[0] = partToGeom(*result_parts.begin());

--- a/src/cgalutils-applyops-hybrid.cc
+++ b/src/cgalutils-applyops-hybrid.cc
@@ -8,7 +8,7 @@
 #include "node.h"
 #include "progress.h"
 
-Location getLocation(const std::shared_ptr<const AbstractNode> &node)
+Location getLocation(const std::shared_ptr<const AbstractNode>& node)
 {
   return node && node->modinst ? node->modinst->location() : Location::NONE;
 }

--- a/src/cgalutils-applyops-hybrid.cc
+++ b/src/cgalutils-applyops-hybrid.cc
@@ -43,7 +43,7 @@ shared_ptr<CGALHybridPolyhedron> applyUnion3DHybrid(
       if (!chgeom || chgeom->isEmpty()) {
         continue;
       }
-      auto poly = CGALUtils::createHybridPolyhedronFromGeometry(*chgeom);
+      auto poly = CGALUtils::createMutableHybridPolyhedronFromGeometry(chgeom);
       if (!poly) {
         continue;
       }
@@ -92,7 +92,7 @@ shared_ptr<CGALHybridPolyhedron> applyOperator3DHybrid(const Geometry::Geometrie
 
   try {
     for (const auto& item : children) {
-      auto chN = item.second ? CGALUtils::createHybridPolyhedronFromGeometry(*item.second) : nullptr;
+      auto chN = item.second ? CGALUtils::createMutableHybridPolyhedronFromGeometry(item.second) : nullptr;
       // Initialize N with first expected geometric object
       if (!foundFirst) {
         if (chN) {

--- a/src/cgalutils-applyops.cc
+++ b/src/cgalutils-applyops.cc
@@ -231,6 +231,9 @@ bool applyHull(const Geometry::Geometries& children, PolySet& result)
  */
 shared_ptr<const Geometry> applyMinkowski(const Geometry::Geometries& children)
 {
+  if (Feature::ExperimentalFastCsg.is_enabled()) {
+    return applyMinkowskiHybrid(children);
+  }
   CGAL::Timer t, t_tot;
   assert(children.size() >= 2);
   Geometry::Geometries::const_iterator it = children.begin();

--- a/src/cgalutils-applyops.cc
+++ b/src/cgalutils-applyops.cc
@@ -392,11 +392,11 @@ shared_ptr<const Geometry> applyMinkowski(const Geometry::Geometries& children)
 
       if (it != std::next(children.begin())) operands[0].reset();
 
-      auto partToGeom = [&](auto &poly) -> shared_ptr<const Geometry> {
-        PolySet *ps = new PolySet(3, /* convex= */ true);
-        createPolySetFromPolyhedron(poly, *ps);
-        return shared_ptr<const Geometry>(ps);
-      };
+      auto partToGeom = [&](auto& poly) -> shared_ptr<const Geometry> {
+          PolySet *ps = new PolySet(3, /* convex= */ true);
+          createPolySetFromPolyhedron(poly, *ps);
+          return shared_ptr<const Geometry>(ps);
+        };
 
       if (result_parts.size() == 1) {
         operands[0] = partToGeom(*result_parts.begin());

--- a/src/cgalutils-convex.cc
+++ b/src/cgalutils-convex.cc
@@ -56,15 +56,15 @@ bool is_weakly_convex(const CGAL::Surface_mesh<CGAL::Point_3<K>>& m) {
 
   for (auto i : m.halfedges()) {
     CGAL::Plane_3<K> p(
-        m.point(m.target(m.opposite(i))),
-        m.point(m.target(i)),
-        m.point(m.target(m.next(i))));
+      m.point(m.target(m.opposite(i))),
+      m.point(m.target(i)),
+      m.point(m.target(m.next(i))));
     auto pt = m.point(m.target(m.next(m.opposite(i))));
     if (p.has_on_positive_side(pt) && CGAL::squared_distance(p, pt) > 1e-8) {
       return false;
     }
   }
-                        
+
   // Also make sure that there is only one shell:
   std::unordered_set<typename Mesh::Face_index, typename CGAL::Handle_hash_function> visited;
   visited.reserve(m.number_of_faces());
@@ -78,7 +78,7 @@ bool is_weakly_convex(const CGAL::Surface_mesh<CGAL::Point_3<K>>& m) {
     to_explore.pop();
 
     CGAL::Halfedge_around_face_iterator<Mesh> he, end;
-    for (boost::tie(he, end) = CGAL::halfedges_around_face(m.halfedge(f), m); he != end; ++he){
+    for (boost::tie(he, end) = CGAL::halfedges_around_face(m.halfedge(f), m); he != end; ++he) {
       typename Mesh::Face_index o = m.face(m.opposite(*he));
 
       if (!visited.count(o)) {

--- a/src/cgalutils-convex.cc
+++ b/src/cgalutils-convex.cc
@@ -91,6 +91,7 @@ bool is_weakly_convex(const CGAL::Surface_mesh<CGAL::Point_3<K>>& m) {
   return visited.size() == m.number_of_faces();
 }
 
+template bool is_weakly_convex(const CGAL::Polyhedron_3<CGAL_HybridKernel3>& p);
 template bool is_weakly_convex(const CGAL::Surface_mesh<CGAL::Point_3<CGAL_HybridKernel3>>& p);
 
 }  // namespace CGALUtils

--- a/src/cgalutils-hybrid.cc
+++ b/src/cgalutils-hybrid.cc
@@ -66,14 +66,11 @@ std::shared_ptr<CGALHybridPolyhedron> createMutableHybridPolyhedronFromGeometry(
 {
   if (auto poly = dynamic_pointer_cast<const CGALHybridPolyhedron>(geom)) {
     return make_shared<CGALHybridPolyhedron>(*poly);
-  }
-  else if (auto ps = dynamic_pointer_cast<const PolySet>(geom)) {
+  } else if (auto ps = dynamic_pointer_cast<const PolySet>(geom))   {
     return createHybridPolyhedronFromPolySet(*ps);
-  }
-  else if (auto nef = dynamic_pointer_cast<const CGAL_Nef_polyhedron>(geom)) {
+  } else if (auto nef = dynamic_pointer_cast<const CGAL_Nef_polyhedron>(geom))   {
     return createHybridPolyhedronFromNefPolyhedron(*nef);
-  }
-  else {
+  } else {
     LOG(message_group::Warning, Location::NONE, "", "Unsupported geometry format.");
     return nullptr;
   }
@@ -83,8 +80,7 @@ std::shared_ptr<const CGALHybridPolyhedron> getHybridPolyhedronFromGeometry(cons
 {
   if (auto poly = dynamic_pointer_cast<const CGALHybridPolyhedron>(geom)) {
     return poly;
-  }
-  else {
+  } else {
     return createMutableHybridPolyhedronFromGeometry(geom);
   }
 }

--- a/src/cgalutils-hybrid.cc
+++ b/src/cgalutils-hybrid.cc
@@ -62,18 +62,30 @@ std::shared_ptr<CGALHybridPolyhedron> createHybridPolyhedronFromNefPolyhedron(co
   return make_shared<CGALHybridPolyhedron>(mesh);
 }
 
-std::shared_ptr<CGALHybridPolyhedron> createHybridPolyhedronFromGeometry(const Geometry& geom)
+std::shared_ptr<CGALHybridPolyhedron> createMutableHybridPolyhedronFromGeometry(const std::shared_ptr<const Geometry>& geom)
 {
-  if (auto poly = dynamic_cast<const CGALHybridPolyhedron *>(&geom)) {
+  if (auto poly = dynamic_pointer_cast<const CGALHybridPolyhedron>(geom)) {
     return make_shared<CGALHybridPolyhedron>(*poly);
-  } else if (auto ps = dynamic_cast<const PolySet *>(&geom)) {
+  }
+  else if (auto ps = dynamic_pointer_cast<const PolySet>(geom)) {
     return createHybridPolyhedronFromPolySet(*ps);
   }
-  if (auto nef = dynamic_cast<const CGAL_Nef_polyhedron *>(&geom)) {
+  else if (auto nef = dynamic_pointer_cast<const CGAL_Nef_polyhedron>(geom)) {
     return createHybridPolyhedronFromNefPolyhedron(*nef);
-  } else {
+  }
+  else {
     LOG(message_group::Warning, Location::NONE, "", "Unsupported geometry format.");
     return nullptr;
+  }
+}
+
+std::shared_ptr<const CGALHybridPolyhedron> getHybridPolyhedronFromGeometry(const std::shared_ptr<const Geometry>& geom)
+{
+  if (auto poly = dynamic_pointer_cast<const CGALHybridPolyhedron>(geom)) {
+    return poly;
+  }
+  else {
+    return createMutableHybridPolyhedronFromGeometry(geom);
   }
 }
 

--- a/src/cgalutils-hybrid.cc
+++ b/src/cgalutils-hybrid.cc
@@ -13,6 +13,21 @@
 
 namespace CGALUtils {
 
+template <typename K>
+std::shared_ptr<CGALHybridPolyhedron> createHybridPolyhedronFromPolyhedron(const CGAL::Polyhedron_3<K>& poly)
+{
+  CGAL::Surface_mesh<CGAL::Point_3<K>> mesh;
+  CGAL::copy_face_graph(poly, mesh);
+
+  auto hybrid_mesh = make_shared<CGALHybridPolyhedron::mesh_t>();
+  copyMesh(mesh, *hybrid_mesh);
+  CGALUtils::triangulateFaces(*hybrid_mesh);
+
+  return make_shared<CGALHybridPolyhedron>(hybrid_mesh);
+}
+
+template std::shared_ptr<CGALHybridPolyhedron> createHybridPolyhedronFromPolyhedron(const CGAL::Polyhedron_3<CGAL::Epick>& poly);
+
 std::shared_ptr<CGALHybridPolyhedron> createHybridPolyhedronFromPolySet(const PolySet& ps)
 {
   auto mesh = make_shared<CGALHybridPolyhedron::mesh_t>();

--- a/src/cgalutils-mesh.cc
+++ b/src/cgalutils-mesh.cc
@@ -118,5 +118,30 @@ void convertNefPolyhedronToTriangleMesh(const CGAL::Nef_polyhedron_3<K>& nef, CG
 template void convertNefPolyhedronToTriangleMesh(const CGAL::Nef_polyhedron_3<CGAL_Kernel3>& nef, CGAL::Surface_mesh<CGAL::Point_3<CGAL_Kernel3>>& mesh);
 template void convertNefPolyhedronToTriangleMesh(const CGAL::Nef_polyhedron_3<CGAL_HybridKernel3>& nef, CGAL::Surface_mesh<CGAL::Point_3<CGAL_HybridKernel3>>& mesh);
 
+/**
+ * Will force lazy coordinates to be exact to avoid subsequent performance issues
+ * (only if the kernel is lazy), and will also collect the mesh's garbage if applicable.
+ */
+void cleanupMesh(CGAL::Surface_mesh<CGAL::Point_3<CGAL_HybridKernel3>>& mesh, bool is_corefinement_result)
+{
+  mesh.collect_garbage();
+#if FAST_CSG_KERNEL_IS_LAZY
+  // If exact corefinement callbacks are enabled, no need to make numbers exact here again.
+  auto make_exact = 
+    Feature::ExperimentalFastCsgExactCorefinementCallback.is_enabled()
+      ? !is_corefinement_result
+      : Feature::ExperimentalFastCsgExact.is_enabled();
+
+  if (make_exact) {
+    for (auto v : mesh.vertices()) {
+      auto &pt = mesh.point(v);
+      CGAL::exact(pt.x());
+      CGAL::exact(pt.y());
+      CGAL::exact(pt.z());
+    }
+  }
+#endif // FAST_CSG_KERNEL_IS_LAZY
+}
+
 } // namespace CGALUtils
 

--- a/src/cgalutils-mesh.cc
+++ b/src/cgalutils-mesh.cc
@@ -105,6 +105,9 @@ template void copyMesh(
 template void copyMesh(
   const CGAL::Surface_mesh<CGAL::Point_3<CGAL_HybridKernel3>>& input,
   CGAL::Surface_mesh<CGAL_Point_3>& output);
+template void copyMesh(
+  const CGAL::Surface_mesh<CGAL::Point_3<CGAL::Epick>>& input,
+  CGAL::Surface_mesh<CGAL::Point_3<CGAL::Epeck>>& output);
 
 template <typename K>
 void convertNefPolyhedronToTriangleMesh(const CGAL::Nef_polyhedron_3<K>& nef, CGAL::Surface_mesh<CGAL::Point_3<K>>& mesh)

--- a/src/cgalutils-mesh.cc
+++ b/src/cgalutils-mesh.cc
@@ -127,14 +127,14 @@ void cleanupMesh(CGAL::Surface_mesh<CGAL::Point_3<CGAL_HybridKernel3>>& mesh, bo
   mesh.collect_garbage();
 #if FAST_CSG_KERNEL_IS_LAZY
   // If exact corefinement callbacks are enabled, no need to make numbers exact here again.
-  auto make_exact = 
+  auto make_exact =
     Feature::ExperimentalFastCsgExactCorefinementCallback.is_enabled()
       ? !is_corefinement_result
       : Feature::ExperimentalFastCsgExact.is_enabled();
 
   if (make_exact) {
     for (auto v : mesh.vertices()) {
-      auto &pt = mesh.point(v);
+      auto& pt = mesh.point(v);
       CGAL::exact(pt.x());
       CGAL::exact(pt.y());
       CGAL::exact(pt.z());

--- a/src/cgalutils-polyhedron.cc
+++ b/src/cgalutils-polyhedron.cc
@@ -221,7 +221,7 @@ struct Copy_polyhedron_to : public CGAL::Modifier_base<typename CGAL::Polyhedron
       do {
         builder.add_vertex_to_facet(index[hc->vertex()]);
         ++hc;
-      } while(hc != hc_end);
+      } while (hc != hc_end);
       builder.end_facet();
     }
     builder.end_surface();

--- a/src/cgalutils-polyhedron.cc
+++ b/src/cgalutils-polyhedron.cc
@@ -258,6 +258,7 @@ void convertNefToPolyhedron(
 }
 
 template void convertNefToPolyhedron(const CGAL_Nef_polyhedron3& nef, CGAL_Polyhedron& polyhedron);
+template void convertNefToPolyhedron(const CGAL::Nef_polyhedron_3<CGAL_HybridKernel3>& nef, CGAL::Polyhedron_3<CGAL_HybridKernel3>& polyhedron);
 
 template <typename Polyhedron>
 bool createPolyhedronFromPolySet(const PolySet& ps, Polyhedron& p)
@@ -275,6 +276,7 @@ bool createPolyhedronFromPolySet(const PolySet& ps, Polyhedron& p)
 
 template bool createPolyhedronFromPolySet(const PolySet& ps, CGAL_Polyhedron& p);
 template bool createPolyhedronFromPolySet(const PolySet& ps, CGAL::Polyhedron_3<CGAL::Epick>& p);
+template bool createPolyhedronFromPolySet(const PolySet& ps, CGAL::Polyhedron_3<CGAL::Epeck>& p);
 
 template <typename Polyhedron>
 bool createPolySetFromPolyhedron(const Polyhedron& p, PolySet& ps)

--- a/src/cgalutils.h
+++ b/src/cgalutils.h
@@ -146,4 +146,5 @@ bool corefineAndComputeDifference(CGAL::Surface_mesh<CGAL::Point_3<K>>& lhs, CGA
 
 template <typename K>
 void convertNefPolyhedronToTriangleMesh(const CGAL::Nef_polyhedron_3<K>& nef, CGAL::Surface_mesh<CGAL::Point_3<K>>& mesh);
+void cleanupMesh(CGAL::Surface_mesh<CGAL::Point_3<CGAL_HybridKernel3>>& mesh, bool is_corefinement_result);
 } // namespace CGALUtils

--- a/src/cgalutils.h
+++ b/src/cgalutils.h
@@ -73,7 +73,7 @@ bool createMeshFromPolySet(const PolySet& ps, CGAL::Surface_mesh<CGAL::Point_3<K
 
 template <typename K>
 bool createPolySetFromNefPolyhedron3(const CGAL::Nef_polyhedron_3<K>& N, PolySet& ps);
-shared_ptr<CGAL_Nef_polyhedron> createNefPolyhedronFromGeometry(const class Geometry& geom);
+shared_ptr<CGAL_Nef_polyhedron> createNefPolyhedronFromGeometry(const class Geometry &geom);
 shared_ptr<const PolySet> getGeometryAsPolySet(const shared_ptr<const Geometry>&);
 shared_ptr<const CGAL_Nef_polyhedron> getGeometryAsNefPolyhedron(const shared_ptr<const Geometry>&);
 

--- a/src/cgalutils.h
+++ b/src/cgalutils.h
@@ -37,6 +37,8 @@ namespace CGALUtils {
 bool applyHull(const Geometry::Geometries& children, PolySet& P);
 template <typename K>
 bool is_weakly_convex(const CGAL::Polyhedron_3<K>& p);
+template <typename K>
+bool is_weakly_convex(const CGAL::Surface_mesh<CGAL::Point_3<K>>& m);
 shared_ptr<const Geometry> applyOperator3D(const Geometry::Geometries& children, OpenSCADOperator op);
 shared_ptr<const Geometry> applyUnion3D(Geometry::Geometries::iterator chbegin, Geometry::Geometries::iterator chend);
 shared_ptr<CGALHybridPolyhedron> applyOperator3DHybrid(const Geometry::Geometries& children, OpenSCADOperator op);
@@ -54,6 +56,7 @@ CGAL_Iso_cuboid_3 boundingBox(const Geometry& geom);
 CGAL_Iso_cuboid_3 createIsoCuboidFromBoundingBox(const BoundingBox& bbox);
 bool is_approximately_convex(const PolySet& ps);
 shared_ptr<const Geometry> applyMinkowski(const Geometry::Geometries& children);
+shared_ptr<const Geometry> applyMinkowskiHybrid(const Geometry::Geometries& children);
 
 template <typename Polyhedron> bool createPolySetFromPolyhedron(const Polyhedron& p, PolySet& ps);
 template <class InputKernel, class OutputKernel>

--- a/src/cgalutils.h
+++ b/src/cgalutils.h
@@ -108,7 +108,8 @@ getCartesianConverter()
     FromKernel, ToKernel, KernelConverter<FromKernel, ToKernel>>();
 }
 shared_ptr<CGAL_Nef_polyhedron> createNefPolyhedronFromHybrid(const CGALHybridPolyhedron& hybrid);
-std::shared_ptr<CGALHybridPolyhedron> createHybridPolyhedronFromGeometry(const Geometry& geom);
+std::shared_ptr<CGALHybridPolyhedron> createMutableHybridPolyhedronFromGeometry(const std::shared_ptr<const Geometry>& geom);
+std::shared_ptr<const CGALHybridPolyhedron> getHybridPolyhedronFromGeometry(const std::shared_ptr<const Geometry>& geom);
 template <typename K>
 std::shared_ptr<CGALHybridPolyhedron> createHybridPolyhedronFromPolyhedron(const CGAL::Polyhedron_3<K>& poly);
 template <typename Polyhedron>

--- a/src/cgalutils.h
+++ b/src/cgalutils.h
@@ -109,6 +109,8 @@ getCartesianConverter()
 }
 shared_ptr<CGAL_Nef_polyhedron> createNefPolyhedronFromHybrid(const CGALHybridPolyhedron& hybrid);
 std::shared_ptr<CGALHybridPolyhedron> createHybridPolyhedronFromGeometry(const Geometry& geom);
+template <typename K>
+std::shared_ptr<CGALHybridPolyhedron> createHybridPolyhedronFromPolyhedron(const CGAL::Polyhedron_3<K>& poly);
 template <typename Polyhedron>
 void triangulateFaces(Polyhedron& polyhedron);
 template <typename Polyhedron>


### PR DESCRIPTION
Saves ~40% render time off a simple example like this compared to the last snapshot (with `--enable=fast-csg --enable=fast-csg-trust-corefinement`), and 18x faster than without `fast-csg`:

```js
$fn=50;

minkowski() {
    difference() {
        hull() {
            translate([3, 0, 0]) cube(0.5, center=true);
            cube(1, center=true);
        }
        translate([0, 0, 0])
            sphere(1);
    }
    sphere(1);
}
// Baseline: 10m55s
// Baseline w/ fast-csg & trust: 1m20s
// This PR w/ fast-csg & trust: 35s
```

Notes:
-   I've tried switching things from Polyhedron_3 to Surface_mesh but it's still slower for some reason. Might revisit.
-   Models using minkowski are likely to hit the over-triangulation of corefinement, which is a known issue that should be fixed by https://github.com/openscad/openscad/pull/4107 (maybe when CGAL 5.5 gets out).