### PR TITLE
Switch to an afterwards check for CGAL version

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -303,7 +303,11 @@ endif()
 # Reconsider this after CGAL 5.4: https://github.com/CGAL/cgal/pull/6029
 set(ORIGINAL_CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH})
 set(CGAL_DO_NOT_WARN_ABOUT_CMAKE_BUILD_TYPE TRUE)
-find_package(CGAL 5.0 REQUIRED COMPONENTS Core)
+# Some older versions do not match with CGAL 5.0 REQUIRED, so we check after.
+find_package(CGAL REQUIRED COMPONENTS Core)
+if (${CGAL_MAJOR_VERSION} LESS 5)
+  message(FATAL_ERROR "CGAL: ${CGAL_MAJOR_VERSION}.${CGAL_MINOR_VERSION} less than required minimum version 5.0")
+endif()
 message(STATUS "CGAL: ${CGAL_MAJOR_VERSION}.${CGAL_MINOR_VERSION}")
 target_compile_definitions(OpenSCAD PRIVATE ENABLE_CGAL)
 # The macro `CGAL_DEBUG` allows to force CGAL assertions, even if `NDEBUG` is defined,


### PR DESCRIPTION
With CGAL 5.0, the in-line version request fails (tested with 5.0.2 in Ubuntu 20.04, the latest LTS for a couple months yet).  This PR swaps it for a version check right afterward.  I currently recommend switching it back to the in-line version request when we upgrade requirements to a higher CGAL version minimum.