### PR TITLE
fix depsfile when using multiple outputs

### DIFF
--- a/src/handle_dep.cc
+++ b/src/handle_dep.cc
@@ -4,6 +4,7 @@
 #include <sstream>
 #include <stdlib.h> // for system()
 #include <unordered_set>
+#include <vector>
 #include <boost/regex.hpp>
 #include <boost/filesystem.hpp>
 namespace fs = boost::filesystem;
@@ -58,14 +59,18 @@ void handle_dep(const std::string& filename)
   }
 }
 
-bool write_deps(const std::string& filename, const std::string& output_file)
+bool write_deps(const std::string& filename, const std::vector<std::string> output_files)
 {
   FILE *fp = fopen(filename.c_str(), "wt");
   if (!fp) {
     fprintf(stderr, "Can't open dependencies file `%s' for writing!\n", filename.c_str());
     return false;
   }
-  fprintf(fp, "%s:", output_file.c_str());
+  for (const auto& filename : output_files) {
+    fprintf(fp, "%s ", filename.c_str());
+  }
+  fseek(fp, -1, SEEK_CUR);
+  fprintf(fp, ":");
 
   for (const auto& str : dependencies) {
     fprintf(fp, " \\\n\t%s", str.c_str());

--- a/src/handle_dep.h
+++ b/src/handle_dep.h
@@ -1,7 +1,8 @@
 #pragma once
 
 #include <string>
+#include <vector>
 
 extern const char *make_command;
 void handle_dep(const std::string& filename);
-bool write_deps(const std::string& filename, const std::string& output_file);
+bool write_deps(const std::string& filename, const std::vector<std::string> output_files);

--- a/src/openscad.cc
+++ b/src/openscad.cc
@@ -317,7 +317,6 @@ struct CommandLine
   const std::string& filename;
   const bool is_stdout;
   std::string output_file;
-  const char *deps_output_file;
   const fs::path& original_path;
   const std::string& parameterFile;
   const std::string& setName;
@@ -493,16 +492,6 @@ int do_export(const CommandLine& cmd, const RenderVariables& render_variables, F
     LOG(message_group::Warning, *nextLocation, builtin_context->documentRoot(), "More than one Root Modifier (!)");
   }
   Tree tree(root_node, fparent.string());
-
-  if (cmd.deps_output_file) {
-    std::string deps_out(cmd.deps_output_file);
-    std::string geom_out(cmd.output_file);
-    int result = write_deps(deps_out, geom_out);
-    if (!result) {
-      LOG(message_group::None, Location::NONE, "", "Error writing deps");
-      return 1;
-    }
-  }
 
   if (curFormat == FileFormat::CSG) {
     // https://github.com/openscad/openscad/issues/128
@@ -1184,7 +1173,6 @@ int main(int argc, char **argv)
             input_file,
             is_stdout,
             output_file,
-            deps_output_file,
             original_path,
             parameterFile,
             parameterSet,
@@ -1200,6 +1188,16 @@ int main(int argc, char **argv)
       }
     } catch (const HardWarningException&) {
       rc = 1;
+    }
+
+    if (deps_output_file) {
+      std::string deps_out(deps_output_file);
+      vector<std::string> geom_out(output_files);
+      int result = write_deps(deps_out, geom_out);
+      if (!result) {
+        LOG(message_group::None, Location::NONE, "", "Error writing deps");
+        return 1;
+      }
     }
   } else if (QtUseGUI()) {
     if (vm.count("export-format")) {


### PR DESCRIPTION
The depsfile was written for each output file, resulting in only the very last output filename actually being in the dependency file. This means that all outputs but the last won't have their dependencies known to make.

This PR changes this so that the depsfile is only written once, after all outputs have been created.
