### PR TITLE
error log improvement

### DIFF
--- a/src/gui/ErrorLog.cc
+++ b/src/gui/ErrorLog.cc
@@ -12,24 +12,29 @@ ErrorLog::ErrorLog(QWidget *parent) : QWidget(parent)
 void ErrorLog::initGUI()
 {
   row = 0;
-  const int numColumns = 4;
-  this->errorLogModel = new QStandardItemModel(row, numColumns, logTable);
   QList<QString> labels = QList<QString>() << QString("Group") << QString("File") << QString("Line") << QString("Info");
+
+  const int numColumns = labels.count();
+  this->errorLogModel = new QStandardItemModel(row, numColumns, logTable);
+
   errorLogModel->setHorizontalHeaderLabels(labels);
   logTable->verticalHeader()->hide();
   logTable->setModel(errorLogModel);
   logTable->setSelectionMode(QAbstractItemView::SelectionMode::SingleSelection);
-  logTable->setColumnWidth(COLUMN_GROUP, 80);
-  logTable->setColumnWidth(COLUMN_FILE, 200);
-  logTable->setColumnWidth(COLUMN_LINENO, 80);
+  logTable->setColumnWidth(errorLog_column::group, 80);
+  logTable->setColumnWidth(errorLog_column::file, 200);
+  logTable->setColumnWidth(errorLog_column::lineNo, 80);
   logTable->addAction(actionRowSelected);
   //last column will stretch itself
+
+  connect(logTable->horizontalHeader(), SIGNAL(sectionResized(int,int,int)), this, SLOT(onSectionResized(int,int,int)));
 }
 
 void ErrorLog::toErrorLog(const Message& log_msg)
 {
   lastMessages.push_back(std::forward<const Message>(log_msg));
   QString currGroup = errorLogComboBox->currentText();
+
   //handle combobox
   if (errorLogComboBox->currentIndex() == 0);
   else if (currGroup.toStdString() != getGroupName(log_msg.group)) return;
@@ -45,7 +50,7 @@ void ErrorLog::showtheErrorInGUI(const Message& log_msg)
   if (log_msg.group == message_group::Error) groupName->setForeground(QColor::fromRgb(255, 0, 0)); //make this item red.
   else if (log_msg.group == message_group::Warning) groupName->setForeground(QColor::fromRgb(252, 211, 3)); //make this item yellow
 
-  errorLogModel->setItem(row, COLUMN_GROUP, groupName);
+  errorLogModel->setItem(row, errorLog_column::group, groupName);
 
   QStandardItem *fileName;
   QStandardItem *lineNo;
@@ -67,12 +72,12 @@ void ErrorLog::showtheErrorInGUI(const Message& log_msg)
   fileName->setEditable(false);
   lineNo->setEditable(false);
   lineNo->setTextAlignment(Qt::AlignVCenter | Qt::AlignRight);
-  errorLogModel->setItem(row, COLUMN_FILE, fileName);
-  errorLogModel->setItem(row, COLUMN_LINENO, lineNo);
+  errorLogModel->setItem(row, errorLog_column::file, fileName);
+  errorLogModel->setItem(row, errorLog_column::lineNo, lineNo);
 
   QStandardItem *msg = new QStandardItem(QString::fromStdString(log_msg.msg));
   msg->setEditable(false);
-  errorLogModel->setItem(row, COLUMN_MESSAGE, msg);
+  errorLogModel->setItem(row, errorLog_column::message, msg);
   errorLogModel->setRowCount(++row);
 
   if (!logTable->selectionModel()->hasSelection()) {
@@ -121,8 +126,8 @@ void ErrorLog::onIndexSelected(const QModelIndex& index)
 {
   if (index.isValid()) {
     const int r = index.row();
-    const int line = getLine(r, COLUMN_LINENO);
-    const auto path = logTable->model()->index(r, COLUMN_FILE).data(Qt::UserRole).toString();
+    const int line = getLine(r, errorLog_column::lineNo);
+    const auto path = logTable->model()->index(r, errorLog_column::file).data(Qt::UserRole).toString();
     emit openFile(path, line - 1);
   }
 }

--- a/src/gui/ErrorLog.cc
+++ b/src/gui/ErrorLog.cc
@@ -80,9 +80,26 @@ void ErrorLog::showtheErrorInGUI(const Message& log_msg)
   errorLogModel->setItem(row, errorLog_column::message, msg);
   errorLogModel->setRowCount(++row);
 
+  this->resize();
+
   if (!logTable->selectionModel()->hasSelection()) {
     logTable->selectRow(0);
   }
+}
+
+void ErrorLog::resize()
+{
+  logTable->resizeRowsToContents();
+}
+
+void ErrorLog::onSectionResized(int logicalIndex, int oldSize, int newSize){
+  this->resize();
+}
+
+void ErrorLog::resizeEvent(QResizeEvent *event)
+{
+  QWidget::resizeEvent(event);
+  this->resize();
 }
 
 void ErrorLog::clearModel()

--- a/src/gui/ErrorLog.h
+++ b/src/gui/ErrorLog.h
@@ -6,6 +6,10 @@
 #include <QStandardItemModel>
 #include "Editor.h"
 
+enum errorLog_column {
+  group = 0, file, lineNo, message
+};
+
 class ErrorLog : public QWidget, public Ui::errorLogWidget
 {
   Q_OBJECT
@@ -30,12 +34,6 @@ private:
 
 private:
   std::list<Message> lastMessages;
-
-private:
-  static constexpr int COLUMN_GROUP = 0;
-  static constexpr int COLUMN_FILE = 1;
-  static constexpr int COLUMN_LINENO = 2;
-  static constexpr int COLUMN_MESSAGE = 3;
 
 signals:
   void openFile(const QString, int);

--- a/src/gui/ErrorLog.h
+++ b/src/gui/ErrorLog.h
@@ -29,8 +29,12 @@ public:
   QHash<QString, bool> logsMap;
   int row;
 
+protected:
+  void resizeEvent(QResizeEvent *event) override;
+
 private:
   void onIndexSelected(const QModelIndex& index);
+  void resize();
 
 private:
   std::list<Message> lastMessages;
@@ -42,4 +46,5 @@ private slots:
   void on_logTable_doubleClicked(const QModelIndex& index);
   void on_errorLogComboBox_currentIndexChanged(const QString& arg1);
   void on_actionRowSelected_triggered(bool);
+  void onSectionResized(int,int,int);
 };

--- a/src/gui/ErrorLog.ui
+++ b/src/gui/ErrorLog.ui
@@ -106,11 +106,6 @@
      </item>
      <item>
       <property name="text">
-       <string>TRACE</string>
-      </property>
-     </item>
-     <item>
-      <property name="text">
        <string>DEPRECATED</string>
       </property>
      </item>

--- a/src/gui/ErrorLog.ui
+++ b/src/gui/ErrorLog.ui
@@ -26,10 +26,10 @@
       <enum>Qt::StrongFocus</enum>
      </property>
      <property name="dragEnabled">
-      <bool>true</bool>
+      <bool>false</bool>
      </property>
      <property name="dragDropMode">
-      <enum>QAbstractItemView::DragOnly</enum>
+      <enum>QAbstractItemView::NoDragDrop</enum>
      </property>
      <property name="selectionMode">
       <enum>QAbstractItemView::SingleSelection</enum>

--- a/src/gui/ErrorLog.ui
+++ b/src/gui/ErrorLog.ui
@@ -25,6 +25,9 @@
      <property name="focusPolicy">
       <enum>Qt::StrongFocus</enum>
      </property>
+     <property name="toolTip">
+      <string>double click to jump to file and line</string>
+     </property>
      <property name="dragEnabled">
       <bool>false</bool>
      </property>


### PR DESCRIPTION
   * static constexpr -> enum
   * map various resizes to resizeRowsToContents()
      * the effect is that row height auto adjusts, which leads to line break
      * (instead of Ellipsis/`...`)
   * add tool tip 
   * disable drag and drop
      * I did not find functionality linked to drag and drop
   * remove TRACE from the ErrorLog UI options

this is #4225, but with TRACE and Message Nr. removed