### PR TITLE
Fix various typos

### DIFF
--- a/examples/Functions/recursion.scad
+++ b/examples/Functions/recursion.scad
@@ -2,7 +2,7 @@
 
 // Recursive functions are very powerful for calculating values.
 // A good number of algorithms make use of recursive definitions,
-// e.g the caluclation of the factorial of a number.
+// e.g the calculation of the factorial of a number.
 // The ternary operator " ? : " is the easiest way to define the
 // termination condition.
 // Note how the following simple implementation will never terminate

--- a/scripts/builder.sh
+++ b/scripts/builder.sh
@@ -189,7 +189,7 @@ build_win32()
 	if [ $DOSNAPSHOT ] ; then
 		./scripts/release-common.sh snapshot mingw32 tests
 	else
-		echo "this script cant yet build releases, only snapshots"
+		echo "this script can't yet build releases, only snapshots"
 		exit 1
 	fi
 	if [ $? -eq 0 ]; then
@@ -208,7 +208,7 @@ build_win64()
 	if [ $DOSNAPSHOT ] ; then
 		./scripts/release-common.sh snapshot mingw64 tests
 	else
-		echo "this script cant yet build releases, only snapshots"
+		echo "this script can't yet build releases, only snapshots"
 		exit 1
 	fi
 	if [ $? -eq 0 ]; then
@@ -226,7 +226,7 @@ build_lin32()
 	if [ $DOSNAPSHOT ] ; then
 		./scripts/release-common.sh snapshot
 	else
-		echo "this script cant yet build releases, only snapshots"
+		echo "this script can't yet build releases, only snapshots"
 		exit 1
 	fi
 }

--- a/scripts/release-common.sh
+++ b/scripts/release-common.sh
@@ -15,7 +15,7 @@
 #  -snapshot Build a snapshot binary (make e.g. experimental features available, build with commit info)
 #  -tests   Build additional package containing the regression tests
 #
-# If no version string or version date is given, todays date will be used (YYYY-MM-DD)
+# If no version string or version date is given, today's date will be used (YYYY-MM-DD)
 # If only version date is given, it will be used also as version string.
 # If no make target is given, release will be used on Windows, none one Mac OS X
 #
@@ -40,7 +40,7 @@ lf2crlf()
     mv $fname".temp" $fname
     return
   fi
-  echo 'warning- cant change eol to cr eol'
+  echo "warning- can't change eol to cr eol"
 }
 
 printUsage()

--- a/src/feature.cc
+++ b/src/feature.cc
@@ -46,7 +46,7 @@ const Feature Feature::ExperimentalVxORenderersDirect("vertex-object-renderers-d
 const Feature Feature::ExperimentalVxORenderersPrealloc("vertex-object-renderers-prealloc", "Enable preallocating buffers in vertex object renderers");
 const Feature Feature::ExperimentalTextMetricsFunctions("textmetrics", "Enable the <code>textmetrics()</code> and <code>fontmetrics()</code> functions.");
 const Feature Feature::ExperimentalImportFunction("import-function", "Enable import function returning data instead of geometry.");
-const Feature Feature::ExperimentalSortStl("sort-stl", "Sort the STL output for predictible, diffable results.");
+const Feature Feature::ExperimentalSortStl("sort-stl", "Sort the STL output for predictable, diffable results.");
 
 Feature::Feature(const std::string& name, const std::string& description)
   : enabled(false), name(name), description(description)

--- a/src/input/InputEventMapper.cc
+++ b/src/input/InputEventMapper.cc
@@ -101,7 +101,7 @@ double InputEventMapper::scale(double val)
 
 double InputEventMapper::getAxisValue(int config)
 {
-  if (config == 0)    // avoid indexing by -1 when using default settings (and causing bizzare behavior)
+  if (config == 0)    // avoid indexing by -1 when using default settings (and causing bizarre behavior)
     return scale(0);
 
   int idx = abs(config) - 1;

--- a/src/libsvg/path.cc
+++ b/src/libsvg/path.cc
@@ -146,7 +146,7 @@ path::arc_to(path_t& path, double x1, double y1, double rx, double ry, double x2
 
   double rmax = fmax(rx, ry);
   unsigned long fn = Calc::get_fragments_from_r(rmax, fValues->fn, fValues->fs, fValues->fa);
-  fn = (unsigned long) ceil(fn * fabs(delta) / 360.0); // beause we are creating a section of an ellipse, not the full ellipse
+  fn = (unsigned long) ceil(fn * fabs(delta) / 360.0); // because we are creating a section of an ellipse, not the full ellipse
   int steps = (std::fabs(delta) * 10.0 / 180) + 4;
   if (steps < fn) // use the maximum of calculated steps and user specified steps
     steps = fn;

--- a/src/value.h
+++ b/src/value.h
@@ -351,7 +351,7 @@ public:
    * EmbeddedVectorType class derives from VectorType and enables O(1) concatenation of vectors
    * by treating their elements as elements of their parent, traversable via VectorType's custom iterator.
    * -- An embedded vector should never exist "in the wild", only as a pseudo-element of a parent vector.
-   *    Eg "Lc*" Expressions return Embedded Vectors but they are necessairly child expressions of a Vector expression.
+   *    Eg "Lc*" Expressions return Embedded Vectors but they are necessarily child expressions of a Vector expression.
    * -- Any VectorType containing embedded elements will be forced to "flatten" upon usage of operator[],
    *    which is the only case of random-access.
    * -- Any loops through VectorTypes should prefer automatic range-based for loops  eg: for(const auto& value : vec) { ... }

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -439,7 +439,7 @@ endfunction()
 function(add_failing_test TESTCMD_BASENAME)
   cmake_parse_arguments(TESTCMD "" "RETVAL;EXE;SCRIPT;SUFFIX" "FILES;ARGS" ${ARGN})
 
-  if ("${TESTCMD_SUFFIX}" STREQUAL "") # Suffix "off" counts as a falsy value, so check diectly for empty string.
+  if ("${TESTCMD_SUFFIX}" STREQUAL "") # Suffix "off" counts as a false value, so check directly for empty string.
     message(FATAL_ERROR "add_failing_test() requires SUFFIX to be set" )
   endif()
   if (NOT TESTCMD_EXE)

--- a/tests/export_pngtest.py
+++ b/tests/export_pngtest.py
@@ -55,7 +55,7 @@ formats = ['pdf']
 parser = argparse.ArgumentParser()
 parser.add_argument('--openscad', required=True, help='Specify OpenSCAD executable')
 parser.add_argument('--format', required=True, choices=[item for sublist in [(f,f.upper()) for f in formats] for item in sublist], help='Specify export format')
-args,remaining_args = parser.parse_known_args()
+args, remaining_args = parser.parse_known_args()
 
 args.format = args.format.lower()
 inputfile = remaining_args[0]
@@ -63,9 +63,9 @@ pngfile = remaining_args[-1]
 remaining_args = remaining_args[1:-1] # Passed on to the OpenSCAD executable
 
 if not os.path.exists(inputfile):
-    failquit('cant find input file named: ' + inputfile)
+    failquit("can't find input file named: " + inputfile)
 if not os.path.exists(args.openscad):
-    failquit('cant find openscad executable named: ' + args.openscad)
+    failquit("can't find openscad executable named: " + args.openscad)
 
 outputdir = os.path.dirname(pngfile)
 inputpath, inputfilename = os.path.split(inputfile)


### PR DESCRIPTION
Found via `codespell -q 3 -S *.po,./src/ext,./libraries/MCAD,./submodules/mimalloc -L childs,clen,nd,synopsys,tesselate,tesselation,tesselator,uncomplete,vie`