### PR TITLE
Fix python 'testing equality to None' issue

### DIFF
--- a/scripts/macosx-sanity-check.py
+++ b/scripts/macosx-sanity-check.py
@@ -169,7 +169,7 @@ if __name__ == '__main__':
         assert(deps)
         for d in deps:
             absfile = lookup_library(d)
-            if absfile == None:
+            if absfile is None:
                 print("Not found: " + d)
                 print("  ..required by " + str(processed[dep]))
                 error = True

--- a/tests/mingw_convert_ctest.py
+++ b/tests/mingw_convert_ctest.py
@@ -187,7 +187,7 @@ def process_templates():
             scadname = filename.replace("-template","")
             # search for path of template output
             scadpath = find_single_file(scadname, winbase + r'\tests\data\scad')
-            if scadpath != None:
+            if scadpath is not None:
                 print('Ovewriting ' + scadpath + ' based on ' + filename + ' using path ' + cmakebase)
                 fout = open(scadpath, 'w')
                 fin = open(templatepath + '\\' + filename, 'r')


### PR DESCRIPTION
"Testing whether an object is 'None' using the == operator is inefficient and potentially incorrect."