### PR TITLE
tessellatePolygonWithHoles() return value fix

### DIFF
--- a/src/geometry/GeometryUtils.cc
+++ b/src/geometry/GeometryUtils.cc
@@ -293,7 +293,7 @@ bool GeometryUtils::tessellatePolygonWithHoles(const std::vector<Vector3f>& vert
     numContours++;
   }
 
-  if (!tessTesselate(tess, TESS_WINDING_ODD, TESS_CONSTRAINED_DELAUNAY_TRIANGLES, 3, 3, normalvec)) return -1;
+  if (!tessTesselate(tess, TESS_WINDING_ODD, TESS_CONSTRAINED_DELAUNAY_TRIANGLES, 3, 3, normalvec)) return false;
 
   const auto vindices = tessGetVertexIndices(tess);
   const auto elements = tessGetElements(tess);


### PR DESCRIPTION
Changes for src/geometry/GeometryUtils.cc:296: Non-boolean value (-1) returned from function returning bool.
According to discussion in #4247 `-1` changed to false