### PR TITLE
recolor the whole text after evaluation

### DIFF
--- a/src/gui/Editor.h
+++ b/src/gui/Editor.h
@@ -28,6 +28,7 @@ public:
   virtual QStringList colorSchemes() = 0;
   virtual bool canUndo() = 0;
   virtual void addTemplate() = 0;
+  virtual void resetHighlighting() = 0;
   virtual void setIndicator(const std::vector<IndicatorData>& indicatorData) = 0;
   virtual QMenu *createStandardContextMenu() = 0;
   virtual QPoint mapToGlobal(const QPoint&) = 0;

--- a/src/gui/MainWindow.cc
+++ b/src/gui/MainWindow.cc
@@ -1809,6 +1809,7 @@ void MainWindow::parseTopLevelDocument()
   this->root_file = nullptr;  // ditto
   this->root_file = parse(this->parsed_file, fulltext, fname, fname, false) ? this->parsed_file : nullptr;
 
+  this->activeEditor->resetHighlighting();
   if (this->root_file != nullptr) {
     //add parameters as annotation in AST
     CommentParser::collectParameters(fulltext, this->root_file);

--- a/src/gui/ScadLexer.cc
+++ b/src/gui/ScadLexer.cc
@@ -199,11 +199,16 @@ void Lex::lex_results(const std::string& input, int start, LexInterface *const o
 #endif
   lexertl::smatch results(input.begin(), input.end());
 
+  //The editor can ask to only lex from a starting point.
+  //This can be faster the lexing the whole text,
+  //but requires the lexer to try to restore the lexer state.
+  //We currently handle comments (COMMENT State) pretty well.
+  //We currently do not handle include/use (PATH State).
   int isstyle = obj->getStyleAt(start - 1);
   if (isstyle == ecomment)
     results.state = rules_.state("COMMENT");
-  lexertl::lookup(sm, results);
 
+  lexertl::lookup(sm, results);
   while (results.id != eEOF) {
     obj->highlighting(start, input, results);
     lexertl::lookup(sm, results);

--- a/src/gui/ScintillaEditor.cc
+++ b/src/gui/ScintillaEditor.cc
@@ -1304,10 +1304,21 @@ void ScintillaEditor::onCharacterThresholdChanged(int val)
 
 void ScintillaEditor::setIndicator(const std::vector<IndicatorData>& indicatorData)
 {
+  qsci->recolor(); //lex and restyle the whole file
+  // We do that here for the following reasons:
+  // * this is a convenient place to hook into
+  //    * this is called after evaluating the file
+  //    * evaluting is called during Preview and Render
+  //    * "automatic reload and preview" causes a preview on file save
+  // * it makes sense to clean up potential artifacts in the syntax highlighting,
+  //    before cleaning up old and setting new indicators
+  
+  //remove all indicators
   qsci->SendScintilla(QsciScintilla::SCI_SETINDICATORCURRENT, hyperlinkIndicatorNumber);
   qsci->SendScintilla(QsciScintilla::SCI_INDICATORCLEARRANGE, 0, qsci->length());
   this->indicatorData = indicatorData;
 
+  //set indicators
   int idx = 0;
   for (const auto& data : indicatorData) {
     int pos = qsci->positionFromLineIndex(data.linenr - 1, data.colnr - 1);

--- a/src/gui/ScintillaEditor.cc
+++ b/src/gui/ScintillaEditor.cc
@@ -1302,23 +1302,20 @@ void ScintillaEditor::onCharacterThresholdChanged(int val)
   qsci->setAutoCompletionThreshold(val <= 0 ? 1 : val);
 }
 
-void ScintillaEditor::setIndicator(const std::vector<IndicatorData>& indicatorData)
-{
-  qsci->recolor(); //lex and restyle the whole file
-  // We do that here for the following reasons:
-  // * this is a convenient place to hook into
-  //    * this is called after evaluating the file
-  //    * evaluting is called during Preview and Render
-  //    * "automatic reload and preview" causes a preview on file save
-  // * it makes sense to clean up potential artifacts in the syntax highlighting,
-  //    before cleaning up old and setting new indicators
+void ScintillaEditor::resetHighlighting(){
+  std::cout << "recolor on setIndicator" << std::endl;
+
+  qsci->recolor(); //lex and restyle the whole text
   
   //remove all indicators
   qsci->SendScintilla(QsciScintilla::SCI_SETINDICATORCURRENT, hyperlinkIndicatorNumber);
   qsci->SendScintilla(QsciScintilla::SCI_INDICATORCLEARRANGE, 0, qsci->length());
+}
+
+void ScintillaEditor::setIndicator(const std::vector<IndicatorData>& indicatorData)
+{
   this->indicatorData = indicatorData;
 
-  //set indicators
   int idx = 0;
   for (const auto& data : indicatorData) {
     int pos = qsci->positionFromLineIndex(data.linenr - 1, data.colnr - 1);

--- a/src/gui/ScintillaEditor.cc
+++ b/src/gui/ScintillaEditor.cc
@@ -1303,8 +1303,6 @@ void ScintillaEditor::onCharacterThresholdChanged(int val)
 }
 
 void ScintillaEditor::resetHighlighting(){
-  std::cout << "recolor on setIndicator" << std::endl;
-
   qsci->recolor(); //lex and restyle the whole text
   
   //remove all indicators

--- a/src/gui/ScintillaEditor.h
+++ b/src/gui/ScintillaEditor.h
@@ -66,6 +66,7 @@ public:
   QStringList colorSchemes() override;
   bool canUndo() override;
   void addTemplate() override;
+  void resetHighlighting() override;
   void setIndicator(const std::vector<IndicatorData>& indicatorData) override;
   QMenu *createStandardContextMenu() override;
   QPoint mapToGlobal(const QPoint&) override;


### PR DESCRIPTION
#4205 works well, when opening a new file.

When editing, not restoring the lexer state for `include` and `use` can create artifacts.

Here an example:
Take this text:
```
echo("test");
use<test123>;
echo("test");
```
add two new lines after use<
```
echo("test");
use<

test123>;
echo("test");
```
and you see incorrect highlighting:
![Screenshot from 2022-04-10 14-30-11](https://user-images.githubusercontent.com/24962768/162618232-4dbd16eb-1b86-404b-b80c-21906b55734c.png)

This merge requests fixes that by recoloring the whole text after a parse of the top level document.

This merge request also removes all indicators, when parsing the file was not successful.