### PR TITLE
Include <fstream> to fix the build with boost >= 1.79.0

### DIFF
--- a/src/glview/Renderer.cc
+++ b/src/glview/Renderer.cc
@@ -11,6 +11,7 @@
 #include "PolySetUtils.h"
 #include "Grid.h"
 #include <Eigen/LU>
+#include <fstream>
 
 #ifndef NULLGL
 


### PR DESCRIPTION
boost::filesystem deprecated the string_file.hpp header with 1.79.0 [1],
which implicitly pulled in <fstream>.
In this case only std::fstream is used anyway, so just include <fstream>
directly.

[1] https://www.boost.org/users/history/version_1_79_0.html