### PR TITLE
Removing deprecated std::unary_function 

### DIFF
--- a/src/core/FreetypeRenderer.h
+++ b/src/core/FreetypeRenderer.h
@@ -180,7 +180,7 @@ private:
     hb_glyph_position_t *glyph_pos;
   };
 
-  struct done_glyph : public std::unary_function<const GlyphData *, void> {
+  struct done_glyph {
     void operator()(const GlyphData *glyph_data) {
       FT_Done_Glyph(glyph_data->get_glyph());
       delete glyph_data;

--- a/src/geometry/cgal/cgalutils-polyhedron.cc
+++ b/src/geometry/cgal/cgalutils-polyhedron.cc
@@ -100,7 +100,7 @@ public:
 #endif
 #ifdef GEN_SURFACE_DEBUG
     printf("points=[");
-    for (int i = 0; i < vertices.size(); ++i) {
+    for (std::size_t i = 0; i < vertices.size(); ++i) {
       if (i > 0) printf(",");
       const CGALPoint& p = vertices[i];
       printf("[%g,%g,%g]", CGAL::to_double(p.x()), CGAL::to_double(p.y()), CGAL::to_double(p.z()));
@@ -126,7 +126,7 @@ public:
       if (pidx++ > 0) printf(",");
 #endif
       indices.clear();
-      for (const auto& v, boost::adaptors::reverse(p)) {
+      for (const auto& v: boost::adaptors::reverse(p)) {
         size_t s = vertices.size();
         size_t idx = vertices.lookup(v);
         // If we added a vertex, also add it to the CGAL builder
@@ -164,7 +164,7 @@ public:
     printf("],\n");
 
     printf("points=[");
-    for (int vidx = 0; vidx < vertices.size(); ++vidx) {
+    for (std::size_t vidx = 0; vidx < vertices.size(); ++vidx) {
       if (vidx > 0) printf(",");
       const Vector3d& v = vertices.getArray()[vidx];
       printf("[%g,%g,%g]", v[0], v[1], v[2]);

--- a/src/glview/VertexArray.h
+++ b/src/glview/VertexArray.h
@@ -34,7 +34,7 @@
 
 // Hash function for opengl vertex data.
 template <typename T>
-struct vertex_hash : std::unary_function<T, size_t> {
+struct vertex_hash {
   std::size_t operator()(T const& vertex) const {
     size_t seed = 0;
     for (size_t i = 0; i < vertex.size(); ++i) boost::hash_combine(seed, vertex.data()[i]);


### PR DESCRIPTION
Due `std::unary_function<>` [link](https://en.cppreference.com/w/cpp/utility/functional/unary_function) is a deprecated с++11 and removed in c++17 and seems not necessary here, we can remove it to fix warnings:
'unary_function<std::vector<signed char>, unsigned long>' is deprecated [-Wdeprecated-declarations]
'unary_function<const FreetypeRenderer::GlyphData *, void>' is deprecated [-Wdeprecated-declarations]

Also minor fix for cgalutils-polyhedron.cc file: signed-unsigned compare and syntax error in alternative implementation (it's disabled by preprocessor by-default)

Checked with gcc and clang, but they are too fresh to spot compatibility problems (or my build flags can be differ from CI)