### PR TITLE
clean up of small things

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -78,7 +78,7 @@
 **Bug Fixes**
 * Raise error when export folder does not exist (fixes #432)
 * Fixes for linear_extrude with scale and/or twist
-* Avoid undefined behavior for `convexity' parameter to linear_extrude
+* Avoid undefined behavior for 'convexity' parameter to linear_extrude
 * Fix echo() formatting error (fixes #2950)
 * Fix search order for use<>
 * Fix large text (fixes #3262)

--- a/doc/TODO.txt
+++ b/doc/TODO.txt
@@ -203,9 +203,7 @@ o Export to other file formats
 
 IDEAS FOR LANGUAGE CHANGES
 --------------------------
-o More strict checking of module parameters to make e.g. this fail:
-  module test(a,b) { a=1; b=2; echo(a,b,c); } test(c=3);
-  (also for built-in modules)
+o (...)
 
 CODE
 ----

--- a/doc/TODO.txt
+++ b/doc/TODO.txt
@@ -65,7 +65,6 @@ o 3D View
   - 4 x split view w/orthogonal cameras?
   - Quick highlighting of object under the cursor in the editor
   - View All
-  - Allow specifying viewpoint in the scad file
   - overlay indicator displaying current view mode
   - Use OpenGL picking to facilitate ray-tracing like features like measuring
     thicknesses, distances, slot thicknesses etc.

--- a/src/core/lexer.l
+++ b/src/core/lexer.l
@@ -93,7 +93,6 @@ extern YYLTYPE parserlloc;
 #define LOCATION_ADD_LINES(loc, cnt) do { (loc).last_column = 1; (loc).last_line += cnt; LOCATION_NEXT(loc); } while (0)
 
 #define LOCATION_COUNT_LINES(loc, text) \
-    std::cout << text << std::endl; \
     for(int i = 0; (text[i]) != '\0'; i++) { \
         if((text[i]) == '\n') { \
             (loc).last_line++; \


### PR DESCRIPTION
* I accidentally left a debug output in the lexer.
* my text editor was confused by the Gravis in the Release Log
* the todo list contains resolved task
   * Allow specifying viewpoint in the scad file
   * More strict checking of module parameters to make e.g. this fail:


> o More strict checking of module parameters to make e.g. this fail:
>   module test(a,b) { a=1; b=2; echo(a,b,c); } test(c=3);
>   (also for built-in modules)

that seams to be done:
```
WARNING: variable c not specified as parameter in file , line 1
WARNING: Parameter a is overwritten with a literal in file , line 1
WARNING: Parameter b is overwritten with a literal in file , line 1
```