### PR TITLE
fix and regenerate ord-tests

### DIFF
--- a/src/core/Expression.cc
+++ b/src/core/Expression.cc
@@ -645,7 +645,7 @@ void Assert::performAssert(const AssignmentList& arguments, const Location& loca
 
   if (!parameters["condition"].toBool()) {
     std::string conditionString = conditionExpression ? STR(" '" << *conditionExpression << "'") : "";
-    std::string messageString = parameters.contains("message") ? (": " + parameters["message"].toEchoString()) : "";
+    std::string messageString = parameters.contains("message") ? (": " + parameters["message"].toEchoStringNoThrow()) : "";
     LOG(message_group::Error, location, context->documentRoot(), "Assertion%1$s failed%2$s", conditionString, messageString);
     throw AssertionFailedException("Assertion Failed", location);
   }
@@ -705,9 +705,9 @@ void Let::doSequentialAssignment(const AssignmentList& assignments, const Locati
   for (const auto& assignment : assignments) {
     Value value = assignment->getExpr()->evaluate(*targetContext);
     if (assignment->getName().empty()) {
-      LOG(message_group::Warning, location, targetContext->documentRoot(), "Assignment without variable name %1$s", value.toEchoString());
+      LOG(message_group::Warning, location, targetContext->documentRoot(), "Assignment without variable name %1$s", value.toEchoStringNoThrow());
     } else if (seen.find(assignment->getName()) != seen.end()) {
-      LOG(message_group::Warning, location, targetContext->documentRoot(), "Ignoring duplicate variable assignment %1$s = %2$s", assignment->getName(), value.toEchoString());
+      LOG(message_group::Warning, location, targetContext->documentRoot(), "Ignoring duplicate variable assignment %1$s = %2$s", assignment->getName(), value.toEchoStringNoThrow());
     } else {
       targetContext->set_variable(assignment->getName(), std::move(value));
       seen.insert(assignment->getName());

--- a/src/core/ImportNode.cc
+++ b/src/core/ImportNode.cc
@@ -121,7 +121,7 @@ static std::shared_ptr<AbstractNode> do_import(const ModuleInstantiation *inst, 
   bool originOk = origin.getVec2(node->origin_x, node->origin_y);
   originOk &= std::isfinite(node->origin_x) && std::isfinite(node->origin_y);
   if (origin.isDefined() && !originOk) {
-    LOG(message_group::Warning, inst->location(), parameters.documentRoot(), "Unable to convert import(..., origin=%1$s) parameter to vec2", origin.toEchoString());
+    LOG(message_group::Warning, inst->location(), parameters.documentRoot(), "Unable to convert import(..., origin=%1$s) parameter to vec2", origin.toEchoStringNoThrow());
   }
 
   const auto& center = parameters["center"];
@@ -138,7 +138,7 @@ static std::shared_ptr<AbstractNode> do_import(const ModuleInstantiation *inst, 
       std::string filePath = boostfs_uncomplete(inst->location().filePath(), parameters.documentRoot()).generic_string();
       LOG(message_group::Warning, Location::NONE, "",
           "Invalid dpi value giving, using default of %1$f dpi. Value must be positive and >= 0.001, file %2$s, import() at line %3$d",
-          origin.toEchoString(), filePath, filePath, inst->location().firstLine()
+          origin.toEchoStringNoThrow(), filePath, filePath, inst->location().firstLine()
           );
     } else {
       node->dpi = val;

--- a/src/core/LinearExtrudeNode.cc
+++ b/src/core/LinearExtrudeNode.cc
@@ -103,14 +103,14 @@ static std::shared_ptr<AbstractNode> builtin_linear_extrude(const ModuleInstanti
   bool originOk = parameters["origin"].getVec2(node->origin_x, node->origin_y);
   originOk &= std::isfinite(node->origin_x) && std::isfinite(node->origin_y);
   if (parameters["origin"].isDefined() && !originOk) {
-    LOG(message_group::Warning, inst->location(), parameters.documentRoot(), "linear_extrude(..., origin=%1$s) could not be converted", parameters["origin"].toEchoString());
+    LOG(message_group::Warning, inst->location(), parameters.documentRoot(), "linear_extrude(..., origin=%1$s) could not be converted", parameters["origin"].toEchoStringNoThrow());
   }
   node->scale_x = node->scale_y = 1;
   bool scaleOK = parameters["scale"].getFiniteDouble(node->scale_x);
   scaleOK &= parameters["scale"].getFiniteDouble(node->scale_y);
   scaleOK |= parameters["scale"].getVec2(node->scale_x, node->scale_y, true);
   if ((parameters["scale"].isDefined()) && (!scaleOK || !std::isfinite(node->scale_x) || !std::isfinite(node->scale_y))) {
-    LOG(message_group::Warning, inst->location(), parameters.documentRoot(), "linear_extrude(..., scale=%1$s) could not be converted", parameters["scale"].toEchoString());
+    LOG(message_group::Warning, inst->location(), parameters.documentRoot(), "linear_extrude(..., scale=%1$s) could not be converted", parameters["scale"].toEchoStringNoThrow());
   }
 
   if (parameters["center"].type() == Value::Type::BOOL) node->center = parameters["center"].toBool();

--- a/src/core/Parameters.cc
+++ b/src/core/Parameters.cc
@@ -77,7 +77,7 @@ bool Parameters::valid(const std::string& name, const Value& value,
   if (value.type() == type) {
     return true;
   }
-  print_argConvert_warning(caller, name, value.type(), {type}, loc,
+  print_argConvert_warning(caller, name, value, {type}, loc,
                            documentRoot());
   return false;
 }
@@ -241,7 +241,7 @@ void print_argCnt_warning(
 void print_argConvert_warning(
   const std::string& name,
   const std::string& where,
-  Value::Type found,
+  const Value& found,
   std::vector<Value::Type> expected,
   const Location& loc,
   const std::string& documentRoot
@@ -258,6 +258,6 @@ void print_argConvert_warning(
     }
     message << ")";
   }
-  message << ", found " << Value::typeName(found);
+  message << ", found " << Value::typeName(found.type()) << " " << "(" << found.toEchoString() <<")";
   LOG(message_group::Warning, loc, documentRoot, "%1$s", message.str());
 }

--- a/src/core/Parameters.cc
+++ b/src/core/Parameters.cc
@@ -258,6 +258,6 @@ void print_argConvert_warning(
     }
     message << ")";
   }
-  message << ", found " << Value::typeName(found.type()) << " " << "(" << found.toEchoString() <<")";
+  message << ", found " << Value::typeName(found.type()) << " " << "(" << found.toEchoStringNoThrow() << ")";
   LOG(message_group::Warning, loc, documentRoot, "%1$s", message.str());
 }

--- a/src/core/Parameters.h
+++ b/src/core/Parameters.h
@@ -74,5 +74,5 @@ void print_argCnt_warning(const std::string& name, int found,
                           const std::string& expected, const Location& loc,
                           const std::string& documentRoot);
 void print_argConvert_warning(const std::string& name, const std::string& where,
-                              Value::Type found, std::vector<Value::Type> expected,
+                              const Value& found, std::vector<Value::Type> expected,
                               const Location& loc, const std::string& documentRoot);

--- a/src/core/RotateExtrudeNode.cc
+++ b/src/core/RotateExtrudeNode.cc
@@ -67,7 +67,7 @@ static std::shared_ptr<AbstractNode> builtin_rotate_extrude(const ModuleInstanti
   bool originOk = parameters["origin"].getVec2(node->origin_x, node->origin_y);
   originOk &= std::isfinite(node->origin_x) && std::isfinite(node->origin_y);
   if (parameters["origin"].isDefined() && !originOk) {
-    LOG(message_group::Warning, inst->location(), parameters.documentRoot(), "rotate_extrude(..., origin=%1$s) could not be converted", parameters["origin"].toEchoString());
+    LOG(message_group::Warning, inst->location(), parameters.documentRoot(), "rotate_extrude(..., origin=%1$s) could not be converted", parameters["origin"].toEchoStringNoThrow());
   }
   node->scale = parameters["scale"].toDouble();
   node->angle = 360;

--- a/src/core/TransformNode.cc
+++ b/src/core/TransformNode.cc
@@ -60,12 +60,12 @@ std::shared_ptr<AbstractNode> builtin_scale(const ModuleInstantiation *inst, Arg
     if (parameters["v"].getDouble(num)) {
       scalevec.setConstant(num);
     } else {
-      LOG(message_group::Warning, inst->location(), parameters.documentRoot(), "Unable to convert scale(%1$s) parameter to a number, a vec3 or vec2 of numbers or a number", parameters["v"].toEchoString());
+      LOG(message_group::Warning, inst->location(), parameters.documentRoot(), "Unable to convert scale(%1$s) parameter to a number, a vec3 or vec2 of numbers or a number", parameters["v"].toEchoStringNoThrow());
     }
   }
   if (OpenSCAD::rangeCheck) {
     if (scalevec[0] == 0 || scalevec[1] == 0 || scalevec[2] == 0 || !std::isfinite(scalevec[0])|| !std::isfinite(scalevec[1])|| !std::isfinite(scalevec[2])) {
-      LOG(message_group::Warning, inst->location(), parameters.documentRoot(), "scale(%1$s)", parameters["v"].toEchoString());
+      LOG(message_group::Warning, inst->location(), parameters.documentRoot(), "scale(%1$s)", parameters["v"].toEchoStringNoThrow());
     }
   }
   node->matrix.scale(scalevec);
@@ -116,13 +116,13 @@ std::shared_ptr<AbstractNode> builtin_rotate(const ModuleInstantiation *inst, Ar
     bool v_supplied = val_v.isDefined();
     if (ok) {
       if (v_supplied) {
-        LOG(message_group::Warning, inst->location(), parameters.documentRoot(), "When parameter a is supplied as vector, v is ignored rotate(a=%1$s, v=%2$s)", val_a.toEchoString(), val_v.toEchoString());
+        LOG(message_group::Warning, inst->location(), parameters.documentRoot(), "When parameter a is supplied as vector, v is ignored rotate(a=%1$s, v=%2$s)", val_a.toEchoStringNoThrow(), val_v.toEchoStringNoThrow());
       }
     } else {
       if (v_supplied) {
-        LOG(message_group::Warning, inst->location(), parameters.documentRoot(), "Problem converting rotate(a=%1$s, v=%2$s) parameter", val_a.toEchoString(), val_v.toEchoString());
+        LOG(message_group::Warning, inst->location(), parameters.documentRoot(), "Problem converting rotate(a=%1$s, v=%2$s) parameter", val_a.toEchoStringNoThrow(), val_v.toEchoStringNoThrow());
       } else {
-        LOG(message_group::Warning, inst->location(), parameters.documentRoot(), "Problem converting rotate(a=%1$s) parameter", val_a.toEchoString());
+        LOG(message_group::Warning, inst->location(), parameters.documentRoot(), "Problem converting rotate(a=%1$s) parameter", val_a.toEchoStringNoThrow());
       }
     }
     Matrix3d M;
@@ -140,12 +140,12 @@ std::shared_ptr<AbstractNode> builtin_rotate(const ModuleInstantiation *inst, Ar
     node->matrix.rotate(angle_axis_degrees(aConverted ? a : 0, v));
     if (val_v.isDefined() && !vConverted) {
       if (aConverted) {
-        LOG(message_group::Warning, inst->location(), parameters.documentRoot(), "Problem converting rotate(..., v=%1$s) parameter", val_v.toEchoString());
+        LOG(message_group::Warning, inst->location(), parameters.documentRoot(), "Problem converting rotate(..., v=%1$s) parameter", val_v.toEchoStringNoThrow());
       } else {
-        LOG(message_group::Warning, inst->location(), parameters.documentRoot(), "Problem converting rotate(a=%1$s, v=%2$s) parameter", val_a.toEchoString(), val_v.toEchoString());
+        LOG(message_group::Warning, inst->location(), parameters.documentRoot(), "Problem converting rotate(a=%1$s, v=%2$s) parameter", val_a.toEchoStringNoThrow(), val_v.toEchoStringNoThrow());
       }
     } else if (!aConverted) {
-      LOG(message_group::Warning, inst->location(), parameters.documentRoot(), "Problem converting rotate(a=%1$s) parameter", val_a.toEchoString());
+      LOG(message_group::Warning, inst->location(), parameters.documentRoot(), "Problem converting rotate(a=%1$s) parameter", val_a.toEchoStringNoThrow());
     }
   }
 
@@ -160,7 +160,7 @@ std::shared_ptr<AbstractNode> builtin_mirror(const ModuleInstantiation *inst, Ar
 
   double x = 1.0, y = 0.0, z = 0.0;
   if (!parameters["v"].getVec3(x, y, z, 0.0)) {
-    LOG(message_group::Warning, inst->location(), parameters.documentRoot(), "Unable to convert mirror(%1$s) parameter to a vec3 or vec2 of numbers", parameters["v"].toEchoString());
+    LOG(message_group::Warning, inst->location(), parameters.documentRoot(), "Unable to convert mirror(%1$s) parameter to a vec3 or vec2 of numbers", parameters["v"].toEchoStringNoThrow());
   }
 
   // x /= sqrt(x*x + y*y + z*z)
@@ -195,7 +195,7 @@ std::shared_ptr<AbstractNode> builtin_translate(const ModuleInstantiation *inst,
   if (ok) {
     node->matrix.translate(translatevec);
   } else {
-    LOG(message_group::Warning, inst->location(), parameters.documentRoot(), "Unable to convert translate(%1$s) parameter to a vec3 or vec2 of numbers", parameters["v"].toEchoString());
+    LOG(message_group::Warning, inst->location(), parameters.documentRoot(), "Unable to convert translate(%1$s) parameter to a vec3 or vec2 of numbers", parameters["v"].toEchoStringNoThrow());
   }
 
   return children.instantiate(node);

--- a/src/core/Value.cc
+++ b/src/core/Value.cc
@@ -429,6 +429,17 @@ std::string Value::toEchoString() const
   }
 }
 
+std::string Value::toEchoStringNoThrow() const
+{
+  std::string ret;
+  try{
+    ret = toEchoString();
+  } catch (EvaluationException& e) {
+     ret = "...";
+  }
+  return ret;
+}
+
 std::string UndefType::toString() const {
   std::ostringstream stream;
   if (!reasons->empty()) {

--- a/src/core/Value.h
+++ b/src/core/Value.h
@@ -579,6 +579,7 @@ public:
   bool getFiniteDouble(double& v) const;
   std::string toString() const;
   std::string toEchoString() const;
+  std::string toEchoStringNoThrow() const; //use this for warnings
   const UndefType& toUndef();
   std::string toUndefString() const;
   std::string chrString() const;

--- a/src/core/builtin_functions.cc
+++ b/src/core/builtin_functions.cc
@@ -433,7 +433,7 @@ Value builtin_lookup(Arguments arguments, const Location& loc)
   }
   double p = arguments[0]->toDouble();
   if (!std::isfinite(p)) {
-    LOG(message_group::Warning, loc, arguments.documentRoot(), "lookup(%1$s, ...) first argument is not a number", arguments[0]->toEchoString());
+    LOG(message_group::Warning, loc, arguments.documentRoot(), "lookup(%1$s, ...) first argument is not a number", arguments[0]->toEchoStringNoThrow());
     return Value::undefined.clone();
   }
 
@@ -576,7 +576,7 @@ static VectorType search(
     for (size_t j = 0; j < searchTableSize; ++j) {
       const auto& entryVec = table[j].toVector();
       if (entryVec.size() <= index_col_num) {
-        LOG(message_group::Warning, loc, session->documentRoot(), "Invalid entry in search vector at index %1$d, required number of values in the entry: %2$d. Invalid entry: %3$s", j, (index_col_num + 1), table[j].toEchoString());
+        LOG(message_group::Warning, loc, session->documentRoot(), "Invalid entry in search vector at index %1$d, required number of values in the entry: %2$d. Invalid entry: %3$s", j, (index_col_num + 1), table[j].toEchoStringNoThrow());
         return VectorType(session);
       }
       const gchar *ptr_st = g_utf8_offset_to_pointer(entryVec[index_col_num].toString().c_str(), 0);

--- a/src/core/builtin_functions.cc
+++ b/src/core/builtin_functions.cc
@@ -87,7 +87,7 @@ static inline bool check_arguments(const char *function_name, const Arguments& a
   for (size_t i = 0; i < N; i++) {
     if (arguments[i]->type() != expected_types[i]) {
       if (warn) {
-        print_argConvert_warning(function_name, "argument " + STR(i), arguments[i]->type(), {expected_types[i]}, loc, arguments.documentRoot());
+        print_argConvert_warning(function_name, "argument " + STR(i), arguments[i]->clone(), {expected_types[i]}, loc, arguments.documentRoot());
       }
       return false;
     }
@@ -194,7 +194,7 @@ static std::vector<double> min_max_arguments(const Arguments& arguments, const L
       // 4/20/14 semantic change per discussion:
       // break on any non-number
       if (element.type() != Value::Type::NUMBER) {
-        print_argConvert_warning(function_name, "vector element " + STR(i), element.type(), {Value::Type::NUMBER}, loc, arguments.documentRoot());
+        print_argConvert_warning(function_name, "vector element " + STR(i), element, {Value::Type::NUMBER}, loc, arguments.documentRoot());
         return {};
       }
       output.push_back(element.toDouble());
@@ -205,7 +205,7 @@ static std::vector<double> min_max_arguments(const Arguments& arguments, const L
       // 4/20/14 semantic change per discussion:
       // break on any non-number
       if (argument->type() != Value::Type::NUMBER) {
-        print_argConvert_warning(function_name, "argument " + STR(i), argument->type(), {Value::Type::NUMBER}, loc, arguments.documentRoot());
+        print_argConvert_warning(function_name, "argument " + STR(i), argument->clone(), {Value::Type::NUMBER}, loc, arguments.documentRoot());
         return {};
       }
       output.push_back(argument->toDouble());

--- a/src/core/control.cc
+++ b/src/core/control.cc
@@ -146,7 +146,7 @@ static std::shared_ptr<AbstractNode> builtin_children(const ModuleInstantiation 
     return children->instantiate(lazyUnionNode(inst), indices);
   } else {
     // Invalid argument
-    LOG(message_group::Warning, inst->location(), parameters.documentRoot(), "Bad parameter type (%1$s) for children, only accept: empty, number, vector, range", parameters["index"].toEchoString());
+    LOG(message_group::Warning, inst->location(), parameters.documentRoot(), "Bad parameter type (%1$s) for children, only accept: empty, number, vector, range", parameters["index"].toEchoStringNoThrow());
     return std::shared_ptr<AbstractNode>();
   }
 }
@@ -188,10 +188,10 @@ static std::shared_ptr<AbstractNode> builtin_assign(const ModuleInstantiation *i
   ContextHandle<Context> assignContext{Context::create<Context>(context)};
   for (auto& argument : arguments) {
     if (!argument.name) {
-      LOG(message_group::Warning, inst->location(), context->documentRoot(), "Assignment without variable name %1$s", argument->toEchoString());
+      LOG(message_group::Warning, inst->location(), context->documentRoot(), "Assignment without variable name %1$s", argument->toEchoStringNoThrow());
     } else {
       if (assignContext->lookup_local_variable(*argument.name)) {
-        LOG(message_group::Warning, inst->location(), context->documentRoot(), "Duplicate variable assignment %1$s = %2$s", *argument.name, argument->toEchoString());
+        LOG(message_group::Warning, inst->location(), context->documentRoot(), "Duplicate variable assignment %1$s = %2$s", *argument.name, argument->toEchoStringNoThrow());
       }
       assignContext->set_variable(*argument.name, std::move(argument.value));
     }

--- a/src/core/primitives.cc
+++ b/src/core/primitives.cc
@@ -217,12 +217,12 @@ static std::shared_ptr<AbstractNode> builtin_cube(const ModuleInstantiation *ins
     converted |= size.getDouble(node->z);
     converted |= size.getVec3(node->x, node->y, node->z);
     if (!converted) {
-      LOG(message_group::Warning, inst->location(), parameters.documentRoot(), "Unable to convert cube(size=%1$s, ...) parameter to a number or a vec3 of numbers", size.toEchoString());
+      LOG(message_group::Warning, inst->location(), parameters.documentRoot(), "Unable to convert cube(size=%1$s, ...) parameter to a number or a vec3 of numbers", size.toEchoStringNoThrow());
     } else if (OpenSCAD::rangeCheck) {
       bool ok = (node->x > 0) && (node->y > 0) && (node->z > 0);
       ok &= std::isfinite(node->x) && std::isfinite(node->y) && std::isfinite(node->z);
       if (!ok) {
-        LOG(message_group::Warning, inst->location(), parameters.documentRoot(), "cube(size=%1$s, ...)", size.toEchoString());
+        LOG(message_group::Warning, inst->location(), parameters.documentRoot(), "cube(size=%1$s, ...)", size.toEchoStringNoThrow());
       }
     }
   }
@@ -346,7 +346,7 @@ static std::shared_ptr<AbstractNode> builtin_sphere(const ModuleInstantiation *i
     node->r = r.toDouble();
     if (OpenSCAD::rangeCheck && (node->r <= 0 || !std::isfinite(node->r))) {
       LOG(message_group::Warning, inst->location(), parameters.documentRoot(),
-          "sphere(r=%1$s)", r.toEchoString());
+          "sphere(r=%1$s)", r.toEchoStringNoThrow());
     }
   }
 
@@ -487,13 +487,13 @@ static std::shared_ptr<AbstractNode> builtin_cylinder(const ModuleInstantiation 
 
   if (OpenSCAD::rangeCheck) {
     if (node->h <= 0 || !std::isfinite(node->h)) {
-      LOG(message_group::Warning, inst->location(), parameters.documentRoot(), "cylinder(h=%1$s, ...)", parameters["h"].toEchoString());
+      LOG(message_group::Warning, inst->location(), parameters.documentRoot(), "cylinder(h=%1$s, ...)", parameters["h"].toEchoStringNoThrow());
     }
     if (node->r1 < 0 || node->r2 < 0 || (node->r1 == 0 && node->r2 == 0) || !std::isfinite(node->r1) || !std::isfinite(node->r2)) {
       LOG(message_group::Warning, inst->location(), parameters.documentRoot(),
           "cylinder(r1=%1$s, r2=%2$s, ...)",
-          (r1.type() == Value::Type::NUMBER ? r1.toEchoString() : r.toEchoString()),
-          (r2.type() == Value::Type::NUMBER ? r2.toEchoString() : r.toEchoString()));
+          (r1.type() == Value::Type::NUMBER ? r1.toEchoStringNoThrow() : r.toEchoStringNoThrow()),
+          (r2.type() == Value::Type::NUMBER ? r2.toEchoStringNoThrow() : r.toEchoStringNoThrow()));
     }
   }
 
@@ -583,7 +583,7 @@ static std::shared_ptr<AbstractNode> builtin_polyhedron(const ModuleInstantiatio
   Parameters parameters = Parameters::parse(std::move(arguments), inst->location(), {"points", "faces", "convexity"}, {"triangles"});
 
   if (parameters["points"].type() != Value::Type::VECTOR) {
-    LOG(message_group::Error, inst->location(), parameters.documentRoot(), "Unable to convert points = %1$s to a vector of coordinates", parameters["points"].toEchoString());
+    LOG(message_group::Error, inst->location(), parameters.documentRoot(), "Unable to convert points = %1$s to a vector of coordinates", parameters["points"].toEchoStringNoThrow());
     return node;
   }
   for (const Value& pointValue : parameters["points"].toVector()) {
@@ -591,7 +591,7 @@ static std::shared_ptr<AbstractNode> builtin_polyhedron(const ModuleInstantiatio
     if (!pointValue.getVec3(point.x, point.y, point.z, 0.0) ||
         !std::isfinite(point.x) || !std::isfinite(point.y) || !std::isfinite(point.z)
         ) {
-      LOG(message_group::Error, inst->location(), parameters.documentRoot(), "Unable to convert points[%1$d] = %2$s to a vec3 of numbers", node->points.size(), pointValue.toEchoString());
+      LOG(message_group::Error, inst->location(), parameters.documentRoot(), "Unable to convert points[%1$d] = %2$s to a vec3 of numbers", node->points.size(), pointValue.toEchoStringNoThrow());
       node->points.push_back({0, 0, 0});
     } else {
       node->points.push_back(point);
@@ -607,19 +607,19 @@ static std::shared_ptr<AbstractNode> builtin_polyhedron(const ModuleInstantiatio
     faces = &parameters["faces"];
   }
   if (faces->type() != Value::Type::VECTOR) {
-    LOG(message_group::Error, inst->location(), parameters.documentRoot(), "Unable to convert faces = %1$s to a vector of vector of point indices", faces->toEchoString());
+    LOG(message_group::Error, inst->location(), parameters.documentRoot(), "Unable to convert faces = %1$s to a vector of vector of point indices", faces->toEchoStringNoThrow());
     return node;
   }
   size_t faceIndex = 0;
   for (const Value& faceValue : faces->toVector()) {
     if (faceValue.type() != Value::Type::VECTOR) {
-      LOG(message_group::Error, inst->location(), parameters.documentRoot(), "Unable to convert faces[%1$d] = %2$s to a vector of numbers", faceIndex, faceValue.toEchoString());
+      LOG(message_group::Error, inst->location(), parameters.documentRoot(), "Unable to convert faces[%1$d] = %2$s to a vector of numbers", faceIndex, faceValue.toEchoStringNoThrow());
     } else {
       size_t pointIndexIndex = 0;
       std::vector<size_t> face;
       for (const Value& pointIndexValue : faceValue.toVector()) {
         if (pointIndexValue.type() != Value::Type::NUMBER) {
-          LOG(message_group::Error, inst->location(), parameters.documentRoot(), "Unable to convert faces[%1$d][%2$d] = %3$s to a number", faceIndex, pointIndexIndex, pointIndexValue.toEchoString());
+          LOG(message_group::Error, inst->location(), parameters.documentRoot(), "Unable to convert faces[%1$d][%2$d] = %3$s to a number", faceIndex, pointIndexIndex, pointIndexValue.toEchoStringNoThrow());
         } else {
           size_t pointIndex = (size_t)pointIndexValue.toDouble();
           if (pointIndex < node->points.size()) {
@@ -707,13 +707,13 @@ static std::shared_ptr<AbstractNode> builtin_square(const ModuleInstantiation *i
     converted |= size.getDouble(node->y);
     converted |= size.getVec2(node->x, node->y);
     if (!converted) {
-      LOG(message_group::Warning, inst->location(), parameters.documentRoot(), "Unable to convert square(size=%1$s, ...) parameter to a number or a vec2 of numbers", size.toEchoString());
+      LOG(message_group::Warning, inst->location(), parameters.documentRoot(), "Unable to convert square(size=%1$s, ...) parameter to a number or a vec2 of numbers", size.toEchoStringNoThrow());
     } else if (OpenSCAD::rangeCheck) {
       bool ok = true;
       ok &= (node->x > 0) && (node->y > 0);
       ok &= std::isfinite(node->x) && std::isfinite(node->y);
       if (!ok) {
-        LOG(message_group::Warning, inst->location(), parameters.documentRoot(), "square(size=%1$s, ...)", size.toEchoString());
+        LOG(message_group::Warning, inst->location(), parameters.documentRoot(), "square(size=%1$s, ...)", size.toEchoStringNoThrow());
       }
     }
   }
@@ -785,7 +785,7 @@ static std::shared_ptr<AbstractNode> builtin_circle(const ModuleInstantiation *i
     node->r = r.toDouble();
     if (OpenSCAD::rangeCheck && ((node->r <= 0) || !std::isfinite(node->r))) {
       LOG(message_group::Warning, inst->location(), parameters.documentRoot(),
-          "circle(r=%1$s)", r.toEchoString());
+          "circle(r=%1$s)", r.toEchoStringNoThrow());
     }
   }
 
@@ -888,7 +888,7 @@ static std::shared_ptr<AbstractNode> builtin_polygon(const ModuleInstantiation *
   Parameters parameters = Parameters::parse(std::move(arguments), inst->location(), {"points", "paths", "convexity"});
 
   if (parameters["points"].type() != Value::Type::VECTOR) {
-    LOG(message_group::Error, inst->location(), parameters.documentRoot(), "Unable to convert points = %1$s to a vector of coordinates", parameters["points"].toEchoString());
+    LOG(message_group::Error, inst->location(), parameters.documentRoot(), "Unable to convert points = %1$s to a vector of coordinates", parameters["points"].toEchoStringNoThrow());
     return node;
   }
   for (const Value& pointValue : parameters["points"].toVector()) {
@@ -896,7 +896,7 @@ static std::shared_ptr<AbstractNode> builtin_polygon(const ModuleInstantiation *
     if (!pointValue.getVec2(point.x, point.y) ||
         !std::isfinite(point.x) || !std::isfinite(point.y)
         ) {
-      LOG(message_group::Error, inst->location(), parameters.documentRoot(), "Unable to convert points[%1$d] = %2$s to a vec2 of numbers", node->points.size(), pointValue.toEchoString());
+      LOG(message_group::Error, inst->location(), parameters.documentRoot(), "Unable to convert points[%1$d] = %2$s to a vec2 of numbers", node->points.size(), pointValue.toEchoStringNoThrow());
       node->points.push_back({0, 0});
     } else {
       node->points.push_back(point);
@@ -907,13 +907,13 @@ static std::shared_ptr<AbstractNode> builtin_polygon(const ModuleInstantiation *
     size_t pathIndex = 0;
     for (const Value& pathValue : parameters["paths"].toVector()) {
       if (pathValue.type() != Value::Type::VECTOR) {
-        LOG(message_group::Error, inst->location(), parameters.documentRoot(), "Unable to convert paths[%1$d] = %2$s to a vector of numbers", pathIndex, pathValue.toEchoString());
+        LOG(message_group::Error, inst->location(), parameters.documentRoot(), "Unable to convert paths[%1$d] = %2$s to a vector of numbers", pathIndex, pathValue.toEchoStringNoThrow());
       } else {
         size_t pointIndexIndex = 0;
         std::vector<size_t> path;
         for (const Value& pointIndexValue : pathValue.toVector()) {
           if (pointIndexValue.type() != Value::Type::NUMBER) {
-            LOG(message_group::Error, inst->location(), parameters.documentRoot(), "Unable to convert paths[%1$d][%2$d] = %3$s to a number", pathIndex, pointIndexIndex, pointIndexValue.toEchoString());
+            LOG(message_group::Error, inst->location(), parameters.documentRoot(), "Unable to convert paths[%1$d][%2$d] = %3$s to a number", pathIndex, pointIndexIndex, pointIndexValue.toEchoStringNoThrow());
           } else {
             size_t pointIndex = (size_t)pointIndexValue.toDouble();
             if (pointIndex < node->points.size()) {
@@ -929,7 +929,7 @@ static std::shared_ptr<AbstractNode> builtin_polygon(const ModuleInstantiation *
       pathIndex++;
     }
   } else if (parameters["paths"].type() != Value::Type::UNDEFINED) {
-    LOG(message_group::Error, inst->location(), parameters.documentRoot(), "Unable to convert paths = %1$s to a vector of vector of point indices", parameters["paths"].toEchoString());
+    LOG(message_group::Error, inst->location(), parameters.documentRoot(), "Unable to convert paths = %1$s to a vector of vector of point indices", parameters["paths"].toEchoStringNoThrow());
     return node;
   }
 

--- a/tests/regression/echotest/cross-tests-expected.echo
+++ b/tests/regression/echotest/cross-tests-expected.echo
@@ -9,9 +9,9 @@ WARNING: Invalid value (INF) in parameter vector for cross() in file cross-tests
 ECHO: undef
 WARNING: cross() number of parameters does not match: expected 2, found 1 in file cross-tests.scad, line 9
 ECHO: undef
-WARNING: cross() parameter could not be converted: argument 0: expected vector, found number in file cross-tests.scad, line 10
+WARNING: cross() parameter could not be converted: argument 0: expected vector, found number (0) in file cross-tests.scad, line 10
 ECHO: undef
-WARNING: cross() parameter could not be converted: argument 0: expected vector, found number in file cross-tests.scad, line 11
+WARNING: cross() parameter could not be converted: argument 0: expected vector, found number (0) in file cross-tests.scad, line 11
 ECHO: undef
 WARNING: cross() number of parameters does not match: expected 2, found 3 in file cross-tests.scad, line 12
 ECHO: undef

--- a/tests/regression/echotest/errors-warnings-expected.echo
+++ b/tests/regression/echotest/errors-warnings-expected.echo
@@ -41,7 +41,7 @@ WARNING: linear_extrude(..., scale=inf) could not be converted in file errors-wa
 ECHO: 10
 ECHO: 15
 ECHO: 20
-WARNING: lookup() parameter could not be converted: argument 0: expected number, found string in file errors-warnings.scad, line 73
+WARNING: lookup() parameter could not be converted: argument 0: expected number, found string ("test") in file errors-warnings.scad, line 73
 ECHO: undef
 WARNING: lookup() number of parameters does not match: expected 2, found 3 in file errors-warnings.scad, line 74
 ECHO: undef

--- a/tests/regression/echotest/errors-warnings-included-expected.echo
+++ b/tests/regression/echotest/errors-warnings-included-expected.echo
@@ -42,7 +42,7 @@ WARNING: linear_extrude(..., scale=inf) could not be converted in file errors-wa
 ECHO: 10
 ECHO: 15
 ECHO: 20
-WARNING: lookup() parameter could not be converted: argument 0: expected number, found string in file errors-warnings.scad, line 73
+WARNING: lookup() parameter could not be converted: argument 0: expected number, found string ("test") in file errors-warnings.scad, line 73
 ECHO: undef
 WARNING: lookup() number of parameters does not match: expected 2, found 3 in file errors-warnings.scad, line 74
 ECHO: undef

--- a/tests/regression/echotest/issue1528-expected.echo
+++ b/tests/regression/echotest/issue1528-expected.echo
@@ -1,2 +1,2 @@
-WARNING: lookup() parameter could not be converted: argument 1: expected vector, found undefined in file issue1528.scad, line 1
+WARNING: lookup() parameter could not be converted: argument 1: expected vector, found undefined (undef) in file issue1528.scad, line 1
 ECHO: undef

--- a/tests/regression/echotest/len-tests-expected.echo
+++ b/tests/regression/echotest/len-tests-expected.echo
@@ -4,5 +4,5 @@ ECHO: 0
 ECHO: 0
 ECHO: 2
 ECHO: 3
-WARNING: len() parameter could not be converted: argument 0: expected string, found undefined in file len-tests.scad, line 12
+WARNING: len() parameter could not be converted: argument 0: expected string, found undefined (undef) in file len-tests.scad, line 12
 ECHO: undef

--- a/tests/regression/echotest/lookup-tests-expected.echo
+++ b/tests/regression/echotest/lookup-tests-expected.echo
@@ -1,10 +1,10 @@
-WARNING: lookup() parameter could not be converted: argument 0: expected number, found undefined in file lookup-tests.scad, line 1
+WARNING: lookup() parameter could not be converted: argument 0: expected number, found undefined (undef) in file lookup-tests.scad, line 1
 ECHO: undef
-WARNING: lookup() parameter could not be converted: argument 0: expected number, found undefined in file lookup-tests.scad, line 2
+WARNING: lookup() parameter could not be converted: argument 0: expected number, found undefined (undef) in file lookup-tests.scad, line 2
 ECHO: undef
-WARNING: lookup() parameter could not be converted: argument 0: expected number, found undefined in file lookup-tests.scad, line 3
+WARNING: lookup() parameter could not be converted: argument 0: expected number, found undefined (undef) in file lookup-tests.scad, line 3
 ECHO: undef
-WARNING: lookup() parameter could not be converted: argument 0: expected number, found undefined in file lookup-tests.scad, line 4
+WARNING: lookup() parameter could not be converted: argument 0: expected number, found undefined (undef) in file lookup-tests.scad, line 4
 ECHO: undef
 ECHO: 0
 ECHO: 0.5

--- a/tests/regression/echotest/min-max-tests-expected.echo
+++ b/tests/regression/echotest/min-max-tests-expected.echo
@@ -6,13 +6,13 @@ WARNING: min() number of parameters does not match: expected at least 1 vector e
 ECHO: undef
 WARNING: max() number of parameters does not match: expected at least 1 vector element, found 0 in file min-max-tests.scad, line 4
 ECHO: undef
-WARNING: min() parameter could not be converted: argument 0: expected number, found undefined in file min-max-tests.scad, line 5
+WARNING: min() parameter could not be converted: argument 0: expected number, found undefined (undef) in file min-max-tests.scad, line 5
 ECHO: undef
-WARNING: max() parameter could not be converted: argument 0: expected number, found undefined in file min-max-tests.scad, line 6
+WARNING: max() parameter could not be converted: argument 0: expected number, found undefined (undef) in file min-max-tests.scad, line 6
 ECHO: undef
-WARNING: min() parameter could not be converted: argument 0: expected number, found string in file min-max-tests.scad, line 7
+WARNING: min() parameter could not be converted: argument 0: expected number, found string ("a") in file min-max-tests.scad, line 7
 ECHO: undef
-WARNING: max() parameter could not be converted: argument 0: expected number, found string in file min-max-tests.scad, line 8
+WARNING: max() parameter could not be converted: argument 0: expected number, found string ("b") in file min-max-tests.scad, line 8
 ECHO: undef
 ECHO: 0
 ECHO: 0
@@ -28,9 +28,9 @@ ECHO: 0
 ECHO: 2
 ECHO: 0
 ECHO: 2
-WARNING: min() parameter could not be converted: argument 0: expected number, found string in file min-max-tests.scad, line 23
+WARNING: min() parameter could not be converted: argument 0: expected number, found string ("a") in file min-max-tests.scad, line 23
 ECHO: undef
-WARNING: max() parameter could not be converted: argument 0: expected number, found string in file min-max-tests.scad, line 24
+WARNING: max() parameter could not be converted: argument 0: expected number, found string ("a") in file min-max-tests.scad, line 24
 ECHO: undef
 ECHO: 0
 ECHO: 5

--- a/tests/regression/echotest/norm-tests-expected.echo
+++ b/tests/regression/echotest/norm-tests-expected.echo
@@ -8,13 +8,13 @@ ECHO: undef
 ECHO: nan
 ECHO: inf
 ECHO: inf
-WARNING: norm() parameter could not be converted: argument 0: expected vector, found string in file norm-tests.scad, line 14
+WARNING: norm() parameter could not be converted: argument 0: expected vector, found string ("") in file norm-tests.scad, line 14
 ECHO: undef
-WARNING: norm() parameter could not be converted: argument 0: expected vector, found string in file norm-tests.scad, line 15
+WARNING: norm() parameter could not be converted: argument 0: expected vector, found string ("abcd") in file norm-tests.scad, line 15
 ECHO: undef
-WARNING: norm() parameter could not be converted: argument 0: expected vector, found bool in file norm-tests.scad, line 16
+WARNING: norm() parameter could not be converted: argument 0: expected vector, found bool (true) in file norm-tests.scad, line 16
 ECHO: undef
-WARNING: norm() parameter could not be converted: argument 0: expected vector, found range in file norm-tests.scad, line 17
+WARNING: norm() parameter could not be converted: argument 0: expected vector, found range ([1 : 1 : 4]) in file norm-tests.scad, line 17
 ECHO: undef
 WARNING: Incorrect arguments to norm() in file norm-tests.scad, line 19
 ECHO: undef
@@ -26,7 +26,7 @@ WARNING: Incorrect arguments to norm() in file norm-tests.scad, line 22
 ECHO: undef
 WARNING: Incorrect arguments to norm() in file norm-tests.scad, line 23
 ECHO: undef
-WARNING: norm() parameter could not be converted: argument 0: expected vector, found undefined in file norm-tests.scad, line 25
+WARNING: norm() parameter could not be converted: argument 0: expected vector, found undefined (undef) in file norm-tests.scad, line 25
 ECHO: undef
 WARNING: norm() number of parameters does not match: expected 1, found 2 in file norm-tests.scad, line 26
 ECHO: undef

--- a/tests/regression/echotest/ord-tests-expected.echo
+++ b/tests/regression/echotest/ord-tests-expected.echo
@@ -1,26 +1,27 @@
 ECHO: 97
 ECHO: 97
+WARNING: ord() number of parameters does not match: expected 1, found 0 in file ord-tests.scad, line 9
 ECHO: undef
 ECHO: undef
-WARNING: ord() argument undef is not of type string, in file ord-tests.scad, line 11
+WARNING: ord() parameter could not be converted: argument 0: expected string, found undefined in file ord-tests.scad, line 11
 ECHO: undef
-WARNING: ord() argument inf is not of type string, in file ord-tests.scad, line 12
+WARNING: ord() parameter could not be converted: argument 0: expected string, found number in file ord-tests.scad, line 12
 ECHO: undef
-WARNING: ord() argument -inf is not of type string, in file ord-tests.scad, line 13
+WARNING: ord() parameter could not be converted: argument 0: expected string, found number in file ord-tests.scad, line 13
 ECHO: undef
-WARNING: ord() argument nan is not of type string, in file ord-tests.scad, line 14
+WARNING: ord() parameter could not be converted: argument 0: expected string, found number in file ord-tests.scad, line 14
 ECHO: undef
-WARNING: ord() argument 3.1416 is not of type string, in file ord-tests.scad, line 15
+WARNING: ord() parameter could not be converted: argument 0: expected string, found number in file ord-tests.scad, line 15
 ECHO: undef
-WARNING: ord() argument [] is not of type string, in file ord-tests.scad, line 16
+WARNING: ord() parameter could not be converted: argument 0: expected string, found vector in file ord-tests.scad, line 16
 ECHO: undef
-WARNING: ord() argument [1, 2, 3] is not of type string, in file ord-tests.scad, line 17
+WARNING: ord() parameter could not be converted: argument 0: expected string, found vector in file ord-tests.scad, line 17
 ECHO: undef
-WARNING: ord() argument ["a", "b"] is not of type string, in file ord-tests.scad, line 18
+WARNING: ord() parameter could not be converted: argument 0: expected string, found vector in file ord-tests.scad, line 18
 ECHO: undef
-WARNING: ord() argument [1 : 1 : 5] is not of type string, in file ord-tests.scad, line 19
+WARNING: ord() parameter could not be converted: argument 0: expected string, found range in file ord-tests.scad, line 19
 ECHO: undef
-WARNING: ord() called with 2 arguments, only 1 argument expected, in file ord-tests.scad, line 20
+WARNING: ord() number of parameters does not match: expected 1, found 2 in file ord-tests.scad, line 20
 ECHO: undef
 ECHO: [116, 101, 115, 116]
 ECHO: "test"
@@ -32,7 +33,7 @@ ECHO: equals = true, len_input = 10, len_output = 10
 ECHO: equals = true, len_input = 10, len_output = 10
 ECHO: equals = true, len_input = 7, len_output = 7
 ECHO: equals = true, len_input = 1, len_output = 1
-WARNING: ord() argument '¤' is not valid utf8 string, in file ord-tests.scad, line 46
-WARNING: ord() argument 'ÄÖ' is not valid utf8 string, in file ord-tests.scad, line 46
-WARNING: ord() argument 'Üß' is not valid utf8 string, in file ord-tests.scad, line 46
+WARNING: ord() argument '¤' is not a valid utf8 string in file ord-tests.scad, line 46
+WARNING: ord() argument 'ÄÖ' is not a valid utf8 string in file ord-tests.scad, line 46
+WARNING: ord() argument 'Üß' is not a valid utf8 string in file ord-tests.scad, line 46
 ECHO: [undef, undef, undef]

--- a/tests/regression/echotest/ord-tests-expected.echo
+++ b/tests/regression/echotest/ord-tests-expected.echo
@@ -3,23 +3,23 @@ ECHO: 97
 WARNING: ord() number of parameters does not match: expected 1, found 0 in file ord-tests.scad, line 9
 ECHO: undef
 ECHO: undef
-WARNING: ord() parameter could not be converted: argument 0: expected string, found undefined in file ord-tests.scad, line 11
+WARNING: ord() parameter could not be converted: argument 0: expected string, found undefined (undef) in file ord-tests.scad, line 11
 ECHO: undef
-WARNING: ord() parameter could not be converted: argument 0: expected string, found number in file ord-tests.scad, line 12
+WARNING: ord() parameter could not be converted: argument 0: expected string, found number (inf) in file ord-tests.scad, line 12
 ECHO: undef
-WARNING: ord() parameter could not be converted: argument 0: expected string, found number in file ord-tests.scad, line 13
+WARNING: ord() parameter could not be converted: argument 0: expected string, found number (-inf) in file ord-tests.scad, line 13
 ECHO: undef
-WARNING: ord() parameter could not be converted: argument 0: expected string, found number in file ord-tests.scad, line 14
+WARNING: ord() parameter could not be converted: argument 0: expected string, found number (nan) in file ord-tests.scad, line 14
 ECHO: undef
-WARNING: ord() parameter could not be converted: argument 0: expected string, found number in file ord-tests.scad, line 15
+WARNING: ord() parameter could not be converted: argument 0: expected string, found number (3.1416) in file ord-tests.scad, line 15
 ECHO: undef
-WARNING: ord() parameter could not be converted: argument 0: expected string, found vector in file ord-tests.scad, line 16
+WARNING: ord() parameter could not be converted: argument 0: expected string, found vector ([]) in file ord-tests.scad, line 16
 ECHO: undef
-WARNING: ord() parameter could not be converted: argument 0: expected string, found vector in file ord-tests.scad, line 17
+WARNING: ord() parameter could not be converted: argument 0: expected string, found vector ([1, 2, 3]) in file ord-tests.scad, line 17
 ECHO: undef
-WARNING: ord() parameter could not be converted: argument 0: expected string, found vector in file ord-tests.scad, line 18
+WARNING: ord() parameter could not be converted: argument 0: expected string, found vector (["a", "b"]) in file ord-tests.scad, line 18
 ECHO: undef
-WARNING: ord() parameter could not be converted: argument 0: expected string, found range in file ord-tests.scad, line 19
+WARNING: ord() parameter could not be converted: argument 0: expected string, found range ([1 : 1 : 5]) in file ord-tests.scad, line 19
 ECHO: undef
 WARNING: ord() number of parameters does not match: expected 1, found 2 in file ord-tests.scad, line 20
 ECHO: undef

--- a/tests/regression/echotest/rands-expected.echo
+++ b/tests/regression/echotest/rands-expected.echo
@@ -1,5 +1,5 @@
-WARNING: rands() parameter could not be converted: argument 0: expected number, found string in file rands.scad, line 12
-WARNING: rands() parameter could not be converted: argument 2: expected number, found string in file rands.scad, line 19
+WARNING: rands() parameter could not be converted: argument 0: expected number, found string ("akhma") in file rands.scad, line 12
+WARNING: rands() parameter could not be converted: argument 2: expected number, found string ("blah") in file rands.scad, line 19
 WARNING: rands() number of parameters does not match: expected 3 or 4, found 2 in file rands.scad, line 24
 WARNING: rands() number of parameters does not match: expected 3 or 4, found 2 in file rands.scad, line 25
 WARNING: rands() number of parameters does not match: expected 3 or 4, found 1 in file rands.scad, line 26
@@ -7,7 +7,7 @@ WARNING: rands() number of parameters does not match: expected 3 or 4, found 0 i
 WARNING: Ignoring unknown variable 'v' in file rands.scad, line 28
 WARNING: Ignoring unknown variable 'v' in file rands.scad, line 28
 WARNING: Ignoring unknown variable 'v' in file rands.scad, line 28
-WARNING: rands() parameter could not be converted: argument 0: expected number, found undefined in file rands.scad, line 28
+WARNING: rands() parameter could not be converted: argument 0: expected number, found undefined (undef) in file rands.scad, line 28
 ECHO: "i hope rands() did not crash"
 ECHO: [1, 1, 1, 1]
 ECHO: [1.96977, 1.55343, 1.99383]

--- a/tests/regression/echotest/text-metrics-test-expected.echo
+++ b/tests/regression/echotest/text-metrics-test-expected.echo
@@ -4,17 +4,17 @@ ECHO: { position = [-116.212, -10.208]; size = [98.96, 20.416]; ascent = 20.1344
 ECHO: { nominal = { ascent = 12.5733; descent = -2.9433; }; max = { ascent = 13.6109; descent = -4.2114; }; interline = 15.9709; font = { family = "Liberation Sans"; style = "Regular"; }; }
 ECHO: { nominal = { ascent = 25.1466; descent = -5.8866; }; max = { ascent = 27.2218; descent = -8.4228; }; interline = 31.9418; font = { family = "Liberation Sans"; style = "Regular"; }; }
 ECHO: "Errors..."
-WARNING: textmetrics() parameter could not be converted: size: expected number, found vector in file text-metrics-test.scad, line 20
-WARNING: textmetrics() parameter could not be converted: text: expected string, found number in file text-metrics-test.scad, line 20
-WARNING: textmetrics() parameter could not be converted: spacing: expected number, found string in file text-metrics-test.scad, line 20
-WARNING: textmetrics() parameter could not be converted: font: expected string, found bool in file text-metrics-test.scad, line 20
-WARNING: textmetrics() parameter could not be converted: direction: expected string, found number in file text-metrics-test.scad, line 20
-WARNING: textmetrics() parameter could not be converted: language: expected string, found range in file text-metrics-test.scad, line 20
-WARNING: textmetrics() parameter could not be converted: script: expected string, found number in file text-metrics-test.scad, line 20
-WARNING: textmetrics() parameter could not be converted: halign: expected string, found number in file text-metrics-test.scad, line 20
-WARNING: textmetrics() parameter could not be converted: valign: expected string, found number in file text-metrics-test.scad, line 20
+WARNING: textmetrics() parameter could not be converted: size: expected number, found vector ([]) in file text-metrics-test.scad, line 20
+WARNING: textmetrics() parameter could not be converted: text: expected string, found number (123) in file text-metrics-test.scad, line 20
+WARNING: textmetrics() parameter could not be converted: spacing: expected number, found string ("") in file text-metrics-test.scad, line 20
+WARNING: textmetrics() parameter could not be converted: font: expected string, found bool (true) in file text-metrics-test.scad, line 20
+WARNING: textmetrics() parameter could not be converted: direction: expected string, found number (0) in file text-metrics-test.scad, line 20
+WARNING: textmetrics() parameter could not be converted: language: expected string, found range ([0 : 1 : 10]) in file text-metrics-test.scad, line 20
+WARNING: textmetrics() parameter could not be converted: script: expected string, found number (0) in file text-metrics-test.scad, line 20
+WARNING: textmetrics() parameter could not be converted: halign: expected string, found number (0) in file text-metrics-test.scad, line 20
+WARNING: textmetrics() parameter could not be converted: valign: expected string, found number (0) in file text-metrics-test.scad, line 20
 ECHO: { position = [0, 0]; size = [0, 0]; ascent = 0; descent = 0; offset = [0, 0]; advance = [0, 0]; }
 WARNING: variable text not specified as parameter in file text-metrics-test.scad, line 25
-WARNING: fontmetrics() parameter could not be converted: size: expected number, found bool in file text-metrics-test.scad, line 25
-WARNING: fontmetrics() parameter could not be converted: font: expected string, found number in file text-metrics-test.scad, line 25
+WARNING: fontmetrics() parameter could not be converted: size: expected number, found bool (true) in file text-metrics-test.scad, line 25
+WARNING: fontmetrics() parameter could not be converted: font: expected string, found number (0) in file text-metrics-test.scad, line 25
 ECHO: { nominal = { ascent = 12.5733; descent = -2.9433; }; max = { ascent = 13.6109; descent = -4.2114; }; interline = 15.9709; font = { family = "Liberation Sans"; style = "Regular"; }; }

--- a/tests/test_cmdline_tool.py
+++ b/tests/test_cmdline_tool.py
@@ -128,7 +128,15 @@ def get_normalized_text(filename):
         f = open(filename)
         text = f.read()
     except: 
-        text = ''
+      try:
+        # 'ord-tests.scad' contains some invalid UTF-8 chars.
+        # latin-1 is for "files in an ASCII compatible encoding,
+        # best effort is acceptable".
+        f = open(filename, encoding="latin-1")
+        text = f.read()
+      except: 
+        # do not fail silenty
+        text = "could not read " + "\n" + filename + "\n" + repr(err) 
     text = normalize_string(text)
     return text.strip("\r\n").replace("\r\n", "\n") + "\n"
 


### PR DESCRIPTION
That was a puzzle.

The ord-tests did not match what I got, when I regenerated the expected files.
No matter how I changed the expected file, the test would always passed.

The problem is here:

https://github.com/openscad/openscad/blob/d777dc24af688b2becff8ac01581ebf1612b42bf/tests/test_cmdline_tool.py#L126-L133

Python throws an exception, as it is not a valid UTF8 file.

Which ord-tests claims to be:
https://github.com/openscad/openscad/blob/d777dc24af688b2becff8ac01581ebf1612b42bf/tests/data/scad/misc/ord-tests.scad#L2-L4

As exception handling, the python script sets the text to empty string.
As both files are not valid UTF-8 Files, both are represented as empty string, which off-course matches.

see http://python-notes.curiousefficiency.org/en/latest/python3/text_file_processing.html#files-in-an-ascii-compatible-encoding-best-effort-is-acceptable for reference why I picked latin-1 as "de-fault" encoding.
