### PR TITLE
only process syntactically relevant brackets for folding (fixes #4144)

### DIFF
--- a/src/gui/ScadLexer.cc
+++ b/src/gui/ScadLexer.cc
@@ -261,9 +261,9 @@ void ScadLexer2::fold(int start, int end)
     bool style = (editor()->SendScintilla(QsciScintilla::SCI_GETSTYLEAT, i - 1) == Comment);
     bool startstyle = (editor()->SendScintilla(QsciScintilla::SCI_GETSTYLEAT, i) == Comment);
 
-    if ((ch == '{') || (ch == '[') || ((!style) && (startstyle))) {
+    if (((ch == '{') || (ch == '[')) && !style || ((!style) && (startstyle))) {
       levelCurrent++;
-    } else if ((ch == '}') || (ch == ']') || ((style) && (!startstyle))) {
+    } else if (((ch == '}') || (ch == ']')) && !style || ((style) && (!startstyle))) {
       levelCurrent--;
     }
 

--- a/src/gui/ScadLexer.cc
+++ b/src/gui/ScadLexer.cc
@@ -258,10 +258,11 @@ void ScadLexer2::fold(int start, int end)
 
     bool atEOL = ((ch == '\r' && chNext != '\n') || (ch == '\n'));
 
-    bool prevStyleIsComment = (editor()->SendScintilla(QsciScintilla::SCI_GETSTYLEAT, i - 1) == Comment);
-    bool currStyleIsComment = (editor()->SendScintilla(QsciScintilla::SCI_GETSTYLEAT, i) == Comment);
+    int prevStyle = editor()->SendScintilla(QsciScintilla::SCI_GETSTYLEAT, i - 1);
+    int currStyle = editor()->SendScintilla(QsciScintilla::SCI_GETSTYLEAT, i);
 
-    if(!currStyleIsComment){
+    bool currStyleIsBracket = (currStyle == 22);
+    if(currStyleIsBracket){
       if ((ch == '{') || (ch == '[') ) {
         levelCurrent++;
       } else if ((ch == '}') || (ch == ']') ) {
@@ -269,6 +270,9 @@ void ScadLexer2::fold(int start, int end)
       }
     }
     
+
+    bool prevStyleIsComment = (prevStyle == Comment);
+    bool currStyleIsComment = (currStyle == Comment);
     bool isStartOfComment = (!prevStyleIsComment) && (currStyleIsComment);
     bool isEndOfComment   = (prevStyleIsComment) && (!currStyleIsComment);
     

--- a/src/gui/ScadLexer.cc
+++ b/src/gui/ScadLexer.cc
@@ -258,12 +258,24 @@ void ScadLexer2::fold(int start, int end)
 
     bool atEOL = ((ch == '\r' && chNext != '\n') || (ch == '\n'));
 
-    bool style = (editor()->SendScintilla(QsciScintilla::SCI_GETSTYLEAT, i - 1) == Comment);
-    bool startstyle = (editor()->SendScintilla(QsciScintilla::SCI_GETSTYLEAT, i) == Comment);
+    bool prevStyleIsComment = (editor()->SendScintilla(QsciScintilla::SCI_GETSTYLEAT, i - 1) == Comment);
+    bool currStyleIsComment = (editor()->SendScintilla(QsciScintilla::SCI_GETSTYLEAT, i) == Comment);
 
-    if (((ch == '{') || (ch == '[')) && !style || ((!style) && (startstyle))) {
+    if(!currStyleIsComment){
+      if ((ch == '{') || (ch == '[') ) {
+        levelCurrent++;
+      } else if ((ch == '}') || (ch == ']') ) {
+        levelCurrent--;
+      }
+    }
+    
+    bool isStartOfComment = (!prevStyleIsComment) && (currStyleIsComment);
+    bool isEndOfComment   = (prevStyleIsComment) && (!currStyleIsComment);
+    
+    if (isStartOfComment) {
       levelCurrent++;
-    } else if (((ch == '}') || (ch == ']')) && !style || ((style) && (!startstyle))) {
+    }
+    if (isEndOfComment){
       levelCurrent--;
     }
 

--- a/src/gui/ScadLexer.cc
+++ b/src/gui/ScadLexer.cc
@@ -261,8 +261,8 @@ void ScadLexer2::fold(int start, int end)
     int prevStyle = editor()->SendScintilla(QsciScintilla::SCI_GETSTYLEAT, i - 1);
     int currStyle = editor()->SendScintilla(QsciScintilla::SCI_GETSTYLEAT, i);
 
-    bool currStyleIsBracket = (currStyle == 22);
-    if(currStyleIsBracket){
+    bool currStyleIsOtherText = (currStyle == OtherText);
+    if(currStyleIsOtherText){
       if ((ch == '{') || (ch == '[') ) {
         levelCurrent++;
       } else if ((ch == '}') || (ch == ']') ) {


### PR DESCRIPTION
this fixes #4144
```
union(){
// parsed }
// inside [ will collapse the curly brace from the union
}
```
```
str1 = "Hallo { ";

cube();

str2 = "} Welt";
```

this has one side effect worth noting:
currently brackets within commented out section can be folded:
```
/*
if(true){
    while(true){
        cube();
    }
}
*/
```
This fix sees this whole comment block as one fold-able comment, ignoring the brackets within.

I could expand the code so that the code makes a "best effort" of matching brackets within the comment, but given that comments are by no means guaranteed to be well formatted, commented out code, this seams more trouble then it is worth.

**Todo:** I will to some more testing and at screenshots for documentation.