### PR TITLE
Various fixes for source code

### DIFF
--- a/scripts/chrpath_linux.c
+++ b/scripts/chrpath_linux.c
@@ -380,7 +380,7 @@ chrpath(const char *filename, const char *newpath, int convert)
 
   if (strlen(newpath) > rpathlen)
   {
-    fprintf(stderr, "new rpath '%s' too large; maximum length %i\n",
+    fprintf(stderr, "new rpath '%s' too large; maximum length %u\n",
             newpath, rpathlen);
     free(dyns);
     free(strtab);

--- a/src/core/Expression.cc
+++ b/src/core/Expression.cc
@@ -330,12 +330,12 @@ Value Vector::evaluate(const std::shared_ptr<const Context>& context) const
     } else {
       VectorType vec(context->session());
       vec.emplace_back(std::move(val));
-      return std::move(vec);
+      return vec;
     }
   } else {
     VectorType vec(context->session());
     for (const auto& e : this->children) vec.emplace_back(e->evaluate(context));
-    return std::move(vec);
+    return vec;
   }
 }
 

--- a/src/core/Expression.cc
+++ b/src/core/Expression.cc
@@ -330,12 +330,12 @@ Value Vector::evaluate(const std::shared_ptr<const Context>& context) const
     } else {
       VectorType vec(context->session());
       vec.emplace_back(std::move(val));
-      return vec;
+      return std::move(vec);
     }
   } else {
     VectorType vec(context->session());
     for (const auto& e : this->children) vec.emplace_back(e->evaluate(context));
-    return vec;
+    return std::move(vec);
   }
 }
 

--- a/src/core/ImportNode.cc
+++ b/src/core/ImportNode.cc
@@ -53,7 +53,7 @@ using namespace boost::assign; // bring 'operator+=()' into scope
 
 #include <cstdint>
 
-extern PolySet *import_amf(std::string, const Location& loc);
+extern PolySet *import_amf(const std::string&, const Location& loc);
 extern Geometry *import_3mf(const std::string&, const Location& loc);
 
 static std::shared_ptr<AbstractNode> do_import(const ModuleInstantiation *inst, Arguments arguments, Children children, ImportType type)

--- a/src/core/LocalScope.cc
+++ b/src/core/LocalScope.cc
@@ -32,9 +32,9 @@ void LocalScope::addFunction(const shared_ptr<class UserFunction>& func)
   this->astFunctions.emplace_back(func->name, func);
 }
 
-void LocalScope::addAssignment(const shared_ptr<Assignment>& ass)
+void LocalScope::addAssignment(const shared_ptr<Assignment>& assignment)
 {
-  this->assignments.push_back(ass);
+  this->assignments.push_back(assignment);
 }
 
 void LocalScope::print(std::ostream& stream, const std::string& indent, const bool inlined) const
