### PR TITLE
improved keyboard navigation in costumizer

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -854,6 +854,7 @@ set(GUI_SOURCES
   src/gui/parameter/ParameterVector.cc
   src/gui/parameter/ParameterVirtualWidget.cc
   src/gui/parameter/ParameterWidget.cc
+  src/gui/parameter/KeyEnterForwarder.cc
   ${INPUT_DRIVER_SOURCES}
   )
 

--- a/src/gui/parameter/GroupWidget.cc
+++ b/src/gui/parameter/GroupWidget.cc
@@ -2,12 +2,18 @@
 
 #include <QLineEdit>
 
+#include "KeyEnterForwarder.h"
+
 GroupWidget::GroupWidget(QString title, QWidget *parent) : QWidget(parent)
 {
   this->toggleButton.setText(title);
   this->toggleButton.setSizePolicy(QSizePolicy::Minimum, QSizePolicy::Maximum);
   this->toggleButton.setToolButtonStyle(Qt::ToolButtonTextBesideIcon);
   this->toggleButton.setCheckable(true);
+
+  KeyEnterForwarder* keyEnterForwarder = new KeyEnterForwarder();
+  toggleButton.installEventFilter(keyEnterForwarder);
+
   setExpanded(false);
 
   // don't waste space
@@ -25,6 +31,7 @@ GroupWidget::GroupWidget(QString title, QWidget *parent) : QWidget(parent)
   setLayout(&mainLayout);
 
   QObject::connect(&toggleButton, SIGNAL(toggled(bool)), this, SLOT(setExpanded(bool)));
+  QObject::connect(keyEnterForwarder, SIGNAL(enterPressed()), &toggleButton, SLOT(toggle()));
 }
 
 void GroupWidget::addWidget(QWidget *widget)
@@ -41,4 +48,8 @@ void GroupWidget::setExpanded(bool expanded)
   } else {
     contentArea.hide();
   }
+}
+
+void GroupWidget::setFocusOnButton(){
+  toggleButton.setFocus();
 }

--- a/src/gui/parameter/GroupWidget.h
+++ b/src/gui/parameter/GroupWidget.h
@@ -1,9 +1,9 @@
 #pragma once
 
 #include <QGridLayout>
-#include <QToolButton>
 #include <QVBoxLayout>
 #include <QWidget>
+#include <QToolButton>
 
 #include "qtgettext.h"
 
@@ -25,4 +25,5 @@ public:
 
 public slots:
   void setExpanded(bool expanded);
+  void setFocusOnButton();
 };

--- a/src/gui/parameter/KeyEnterForwarder.cc
+++ b/src/gui/parameter/KeyEnterForwarder.cc
@@ -1,0 +1,43 @@
+/*
+ *  OpenSCAD (www.openscad.org)
+ *  Copyright (C) 2009-2014 Clifford Wolf <clifford@clifford.at> and
+ *                          Marius Kintel <marius@kintel.net>
+ *
+ *  This program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  As a special exception, you have permission to link this program
+ *  with the CGAL library and distribute executables, as long as you
+ *  follow the requirements of the GNU GPL in regard to all of the
+ *  software in the executable aside from CGAL.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program; if not, write to the Free Software
+ *  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ *
+ */
+
+#include "KeyEnterForwarder.h"
+
+bool KeyEnterForwarder::eventFilter(QObject* obj, QEvent* event)
+{
+    if (event->type()==QEvent::KeyPress) {
+        QKeyEvent* key = static_cast<QKeyEvent*>(event);
+        if ( (key->key()==Qt::Key_Enter) || (key->key()==Qt::Key_Return) ) {
+            emit enterPressed();
+        } else {
+            return QObject::eventFilter(obj, event);
+        }
+        return true;
+    } else {
+        return QObject::eventFilter(obj, event);
+    }
+    return false;
+}

