### PR TITLE
Disable depth test after extracting pixel data.

### DIFF
--- a/src/MouseSelector.cc
+++ b/src/MouseSelector.cc
@@ -187,6 +187,8 @@ int MouseSelector::select(const Renderer *renderer, int x, int y) {
   GLubyte color[3] = { 0 };
   glReadPixels(x, y, 1, 1, GL_RGB, GL_UNSIGNED_BYTE, color);
   OPENGL_TEST("glReadPixels");
+  glDisable(GL_DEPTH_TEST);
+
   int index = (uint32_t)color[0] | ((uint32_t)color[1] << 8) | ((uint32_t)color[2] << 16);
 
   // Switch the active framebuffer back to the default


### PR DESCRIPTION
Testing the fix for screen going black on context menu from https://github.com/openscad/openscad/issues/3725#issuecomment-1042413285

Fixes #3725