@@ -45,8 +45,8 @@ void LocalScope::print(std::ostream& stream, const std::string& indent, const bo
   for (const auto& m : this->astModules) {
     m.second->print(stream, indent);
   }
-  for (const auto& ass : this->assignments) {
-    ass->print(stream, indent);
+  for (const auto& assignment : this->assignments) {
+    assignment->print(stream, indent);
   }
   for (const auto& inst : this->moduleInstantiations) {
     inst->print(stream, indent, inlined);

--- a/src/core/RoofNode.h
+++ b/src/core/RoofNode.h
@@ -23,7 +23,7 @@ public:
   class roof_exception : public std::exception
   {
 public:
-    roof_exception(const std::string message) : m(message) {}
+    roof_exception(const std::string& message) : m(message) {}
     std::string message() {return m;}
 private:
     std::string m;

--- a/src/core/SourceFile.cc
+++ b/src/core/SourceFile.cc
@@ -53,7 +53,7 @@ void SourceFile::print(std::ostream& stream, const std::string& indent) const
   scope.print(stream, indent);
 }
 
-void SourceFile::registerUse(const std::string path, const Location& loc)
+void SourceFile::registerUse(const std::string& path, const Location& loc)
 {
   PRINTDB("registerUse(): (%p) %d, %d - %d, %d (%s) -> %s", this %
           loc.firstLine() % loc.firstColumn() %
@@ -107,7 +107,7 @@ time_t SourceFile::include_modified(const std::string& filename) const
 {
   struct stat st;
 
-  if (StatCache::stat(filename.c_str(), st) == 0) {
+  if (StatCache::stat(filename, st) == 0) {
     return st.st_mtime;
   }
 

--- a/src/core/SourceFile.h
+++ b/src/core/SourceFile.h
@@ -21,7 +21,7 @@ public:
 
   void setModulePath(const std::string& path) { this->path = path; }
   const std::string& modulePath() const { return this->path; }
-  void registerUse(const std::string path, const Location& loc);
+  void registerUse(const std::string& path, const Location& loc);
   void registerInclude(const std::string& localpath, const std::string& fullpath, const Location& loc);
   std::time_t includesChanged() const;
   std::time_t handleDependencies(bool is_root = true);

--- a/src/core/SourceFileCache.cc
+++ b/src/core/SourceFileCache.cc
@@ -40,7 +40,7 @@ std::time_t SourceFileCache::evaluate(const std::string& mainFile, const std::st
 
   // Create cache ID
   struct stat st;
-  bool valid = (StatCache::stat(filename.c_str(), st) == 0);
+  bool valid = (StatCache::stat(filename, st) == 0);
 
   // If file isn't there, just return and let the cache retain the old file
   if (!valid) return 0;

--- a/src/core/SourceFileCache.h
+++ b/src/core/SourceFileCache.h
@@ -14,7 +14,7 @@ public:
 
   std::time_t evaluate(const std::string& mainFile, const std::string& filename, class SourceFile *& sourceFile);
   class SourceFile *lookup(const std::string& filename);
-  size_t size() { return this->entries.size(); }
+  size_t size() const { return this->entries.size(); }
   void clear();
   static void clear_markers();
 

--- a/src/core/Tree.cc
+++ b/src/core/Tree.cc
@@ -69,7 +69,7 @@ void Tree::setRoot(const std::shared_ptr<const AbstractNode> &root)
   this->nodecachemap.clear();
 }
 
-void Tree::setDocumentPath(const std::string path){
+void Tree::setDocumentPath(const std::string& path){
   this->document_path = path;
 }
 

--- a/src/core/Tree.h
+++ b/src/core/Tree.h
@@ -16,7 +16,7 @@ public:
   ~Tree();
 
   void setRoot(const std::shared_ptr<const AbstractNode> &root);
-  void setDocumentPath(const std::string path);
+  void setDocumentPath(const std::string& path);
   const std::shared_ptr<const AbstractNode>& root() const { return this->root_node; }
 
   const std::string getString(const AbstractNode& node, const std::string& indent) const;

--- a/src/core/UserModule.cc
+++ b/src/core/UserModule.cc
@@ -42,7 +42,7 @@ static void NOINLINE print_err(std::string name, const Location& loc, const std:
   LOG(message_group::Error, loc, context->documentRoot(), "Recursion detected calling module '%1$s'", name);
 }
 
-static void NOINLINE print_trace(const UserModule *mod,std::shared_ptr<const UserModuleContext> context, const AssignmentList parameters){
+static void NOINLINE print_trace(const UserModule *mod,std::shared_ptr<const UserModuleContext> context, const AssignmentList& parameters){
   std::stringstream stream ;
   if (parameters.size() == 0){
       //nothing to do

--- a/src/core/Value.cc
+++ b/src/core/Value.cc
@@ -913,7 +913,7 @@ public:
          ++it1, ++it2) {
       sum.emplace_back(*it1 + *it2);
     }
-    return std::move(sum);
+    return sum;
   }
 };
 
@@ -938,7 +938,7 @@ public:
     for (size_t i = 0; i < op1.size() && i < op2.size(); ++i) {
       sum.emplace_back(op1[i] - op2[i]);
     }
-    return std::move(sum);
+    return sum;
   }
 };
 
@@ -954,7 +954,7 @@ Value multvecnum(const VectorType& vecval, const Value& numval)
   for (const auto& val : vecval) {
     dstv.emplace_back(val * numval);
   }
-  return std::move(dstv);
+  return dstv;
 }
 
 Value multmatvec(const VectorType& matrixvec, const VectorType& vectorvec)
@@ -978,7 +978,7 @@ Value multmatvec(const VectorType& matrixvec, const VectorType& vectorvec)
     }
     dstv.emplace_back(Value(r_e));
   }
-  return std::move(dstv);
+  return dstv;
 }
 
 Value multvecmat(const VectorType& vectorvec, const VectorType& matrixvec)
@@ -1089,13 +1089,13 @@ Value Value::operator/(const Value& v) const
     for (const auto& vecval : this->toVector()) {
       dstv.emplace_back(vecval / v);
     }
-    return std::move(dstv);
+    return dstv;
   } else if (this->type() == Type::NUMBER && v.type() == Type::VECTOR) {
     VectorType dstv(v.toVector().evaluation_session());
     for (const auto& vecval : v.toVector()) {
       dstv.emplace_back(*this / vecval);
     }
-    return std::move(dstv);
+    return dstv;
   }
   return Value::undef(STR("undefined operation (" << this->typeName() << " / " << v.typeName() << ")"));
 }
