### PR TITLE
syntax highlight: include and use have a unique syntax

### DIFF
--- a/src/gui/ScadLexer.cc
+++ b/src/gui/ScadLexer.cc
@@ -111,11 +111,19 @@ Lex::Lex()
 
 void Lex::default_rules()
 {
+  rules_.push_state("PATH");
   rules_.push_state("COMMENT");
 
-  std::string keywords("module function use echo include import projection render "
+  std::string keywords("module function echo import projection render "
                        "return if else let for each assert");
   defineRules(keywords, ekeyword);
+
+  //include and use have a unique syntax
+  rules_.push("INITIAL", "use", ekeyword, "PATH");
+  rules_.push("INITIAL", "include", ekeyword, "PATH");  
+  rules_.push("PATH", ".|\n", etext, "INITIAL"); // catches things like (); but also acts as a "fail safe" so that the path state is allways leaved
+  rules_.push("PATH", "[\\+\\-\\*\\/%\\^!=]", eoperator, "INITIAL"); //include and use can be used as variable names
+  rules_.push("PATH", "[ \t\r\n]*<[^>]*>", eQuotedString, "INITIAL");
 
   std::string transformations("translate rotate scale linear_extrude "
                               "rotate_extrude resize mirror multmatrix color "
@@ -194,7 +202,7 @@ void Lex::lex_results(const std::string& input, int start, LexInterface *const o
 
   int isstyle = obj->getStyleAt(start - 1);
   if (isstyle == ecomment)    // WARNING - hardcoded number, not positive about this!
-    results.state = 1;
+    results.state = rules_.state("COMMENT");
   lexertl::lookup(sm, results);
 
   while (results.id != eEOF) {

--- a/src/gui/ScadLexer.cc
+++ b/src/gui/ScadLexer.cc
@@ -201,7 +201,7 @@ void Lex::lex_results(const std::string& input, int start, LexInterface *const o
   lexertl::smatch results(input.begin(), input.end());
 
   int isstyle = obj->getStyleAt(start - 1);
-  if (isstyle == ecomment)    // WARNING - hardcoded number, not positive about this!
+  if (isstyle == ecomment)
     results.state = rules_.state("COMMENT");
   lexertl::lookup(sm, results);
 

--- a/src/gui/ScadLexer.cc
+++ b/src/gui/ScadLexer.cc
@@ -121,8 +121,7 @@ void Lex::default_rules()
   //include and use have a unique syntax
   rules_.push("INITIAL", "use", ekeyword, "PATH");
   rules_.push("INITIAL", "include", ekeyword, "PATH");  
-  rules_.push("PATH", ".|\n", etext, "INITIAL"); // catches things like (); but also acts as a "fail safe" so that the path state is allways leaved
-  rules_.push("PATH", "[\\+\\-\\*\\/%\\^!=]", eoperator, "INITIAL"); //include and use can be used as variable names
+  rules_.push("PATH", ".|\n", etext, "INITIAL"); //leave this state; "use" and "include" can also be used as variable names 
   rules_.push("PATH", "[ \t\r\n]*<[^>]*>", eQuotedString, "INITIAL");
 
   std::string transformations("translate rotate scale linear_extrude "


### PR DESCRIPTION
`use` and `include` are not normal keywords. The usage of angle brackets `<>` is unique and has some interesting effects, that should be reflected by the syntax highlighting.

I will post some examples in future comments.

The main reference for openscad syntax for the purpose of this discussion is the lexer:

https://github.com/openscad/openscad/blob/667abf11c60a514ab28456e410309c621557f03a/src/core/lexer.l#L142-L147
https://github.com/openscad/openscad/blob/667abf11c60a514ab28456e410309c621557f03a/src/core/lexer.l#L151-L166

This merge request should bring syntax highlight closer inline with the current syntax interpretation.
If any of the example look like bugs (not features) this is out of scope for this merge request.