### PR TITLE
option to highlight evaluated AST-Nodes in the editor

### DIFF
--- a/src/core/AST.h
+++ b/src/core/AST.h
@@ -59,7 +59,7 @@ protected:
     this->evaluated=true;
   }
 private:
-  volatile mutable bool evaluated=false;
+  mutable bool evaluated=false;
 };
 
 std::ostream& operator<<(std::ostream& stream, const ASTNode& ast);

--- a/src/core/AST.h
+++ b/src/core/AST.h
@@ -46,13 +46,20 @@ public:
   virtual ~ASTNode() {}
 
   virtual void print(std::ostream& stream, const std::string& indent) const = 0;
+  virtual void gatherChilderen(std::vector<const ASTNode*>& nodes) const = 0;
 
   std::string dump(const std::string& indent) const;
   const Location& location() const { return loc; }
   void setLocation(const Location& loc) { this->loc = loc; }
+  bool isEvaluated() const {return this->evaluated;}
 
 protected:
   Location loc;
+  void setEvaluated() const {
+    this->evaluated=true;
+  }
+private:
+  volatile mutable bool evaluated=false;
 };
 
 std::ostream& operator<<(std::ostream& stream, const ASTNode& ast);

--- a/src/core/Assignment.cc
+++ b/src/core/Assignment.cc
@@ -47,6 +47,10 @@ const Annotation *Assignment::annotation(const std::string& name) const
   return found == annotations.end() ? nullptr : found->second;
 }
 
+const shared_ptr<Expression>& Assignment::getExpr() const {
+  setEvaluated();
+  return expr;
+}
 
 void Assignment::print(std::ostream& stream, const std::string& indent) const
 {
@@ -59,6 +63,12 @@ void Assignment::print(std::ostream& stream, const std::string& indent) const
     if (parameter) parameter->print(stream, indent);
   }
   stream << indent << this->name << " = " << *this->expr << ";\n";
+}
+
+void Assignment::gatherChilderen(std::vector<const ASTNode*>& nodes) const
+{
+  nodes.push_back(this);
+  if(expr) expr.get()->gatherChilderen(nodes);
 }
 
 std::ostream& operator<<(std::ostream& stream, const AssignmentList& assignments)

--- a/src/core/Assignment.h
+++ b/src/core/Assignment.h
@@ -20,7 +20,7 @@ public:
 
   void print(std::ostream& stream, const std::string& indent) const override;
   const std::string& getName() const { return name; }
-  const shared_ptr<Expression>& getExpr() const { return expr; }
+  const shared_ptr<Expression>& getExpr() const;
   const AnnotationMap& getAnnotations() const { return annotations; }
   // setExpr used by customizer ParameterObject etc.
   void setExpr(shared_ptr<Expression> e) { expr = std::move(e); }
@@ -31,6 +31,8 @@ public:
 
   const Location& locationOfOverwrite() const { return locOfOverwrite; }
   void setLocationOfOverwrite(const Location& locOfOverwrite) { this->locOfOverwrite = locOfOverwrite; }
+
+  void gatherChilderen(std::vector<const ASTNode*>& nodes) const override;
 
 protected:
   const std::string name;

--- a/src/core/Expression.cc
+++ b/src/core/Expression.cc
@@ -697,7 +697,6 @@ void FunctionCall::gatherChilderen(std::vector<const ASTNode*>& nodes) const
   }
 }
 
