### PR TITLE
Fix error handling when creating an offscreen OpenGL context on Windows.

### DIFF
--- a/src/glview/OffscreenContextWGL.cc
+++ b/src/glview/OffscreenContextWGL.cc
@@ -97,6 +97,7 @@ bool create_wgl_dummy_context(OffscreenContext& ctx)
   //  and ctx->dev_context if successful
 
   // create window
+  LPCWSTR lpClassName = L"OpenSCAD";
 
   HINSTANCE inst = GetModuleHandleW(0);
   WNDCLASSW wc;
@@ -104,17 +105,19 @@ bool create_wgl_dummy_context(OffscreenContext& ctx)
   wc.style = CS_OWNDC;
   wc.lpfnWndProc = WndProc;
   wc.hInstance = inst;
-  wc.lpszClassName = L"OpenSCAD";
+  wc.lpszClassName = lpClassName;
   ATOM class_atom = RegisterClassW(&wc);
 
   if (class_atom == 0) {
-    std::cerr << "MS GDI - RegisterClass failed\n";
-    std::cerr << "last-error code: " << GetLastError() << "\n";
-    return false;
+    const DWORD last_error = GetLastError();
+    if (last_error != ERROR_CLASS_ALREADY_EXISTS) {
+      std::cerr << "MS GDI - RegisterClass failed\n";
+      std::cerr << "last-error code: " << last_error << "\n";
+      return false;
+    }
   }
 
-  LPCTSTR lpClassName = L"OpenSCAD";
-  LPCTSTR lpWindowName = L"OpenSCAD";
+  LPCWSTR lpWindowName = L"OpenSCAD";
   DWORD dwStyle = WS_CAPTION | WS_POPUPWINDOW; // | WS_VISIBLE
   int x = 0;
   int y = 0;


### PR DESCRIPTION
Fixes #4180

When animating from the command line interface, the code registers the
window class on each frame. This worked for the first frame, but the
registration for the second frame seemed to fail. Actually,
RegisterClassW was merely indicating that the second registration was
redundant.

This change ignores ERROR_CLASS_ALREADY_EXISTS, which seems to be the
least intrusive way to solve the problem.

I tested the solution in a proof-of-concept program, but I haven't tested
this actual patch because building OpenSCAD for Windows is onerous.

(There will probably still be bugs here.  It looks like the code never
destroys the windows it creates, and it creates a new one for each frame.
And each of those windows has its own DC because of the CS_OWNDC in the
window class.  So a many-frame animation is going to burn up GDI
resources.  Those lingering issues will be easier to detect and debug
once we can get past the initialization issues.)