--- a/src/gui/parameter/KeyEnterForwarder.h
+++ b/src/gui/parameter/KeyEnterForwarder.h
@@ -1,0 +1,39 @@
+/*
+ *  OpenSCAD (www.openscad.org)
+ *  Copyright (C) 2009-2014 Clifford Wolf <clifford@clifford.at> and
+ *                          Marius Kintel <marius@kintel.net>
+ *
+ *  This program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  As a special exception, you have permission to link this program
+ *  with the CGAL library and distribute executables, as long as you
+ *  follow the requirements of the GNU GPL in regard to all of the
+ *  software in the executable aside from CGAL.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program; if not, write to the Free Software
+ *  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ *
+ */
+
+#pragma once
+
+#include <QKeyEvent>
+
+class KeyEnterForwarder : public QObject
+{
+    Q_OBJECT
+protected:
+    bool eventFilter(QObject* obj, QEvent* event);
+
+signals:
+  void enterPressed();
+};

--- a/src/gui/parameter/ParameterCheckBox.cc
+++ b/src/gui/parameter/ParameterCheckBox.cc
@@ -1,4 +1,5 @@
 #include "ParameterCheckBox.h"
+#include "KeyEnterForwarder.h"
 
 ParameterCheckBox::ParameterCheckBox(QWidget *parent, BoolParameter *parameter, DescriptionStyle descriptionStyle) :
   ParameterVirtualWidget(parent, parameter),
@@ -11,6 +12,10 @@ ParameterCheckBox::ParameterCheckBox(QWidget *parent, BoolParameter *parameter, 
     //large checkbox, when we have the space
     checkBox->setStyleSheet("QCheckBox::indicator { width: 20px; height: 20px; } QCheckBox { spacing: 0px; }");
   }
+
+  KeyEnterForwarder* keyEnterForwarder = new KeyEnterForwarder();
+  checkBox->installEventFilter(keyEnterForwarder);
+  connect(keyEnterForwarder, SIGNAL(enterPressed()), checkBox, SLOT(toggle()));
 
   connect(checkBox, SIGNAL(clicked()), this, SLOT(onChanged()));
   setValue();

--- a/src/gui/parameter/ParameterSlider.ui
+++ b/src/gui/parameter/ParameterSlider.ui
@@ -70,11 +70,14 @@
    </item>
    <item>
     <widget class="QSlider" name="slider">
-     <property name="orientation">
-      <enum>Qt::Horizontal</enum>
+     <property name="focusPolicy">
+      <enum>Qt::ClickFocus</enum>
      </property>
      <property name="tracking">
       <bool>false</bool>
+     </property>
+     <property name="orientation">
+      <enum>Qt::Horizontal</enum>
      </property>
     </widget>
    </item>

--- a/src/gui/parameter/ParameterWidget.cc
+++ b/src/gui/parameter/ParameterWidget.cc
@@ -429,7 +429,6 @@ bool ParameterWidget::focusNextPrevChild(bool next){
   // we do not want the focus to leave this widget
   // so we cycle last->first and first->last manual
 
-  bool bChildHasFocus=false;
   for(auto child : QObject::findChildren<QWidget*>()){
     if(child->hasFocus()){
       //when a child is focused, we do not need to do anything
@@ -437,26 +436,29 @@ bool ParameterWidget::focusNextPrevChild(bool next){
     }
   }
 
+  //when no child is focues
+
   if(next) { //when moving forward,
     checkBoxAutoPreview->setFocus(); //set focus to first widget
     return true;
   }
 
+  //when moving backwards, we need to manually find a suitable widget 
   auto groups = QObject::findChildren<GroupWidget*>();
   if(groups.empty()){
-    scrollArea->setFocus();
+    scrollArea->setFocus(Qt::BacktabFocusReason);
     return true;
   }
   
   auto lastGroup = groups.last();
   if(!lastGroup->isExpanded()){
-    lastGroup->setFocus();
+    lastGroup->setFocusOnButton();
     return true;
   }
   
   auto parameterWidgets = lastGroup->findChildren<ParameterVirtualWidget*>();
   if(parameterWidgets.empty()){
-    lastGroup->setFocus();
+    lastGroup->setFocusOnButton();
     return true;
   }
   
@@ -469,12 +471,13 @@ bool ParameterWidget::focusNextPrevChild(bool next){
     if((*widgetIterator)->isVisible()){
       const auto focusPolicy = (*widgetIterator)->focusPolicy();
       if((Qt::StrongFocus == focusPolicy) || (Qt::TabFocus == focusPolicy)){
-        (*widgetIterator)->setFocus();
+        (*widgetIterator)->setFocus(Qt::BacktabFocusReason);
         return true;
       }
     }
     --widgetIterator;
   }
-  
+
+  lastGroup->setFocus(Qt::BacktabFocusReason);
   return true;
 }

--- a/src/gui/parameter/ParameterWidget.cc
+++ b/src/gui/parameter/ParameterWidget.cc
@@ -422,3 +422,59 @@ void ParameterWidget::cleanSets()
     }
   }
 }