@@ -1117,7 +1117,7 @@ Value Value::operator-() const
     for (const auto& vecval : this->toVector()) {
       dstv.emplace_back(-vecval);
     }
-    return std::move(dstv);
+    return dstv;
   }
   return Value::undef(STR("undefined operation (-" << this->typeName() << ")"));
 }

--- a/src/core/Value.cc
+++ b/src/core/Value.cc
@@ -913,7 +913,7 @@ public:
          ++it1, ++it2) {
       sum.emplace_back(*it1 + *it2);
     }
-    return sum;
+    return std::move(sum);
   }
 };
 
@@ -938,7 +938,7 @@ public:
     for (size_t i = 0; i < op1.size() && i < op2.size(); ++i) {
       sum.emplace_back(op1[i] - op2[i]);
     }
-    return sum;
+    return std::move(sum);
   }
 };
 
@@ -954,7 +954,7 @@ Value multvecnum(const VectorType& vecval, const Value& numval)
   for (const auto& val : vecval) {
     dstv.emplace_back(val * numval);
   }
-  return dstv;
+  return std::move(dstv);
 }
 
 Value multmatvec(const VectorType& matrixvec, const VectorType& vectorvec)
@@ -978,7 +978,7 @@ Value multmatvec(const VectorType& matrixvec, const VectorType& vectorvec)
     }
     dstv.emplace_back(Value(r_e));
   }
-  return dstv;
+  return std::move(dstv);
 }
 
 Value multvecmat(const VectorType& vectorvec, const VectorType& matrixvec)
@@ -1089,13 +1089,13 @@ Value Value::operator/(const Value& v) const
     for (const auto& vecval : this->toVector()) {
       dstv.emplace_back(vecval / v);
     }
-    return dstv;
+    return std::move(dstv);
   } else if (this->type() == Type::NUMBER && v.type() == Type::VECTOR) {
     VectorType dstv(v.toVector().evaluation_session());
     for (const auto& vecval : v.toVector()) {
       dstv.emplace_back(*this / vecval);
     }
-    return dstv;
+    return std::move(dstv);
   }
   return Value::undef(STR("undefined operation (" << this->typeName() << " / " << v.typeName() << ")"));
 }
@@ -1117,7 +1117,7 @@ Value Value::operator-() const
     for (const auto& vecval : this->toVector()) {
       dstv.emplace_back(-vecval);
     }
-    return dstv;
+    return std::move(dstv);
   }
   return Value::undef(STR("undefined operation (-" << this->typeName() << ")"));
 }

--- a/src/core/builtin_functions.cc
+++ b/src/core/builtin_functions.cc
@@ -173,7 +173,7 @@ Value builtin_rands(Arguments arguments, const Location& loc)
       vec.emplace_back(distributor(deterministic_rng));
     }
   }
-  return std::move(vec);
+  return vec;
 }
 
 static std::vector<double> min_max_arguments(const Arguments& arguments, const Location& loc, const char *function_name)
@@ -424,7 +424,7 @@ Value builtin_concat(Arguments arguments, const Location& loc)
       result.emplace_back(std::move(argument.value));
     }
   }
-  return std::move(result);
+  return result;
 }
 
 Value builtin_lookup(Arguments arguments, const Location& loc)
@@ -672,7 +672,7 @@ Value builtin_search(Arguments arguments, const Location& loc)
   } else {
     return Value::undefined.clone();
   }
-  return std::move(returnvec);
+  return returnvec;
 }
 
 #define QUOTE(x__) # x__
@@ -686,7 +686,7 @@ Value builtin_version(Arguments arguments, const Location& loc)
 #ifdef OPENSCAD_DAY
   vec.emplace_back(double(OPENSCAD_DAY));
 #endif
-  return std::move(vec);
+  return vec;
 }
 
 Value builtin_version_num(Arguments arguments, const Location& loc)
@@ -827,7 +827,7 @@ Value builtin_textmetrics(Arguments arguments, const Location& loc)
   text_metrics.set("descent", metrics.descent);
   text_metrics.set("offset", std::move(offset));
   text_metrics.set("advance", std::move(advance));
-  return std::move(text_metrics);
+  return text_metrics;
 }
 
 Value builtin_fontmetrics(Arguments arguments, const Location& loc)
