### PR TITLE
add location to "Can't open library" and "Can't open include file" warning

### DIFF
--- a/src/core/lexer.l
+++ b/src/core/lexer.l
@@ -155,7 +155,7 @@ use[ \t\r\n]*"<"		{ BEGIN(cond_use); }
 							BEGIN(INITIAL);
 							fs::path fullpath = find_valid_path(sourcefile()->parent_path(), fs::path(filename), &openfilenames);
 							if (fullpath.empty()) {
-							LOG(message_group::Warning,Location::NONE,"","Can't open library '%1$s'.",filename);
+							LOG(message_group::Warning,LOCATION(parserlloc),"","Can't open library '%1$s'.",filename);
 								parserlval.text = strdup(filename.c_str());
 							} else {
 								handle_dep(fullpath.generic_string());

--- a/src/core/lexer.l
+++ b/src/core/lexer.l
@@ -316,7 +316,7 @@ void includefile(const Location& loc)
   }
   else {
     rootfile->registerInclude(localpath.generic_string(), localpath.generic_string(), Location::NONE);
-    LOG(message_group::Warning,Location::NONE,"","Can't open include file '%1$s'.",localpath.generic_string());
+    LOG(message_group::Warning,LOCATION(parserlloc),"","Can't open include file '%1$s'.",localpath.generic_string());
     return;
   };
 
@@ -329,7 +329,7 @@ void includefile(const Location& loc)
 
   yyin = fopen(fullname.c_str(), "r");
   if (!yyin) {
-    LOG(message_group::Warning,Location::NONE,"","Can't open include file '%1$s'.",localpath.generic_string());
+    LOG(message_group::Warning,LOCATION(parserlloc),"","Can't open include file '%1$s'.",localpath.generic_string());
     filename_stack.pop_back();
     return;
   }

--- a/tests/regression/echotest/include-recursive-test-expected.echo
+++ b/tests/regression/echotest/include-recursive-test-expected.echo
@@ -1,12 +1,12 @@
-WARNING: Can't open include file 'include-recursive-test.scad'.
-WARNING: Can't open include file '../misc/include-recursive-test.scad'.
-WARNING: Can't open include file '../../scad/misc/include-recursive-test.scad'.
-WARNING: Can't open include file 'include-recursive-test.scad'.
-WARNING: Can't open include file '../misc/include-recursive-test.scad'.
-WARNING: Can't open include file '../../scad/misc/include-recursive-test.scad'.
-WARNING: Can't open include file 'include-recursive-test.scad'.
-WARNING: Can't open include file '../misc/include-recursive-test.scad'.
-WARNING: Can't open include file '../../scad/misc/include-recursive-test.scad'.
+WARNING: Can't open include file 'include-recursive-test.scad'. in file ../../tests/data/scad/misc/include-recursive-test.scad, line 1
+WARNING: Can't open include file '../misc/include-recursive-test.scad'. in file ../../tests/data/scad/misc/include-recursive-test.scad, line 2
+WARNING: Can't open include file '../../scad/misc/include-recursive-test.scad'. in file ../../tests/data/scad/misc/include-recursive-test.scad, line 3
+WARNING: Can't open include file 'include-recursive-test.scad'. in file ../../tests/data/scad/misc/include-recursive-test.scad, line 1
+WARNING: Can't open include file '../misc/include-recursive-test.scad'. in file ../../tests/data/scad/misc/include-recursive-test.scad, line 2
+WARNING: Can't open include file '../../scad/misc/include-recursive-test.scad'. in file ../../tests/data/scad/misc/include-recursive-test.scad, line 3
+WARNING: Can't open include file 'include-recursive-test.scad'. in file ../../tests/data/scad/misc/include-recursive-test.scad, line 1
+WARNING: Can't open include file '../misc/include-recursive-test.scad'. in file ../../tests/data/scad/misc/include-recursive-test.scad, line 2
+WARNING: Can't open include file '../../scad/misc/include-recursive-test.scad'. in file ../../tests/data/scad/misc/include-recursive-test.scad, line 3
 ECHO: "INC"
 ECHO: "INC"
 ECHO: "INC"

--- a/tests/regression/echotest/include-tests-expected.echo
+++ b/tests/regression/echotest/include-tests-expected.echo
@@ -1,6 +1,6 @@
-WARNING: Can't open include file 'not_exist.scad'.
-WARNING: Can't open include file 'non/existent/path/non-file'.
-WARNING: Can't open include file 'test/'.
-WARNING: Can't open include file '/'.
+WARNING: Can't open include file 'not_exist.scad'. in file ../../tests/data/scad/misc/sub1/included.scad, line 3
+WARNING: Can't open include file 'non/existent/path/non-file'. in file ../../tests/data/scad/misc/include-tests.scad, line 8
+WARNING: Can't open include file 'test/'. in file ../../tests/data/scad/misc/include-tests.scad, line 20
+WARNING: Can't open include file '/'. in file ../../tests/data/scad/misc/include-tests.scad, line 23
 ECHO: "included.scad"
 ECHO: "included2.scad"

--- a/tests/regression/echotest/use-tests-expected.echo
+++ b/tests/regression/echotest/use-tests-expected.echo
@@ -1,7 +1,7 @@
-WARNING: Can't open library ''.
-WARNING: Can't open library 'non/existent/path/non-file'.
-WARNING: Can't open library 'test/'.
-WARNING: Can't open library '/'.
+WARNING: Can't open library ''. in file ../../tests/data/scad/misc/use-tests.scad, line 2
+WARNING: Can't open library 'non/existent/path/non-file'. in file ../../tests/data/scad/misc/use-tests.scad, line 8
+WARNING: Can't open library 'test/'. in file ../../tests/data/scad/misc/use-tests.scad, line 20
+WARNING: Can't open library '/'. in file ../../tests/data/scad/misc/use-tests.scad, line 23
 WARNING: Ignoring unknown module 'test3' in file use-tests.scad, line 42
 WARNING: Ignoring unknown module 'test4' in file use-tests.scad, line 43
 WARNING: Ignoring unknown variable 'test2_variable' in file use-tests.scad, line 49


### PR DESCRIPTION
I think it is useful to know, in which file a failing include/use statement is, as include and use can be nested.

I think that the location being set to none could go back to the times where why did not have the filename in the location datastructure and thus only outputted the line number (which is of little use for this warning). But now that we have filepaths, having the location of the statement is actually useful.

![Screenshot from 2022-04-09 20-31-26](https://user-images.githubusercontent.com/24962768/162587357-d05471f2-11c9-4b67-b69e-a75ec89f784e.png)

![Screenshot from 2022-04-09 20-31-34](https://user-images.githubusercontent.com/24962768/162587361-54b4e854-74e1-4a6c-b099-2da10a2b2157.png)

Generating the relative path of the file is a bit tricky/wonky (I think due to include/use within include/use being relative to the file being parsed) as the test cases show, when comparing GUI and console.
The main reason for the relative paths was so that the test results are stable.