### PR TITLE
Fix using a relative path to `import` JSON in a `use`d file

### DIFF
--- a/src/core/builtin_functions.cc
+++ b/src/core/builtin_functions.cc
@@ -37,6 +37,7 @@
 #include "FreetypeRenderer.h"
 #include "Parameters.h"
 #include "import.h"
+#include "fileutils.h"
 
 #include <cmath>
 #include <sstream>
@@ -933,7 +934,8 @@ Value builtin_is_object(Arguments arguments, const Location& loc)
 Value builtin_import(Arguments arguments, const Location& loc)
 {
   const Parameters parameters = Parameters::parse(std::move(arguments), loc, {}, {"file"});
-  std::string file = parameters.get("file", "");
+  std::string raw_filename = parameters.get("file", "");
+  std::string file = lookup_file(raw_filename, loc.filePath().parent_path().string(), parameters.documentRoot());
   return import_json(file, arguments.session(), loc);
 }
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -620,6 +620,7 @@ list(APPEND ECHO_FILES ${FUNCTION_FILES} ${MISC_FILES} ${REDEFINITION_FILES}
   ${TEST_DATA_DIR}/use-order-test/use-order-test.scad
   ${TEST_SCAD_DIR}/misc/text-metrics-test.scad
   ${TEST_SCAD_DIR}/json/import-json.scad
+  ${TEST_SCAD_DIR}/json/import-json-relative-path.scad
   ${TEST_SCAD_DIR}/misc/vector-swizzling.scad
   ${TEST_SCAD_DIR}/misc/linenumber.scad
 )
@@ -843,6 +844,7 @@ experimental_tests(throwntogethertest_text-metrics)
 experimental_tests(dxfpngtest_text-metrics)
 experimental_tests(svgpngtest_text-metrics)
 experimental_tests(echotest_import-json)
+experimental_tests(echotest_import-json-relative-path)
 
 # Test config handling
 

--- a/tests/data/scad/json/import-json-relative-path.scad
+++ b/tests/data/scad/json/import-json-relative-path.scad
@@ -1,0 +1,11 @@
+use <submodule/submodule.scad>;
+data = get_data();
+
+echo(data);
+
+echo(data.string); // ECHO: "hallo world!"
+echo(data.array_number); // ECHO: [0, 1, 2, 3, 5]
+echo(data["array-string"]); // ECHO: ["one", "two", "three"]
+echo(data.object.name); // ECHO: "The object name"
+echo(data.object.nested.value); // ECHO: 42
+

--- a/tests/data/scad/json/submodule/submodule.scad
+++ b/tests/data/scad/json/submodule/submodule.scad
@@ -1,0 +1,1 @@
+function get_data () = import("../../../json/data.json");

--- a/tests/regression/echotest/import-json-relative-path-expected.echo
+++ b/tests/regression/echotest/import-json-relative-path-expected.echo
@@ -1,0 +1,6 @@
+ECHO: { array-mixed = ["one", 1, false]; array-string = ["one", "two", "three"]; array_number = [0, 1, 2, 3, 5]; bool = true; float = 3.5e-10; number = 2; object = { name = "The object name"; nested = { value = 42; }; number = 4; }; string = "hallo world!"; }
+ECHO: "hallo world!"
+ECHO: [0, 1, 2, 3, 5]
+ECHO: ["one", "two", "three"]
+ECHO: "The object name"
+ECHO: 42


### PR DESCRIPTION
Previously we took the filename as-is, which caused us to attempt to
open skewed paths.

Add a test.