+
+bool ParameterWidget::focusNextPrevChild(bool next){
+  QWidget::focusNextPrevChild(next);
+
+  // we do not want the focus to leave this widget
+  // so we cycle last->first and first->last manual
+
+  bool bChildHasFocus=false;
+  for(auto child : QObject::findChildren<QWidget*>()){
+    if(child->hasFocus()){
+      //when a child is focused, we do not need to do anything
+      return true;
+    }
+  }
+
+  if(next) { //when moving forward,
+    checkBoxAutoPreview->setFocus(); //set focus to first widget
+    return true;
+  }
+
+  auto groups = QObject::findChildren<GroupWidget*>();
+  if(groups.empty()){
+    scrollArea->setFocus();
+    return true;
+  }
+  
+  auto lastGroup = groups.last();
+  if(!lastGroup->isExpanded()){
+    lastGroup->setFocus();
+    return true;
+  }
+  
+  auto parameterWidgets = lastGroup->findChildren<ParameterVirtualWidget*>();
+  if(parameterWidgets.empty()){
+    lastGroup->setFocus();
+    return true;
+  }
+  
+  auto lastParameterWidget = parameterWidgets.last();
+  auto widgets = lastParameterWidget->findChildren<QWidget*>();
+
+  auto widgetIterator = widgets.end();
+  --widgetIterator;
+  while(widgetIterator != widgets.begin()) {
+    if((*widgetIterator)->isVisible()){
+      const auto focusPolicy = (*widgetIterator)->focusPolicy();
+      if((Qt::StrongFocus == focusPolicy) || (Qt::TabFocus == focusPolicy)){
+        (*widgetIterator)->setFocus();
+        return true;
+      }
+    }
+    --widgetIterator;
+  }
+  
+  return true;
+}

--- a/src/gui/parameter/ParameterWidget.h
+++ b/src/gui/parameter/ParameterWidget.h
@@ -47,6 +47,9 @@ private:
   QTimer autoPreviewTimer;
   bool modified = false;
 
+protected:
+  bool focusNextPrevChild(bool next) override;
+
 public:
   ParameterWidget(QWidget *parent = nullptr);
   void readFile(QString scadFile);


### PR DESCRIPTION
*  changed QSlider from StrongFocus (default) to ClickFocus,
   * this removes the QSlider from the tab navigation. 
   * which makes sense, as for keyboard access, the slider is redundant to the spinbox (which has more functionality)
*  tab/alt-tab now cycles within the parameter widget/customizer
* the group expand buttons and checkboxes now respond to enter
   * (something is funny with the return key on my system (ubuntu Ubuntu 22.04 LTS), but issues with the return key and qt are both known by some and denied by others to exist (main argument being about confusing return and enter key))