### PR TITLE
warning when a \n is found in use<> or include<>

### DIFF
--- a/src/core/lexer.l
+++ b/src/core/lexer.l
@@ -151,7 +151,8 @@ include[ \t\r\n]*"<"	{ BEGIN(cond_include); filepath = filename = ""; LOCATION_C
 <cond_include>{
 [\n\r]					{
 							LOCATION_ADD_LINES(parserlloc, yyleng);
-							LOG(message_group::Warning,LOCATION(parserlloc),"","new lines in 'include'-statement is not definded - behavior may change in the future");
+							// see merge request #4221
+							LOG(message_group::Warning,LOCATION(parserlloc),"","new lines in 'include<>'-statement is not defined - behavior may change in the future");
 }
 [^\t\r\n>]*"/"			{ filepath = yytext; }
 [^\t\r\n>/]+			{ filename = yytext; }
@@ -164,7 +165,8 @@ use[ \t\r\n]*"<"		{ BEGIN(cond_use); LOCATION_COUNT_LINES(parserlloc, yytext); }
 <cond_use>{
 [\n\r]					{
 							LOCATION_ADD_LINES(parserlloc, yyleng);
-							LOG(message_group::Warning,LOCATION(parserlloc),"","new lines 'use'-statement is not definded - behavior may change in the future");
+							// see merge request #4221
+							LOG(message_group::Warning,LOCATION(parserlloc),"","new lines 'use<>'-statement is not defined - behavior may change in the future");
 }
 [^\t\r\n>]+				{ filename = yytext; }
  ">"					{

--- a/src/core/lexer.l
+++ b/src/core/lexer.l
@@ -149,7 +149,10 @@ LOCATION_NEXT(parserlloc);
 
 include[ \t\r\n]*"<"	{ BEGIN(cond_include); filepath = filename = ""; LOCATION_COUNT_LINES(parserlloc, yytext); }
 <cond_include>{
-[\n\r]					{ LOCATION_ADD_LINES(parserlloc, yyleng); }
+[\n\r]					{
+							LOCATION_ADD_LINES(parserlloc, yyleng);
+							LOG(message_group::Warning,LOCATION(parserlloc),"","new lines in 'include'-statement is not definded - behavior may change in the future");
+}
 [^\t\r\n>]*"/"			{ filepath = yytext; }
 [^\t\r\n>/]+			{ filename = yytext; }
 ">"						{ BEGIN(INITIAL); includefile(LOCATION(parserlloc));  }
@@ -159,7 +162,10 @@ include[ \t\r\n]*"<"	{ BEGIN(cond_include); filepath = filename = ""; LOCATION_C
 
 use[ \t\r\n]*"<"		{ BEGIN(cond_use); LOCATION_COUNT_LINES(parserlloc, yytext); }
 <cond_use>{
-[\n\r]					{ LOCATION_ADD_LINES(parserlloc, yyleng); }
+[\n\r]					{
+							LOCATION_ADD_LINES(parserlloc, yyleng);
+							LOG(message_group::Warning,LOCATION(parserlloc),"","new lines 'use'-statement is not definded - behavior may change in the future");
+}
 [^\t\r\n>]+				{ filename = yytext; }
  ">"					{
 							BEGIN(INITIAL);

--- a/tests/data/scad/misc/linenumber.scad
+++ b/tests/data/scad/misc/linenumber.scad
@@ -1,7 +1,7 @@
 use <line 1> include <line 1>
 
 cube("line 3");
-
+// see merge request #4221 and #4211 for context
 include
 < line 6
 line 7

--- a/tests/regression/echotest/linenumber-expected.echo
+++ b/tests/regression/echotest/linenumber-expected.echo
@@ -1,11 +1,11 @@
 WARNING: Can't open library 'line 1'. in file ../../tests/data/scad/misc/linenumber.scad, line 1
 WARNING: Can't open include file 'line 1'. in file ../../tests/data/scad/misc/linenumber.scad, line 1
-WARNING: new lines in 'include'-statement is not definded - behavior may change in the future in file ../../tests/data/scad/misc/linenumber.scad, line 7
-WARNING: new lines in 'include'-statement is not definded - behavior may change in the future in file ../../tests/data/scad/misc/linenumber.scad, line 8
-WARNING: new lines in 'include'-statement is not definded - behavior may change in the future in file ../../tests/data/scad/misc/linenumber.scad, line 9
-WARNING: new lines in 'include'-statement is not definded - behavior may change in the future in file ../../tests/data/scad/misc/linenumber.scad, line 10
+WARNING: new lines in 'include<>'-statement is not defined - behavior may change in the future in file ../../tests/data/scad/misc/linenumber.scad, line 7
+WARNING: new lines in 'include<>'-statement is not defined - behavior may change in the future in file ../../tests/data/scad/misc/linenumber.scad, line 8
+WARNING: new lines in 'include<>'-statement is not defined - behavior may change in the future in file ../../tests/data/scad/misc/linenumber.scad, line 9
+WARNING: new lines in 'include<>'-statement is not defined - behavior may change in the future in file ../../tests/data/scad/misc/linenumber.scad, line 10
 WARNING: Can't open include file 'line 9'. in file ../../tests/data/scad/misc/linenumber.scad, line 10
-WARNING: new lines 'use'-statement is not definded - behavior may change in the future in file ../../tests/data/scad/misc/linenumber.scad, line 16
+WARNING: new lines 'use<>'-statement is not defined - behavior may change in the future in file ../../tests/data/scad/misc/linenumber.scad, line 16
 WARNING: Can't open library 'line 16'. in file ../../tests/data/scad/misc/linenumber.scad, line 16
 WARNING: Unable to convert cube(size="line 3", ...) parameter to a number or a vec3 of numbers in file linenumber.scad, line 3
 WARNING: Unable to convert cube(size="line 12", ...) parameter to a number or a vec3 of numbers in file linenumber.scad, line 12

--- a/tests/regression/echotest/linenumber-expected.echo
+++ b/tests/regression/echotest/linenumber-expected.echo
@@ -1,6 +1,11 @@
 WARNING: Can't open library 'line 1'. in file ../../tests/data/scad/misc/linenumber.scad, line 1
 WARNING: Can't open include file 'line 1'. in file ../../tests/data/scad/misc/linenumber.scad, line 1
+WARNING: new lines in 'include'-statement is not definded - behavior may change in the future in file ../../tests/data/scad/misc/linenumber.scad, line 7
+WARNING: new lines in 'include'-statement is not definded - behavior may change in the future in file ../../tests/data/scad/misc/linenumber.scad, line 8
+WARNING: new lines in 'include'-statement is not definded - behavior may change in the future in file ../../tests/data/scad/misc/linenumber.scad, line 9
+WARNING: new lines in 'include'-statement is not definded - behavior may change in the future in file ../../tests/data/scad/misc/linenumber.scad, line 10
 WARNING: Can't open include file 'line 9'. in file ../../tests/data/scad/misc/linenumber.scad, line 10
+WARNING: new lines 'use'-statement is not definded - behavior may change in the future in file ../../tests/data/scad/misc/linenumber.scad, line 16
 WARNING: Can't open library 'line 16'. in file ../../tests/data/scad/misc/linenumber.scad, line 16
 WARNING: Unable to convert cube(size="line 3", ...) parameter to a number or a vec3 of numbers in file linenumber.scad, line 3
 WARNING: Unable to convert cube(size="line 12", ...) parameter to a number or a vec3 of numbers in file linenumber.scad, line 12


### PR DESCRIPTION
this is supported syntax:
```
use <test>
use
<test>
use
   <test>
```

This is a quirk of the lexter, not a feature:
```
use
<
test
>
use <
ignored line
used line
>
assert(false);
```
**In release**, it even throws of the line counting.
`[\n\r]` was unhandled, only the last path/filename was used as such.

**In nightly**, I recently fixed the line counting.
Doing so, I specifically added handling of `[\n\r]`.
That feels wrong, as it really is not well defined. But I do not want to make it an error for compatibility.
Making it a warning is a fair compromise.

We could argue, that this is a feature:
```
include<folder/
file.scad>

include
<folder/
file.scad>
```
but it is inconsistent
```
include<folder/
subfoler/
file.scad>

include<folder\
file.scad>

include
<folder\
file.scad>

use
<folder/
file.scad>

use
<folder\
file.scad>
```
that I want to support it for compatibility, but not as a feature.