@@ -866,7 +866,7 @@ Value builtin_fontmetrics(Arguments arguments, const Location& loc)
   font_metrics.set("interline", metrics.interline);
   font_metrics.set("font", font);
 
-  return std::move(font_metrics);
+  return font_metrics;
 }
 
 Value builtin_is_undef(const std::shared_ptr<const Context>& context, const FunctionCall *call)

--- a/src/core/builtin_functions.cc
+++ b/src/core/builtin_functions.cc
@@ -173,7 +173,7 @@ Value builtin_rands(Arguments arguments, const Location& loc)
       vec.emplace_back(distributor(deterministic_rng));
     }
   }
-  return vec;
+  return std::move(vec);
 }
 
 static std::vector<double> min_max_arguments(const Arguments& arguments, const Location& loc, const char *function_name)
@@ -424,7 +424,7 @@ Value builtin_concat(Arguments arguments, const Location& loc)
       result.emplace_back(std::move(argument.value));
     }
   }
-  return result;
+  return std::move(result);
 }
 
 Value builtin_lookup(Arguments arguments, const Location& loc)
@@ -672,7 +672,7 @@ Value builtin_search(Arguments arguments, const Location& loc)
   } else {
     return Value::undefined.clone();
   }
-  return returnvec;
+  return std::move(returnvec);
 }
 
 #define QUOTE(x__) # x__
@@ -686,7 +686,7 @@ Value builtin_version(Arguments arguments, const Location& loc)
 #ifdef OPENSCAD_DAY
   vec.emplace_back(double(OPENSCAD_DAY));
 #endif
-  return vec;
+  return std::move(vec);
 }
 
 Value builtin_version_num(Arguments arguments, const Location& loc)
@@ -827,7 +827,7 @@ Value builtin_textmetrics(Arguments arguments, const Location& loc)
   text_metrics.set("descent", metrics.descent);
   text_metrics.set("offset", std::move(offset));
   text_metrics.set("advance", std::move(advance));
-  return text_metrics;
+  return std::move(text_metrics);
 }
 
 Value builtin_fontmetrics(Arguments arguments, const Location& loc)
@@ -866,7 +866,7 @@ Value builtin_fontmetrics(Arguments arguments, const Location& loc)
   font_metrics.set("interline", metrics.interline);
   font_metrics.set("font", font);
 
-  return font_metrics;
+  return std::move(font_metrics);
 }
 
 Value builtin_is_undef(const std::shared_ptr<const Context>& context, const FunctionCall *call)

--- a/src/core/customizer/CommentParser.cc
+++ b/src/core/customizer/CommentParser.cc
@@ -45,7 +45,7 @@ static int getLineToStop(const std::string& fulltext){
 
     if (!inString && fulltext.compare(i, 2, "//") == 0) {
       i++;
-      while (fulltext[i] != '\n' && i < fulltext.length()) i++;
+      while (i < fulltext.length() && fulltext[i] != '\n') i++;
       lineNo++;
       continue;
     }
@@ -67,7 +67,7 @@ static int getLineToStop(const std::string& fulltext){
       }
     }
 
-    if (fulltext[i] == '{') {
+    if (i < fulltext.length() && fulltext[i] == '{') {
       return lineNo;
     }
   }
@@ -84,13 +84,13 @@ static std::string getComment(const std::string& fulltext, int line)
   if (line < 1) return "";
 
   // Locate line
-  unsigned int start = 0;
+  std::size_t start = 0;
   for (; start < fulltext.length(); ++start) {
     if (line <= 1) break;
     if (fulltext[start] == '\n') line--;
   }
 
-  int end = start + 1;
+  std::size_t end = start + 1;
   while (end < fulltext.size() && fulltext[end] != '\n') end++;
 
   std::string comment = fulltext.substr(start, end - start);
@@ -216,7 +216,7 @@ static GroupList collectGroups(const std::string& fulltext)
 
     if (!inString && fulltext.compare(i, 2, "//") == 0) {
       i++;
-      while (fulltext[i] != '\n' && i < fulltext.length() ) i++;
+      while (i < fulltext.length() && fulltext[i] != '\n') i++;
       lineNo++;
       continue;
     }

