### PR TITLE
Remove unused qscintilla-devel build dependency for fedora

### DIFF
--- a/scripts/uni-get-dependencies.sh
+++ b/scripts/uni-get-dependencies.sh
@@ -10,7 +10,7 @@ get_fedora_deps_yum()
   fontconfig-devel freetype-devel \
   boost-devel mpfr-devel gmp-devel glew-devel CGAL-devel gcc gcc-c++ pkgconfig \
   opencsg-devel git libXmu-devel curl imagemagick ImageMagick glib2-devel make \
-  xorg-x11-server-Xvfb gettext qscintilla-devel qscintilla-qt5-devel \
+  xorg-x11-server-Xvfb gettext qscintilla-qt5-devel \
   mesa-dri-drivers double-conversion-devel
 }
 
@@ -20,7 +20,7 @@ get_fedora_deps_dnf()
   fontconfig-devel freetype-devel \
   boost-devel mpfr-devel gmp-devel glew-devel CGAL-devel gcc gcc-c++ pkgconfig \
   opencsg-devel git libXmu-devel curl ImageMagick glib2-devel make \
-  xorg-x11-server-Xvfb gettext qscintilla-devel qscintilla-qt5-devel \
+  xorg-x11-server-Xvfb gettext qscintilla-qt5-devel \
   mesa-dri-drivers libzip-devel ccache qt5-qtmultimedia-devel qt5-qtsvg-devel \
   double-conversion-devel
  dnf -y install libxml2-devel


### PR DESCRIPTION
Remove unused (and non existing in package archive) fedora build dependency: qscintilla-devel
![Screenshot_20220319_144752](https://user-images.githubusercontent.com/30468956/159123688-33db0646-0a6f-44e5-a90c-4a28760be781.png)

Openscad builds just fine without this dependency and fails while trying to install this non-existing package. 
qscintilla-qt5-devel should include all the neccessary files.