### PR TITLE
fix preference setting for RotateVPRelGain

### DIFF
--- a/src/gui/input/AxisConfigWidget.cc
+++ b/src/gui/input/AxisConfigWidget.cc
@@ -158,6 +158,7 @@ void AxisConfigWidget::init() {
   initUpdateDoubleSpinBox(this->doubleSpinBoxTranslationGain, Settings::Settings::inputTranslationGain);
   initUpdateDoubleSpinBox(this->doubleSpinBoxTranslationVPRelGain, Settings::Settings::inputTranslationVPRelGain);
   initUpdateDoubleSpinBox(this->doubleSpinBoxRotateGain, Settings::Settings::inputRotateGain);
+  initUpdateDoubleSpinBox(this->doubleSpinBoxRotateVPRelGain, Settings::Settings::inputRotateVPRelGain);
   initUpdateDoubleSpinBox(this->doubleSpinBoxZoomGain, Settings::Settings::inputZoomGain);
 
   //use a custom style for the axis indicators,
@@ -388,6 +389,13 @@ void AxisConfigWidget::on_doubleSpinBoxDeadzone8_valueChanged(double val)
 void AxisConfigWidget::on_doubleSpinBoxRotateGain_valueChanged(double val)
 {
   Settings::Settings::inputRotateGain.setValue(val);
+  emit inputGainChanged();
+  writeSettings();
+}
+
+void AxisConfigWidget::on_doubleSpinBoxRotateVPRelGain_valueChanged(double val)
+{
+  Settings::Settings::inputRotateVPRelGain.setValue(val);
   emit inputGainChanged();
   writeSettings();
 }

--- a/src/gui/input/AxisConfigWidget.h
+++ b/src/gui/input/AxisConfigWidget.h
@@ -35,8 +35,8 @@ public slots:
   void on_comboBoxZoom_activated(int val);
   void on_comboBoxZoom2_activated(int val);
 
-
   void on_doubleSpinBoxRotateGain_valueChanged(double val);
+  void on_doubleSpinBoxRotateVPRelGain_valueChanged(double val);
   void on_doubleSpinBoxTranslationGain_valueChanged(double val);
   void on_doubleSpinBoxTranslationVPRelGain_valueChanged(double val);
   void on_doubleSpinBoxZoomGain_valueChanged(double val);


### PR DESCRIPTION
this adresses on aspect of #3937

> Also `rotateVPRelGain` is not saved at all. (Seems to be missing at [AxisConfigWidget.cc](https://github.com/openscad/openscad/blob/8d59f235d40f0b34a87a24f1121e54913311be48/src/input/AxisConfigWidget.cc#L157))