-
 Expression *FunctionCall::create(const std::string& funcname, const AssignmentList& arglist, Expression *expr, const Location& loc)
 {
   if (funcname == "assert") {
@@ -865,7 +864,7 @@ LcIf::LcIf(Expression *cond, Expression *ifexpr, Expression *elseexpr, const Loc
 
 Value LcIf::evaluate(const std::shared_ptr<const Context>& context) const
 {
-setEvaluated();
+  setEvaluated();
   const shared_ptr<Expression>& expr = this->cond->evaluate(context).toBool() ? this->ifexpr : this->elseexpr;
   if (expr) {
     return expr->evaluate(context);
@@ -942,7 +941,6 @@ void LcEach::gatherChilderen(std::vector<const ASTNode*>& nodes) const
   nodes.push_back(this);
   if (this->expr) this->expr->gatherChilderen(nodes);
 }
-
 
 LcFor::LcFor(const AssignmentList& args, Expression *expr, const Location& loc)
   : ListComprehension(loc), arguments(args), expr(expr)

--- a/src/core/Expression.cc
+++ b/src/core/Expression.cc
@@ -553,6 +553,7 @@ FunctionCall::FunctionCall(Expression *expr, const AssignmentList& args, const L
 
 boost::optional<CallableFunction> FunctionCall::evaluate_function_expression(const std::shared_ptr<const Context>& context) const
 {
+  setEvaluated();
   if (isLookup) {
     return context->lookup_function(name, location());
   } else {
@@ -692,7 +693,7 @@ void FunctionCall::gatherChilderen(std::vector<const ASTNode*>& nodes) const
 {
   nodes.push_back(this);
   for(auto argument : this->arguments){
-    argument.get()->gatherChilderen(nodes);
+    argument->gatherChilderen(nodes);
   }
 }
 
@@ -738,6 +739,7 @@ void Assert::performAssert(const AssignmentList& arguments, const Location& loca
 
 const Expression *Assert::evaluateStep(const std::shared_ptr<const Context>& context) const
 {
+  this->setEvaluated();
   performAssert(this->arguments, this->loc, context);
   return expr.get();
 }
@@ -790,9 +792,9 @@ void Echo::print(std::ostream& stream, const std::string&) const
 void Echo::gatherChilderen(std::vector<const ASTNode*>& nodes) const
 {
   nodes.push_back(this);
-  if(this->expr) this->expr.get()->gatherChilderen(nodes);
+  if(this->expr) this->expr->gatherChilderen(nodes);
   for(auto argument : arguments){
-    argument.get()->gatherChilderen(nodes);
+    argument->gatherChilderen(nodes);
   }
 }
 
@@ -826,6 +828,7 @@ ContextHandle<Context> Let::sequentialAssignmentContext(const AssignmentList& as
 
 const Expression *Let::evaluateStep(ContextHandle<Context>& targetContext) const
 {
+  this->setEvaluated();
   doSequentialAssignment(this->arguments, this->location(), targetContext);
   return this->expr.get();
 }
@@ -847,7 +850,7 @@ void Let::gatherChilderen(std::vector<const ASTNode*>& nodes) const
 {
   nodes.push_back(this);
   for(auto argument : this->arguments){
-    argument.get()->gatherChilderen(nodes);
+    argument->gatherChilderen(nodes);
   }
 }
 
@@ -937,7 +940,7 @@ void LcEach::print(std::ostream& stream, const std::string&) const
 void LcEach::gatherChilderen(std::vector<const ASTNode*>& nodes) const
 {
   nodes.push_back(this);
-  if (this->expr) this->expr.get()->gatherChilderen(nodes);
+  if (this->expr) this->expr->gatherChilderen(nodes);
 }
 
 
@@ -1089,13 +1092,13 @@ void LcForC::gatherChilderen(std::vector<const ASTNode*>& nodes) const
 {
   nodes.push_back(this);
   for(auto argument : arguments){
-    argument.get()->gatherChilderen(nodes);
+    argument->gatherChilderen(nodes);
   }
   this->cond.get()->gatherChilderen(nodes);
   for(auto argument : incr_arguments){
-    argument.get()->gatherChilderen(nodes);
+    argument->gatherChilderen(nodes);
   }
-  this->expr.get()->gatherChilderen(nodes);
+  this->expr->gatherChilderen(nodes);
 }
 
 LcLet::LcLet(const AssignmentList& args, Expression *expr, const Location& loc)
@@ -1118,7 +1121,7 @@ void LcLet::gatherChilderen(std::vector<const ASTNode*>& nodes) const
 {
   nodes.push_back(this);
   for(auto argument : arguments){
-    argument.get()->gatherChilderen(nodes);
+    argument->gatherChilderen(nodes);
   }
-  this->expr.get()->gatherChilderen(nodes);
+  this->expr->gatherChilderen(nodes);
 }

--- a/src/core/Expression.h
+++ b/src/core/Expression.h
@@ -32,6 +32,7 @@ public:
   UnaryOp(Op op, Expression *expr, const Location& loc);
   Value evaluate(const std::shared_ptr<const Context>& context) const override;
   void print(std::ostream& stream, const std::string& indent) const override;
+  void gatherChilderen(std::vector<const ASTNode*>& nodes) const override;
 
 private:
   const char *opString() const;
@@ -63,6 +64,7 @@ public:
   BinaryOp(Expression *left, Op op, Expression *right, const Location& loc);
   Value evaluate(const std::shared_ptr<const Context>& context) const override;
   void print(std::ostream& stream, const std::string& indent) const override;
+  void gatherChilderen(std::vector<const ASTNode*>& nodes) const override;
 
 private:
   const char *opString() const;
@@ -79,6 +81,8 @@ public:
   const Expression *evaluateStep(const std::shared_ptr<const Context>& context) const;
   Value evaluate(const std::shared_ptr<const Context>& context) const override;
   void print(std::ostream& stream, const std::string& indent) const override;
+  void gatherChilderen(std::vector<const ASTNode*>& nodes) const override;
+
 private:
   shared_ptr<Expression> cond;
   shared_ptr<Expression> ifexpr;
@@ -91,6 +95,8 @@ public:
   ArrayLookup(Expression *array, Expression *index, const Location& loc);
   Value evaluate(const std::shared_ptr<const Context>& context) const override;
   void print(std::ostream& stream, const std::string& indent) const override;
+  void gatherChilderen(std::vector<const ASTNode*>& nodes) const override;
+
 private:
   shared_ptr<Expression> array;
   shared_ptr<Expression> index;
@@ -114,6 +120,7 @@ public:
 
   Value evaluate(const std::shared_ptr<const Context>& context) const override;
   void print(std::ostream& stream, const std::string& indent) const override;
+  void gatherChilderen(std::vector<const ASTNode*>& nodes) const override;
   bool isLiteral() const override { return true;}
 private:
   boost::variant<bool, double, std::string, boost::none_t> value;
@@ -129,6 +136,7 @@ public:
   const Expression *getEnd() const { return end.get(); }
   Value evaluate(const std::shared_ptr<const Context>& context) const override;
   void print(std::ostream& stream, const std::string& indent) const override;
+  void gatherChilderen(std::vector<const ASTNode*>& nodes) const override;
   bool isLiteral() const override;
 private:
   shared_ptr<Expression> begin;
@@ -143,6 +151,7 @@ public:
   const std::vector<shared_ptr<Expression>>& getChildren() const { return children; }
   Value evaluate(const std::shared_ptr<const Context>& context) const override;
   void print(std::ostream& stream, const std::string& indent) const override;
+  void gatherChilderen(std::vector<const ASTNode*>& nodes) const override;
   void emplace_back(Expression *expr);
   bool isLiteral() const override;
 private:
@@ -156,6 +165,7 @@ public:
   Lookup(const std::string& name, const Location& loc);
   Value evaluate(const std::shared_ptr<const Context>& context) const override;
   void print(std::ostream& stream, const std::string& indent) const override;
+  void gatherChilderen(std::vector<const ASTNode*>& nodes) const override;
   const std::string& get_name() const { return name; }
 private:
   std::string name;
@@ -167,6 +177,7 @@ public:
   MemberLookup(Expression *expr, const std::string& member, const Location& loc);
   Value evaluate(const std::shared_ptr<const Context>& context) const override;
   void print(std::ostream& stream, const std::string& indent) const override;
+  void gatherChilderen(std::vector<const ASTNode*>& nodes) const override;
 private:
   shared_ptr<Expression> expr;
   std::string member;
@@ -179,6 +190,7 @@ public:
   boost::optional<CallableFunction> evaluate_function_expression(const std::shared_ptr<const Context>& context) const;
   Value evaluate(const std::shared_ptr<const Context>& context) const override;
   void print(std::ostream& stream, const std::string& indent) const override;
+  void gatherChilderen(std::vector<const ASTNode*>& nodes) const override;
   const std::string& get_name() const { return name; }
   static Expression *create(const std::string& funcname, const AssignmentList& arglist, Expression *expr, const Location& loc);
 public:
@@ -194,6 +206,7 @@ public:
   FunctionDefinition(Expression *expr, const AssignmentList& parameters, const Location& loc);
   Value evaluate(const std::shared_ptr<const Context>& context) const override;
   void print(std::ostream& stream, const std::string& indent) const override;
+  void gatherChilderen(std::vector<const ASTNode*>& nodes) const override;
 public:
   shared_ptr<const Context> context;
   AssignmentList parameters;
@@ -208,6 +221,7 @@ public:
   const Expression *evaluateStep(const std::shared_ptr<const Context>& context) const;
   Value evaluate(const std::shared_ptr<const Context>& context) const override;
   void print(std::ostream& stream, const std::string& indent) const override;
+  void gatherChilderen(std::vector<const ASTNode*>& nodes) const override;
 private:
   AssignmentList arguments;
   shared_ptr<Expression> expr;
@@ -220,6 +234,7 @@ public:
   const Expression *evaluateStep(const std::shared_ptr<const Context>& context) const;
   Value evaluate(const std::shared_ptr<const Context>& context) const override;
   void print(std::ostream& stream, const std::string& indent) const override;
+  void gatherChilderen(std::vector<const ASTNode*>& nodes) const override;
 private:
   AssignmentList arguments;
   shared_ptr<Expression> expr;
@@ -234,6 +249,7 @@ public:
   const Expression *evaluateStep(ContextHandle<Context>& targetContext) const;
   Value evaluate(const std::shared_ptr<const Context>& context) const override;
   void print(std::ostream& stream, const std::string& indent) const override;
+  void gatherChilderen(std::vector<const ASTNode*>& nodes) const override;
 private:
   AssignmentList arguments;
   shared_ptr<Expression> expr;
@@ -252,6 +268,7 @@ public:
   LcIf(Expression *cond, Expression *ifexpr, Expression *elseexpr, const Location& loc);
   Value evaluate(const std::shared_ptr<const Context>& context) const override;
   void print(std::ostream& stream, const std::string& indent) const override;
+  void gatherChilderen(std::vector<const ASTNode*>& nodes) const override;
 private:
   shared_ptr<Expression> cond;
   shared_ptr<Expression> ifexpr;
@@ -265,6 +282,7 @@ public:
   static void forEach(const AssignmentList& assignments, const Location& loc, const std::shared_ptr<const Context>& context, std::function<void(const std::shared_ptr<const Context>&)> operation);
   Value evaluate(const std::shared_ptr<const Context>& context) const override;
   void print(std::ostream& stream, const std::string& indent) const override;
+  void gatherChilderen(std::vector<const ASTNode*>& nodes) const override;
 private:
   AssignmentList arguments;
   shared_ptr<Expression> expr;
@@ -276,6 +294,7 @@ public:
   LcForC(const AssignmentList& args, const AssignmentList& incrargs, Expression *cond, Expression *expr, const Location& loc);
   Value evaluate(const std::shared_ptr<const Context>& context) const override;
   void print(std::ostream& stream, const std::string& indent) const override;
+  void gatherChilderen(std::vector<const ASTNode*>& nodes) const override;
 private:
   AssignmentList arguments;
   AssignmentList incr_arguments;
@@ -289,6 +308,7 @@ public:
   LcEach(Expression *expr, const Location& loc);
   Value evaluate(const std::shared_ptr<const Context>& context) const override;
   void print(std::ostream& stream, const std::string& indent) const override;
+  void gatherChilderen(std::vector<const ASTNode*>& nodes) const override;
 private:
   Value evalRecur(Value&& v, const std::shared_ptr<const Context>& context) const;
   shared_ptr<Expression> expr;
@@ -300,6 +320,7 @@ public:
   LcLet(const AssignmentList& args, Expression *expr, const Location& loc);
   Value evaluate(const std::shared_ptr<const Context>& context) const override;
   void print(std::ostream& stream, const std::string& indent) const override;
+  void gatherChilderen(std::vector<const ASTNode*>& nodes) const override;
 private:
   AssignmentList arguments;
   shared_ptr<Expression> expr;

--- a/src/core/LocalScope.cc
+++ b/src/core/LocalScope.cc
@@ -53,6 +53,21 @@ void LocalScope::print(std::ostream& stream, const std::string& indent, const bo
   }
 }
 
+void LocalScope::gatherChilderen(std::vector<const ASTNode*>& nodes) const
+{
+  for (const auto& f : this->astFunctions) {
+    f.second->gatherChilderen(nodes);
+  }
+  for (const auto& m : this->astModules) {
+    m.second->gatherChilderen(nodes);
+  }
+  for (const auto& assignment : this->assignments) {
+    assignment->gatherChilderen(nodes);
+  }
+  for (const auto& inst : this->moduleInstantiations) {
+    inst->gatherChilderen(nodes);
+  }
+}
 std::shared_ptr<AbstractNode> LocalScope::instantiateModules(const std::shared_ptr<const Context>& context, const std::shared_ptr<AbstractNode> &target) const
 {
   for (const auto& modinst : this->moduleInstantiations) {

--- a/src/core/LocalScope.cc
+++ b/src/core/LocalScope.cc
@@ -68,6 +68,7 @@ void LocalScope::gatherChilderen(std::vector<const ASTNode*>& nodes) const
     inst->gatherChilderen(nodes);
   }
 }
+
 std::shared_ptr<AbstractNode> LocalScope::instantiateModules(const std::shared_ptr<const Context>& context, const std::shared_ptr<AbstractNode> &target) const
 {
   for (const auto& modinst : this->moduleInstantiations) {

--- a/src/core/LocalScope.h
+++ b/src/core/LocalScope.h
@@ -31,5 +31,5 @@ public:
   std::unordered_map<std::string, shared_ptr<UserModule>> modules;
   std::vector<std::pair<std::string, shared_ptr<UserModule>>> astModules;
 
-  void gatherChilderen(std::vector<const ASTNode*>& nodes) const /*override*/;
+  void gatherChilderen(std::vector<const ASTNode*>& nodes) const;
 };

--- a/src/core/LocalScope.h
+++ b/src/core/LocalScope.h
@@ -30,4 +30,6 @@ public:
 
   std::unordered_map<std::string, shared_ptr<UserModule>> modules;
   std::vector<std::pair<std::string, shared_ptr<UserModule>>> astModules;
+
+  void gatherChilderen(std::vector<const ASTNode*>& nodes) const /*override*/;
 };

--- a/src/core/ModuleInstantiation.cc
+++ b/src/core/ModuleInstantiation.cc
@@ -37,6 +37,11 @@ void ModuleInstantiation::print(std::ostream& stream, const std::string& indent,
     stream << indent << "}\n";
   }
 }
+void ModuleInstantiation::gatherChilderen(std::vector<const ASTNode*>& nodes) const
+{
+  nodes.push_back(this);
+  scope.gatherChilderen(nodes);
+}
 
 void IfElseModuleInstantiation::print(std::ostream& stream, const std::string& indent, const bool inlined) const
 {
@@ -58,6 +63,12 @@ void IfElseModuleInstantiation::print(std::ostream& stream, const std::string& i
   }
 }
 
+void IfElseModuleInstantiation::gatherChilderen(std::vector<const ASTNode*>& nodes) const
+{
+  ModuleInstantiation::gatherChilderen(nodes);
+  if (else_scope) else_scope.get()->gatherChilderen(nodes);
+}
+
 /**
  * This is separated because PRINTB uses quite a lot of stack space
  * and the method using it evaluate()
@@ -71,6 +82,8 @@ static void NOINLINE print_trace(const ModuleInstantiation *mod, const std::shar
 
 std::shared_ptr<AbstractNode> ModuleInstantiation::evaluate(const std::shared_ptr<const Context> context) const
 {
+  setEvaluated();
+
   boost::optional<InstantiableModule> module = context->lookup_module(this->name(), this->loc);
   if (!module) {
     return nullptr;

--- a/src/core/ModuleInstantiation.cc
+++ b/src/core/ModuleInstantiation.cc
@@ -40,6 +40,9 @@ void ModuleInstantiation::print(std::ostream& stream, const std::string& indent,
 void ModuleInstantiation::gatherChilderen(std::vector<const ASTNode*>& nodes) const
 {
   nodes.push_back(this);
+  for(auto argument : arguments){
+    argument->gatherChilderen(nodes);
+  }
   scope.gatherChilderen(nodes);
 }
 
@@ -66,7 +69,7 @@ void IfElseModuleInstantiation::print(std::ostream& stream, const std::string& i
 void IfElseModuleInstantiation::gatherChilderen(std::vector<const ASTNode*>& nodes) const
 {
   ModuleInstantiation::gatherChilderen(nodes);
-  if (else_scope) else_scope.get()->gatherChilderen(nodes);
+  if (else_scope) else_scope->gatherChilderen(nodes);
 }
 
 /**

--- a/src/core/ModuleInstantiation.cc
+++ b/src/core/ModuleInstantiation.cc
@@ -37,6 +37,7 @@ void ModuleInstantiation::print(std::ostream& stream, const std::string& indent,
     stream << indent << "}\n";
   }
 }
+
 void ModuleInstantiation::gatherChilderen(std::vector<const ASTNode*>& nodes) const
 {
   nodes.push_back(this);

--- a/src/core/ModuleInstantiation.h
+++ b/src/core/ModuleInstantiation.h
@@ -17,6 +17,8 @@ public:
   void print(std::ostream& stream, const std::string& indent) const override { print(stream, indent, false); }
   std::shared_ptr<AbstractNode> evaluate(const std::shared_ptr<const Context> context) const;
 
+  void gatherChilderen(std::vector<const ASTNode*>& nodes) const override;
+
   const std::string& name() const { return this->modname; }
   bool isBackground() const { return this->tag_background; }
   bool isHighlight() const { return this->tag_highlight; }
@@ -28,6 +30,7 @@ public:
   bool tag_root;
   bool tag_highlight;
   bool tag_background;
+  
 protected:
   std::string modname;
 };
@@ -41,6 +44,7 @@ public:
   LocalScope *makeElseScope();
   LocalScope *getElseScope() const { return this->else_scope.get(); }
   void print(std::ostream& stream, const std::string& indent, const bool inlined) const final;
+  void gatherChilderen(std::vector<const ASTNode*>& nodes) const override;
 private:
   std::unique_ptr<LocalScope> else_scope;
 };

--- a/src/core/SourceFile.cc
+++ b/src/core/SourceFile.cc
@@ -178,6 +178,7 @@ time_t SourceFile::handleDependencies(bool is_root)
 
 std::shared_ptr<AbstractNode> SourceFile::instantiate(const std::shared_ptr<const Context>& context, std::shared_ptr<const FileContext> *resulting_file_context) const
 {
+  setEvaluated();
   auto node = std::make_shared<RootNode>();
   try {
     ContextHandle<FileContext> file_context{Context::create<FileContext>(context, this)};

--- a/src/core/SourceFile.cc
+++ b/src/core/SourceFile.cc
@@ -53,6 +53,12 @@ void SourceFile::print(std::ostream& stream, const std::string& indent) const
   scope.print(stream, indent);
 }
 
+void SourceFile::gatherChilderen(std::vector<const ASTNode*>& nodes) const
+{
+  nodes.push_back(this);
+  scope.gatherChilderen(nodes);
+}
+
 void SourceFile::registerUse(const std::string& path, const Location& loc)
 {
   PRINTDB("registerUse(): (%p) %d, %d - %d, %d (%s) -> %s", this %

--- a/src/core/SourceFile.h
+++ b/src/core/SourceFile.h
@@ -18,6 +18,7 @@ public:
 
   std::shared_ptr<AbstractNode> instantiate(const std::shared_ptr<const Context>& context, std::shared_ptr<const class FileContext> *resulting_file_context) const;
   void print(std::ostream& stream, const std::string& indent) const override;
+  void gatherChilderen(std::vector<const ASTNode*>& nodes) const override;
 
   void setModulePath(const std::string& path) { this->path = path; }
   const std::string& modulePath() const { return this->path; }

--- a/src/core/UserModule.cc
+++ b/src/core/UserModule.cc
@@ -80,6 +80,8 @@ std::shared_ptr<AbstractNode> UserModule::instantiate(const std::shared_ptr<cons
     return nullptr;
   }
 
+  this->setEvaluated();
+
   StaticModuleNameStack name{inst->name()}; // push on static stack, pop at end of method!
   ContextHandle<UserModuleContext> module_context{Context::create<UserModuleContext>(
                                                     defining_context,
@@ -130,7 +132,7 @@ void UserModule::gatherChilderen(std::vector<const ASTNode*>& nodes) const
 {
   nodes.push_back(this);
   for(auto parameter : parameters){
-    if (parameter->getExpr()) parameter->getExpr()->gatherChilderen(nodes);
+    parameter->gatherChilderen(nodes);
   }
   body.gatherChilderen(nodes);
 }

--- a/src/core/UserModule.cc
+++ b/src/core/UserModule.cc
@@ -125,3 +125,12 @@ void UserModule::print(std::ostream& stream, const std::string& indent) const
     stream << indent << "}\n";
   }
 }
+
+void UserModule::gatherChilderen(std::vector<const ASTNode*>& nodes) const
+{
+  nodes.push_back(this);
+  for(auto parameter : parameters){
+    if (parameter->getExpr()) parameter->getExpr()->gatherChilderen(nodes);
+  }
+  body.gatherChilderen(nodes);
+}

--- a/src/core/UserModule.h
+++ b/src/core/UserModule.h
@@ -38,4 +38,6 @@ public:
   std::string name;
   AssignmentList parameters;
   LocalScope body;
+
+  void gatherChilderen(std::vector<const ASTNode*>& nodes) const override;
 };

--- a/src/core/function.cc
+++ b/src/core/function.cc
@@ -58,3 +58,12 @@ void UserFunction::print(std::ostream& stream, const std::string& indent) const
   }
   stream << ") = " << *expr << ";\n";
 }
+
+void UserFunction::gatherChilderen(std::vector<const ASTNode*>& nodes) const
+{
+  nodes.push_back(this);
+  for(auto parameter : parameters){
+    parameter->gatherChilderen(nodes);
+  }
+  expr->gatherChilderen(nodes);
+}

--- a/src/core/function.h
+++ b/src/core/function.h
@@ -38,6 +38,7 @@ public:
   UserFunction(const char *name, AssignmentList& parameters, shared_ptr<Expression> expr, const Location& loc);
 
   void print(std::ostream& stream, const std::string& indent) const override;
+  void gatherChilderen(std::vector<const ASTNode*>& nodes) const override;
 };
 
 

--- a/src/gui/MainWindow.cc
+++ b/src/gui/MainWindow.cc
@@ -1209,12 +1209,23 @@ void MainWindow::instantiateRoot()
     std::shared_ptr<const FileContext> file_context;
     this->absolute_root_node = this->root_file->instantiate(*builtin_context, &file_context);
         auto editor = (ScintillaEditor *) this->activeEditor;
+std::vector<const ASTNode*> astNodes;
     if( (editor != nullptr) ){
-          std::vector<const ASTNode*> nodes;
-          this->root_file->gatherChilderen(nodes);
-          editor->evalutated(this->root_file->getFullpath(), nodes);
+          
+          this->root_file->gatherChilderen(astNodes);
+          editor->evalutated(this->root_file->getFullpath(), astNodes);
         }
-      
+        uint64_t nodes = 0;
+        uint64_t evaluated = 0;
+          for (auto astNode : astNodes) {
+        if(astNode) {
+          nodes++;
+            if(astNode->isEvaluated()){
+              evaluated++;
+            }
+          }
+        }
+    LOG(message_group::None, Location::NONE, "", "Evalutated %1d/%2d", evaluated, nodes);
 
     if (file_context) {
       this->qglview->cam.updateView(file_context, false);

--- a/src/gui/MainWindow.cc
+++ b/src/gui/MainWindow.cc
@@ -1208,6 +1208,14 @@ void MainWindow::instantiateRoot()
 
     std::shared_ptr<const FileContext> file_context;
     this->absolute_root_node = this->root_file->instantiate(*builtin_context, &file_context);
+        auto editor = (ScintillaEditor *) this->activeEditor;
+    if( (editor != nullptr) ){
+          std::vector<const ASTNode*> nodes;
+          this->root_file->gatherChilderen(nodes);
+          editor->evalutated(this->root_file->getFullpath(), nodes);
+        }
+      
+
     if (file_context) {
       this->qglview->cam.updateView(file_context, false);
     }

--- a/src/gui/MainWindow.cc
+++ b/src/gui/MainWindow.cc
@@ -1208,25 +1208,25 @@ void MainWindow::instantiateRoot()
 
     std::shared_ptr<const FileContext> file_context;
     this->absolute_root_node = this->root_file->instantiate(*builtin_context, &file_context);
+    if(designShowEvaluated->isChecked()){
         auto editor = (ScintillaEditor *) this->activeEditor;
-std::vector<const ASTNode*> astNodes;
-    if( (editor != nullptr) ){
-          
+        std::vector<const ASTNode*> astNodes;
+        if( (editor != nullptr) ){
           this->root_file->gatherChilderen(astNodes);
           editor->evalutated(this->root_file->getFullpath(), astNodes);
         }
         uint64_t nodes = 0;
         uint64_t evaluated = 0;
-          for (auto astNode : astNodes) {
-        if(astNode) {
-          nodes++;
+        for (auto astNode : astNodes) {
+          if(astNode) {
+            nodes++;
             if(astNode->isEvaluated()){
               evaluated++;
             }
           }
         }
-    LOG(message_group::None, Location::NONE, "", "Evalutated %1d/%2d", evaluated, nodes);
-
+        LOG(message_group::None, Location::NONE, "", "AST-Nodes in Root File evalutated %1d/%2d", evaluated, nodes);
+    }
     if (file_context) {
       this->qglview->cam.updateView(file_context, false);
     }

--- a/src/gui/MainWindow.ui
+++ b/src/gui/MainWindow.ui
@@ -309,6 +309,7 @@
     <addaction name="designActionRender"/>
     <addaction name="designAction3DPrint"/>
     <addaction name="separator"/>
+    <addaction name="designShowEvaluated"/>
     <addaction name="designCheckValidity"/>
     <addaction name="designActionDisplayAST"/>
     <addaction name="designActionDisplayCSGTree"/>
@@ -944,6 +945,17 @@
    </property>
    <property name="shortcut">
     <string>F8</string>
+   </property>
+  </action>
+  <action name="designShowEvaluated">
+   <property name="checkable">
+    <bool>true</bool>
+   </property>
+   <property name="checked">
+    <bool>false</bool>
+   </property>
+   <property name="text">
+    <string>&amp;Highlight Evaluated AST-Nodes</string>
    </property>
   </action>
   <action name="designCheckValidity">

--- a/src/gui/Preferences.cc
+++ b/src/gui/Preferences.cc
@@ -681,6 +681,7 @@ void Preferences::on_lineEditColorEvalutate_textChanged(const QString& text)
 {
   QSettingsCached settings;
   settings.setValue("editor/backgroundColorEvaluated", text);
+  emit backgroundColorEvaluatedChanged(text);
 }
 
 void Preferences::on_pushButtonColorEvalutate_pressed()

--- a/src/gui/Preferences.cc
+++ b/src/gui/Preferences.cc
@@ -31,6 +31,7 @@
 #include <QKeyEvent>
 #include <QStatusBar>
 #include <QSettings>
+#include <QColorDialog>
 #include <boost/algorithm/string.hpp>
 #include "GeometryCache.h"
 #include "AutoUpdater.h"
@@ -680,7 +681,21 @@ void Preferences::on_lineEditColorEvalutate_textChanged(const QString& text)
 {
   QSettingsCached settings;
   settings.setValue("editor/backgroundColorEvaluated", text);
-  emit characterThresholdChanged(text.toInt());
+}
+
+void Preferences::on_pushButtonColorEvalutate_pressed()
+{
+  QColorDialog *dialog = new QColorDialog(this);
+  dialog->setAttribute(Qt::WA_DeleteOnClose);
+  dialog->setOption(QColorDialog::ShowAlphaChannel);
+  dialog->setCurrentColor(QColor(lineEditColorEvalutate->text()));
+  connect(dialog, SIGNAL(colorSelected(QColor)), this, SLOT(colorEvalutatePicked(QColor)));
+  dialog->open();
+}
+
+void Preferences::colorEvalutatePicked(QColor color)
+{
+  lineEditColorEvalutate->setText(color.name(QColor::HexArgb));
 }
 
 void Preferences::on_lineEditStepSize_textChanged(const QString& text)

--- a/src/gui/Preferences.cc
+++ b/src/gui/Preferences.cc
@@ -142,6 +142,7 @@ void Preferences::init() {
   this->defaultmap["editor/enableAutocomplete"] = true;
   this->defaultmap["editor/characterThreshold"] = 1;
   this->defaultmap["editor/stepSize"] = 1;
+  this->defaultmap["editor/backgroundColorEvaluated"] = "#A1DC98";
 
   // Toolbar
   QActionGroup *group = new QActionGroup(this);
@@ -675,6 +676,13 @@ void Preferences::on_lineEditCharacterThreshold_textChanged(const QString& text)
   emit characterThresholdChanged(text.toInt());
 }
 
+void Preferences::on_lineEditColorEvalutate_textChanged(const QString& text)
+{
+  QSettingsCached settings;
+  settings.setValue("editor/backgroundColorEvaluated", text);
+  emit characterThresholdChanged(text.toInt());
+}
+
 void Preferences::on_lineEditStepSize_textChanged(const QString& text)
 {
   QSettingsCached settings;
@@ -1008,6 +1016,7 @@ void Preferences::updateGUI()
   BlockSignals<QCheckBox *>(this->checkBoxEnableAutocomplete)->setChecked(getValue("editor/enableAutocomplete").toBool());
   BlockSignals<QLineEdit *>(this->lineEditCharacterThreshold)->setText(getValue("editor/characterThreshold").toString());
   BlockSignals<QLineEdit *>(this->lineEditStepSize)->setText(getValue("editor/stepSize").toString());
+  BlockSignals<QLineEdit *>(this->lineEditColorEvalutate)->setText(getValue("editor/backgroundColorEvaluated").toString());
 
   this->secLabelOnRenderCompleteSound->setEnabled(getValue("advanced/enableSoundNotification").toBool());
   this->undockCheckBox->setEnabled(this->reorderCheckBox->isChecked());

--- a/src/gui/Preferences.h
+++ b/src/gui/Preferences.h
@@ -129,6 +129,7 @@ signals:
   void characterThresholdChanged(int val) const;
   void stepSizeChanged(int val) const;
   void toolbarExportChanged() const;
+  void backgroundColorEvaluatedChanged(const QString& text);
 
 private slots:
   void on_lineEditStepSize_textChanged(const QString& arg1);

--- a/src/gui/Preferences.h
+++ b/src/gui/Preferences.h
@@ -74,6 +74,7 @@ public slots:
   // editor settings
   //
   void on_lineEditColorEvalutate_textChanged(const QString&);
+  void on_pushButtonColorEvalutate_pressed();
 
   // Indentation
   void on_checkBoxAutoIndent_toggled(bool);
@@ -133,6 +134,8 @@ private slots:
   void on_lineEditStepSize_textChanged(const QString& arg1);
 
   void on_checkBoxEnableNumberScrollWheel_toggled(bool checked);
+
+  void colorEvalutatePicked(QColor c);
 
 private:
   Preferences(QWidget *parent = nullptr);

--- a/src/gui/Preferences.h
+++ b/src/gui/Preferences.h
@@ -73,6 +73,7 @@ public slots:
   //
   // editor settings
   //
+  void on_lineEditColorEvalutate_textChanged(const QString&);
 
   // Indentation
   void on_checkBoxAutoIndent_toggled(bool);

--- a/src/gui/Preferences.ui
+++ b/src/gui/Preferences.ui
@@ -698,12 +698,73 @@
                   <property name="text">
                    <string>Color syntax highlighting</string>
                   </property>
+                  <property name="wordWrap">
+                   <bool>true</bool>
+                  </property>
                  </widget>
                 </item>
                </layout>
               </item>
+
               <item row="2" column="0">
-               <spacer name="horizontalSpacer_6">
+               <layout class="QHBoxLayout" name="horizontalLayout_EvalColor">
+                <item>
+                 <spacer name="horizontalSpacer_EvalColor">
+                  <property name="orientation">
+                   <enum>Qt::Horizontal</enum>
+                  </property>
+                  <property name="sizeType">
+                   <enum>QSizePolicy::Expanding</enum>
+                  </property>
+                  <property name="sizeHint" stdset="0">
+                   <size>
+                    <width>30</width>
+                    <height>20</height>
+                   </size>
+                  </property>
+                 </spacer>
+                </item>
+                <item>
+                 <widget class="QLabel" name="labelColorEvaluated">
+                  <property name="text">
+                   <string>color for evaluted nodes</string>
+                  </property>
+                  <property name="wordWrap">
+                   <bool>true</bool>
+                  </property>
+                 </widget>
+                </item>
+               </layout>
+              </item>
+              <item row="2" column="1">
+               <layout class="QHBoxLayout" name="horizontalLayout_labelColorEvaluate">
+                <item>
+                 <widget class="QLineEdit" name="lineEditColorEvalutate">
+                  <property name="sizePolicy">
+                   <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+                    <horstretch>0</horstretch>
+                    <verstretch>0</verstretch>
+                   </sizepolicy>
+                  </property>
+                 </widget>
+                </item>
+                <item>
+                <spacer name="horizontalSpacer_6">
+                 <property name="orientation">
+                  <enum>Qt::Horizontal</enum>
+                 </property>
+                 <property name="sizeHint" stdset="0">
+                  <size>
+                   <width>198</width>
+                   <height>20</height>
+                  </size>
+                 </property>
+                </spacer>
+               </item>
+               </layout>
+              </item>
+              <item row="3" column="0">
+               <spacer name="horizontalSpacer_61">
                 <property name="orientation">
                  <enum>Qt::Horizontal</enum>
                 </property>
@@ -715,7 +776,7 @@
                 </property>
                </spacer>
               </item>
-              <item row="2" column="1">
+              <item row="3" column="1">
                <widget class="QCheckBox" name="mouseWheelZoomBox">
                 <property name="text">
                  <string>Ctrl/Cmd-Mouse-wheel zooms text</string>

--- a/src/gui/Preferences.ui
+++ b/src/gui/Preferences.ui
@@ -749,6 +749,13 @@
                  </widget>
                 </item>
                 <item>
+                 <widget class="QPushButton" name="pushButtonColorEvalutate">
+                  <property name="text">
+                   <string>Color Picker</string>
+                  </property>
+                 </widget>
+                </item>
+                <item>
                 <spacer name="horizontalSpacer_6">
                  <property name="orientation">
                   <enum>Qt::Horizontal</enum>

--- a/src/gui/ScintillaEditor.cc
+++ b/src/gui/ScintillaEditor.cc
@@ -222,8 +222,8 @@ ScintillaEditor::ScintillaEditor(QWidget *parent) : EditorInterface(parent)
   connect(qsci, SIGNAL(indicatorClicked(int,int,Qt::KeyboardModifiers)), this, SLOT(onIndicatorClicked(int,int,Qt::KeyboardModifiers)));
   connect(qsci, SIGNAL(indicatorReleased(int,int,Qt::KeyboardModifiers)), this, SLOT(onIndicatorReleased(int,int,Qt::KeyboardModifiers)));
 
-  qsci->indicatorDefine(QsciScintilla::FullBoxIndicator, usedIndicatorNumber);
-  qsci->setIndicatorDrawUnder(true, usedIndicatorNumber);
+  qsci->indicatorDefine(QsciScintilla::FullBoxIndicator, evaluatedIndicatorNumber);
+  qsci->setIndicatorDrawUnder(true, evaluatedIndicatorNumber);
     
 #if QSCINTILLA_VERSION >= 0x020b00
   connect(qsci, SIGNAL(SCN_URIDROPPED(const QUrl&)), this, SIGNAL(uriDropped(const QUrl&)));
@@ -572,7 +572,7 @@ void ScintillaEditor::setColormap(const EditorColorScheme *colorScheme)
     qsci->setIndicatorOutlineColor(readColor(colors, "hyperlink-indicator-outline", QColor(139, 24, 168, 100)), hyperlinkIndicatorNumber); //violet
     qsci->setIndicatorHoverForegroundColor(readColor(colors, "hyperlink-indicator-hover", QColor(139, 24, 168, 100)), hyperlinkIndicatorNumber); //violet
 
-    qsci->setIndicatorForegroundColor(QColor(180, 255, 180, 100), usedIndicatorNumber);
+    qsci->setIndicatorForegroundColor(QColor(180, 255, 180, 100), evaluatedIndicatorNumber);
     
     qsci->setWhitespaceForegroundColor(readColor(colors, "whitespace-foreground", textColor));
     qsci->setMarginsBackgroundColor(readColor(colors, "margin-background", paperColor));
@@ -1461,10 +1461,10 @@ void ScintillaEditor::setFocus()
 void ScintillaEditor::evalutated(std::string rootFileName, std::vector<const ASTNode*> astNodes)
 {
   QString color = Preferences::inst()->getValue("editor/backgroundColorEvaluated").toString();
-  qsci->setIndicatorForegroundColor(QColor(color), usedIndicatorNumber);
+  qsci->setIndicatorForegroundColor(QColor(color), evaluatedIndicatorNumber);
 
   //remove all indicators
-  qsci->SendScintilla(QsciScintilla::SCI_SETINDICATORCURRENT, usedIndicatorNumber);
+  qsci->SendScintilla(QsciScintilla::SCI_SETINDICATORCURRENT, evaluatedIndicatorNumber);
   qsci->SendScintilla(QsciScintilla::SCI_INDICATORCLEARRANGE, 0, qsci->length());
 
     for (auto astNode : astNodes) {
@@ -1474,21 +1474,21 @@ void ScintillaEditor::evalutated(std::string rootFileName, std::vector<const AST
 
 void ScintillaEditor::evalutated(std::string rootFileName, const ASTNode* astNode)
 {
-        bool isLocation = !astNode->location().isNone();
-        if(isLocation){
-          bool isRootFile = astNode->location().fileName() == rootFileName;
-          bool isEvaluated = astNode->isEvaluated();
-          bool setIndicator = isRootFile && isEvaluated;
+  bool isLocation = !astNode->location().isNone();
+  if(isLocation){
+    bool isRootFile = astNode->location().fileName() == rootFileName;
+    bool isEvaluated = astNode->isEvaluated();
+    bool setIndicator = isRootFile && isEvaluated;
 
-          if( setIndicator ){
-            auto data = astNode->location();
-            int startPos = qsci->positionFromLineIndex(data.firstLine() - 1, data.firstColumn() - 1);
-            int stopPos  = qsci->positionFromLineIndex(data.lastLine() - 1,  data.lastColumn()  - 1);
+    if( setIndicator ){
+      auto data = astNode->location();
+      int startPos = qsci->positionFromLineIndex(data.firstLine() - 1, data.firstColumn() - 1);
+      int stopPos  = qsci->positionFromLineIndex(data.lastLine() - 1,  data.lastColumn()  - 1);
 
-            int nrOfChars = stopPos - startPos;
-            qsci->SendScintilla(QsciScintilla::SCI_SETINDICATORVALUE, usedIndicatorNumber);
-            qsci->SendScintilla(QsciScintilla::SCI_INDICATORFILLRANGE, startPos, nrOfChars);
-          }
-        }
+      int nrOfChars = stopPos - startPos;
+      qsci->SendScintilla(QsciScintilla::SCI_SETINDICATORVALUE, evaluatedIndicatorNumber);
+      qsci->SendScintilla(QsciScintilla::SCI_INDICATORFILLRANGE, startPos, nrOfChars);
+    }
+  }
 }
 

--- a/src/gui/ScintillaEditor.cc
+++ b/src/gui/ScintillaEditor.cc
@@ -224,7 +224,6 @@ ScintillaEditor::ScintillaEditor(QWidget *parent) : EditorInterface(parent)
 
   qsci->indicatorDefine(QsciScintilla::FullBoxIndicator, usedIndicatorNumber);
   qsci->setIndicatorDrawUnder(true, usedIndicatorNumber);
-  qsci->setIndicatorForegroundColor(QColor("#A1DC98"), usedIndicatorNumber);
     
 #if QSCINTILLA_VERSION >= 0x020b00
   connect(qsci, SIGNAL(SCN_URIDROPPED(const QUrl&)), this, SIGNAL(uriDropped(const QUrl&)));
@@ -1461,10 +1460,13 @@ void ScintillaEditor::setFocus()
 
 void ScintillaEditor::evalutated(std::string rootFileName, std::vector<const ASTNode*> astNodes)
 {
+  QString color = Preferences::inst()->getValue("editor/backgroundColorEvaluated").toString();
+  qsci->setIndicatorForegroundColor(QColor(color), usedIndicatorNumber);
+
   //remove all indicators
   qsci->SendScintilla(QsciScintilla::SCI_SETINDICATORCURRENT, usedIndicatorNumber);
   qsci->SendScintilla(QsciScintilla::SCI_INDICATORCLEARRANGE, 0, qsci->length());
-//std::cout << astNodes.size()<< std::endl;
+
     for (auto astNode : astNodes) {
         if(astNode) evalutated(rootFileName, astNode);
     }
@@ -1477,7 +1479,7 @@ void ScintillaEditor::evalutated(std::string rootFileName, const ASTNode* astNod
           bool isRootFile = astNode->location().fileName() == rootFileName;
           bool isEvaluated = astNode->isEvaluated();
           bool setIndicator = isRootFile && isEvaluated;
-//std::cout << isRootFile << isEvaluated << setIndicator << std::endl;
+
           if( setIndicator ){
             auto data = astNode->location();
             int startPos = qsci->positionFromLineIndex(data.firstLine() - 1, data.firstColumn() - 1);

--- a/src/gui/ScintillaEditor.cc
+++ b/src/gui/ScintillaEditor.cc
@@ -1327,6 +1327,11 @@ void ScintillaEditor::onCharacterThresholdChanged(int val)
   qsci->setAutoCompletionThreshold(val <= 0 ? 1 : val);
 }
 
+void ScintillaEditor::onBackgroundColorEvaluatedChanged(const QString& text){
+  QString color = Preferences::inst()->getValue("editor/backgroundColorEvaluated").toString();
+  qsci->setIndicatorForegroundColor(QColor(color), evaluatedIndicatorNumber);
+}
+
 void ScintillaEditor::resetHighlighting(){
   qsci->recolor(); //lex and restyle the whole text
   

--- a/src/gui/ScintillaEditor.h
+++ b/src/gui/ScintillaEditor.h
@@ -162,7 +162,7 @@ private:
   static const int errorIndicatorNumber = 8; // first 8 are used by lexers
   static const int findIndicatorNumber = 9;
   static const int hyperlinkIndicatorNumber = 10;
-  static const int usedIndicatorNumber = 11;
+  static const int evaluatedIndicatorNumber = 11;
   static const int hyperlinkIndicatorOffset = 100;
   static const int errMarkerNumber = 2;
   static const int bmMarkerNumber = 3;

--- a/src/gui/ScintillaEditor.h
+++ b/src/gui/ScintillaEditor.h
@@ -148,6 +148,7 @@ private slots:
   void applySettings();
   void onAutocompleteChanged(bool state);
   void onCharacterThresholdChanged(int val);
+  void onBackgroundColorEvaluatedChanged(const QString& text);
   void fireModificationChanged();
   void onIndicatorClicked(int line, int col, Qt::KeyboardModifiers state);
   void onIndicatorReleased(int line, int col, Qt::KeyboardModifiers state);

--- a/src/gui/ScintillaEditor.h
+++ b/src/gui/ScintillaEditor.h
@@ -75,6 +75,9 @@ public:
   void setFocus() override;
   void setupAutoComplete(const bool forceOff = false);
 
+  void evalutated(std::string rootFileName, std::vector<const ASTNode*> astNodes);
+  void evalutated(std::string rootFileName, const ASTNode* astNode);
+
 private:
   void getRange(int *lineFrom, int *lineTo);
   void setColormap(const EditorColorScheme *colorScheme);
@@ -159,6 +162,7 @@ private:
   static const int errorIndicatorNumber = 8; // first 8 are used by lexers
   static const int findIndicatorNumber = 9;
   static const int hyperlinkIndicatorNumber = 10;
+  static const int usedIndicatorNumber = 11;
   static const int hyperlinkIndicatorOffset = 100;
   static const int errMarkerNumber = 2;
   static const int bmMarkerNumber = 3;

--- a/src/gui/TabManager.cc
+++ b/src/gui/TabManager.cc
@@ -187,6 +187,7 @@ void TabManager::createTab(const QString& filename)
   connect(Preferences::inst(), SIGNAL(editorConfigChanged()), editor, SLOT(applySettings()));
   connect(Preferences::inst(), SIGNAL(autocompleteChanged(bool)), editor, SLOT(onAutocompleteChanged(bool)));
   connect(Preferences::inst(), SIGNAL(characterThresholdChanged(int)), editor, SLOT(onCharacterThresholdChanged(int)));
+  connect(Preferences::inst(), SIGNAL(backgroundColorEvaluatedChanged(const QString&)), editor, SLOT(onBackgroundColorEvaluatedChanged(const QString&)));
   ((ScintillaEditor *)editor)->public_applySettings();
   editor->addTemplate();
 


### PR DESCRIPTION
implementing #4254 "mark unused code" is not trivial, but highlighting evaluated nodes is very close in effect.

This works very well for a single file. The statistic is very useful for finding death code.
Note that it works very specifically - if a default value of a user modul is unused, that is shown and counted as such.

Implementation details: gatherChilderen creates a linear way to access the ast-nodes. (The live time is limited to the live time of the corresponding ast-tree). gatherChilderen is based on and can be checked against print.
setEvaluated is a bit of a hack (mutable/const), but it makes sense, as it is a "set only flag".

The infrastructure changes and the feature it self have a lot of untapped potential.

This feature can later be expanded to cover multiple files, which would allow for a "code coverage" analyzes for library maintainers.

The infrastructure change (gatherChilderen) allows to transport meta information from the AST-Node into the editor (or other components).

qt handels invalid inputs to the color field gracefully.