--- a/src/core/customizer/ParameterObject.cc
+++ b/src/core/customizer/ParameterObject.cc
@@ -7,7 +7,7 @@
 
 namespace {
 
-bool set_enum_value(json& o, const std::string name, const EnumParameter::EnumItem& item)
+bool set_enum_value(json& o, const std::string& name, const EnumParameter::EnumItem& item)
 {
   EnumParameter::EnumValue itemValue = item.value;
   double *doubleValue = boost::get<double>(&itemValue);
@@ -388,7 +388,7 @@ struct NumericLimits
   boost::optional<double> maximum;
   boost::optional<double> step;
 };
-static NumericLimits parseNumericLimits(const Expression *parameter, const std::vector<double> values)
+static NumericLimits parseNumericLimits(const Expression *parameter, const std::vector<double>& values)
 {
   NumericLimits output;
 

--- a/src/ext/libtess2/Source/bucketalloc.c
+++ b/src/ext/libtess2/Source/bucketalloc.c
@@ -165,7 +165,7 @@ void bucketFree( struct BucketAlloc *ba, void *ptr )
 	}
 	else
 	{
-		printf("ERROR! pointer 0x%p does not belong to allocator '%s'\n", ba->name);
+		printf("ERROR! pointer 0x%p does not belong to allocator '%s'\n", ptr, ba->name);
 	}
 #else
 	// Add the node in front of the free list.

--- a/src/ext/polyclipping/clipper.cpp
+++ b/src/ext/polyclipping/clipper.cpp
@@ -4520,7 +4520,7 @@ void MinkowskiSum(const Path& pattern, const Path& path, Paths& solution, bool p
 }
 //------------------------------------------------------------------------------
 
-void TranslatePath(const Path& input, Path& output, const IntPoint delta)
+void TranslatePath(const Path& input, Path& output, const IntPoint& delta)
 {
   //precondition: input != output
   output.resize(input.size());

--- a/src/ext/polyclipping/clipper.hpp
+++ b/src/ext/polyclipping/clipper.hpp
@@ -118,7 +118,7 @@ struct DoublePoint
   double X;
   double Y;
   DoublePoint(double x = 0, double y = 0) : X(x), Y(y) {}
-  DoublePoint(IntPoint ip) : X((double)ip.X), Y((double)ip.Y) {}
+  DoublePoint(const IntPoint& ip) : X((double)ip.X), Y((double)ip.Y) {}
 };
 //------------------------------------------------------------------------------
 

--- a/src/geometry/cgal/Polygon2d-CGAL.cc
+++ b/src/geometry/cgal/Polygon2d-CGAL.cc
@@ -14,7 +14,7 @@ struct FaceInfo
 {
   FaceInfo() : nesting_level(42) {}
   int nesting_level;
-  bool in_domain() { return nesting_level % 2 == 1; }
+  bool in_domain() const { return nesting_level % 2 == 1; }
 };
 
 

--- a/src/geometry/cgal/cgalutils-corefinement-visitor.h
+++ b/src/geometry/cgal/cgalutils-corefinement-visitor.h
@@ -70,13 +70,13 @@ private:
 public:
   CorefinementVisitorDelegate_(TriangleMesh& m1, TriangleMesh& m2, TriangleMesh& mout,
                                bool forceNewLazyNumbersToExact)
-    : mesh1_(&m1), mesh2_(&m2), meshOut_(&mout), forceNewLazyNumbersToExact_(forceNewLazyNumbersToExact)
+    : forceNewLazyNumbersToExact_(forceNewLazyNumbersToExact), mesh1_(&m1), mesh2_(&m2), meshOut_(&mout)
   {
     TriangleMesh *meshes[3] = {&m1, &m2, &mout};
 
     // Give each existing face its own global patch id.
     PatchId nextPatchId = 1;
-    for (auto mi = 0; mi < 3; mi++) {
+    for (std::size_t mi = 0; mi < 3; mi++) {
       auto& m = *meshes[mi];
 
       if (mi != indexOf(m)) {
@@ -112,7 +112,7 @@ public:
   {
     auto mi = indexOf(tm);
     auto id = getPatchId(faceBeingSplit_[mi], tm);
-    setPatchId(fi, tm, getPatchId(faceBeingSplit_[mi], tm));
+    setPatchId(fi, tm, id);
 
 #if CGAL_VERSION_NR < CGAL_VERSION_NUMBER(5, 4, 0)
     if (forceNewLazyNumbersToExact_) {

--- a/src/geometry/roof_ss.cc
+++ b/src/geometry/roof_ss.cc
@@ -149,7 +149,7 @@ PolySet *straight_skeleton_roof(const Polygon2d& poly)
     return hat;
   } catch (RoofNode::roof_exception& e) {
     delete hat;
-    throw e;
+    throw;
   }
 }
 

--- a/src/geometry/roof_vd.cc
+++ b/src/geometry/roof_vd.cc
@@ -410,7 +410,7 @@ PolySet *voronoi_diagram_roof(const Polygon2d& poly, double fa, double fs)
     }
   } catch (RoofNode::roof_exception& e) {
     delete hat;
-    throw e;
+    throw;
   }
 
   return hat;

--- a/src/glview/OffscreenContextWGL.cc
+++ b/src/glview/OffscreenContextWGL.cc
@@ -206,6 +206,7 @@ OffscreenContext *create_offscreen_context(int w, int h)
   // This call alters ctx->window and ctx->openGLContext
   //  and ctx->dev_context if successful
   if (!create_wgl_dummy_context(*ctx)) {
+    delete ctx;
     return nullptr;
   }
 

--- a/src/glview/VertexArray.cc
+++ b/src/glview/VertexArray.cc
@@ -16,7 +16,6 @@ void VertexData::fillInterleavedBuffer(GLbyte *interleaved_buffer) const
 {
   // All attribute vectors need to be the same size to interleave
   if (attributes_.size()) {
-    size_t idx = 0;
     size_t last_size = attributes_[0]->size() / attributes_[0]->count();
 
     GLbyte *dst_start = interleaved_buffer;

--- a/src/glview/preview/OpenCSGRenderer.cc
+++ b/src/glview/preview/OpenCSGRenderer.cc
@@ -147,7 +147,6 @@ OpenCSGVBOPrim *OpenCSGRenderer::createVBOPrimitive(const std::shared_ptr<OpenCS
 void OpenCSGRenderer::createCSGProducts(const CSGProducts& products, const Renderer::shaderinfo_t *shaderinfo, bool highlight_mode, bool background_mode)
 {
   size_t vbo_count = products.products.size();
-  size_t vbo_index = 0;
   if (vbo_count) {
     if (Feature::ExperimentalVxORenderersIndexing.is_enabled()) {
       vbo_count *= 2;
@@ -157,6 +156,7 @@ void OpenCSGRenderer::createCSGProducts(const CSGProducts& products, const Rende
   }
 
 #ifdef ENABLE_OPENCSG
+  size_t vbo_index = 0;
   for (const auto& product : products.products) {
     Color4f last_color;
     std::unique_ptr<OpenCSGPrimitives> primitives = std::make_unique<OpenCSGPrimitives>();

--- a/src/gui/Animate.cc
+++ b/src/gui/Animate.cc
@@ -361,7 +361,6 @@ const QList<QAction *>& Animate::actions(){
 void Animate::onActionEvent(InputEventAction *event)
 {
   const std::string actionString = event->action;
-  const std::string target = actionString.substr(0, actionString.find("::"));
   const std::string actionName = actionString.substr(actionString.find("::")+2, std::string::npos);
   for(auto action : action_list){
     if(actionName == action->objectName().toStdString()){

--- a/src/gui/AutoUpdater.h
+++ b/src/gui/AutoUpdater.h
@@ -8,7 +8,7 @@ class AutoUpdater : public QObject
   Q_OBJECT;
 
 public:
-  AutoUpdater() : updateAction(nullptr) {}
+  AutoUpdater() : updateAction(nullptr), updateMenu(nullptr) {}
   ~AutoUpdater() {}
 
   virtual void setAutomaticallyChecksForUpdates(bool on) = 0;

--- a/src/gui/Network.h
+++ b/src/gui/Network.h
@@ -63,7 +63,7 @@ public:
   using reply_func_t = std::function<QNetworkReply *(QNetworkAccessManager&, QNetworkRequest&)>;
   using transform_func_t = std::function<ResultType(QNetworkReply *)>;
 
-  NetworkRequest(const QUrl url, const std::vector<int> accepted_codes, const int timeout_seconds) : url(url), accepted_codes(accepted_codes), timeout_seconds(timeout_seconds) { }
+  NetworkRequest(const QUrl& url, const std::vector<int>& accepted_codes, const int timeout_seconds) : url(url), accepted_codes(accepted_codes), timeout_seconds(timeout_seconds) { }
   virtual ~NetworkRequest() { }
 
   void set_progress_func(network_progress_func_t progress_func) { this->progress_func = progress_func; }

--- a/src/gui/input/AxisConfigWidget.cc
+++ b/src/gui/input/AxisConfigWidget.cc
@@ -135,8 +135,6 @@ void AxisConfigWidget::init() {
   installIgnoreWheelWhenNotFocused(this);
 
   for (int i = 0; i < InputEventMapper::getMaxAxis(); ++i) {
-    std::string s = std::to_string(i);
-
     auto spinTrim = this->findChild<QDoubleSpinBox *>(QString("doubleSpinBoxTrim%1").arg(i));
     if (spinTrim) {
       initUpdateDoubleSpinBox(spinTrim, Settings::Settings::axisTrim(i));

--- a/src/gui/input/ButtonConfigWidget.cc
+++ b/src/gui/input/ButtonConfigWidget.cc
@@ -43,7 +43,6 @@ ButtonConfigWidget::~ButtonConfigWidget()
 
 void ButtonConfigWidget::updateButtonState(int nr, bool pressed) const {
   QString style = pressed ? ButtonConfigWidget::ActiveStyleString : ButtonConfigWidget::EmptyString;
-  std::string number = std::to_string(nr);
 
   auto label = this->findChild<QLabel *>(QString("labelInputButton%1").arg(nr));
   if (label == nullptr) return;

--- a/src/gui/input/InputEventMapper.cc
+++ b/src/gui/input/InputEventMapper.cc
@@ -252,7 +252,7 @@ void InputEventMapper::onZoomEvent(InputEventZoom *event)
   InputDriverManager::instance()->postEvent(event);
 }
 
-int InputEventMapper::parseSettingValue(const std::string val)
+int InputEventMapper::parseSettingValue(const std::string& val)
 {
   if (val.length() != 2) {
     return 0;

--- a/src/gui/input/InputEventMapper.h
+++ b/src/gui/input/InputEventMapper.h
@@ -48,7 +48,7 @@ private:
 
   double scale(double val);
   double getAxisValue(int config);
-  int parseSettingValue(const std::string val);
+  int parseSettingValue(const std::string& val);
   bool generateDeferredEvents();
   void considerGeneratingDeferredEvents();
   bool button_state[InputDriver::max_buttons];

--- a/src/handle_dep.cc
+++ b/src/handle_dep.cc
@@ -59,15 +59,15 @@ void handle_dep(const std::string& filename)
   }
 }
 
-bool write_deps(const std::string& filename, const std::vector<std::string> output_files)
+bool write_deps(const std::string& filename, const std::vector<std::string>& output_files)
 {
   FILE *fp = fopen(filename.c_str(), "wt");
   if (!fp) {
     fprintf(stderr, "Can't open dependencies file `%s' for writing!\n", filename.c_str());
     return false;
   }
-  for (const auto& filename : output_files) {
-    fprintf(fp, "%s ", filename.c_str());
+  for (const auto& output_file : output_files) {
+    fprintf(fp, "%s ", output_file.c_str());
   }
   fseek(fp, -1, SEEK_CUR);
   fprintf(fp, ":");

--- a/src/handle_dep.h
+++ b/src/handle_dep.h
@@ -5,4 +5,4 @@
 
 extern const char *make_command;
 void handle_dep(const std::string& filename);
-bool write_deps(const std::string& filename, const std::vector<std::string> output_files);
+bool write_deps(const std::string& filename, const std::vector<std::string>& output_files);

--- a/src/io/export_3mf.cc
+++ b/src/io/export_3mf.cc
@@ -57,9 +57,9 @@ using namespace NMR;
 #include "cgalutils.h"
 #include "CGAL_Nef_polyhedron.h"
 
-static void export_3mf_error(const std::string msg, PLib3MFModel *& model)
+static void export_3mf_error(const std::string& msg, PLib3MFModel *& model)
 {
-  LOG(message_group::Export_Error, Location::NONE, "", std::string(msg));
+  LOG(message_group::Export_Error, Location::NONE, "", msg);
   if (model) {
     lib3mf_release(model);
     model = nullptr;
@@ -217,9 +217,9 @@ void export_3mf(const shared_ptr<const Geometry>& geom, std::ostream& output)
 #include "cgalutils.h"
 #include "CGAL_Nef_polyhedron.h"
 
-static void export_3mf_error(const std::string msg)
+static void export_3mf_error(const std::string& msg)
 {
-  LOG(message_group::Export_Error, Location::NONE, "", std::string(msg));
+  LOG(message_group::Export_Error, Location::NONE, "", msg);
 }
 
 /*

--- a/src/io/import_amf.cc
+++ b/src/io/import_amf.cc
@@ -91,7 +91,7 @@ protected:
 public:
   AmfImporter(const Location& loc);
   virtual ~AmfImporter();
-  PolySet *read(const std::string filename);
+  PolySet *read(const std::string& filename);
 
   virtual xmlTextReaderPtr createXmlReader(const char *filename);
 };
@@ -246,7 +246,7 @@ int AmfImporter::streamFile(const char *filename)
   return ret;
 }
 
-PolySet *AmfImporter::read(const std::string filename)
+PolySet *AmfImporter::read(const std::string& filename)
 {
   funcs[coordinates_x] = set_x;
   funcs[coordinates_y] = set_y;
@@ -357,14 +357,14 @@ xmlTextReaderPtr AmfImporterZIP::createXmlReader(const char *filepath)
   }
 }
 
-PolySet *import_amf(const std::string filename, const Location& loc) {
+PolySet *import_amf(const std::string& filename, const Location& loc) {
   AmfImporterZIP importer(loc);
   return importer.read(filename);
 }
 
 #else
 
-PolySet *import_amf(const std::string filename, const Location& loc) {
+PolySet *import_amf(const std::string& filename, const Location& loc) {
   AmfImporter importer(loc);
   return importer.read(filename);
 }

--- a/src/io/import_nef.cc
+++ b/src/io/import_nef.cc
@@ -20,7 +20,6 @@ CGAL_Nef_polyhedron *import_nef3(const std::string& filename, const Location& lo
     return N;
   }
 
-  std::string msg = "";
   try {
     auto nef = make_shared<CGAL_Nef_polyhedron3>();
     f >> *nef;

--- a/src/io/libsvg/shape.cc
+++ b/src/io/libsvg/shape.cc
@@ -117,7 +117,7 @@ shape::set_attrs(attr_map_t& attrs, void *context)
 }
 
 const std::string
-shape::get_style(std::string name) const
+shape::get_style(const std::string& name) const
 {
   std::vector<std::string> styles;
   boost::split(styles, this->style, boost::is_any_of(";"));

--- a/src/io/libsvg/shape.h
+++ b/src/io/libsvg/shape.h
@@ -78,7 +78,7 @@ protected:
   double get_stroke_width() const;
   ClipperLib::EndType get_stroke_linecap() const;
   ClipperLib::JoinType get_stroke_linejoin() const;
-  const std::string get_style(std::string name) const;
+  const std::string get_style(const std::string& name) const;
   void draw_ellipse(path_t& path, double x, double y, double rx, double ry, void *context);
   void offset_path(path_list_t& path_list, path_t& path, double stroke_width, ClipperLib::EndType stroke_linecap);
   void collect_transform_matrices(std::vector<Eigen::Matrix3d>& matrices, shape *s);

--- a/src/openscad.cc
+++ b/src/openscad.cc
@@ -291,7 +291,7 @@ static bool checkAndExport(shared_ptr<const Geometry> root_geom, unsigned nd,
   return true;
 }
 
-void set_render_color_scheme(const std::string color_scheme, const bool exit_if_not_found)
+void set_render_color_scheme(const std::string& color_scheme, const bool exit_if_not_found)
 {
   if (color_scheme.empty()) {
     return;

--- a/src/utils/printutils.h
+++ b/src/utils/printutils.h
@@ -176,6 +176,11 @@ public:
   {
   }
 
+  template <typename ... Args>
+  MessageClass(const std::string& fmt, Args&&... args) : fmt(fmt), args(std::forward<Args>(args)...)
+  {
+  }
+
   std::string format() const
   {
     return format(std::index_sequence_for<Ts...>{});

--- a/src/utils/svg.cc
+++ b/src/utils/svg.cc
@@ -22,7 +22,7 @@ std::string svg_header(int widthpx, int heightpx)
   return out.str();
 }
 
-std::string svg_label(std::string s)
+std::string svg_label(const std::string& s)
 {
   std::ostringstream out;
   out << "   <text fill='black' x='20' y='40' font-size='24'>" << s << "</text>";

--- a/src/utils/svg.h
+++ b/src/utils/svg.h
@@ -15,7 +15,7 @@ extern int svg_px_width;
 extern int svg_px_height;
 
 std::string svg_header(int widthpx = SVG_PXW, int heightpx = SVG_PXH);
-std::string svg_label(std::string s);
+std::string svg_label(const std::string& s);
 std::string svg_border();
 std::string svg_axes();
 std::string dump_svg(const CGAL_Nef_polyhedron2& N);


### PR DESCRIPTION
This patch contains various changes spotted by cppcheck, compiler with enabled warnings and random files wandering
* fixes for format output
* passing arguments by const reference
* `StatCache::stat` took `std::string` as a 1st argument
* removed unused variables
* we should use `throw;` to rethrow an exception
* we should check index before accessing an element (src/core/customizer/CommentParser.cc)
* memory leak in error handler in src/glview/OffscreenContextWGL.cc

Found suspicious but not fixed: 
src/geometry/GeometryUtils.cc:296 Non-boolean value (-1)  returned from function returning bool. I need some clarification from codeowners is it false or is it true should be.
