### PR TITLE
Fix segfault if app closed while lots of logging

### DIFF
--- a/src/gui/MainWindow.cc
+++ b/src/gui/MainWindow.cc
@@ -1298,7 +1298,8 @@ void MainWindow::compileCSG()
     CSGTreeEvaluator csgrenderer(this->tree, &geomevaluator);
 #endif
 
-    progress_report_prep(this->root_node, report_func, this);
+    if (!isClosing) progress_report_prep(this->root_node, report_func, this);
+    else return;
     try {
 #ifdef ENABLE_OPENCSG
       this->processEvents();
@@ -2162,7 +2163,8 @@ void MainWindow::cgalRender()
   this->progresswidget = new ProgressWidget(this);
   connect(this->progresswidget, SIGNAL(requestShow()), this, SLOT(showProgress()));
 
-  progress_report_prep(this->root_node, report_func, this);
+  if (!isClosing) progress_report_prep(this->root_node, report_func, this);
+  else return;
 
   this->cgalworker->start(this->tree);
 }
@@ -3229,6 +3231,8 @@ void MainWindow::helpFontInfo()
 void MainWindow::closeEvent(QCloseEvent *event)
 {
   if (tabManager->shouldClose()) {
+    isClosing=true;
+    progress_report_fin();
     // Disable invokeMethod calls for consoleOutput during shutdown,
     // otherwise will segfault if echos are in progress.
     hideCurrentOutput();

--- a/src/gui/MainWindow.h
+++ b/src/gui/MainWindow.h
@@ -87,6 +87,7 @@ public:
   ~MainWindow();
 
 private:
+  volatile bool isClosing=false;
   void consoleOutputRaw(const QString& msg);
 
 protected:


### PR DESCRIPTION
ISSUE:
During application close widgets are cleaned up, so the MainWindow::progresswidget pointer is cleared.  This causes a segfault in 
MainWindow::report_func here:
    // FIXME: Check if cancel was requested by e.g. Application quit
    if (thisp->progresswidget->wasCanceled()) throw ProgressCancelException();

Perhaps the comment is implying that this is a known bug?

REPRODUCE:
Close the app while running this (broken) .scad file (or any file that generates a lot of warnings):
```
module shell(x)
{
   for(i=[0:360])
   {
   hull()
   {
     cube([x,x,1]);
     rotate([0,i,0]) translate([i,0,0]) cube([x,x,1]); 
   }
   }
}
shell(x=foo);
```

FIX:
In MainWindow::closeEvent() progress_report_fin() is called to stop any global progress reports from passing through to the deleted window.  

In MainWindow an "isClosing" flag is created and checked before calls to "progress_report_prep" to stop the MainWindow from re-registering the deleted progress window as a progress report handler.  Additionally if "isClosing" is true, the compilation and rendering functions return right away, since their work is no longer necessary.