### PR TITLE
Support performance timings of heavy operations

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -60,6 +60,7 @@ option(PROFILE "Enable compiling with profiling / test coverage instrumentation"
 option(MXECROSS "Enable setup for MXE cross platform build" OFF)
 option(OFFLINE_DOCS "Download Documentation for offline usage" OFF)
 option(USE_MIMALLOC "Use mimalloc as malloc replacement." ON)
+option(PERFORMANCE_TIMINGS "Print time spent in various costly CSG operations." OFF)
 
 if(APPLE)
   option(APPLE_UNIX "Build OpenSCAD in Unix mode in MaxOS X instead of an Apple Bundle" OFF)
@@ -83,6 +84,10 @@ if(WASM)
   set(ENV{PKG_CONFIG_PATH} "/emsdk/upstream/emscripten/cache/sysroot/lib/pkgconfig")
   target_compile_options(OpenSCAD PRIVATE "-pthread")
   target_compile_definitions(OpenSCAD PRIVATE CGAL_DISABLE_ROUNDING_MATH_CHECK)
+endif()
+
+if(PERFORMANCE_TIMINGS)
+  target_compile_definitions(OpenSCAD PRIVATE PERFORMANCE_TIMINGS)
 endif()
 
 if(NULLGL)

--- a/src/CGALHybridPolyhedron.cc
+++ b/src/CGALHybridPolyhedron.cc
@@ -213,11 +213,11 @@ void CGALHybridPolyhedron::transform(const Transform3d& mat)
     auto t = CGALUtils::createAffineTransformFromMatrix<CGAL_HybridKernel3>(mat);
 
     if (auto mesh = getMesh()) {
-			SCOPED_PERFORMANCE_TIMER("mesh transform");
+      SCOPED_PERFORMANCE_TIMER("mesh transform");
       CGALUtils::transform(*mesh, mat);
       CGALUtils::cleanupMesh(*mesh, /* is_corefinement_result */ false);
     } else if (auto nef = getNefPolyhedron()) {
-			SCOPED_PERFORMANCE_TIMER("nef transform");
+      SCOPED_PERFORMANCE_TIMER("nef transform");
       CGALUtils::transform(*nef, mat);
     } else {
       assert(!"Bad hybrid polyhedron state");
@@ -409,7 +409,7 @@ bool CGALHybridPolyhedron::meshBinOp(
 std::shared_ptr<CGAL_HybridNef> CGALHybridPolyhedron::convertToNef()
 {
   if (auto mesh = getMesh()) {
-		SCOPED_PERFORMANCE_TIMER("mesh -> nef");
+    SCOPED_PERFORMANCE_TIMER("mesh -> nef");
     auto nef = make_shared<CGAL_HybridNef>(*mesh);
     data = nef;
     return nef;
@@ -425,7 +425,7 @@ std::shared_ptr<CGAL_HybridMesh> CGALHybridPolyhedron::convertToMesh()
   if (auto mesh = getMesh()) {
     return mesh;
   } else if (auto nef = getNefPolyhedron()) {
-		SCOPED_PERFORMANCE_TIMER("nef -> mesh");
+    SCOPED_PERFORMANCE_TIMER("nef -> mesh");
     auto mesh = make_shared<CGAL_HybridMesh>();
     CGALUtils::convertNefPolyhedronToTriangleMesh(*nef, *mesh);
     CGALUtils::cleanupMesh(*mesh, /* is_corefinement_result */ false);

--- a/src/cgalutils-hybrid.cc
+++ b/src/cgalutils-hybrid.cc
@@ -10,12 +10,15 @@
 
 #include "CGAL_Nef_polyhedron.h"
 #include "polyset-utils.h"
+#include "scoped_timer.h"
 
 namespace CGALUtils {
 
 template <typename K>
 std::shared_ptr<CGALHybridPolyhedron> createHybridPolyhedronFromPolyhedron(const CGAL::Polyhedron_3<K>& poly)
 {
+  SCOPED_PERFORMANCE_TIMER("createHybridPolyhedronFromPolyhedron");
+
   CGAL::Surface_mesh<CGAL::Point_3<K>> mesh;
   CGAL::copy_face_graph(poly, mesh);
 
@@ -30,6 +33,7 @@ template std::shared_ptr<CGALHybridPolyhedron> createHybridPolyhedronFromPolyhed
 
 std::shared_ptr<CGALHybridPolyhedron> createHybridPolyhedronFromPolySet(const PolySet& ps)
 {
+  SCOPED_PERFORMANCE_TIMER("createHybridPolyhedronFromPolySet");
   auto mesh = make_shared<CGAL_HybridMesh>();
 
   auto err = createMeshFromPolySet(ps, *mesh);
@@ -53,6 +57,7 @@ std::shared_ptr<CGALHybridPolyhedron> createHybridPolyhedronFromPolySet(const Po
 
 std::shared_ptr<CGALHybridPolyhedron> createHybridPolyhedronFromNefPolyhedron(const CGAL_Nef_polyhedron& nef)
 {
+  SCOPED_PERFORMANCE_TIMER("createHybridPolyhedronFromNefPolyhedron");
   assert(nef.p3);
 
   auto mesh = make_shared<CGAL_HybridMesh>();

--- a/src/scoped_timer.h
+++ b/src/scoped_timer.h
@@ -1,6 +1,7 @@
 #pragma once
 
-class ScopedTimer {
+class ScopedTimer
+{
 public:
   ScopedTimer(const std::string& name) : name(name) {
     t.start();

--- a/src/scoped_timer.h
+++ b/src/scoped_timer.h
@@ -1,0 +1,25 @@
+#pragma once
+
+class ScopedTimer {
+public:
+  ScopedTimer(const std::string& name) : name(name) {
+    t.start();
+  }
+  ~ScopedTimer() {
+    t.stop();
+    printf("[%s] time %f s\n", name.c_str(), t.time());
+  }
+private:
+  std::string name;
+  CGAL::Timer t;
+};
+
+#ifndef PERFORMANCE_TIMINGS
+#define PERFORMANCE_TIMINGS 1
+#endif
+
+#if PERFORMANCE_TIMINGS
+#define SCOPED_PERFORMANCE_TIMER(name) ScopedTimer timer(name)
+#else
+#define SCOPED_PERFORMANCE_TIMER(name)
+#endif

--- a/src/scoped_timer.h
+++ b/src/scoped_timer.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <CGAL/Real_timer.h>
+
 class ScopedTimer
 {
 public:
@@ -12,7 +14,7 @@ public:
   }
 private:
   std::string name;
-  CGAL::Timer t;
+  CGAL::Real_timer t;
 };
 
 #ifndef PERFORMANCE_TIMINGS


### PR DESCRIPTION
Now that there are tests being done comparing our CGAL (corefinement) rendering with alternatives (e.g. [against exciting new Manifold library](https://elalish.blogspot.com/2022/03/manifold-performance.html)), it's time to look at the details of the timings :-)

(reused code from https://github.com/openscad/openscad/pull/3641)

To build for performance comparisons
```bash
git clone https://github.com/ochafik/openscad.git --single-branch -b perf-timings openscad-perf-timings
cd openscad-perf-timings
git submodule init && git submodule update

mkdir build && cd build && cmake .. \
  -DCMAKE_BUILD_TYPE=Release -DEXPERIMENTAL=ON -DPERFORMANCE_TIMINGS=ON
```

I tried to match the testing conditions mentioned by the author of the [Manifold library](https://github.com/elalish/manifold) in [his post](https://elalish.blogspot.com/2022/03/manifold-performance.html):

```js
$fn=320; // Gives ~101k faces per sphere
// $fn=1000 // Gives ~1M faces per sphere
// $fn=3200 // Gives ~10M faces per sphere

difference() {
  sphere();
  translate([0.5, 0, 0]) sphere();
}
```

Tested with:
```bash
# MacOS:
# ln -s ./build/OpenSCAD.app/Contents/MacOS/OpenSCAD openscad
 
time ./openscad bigspheres.scad --enable=fast-csg --enable=fast-csg-trust-corefinement \
    -o diff.off '-D$fn=1000'

# STL is just so much slower
```

Results:

| $fn | # faces in each sphere | Total time (STL) | Total time (OFF) | PolySet -> hybrid | Corefinement Difference time |
| -- | -- | -- | -- | -- | -- |
| 100 | ~10k | 0.3sec | 0.26sec | 0.01sec | 0.08sec |
| 320 | ~101k | 1.5sec | 0.9sec | 0.06sec | 0.35sec |
| 1000 | ~1M | 13.9sec | 7.5sec | 0.63sec | 3.3sec |
| 3200 | ~10M | 173sec | 87sec | 7.7sec | 38.7sec |

I need to instrument imports & exports to understand where the most time is spent, but it seems the underlying union time in corefinement is more comparable to the (*mono-threaded CPU*) figures published for Manifold at the 100k and 1M faces.

@elalish could you share your raw figures and methodology?