### PR TITLE
Stack usage optimization for tostream_visitor

### DIFF
--- a/src/core/Value.h
+++ b/src/core/Value.h
@@ -578,13 +578,9 @@ public:
   bool getDouble(double& v) const;
   bool getFiniteDouble(double& v) const;
   std::string toString() const;
-  std::string toString(const tostring_visitor *visitor) const;
   std::string toEchoString() const;
-  std::string toEchoString(const tostring_visitor *visitor) const;
   const UndefType& toUndef();
   std::string toUndefString() const;
-  void toStream(std::ostringstream& stream) const;
-  void toStream(const tostream_visitor *visitor) const;
   std::string chrString() const;
   bool getVec2(double& x, double& y, bool ignoreInfinite = false) const;
   bool getVec3(double& x, double& y, double& z) const;


### PR DESCRIPTION
This change was tested against the sample code in #4172, and while it does not fix the crash, it delays the crash until higher values of `b`, by going through fewer function calls, and re-using `tostream_visitor` instead of constructing new ones for each nested vector. 

My testing showed the lowest value to trigger a crash went up by about 1000 after changes.
Lowest b value required to trigger a crash, built with `g++-10`
```
RelWithDebInfo build:
  unedited master: b=5390
  with changes:    b=6378
Release build:
  unedited master: b=4936
  with changes:    b=6081
Debug build:
  unedited master: b=3465
  with changes:    b=3905
```

Also removed some `Value::toString|toStream` functions which were not being used.