### PR TITLE
adjustable edge in preview

### DIFF
--- a/shaders/Preview.frag
+++ b/shaders/Preview.frag
@@ -1,6 +1,8 @@
 #version 110
 
 uniform vec4 color1, color2;
+uniform float totalHalfEdgeThickness; // total thickness of half-edge (per triangle) including fade, (must be >= fade)
+uniform float edgeFadeThickness; // thickness of fade (antialiasing) in screen pixels
 varying vec3 vBC;
 varying float shading;
 
@@ -11,8 +13,8 @@ vec3 smoothstep3f(vec3 edge0, vec3 edge1, vec3 x) {
 }
 
 float edgeFactor() {
-  const float th = 1.414; // total thickness of half-edge (per triangle) including fade, (must be >= fade)
-  const float fade = 1.414; // thickness of fade (antialiasing) in screen pixels
+  float th = totalHalfEdgeThickness;
+  float fade = edgeFadeThickness;
   vec3 d = fwidth(vBC);
   vec3 a3 = smoothstep((th-fade)*d, th*d, vBC);
   return min(min(a3.x, a3.y), a3.z);

--- a/shaders/Preview.vert
+++ b/shaders/Preview.vert
@@ -2,6 +2,8 @@
 
 uniform vec4 color1;        // face color
 uniform vec4 color2;        // edge color
+uniform float totalHalfEdgeThickness; // total thickness of half-edge (per triangle) including fade, (must be >= fade)
+uniform float edgeFadeThickness; // thickness of fade (antialiasing) in screen pixels
 attribute vec3 barycentric; // barycentric form of vertex coord
                             // either [1,0,0], [0,1,0] or [0,0,1] under normal circumstances (no edges disabled)
 varying vec3 vBC;           // varying barycentric coords

--- a/shaders/Preview.vert
+++ b/shaders/Preview.vert
@@ -2,8 +2,6 @@
 
 uniform vec4 color1;        // face color
 uniform vec4 color2;        // edge color
-uniform float totalHalfEdgeThickness; // total thickness of half-edge (per triangle) including fade, (must be >= fade)
-uniform float edgeFadeThickness; // thickness of fade (antialiasing) in screen pixels
 attribute vec3 barycentric; // barycentric form of vertex coord
                             // either [1,0,0], [0,1,0] or [0,0,1] under normal circumstances (no edges disabled)
 varying vec3 vBC;           // varying barycentric coords

--- a/src/glview/GLView.cc
+++ b/src/glview/GLView.cc
@@ -43,6 +43,7 @@ void GLView::setRenderer(Renderer *r)
 {
   renderer = r;
   if (this->renderer) {
+renderer->setTotalHalfEdgeThickness(this->totalHalfEdgeThickness);
     this->renderer->resize(cam.pixel_width, cam.pixel_height);
   }
 }
@@ -763,5 +764,21 @@ void GLView::decodeMarkerValue(double i, double l, int size_div_sm)
 
       }
     }
+  }
+}
+
+void GLView::setTotalHalfEdgeThickness(float value){
+   this->totalHalfEdgeThickness = value;
+  if (auto renderer = this->getRenderer()) {
+    renderer->setTotalHalfEdgeThickness(value);
+    //update();
+  }
+}
+
+void GLView::setTotalHalfEdgeThickness(float value){
+   this->totalHalfEdgeThickness = value;
+  if (auto renderer = this->getRenderer()) {
+    renderer->setTotalHalfEdgeThickness(value);
+    //update();
   }
 }

--- a/src/glview/GLView.cc
+++ b/src/glview/GLView.cc
@@ -37,6 +37,9 @@ GLView::GLView()
   static int sId = 0;
   this->opencsg_id = sId++;
 #endif
+  this->edgeColor[0] = 0.0;
+  this->edgeColor[1] = 0.0;
+  this->edgeColor[2] = 0.0;
 }
 
 void GLView::setRenderer(Renderer *r)
@@ -775,10 +778,16 @@ void GLView::setTotalHalfEdgeThickness(float value){
   }
 }
 
-void GLView::setTotalHalfEdgeThickness(float value){
-   this->totalHalfEdgeThickness = value;
-  if (auto renderer = this->getRenderer()) {
-    renderer->setTotalHalfEdgeThickness(value);
-    //update();
-  }
+void GLView::setEdgeColorOverwrite(bool flag){
+  edgeColorOverwrite = flag;
+  renderer->setEdgeColorOverwrite(flag);
+  //update();
+}
+
+void GLView::setEdgeColor(float red, float green, float blue){
+  edgeColor[0] = red;
+  edgeColor[1] = green;
+  edgeColor[2] = blue;
+  renderer->setEdgeColor(red, green, blue);
+  //update();
 }

--- a/src/glview/GLView.cc
+++ b/src/glview/GLView.cc
@@ -46,6 +46,7 @@ void GLView::setRenderer(Renderer *r)
 {
   renderer = r;
   if (this->renderer) {
+    renderer->setEdgeColorOverwrite(edgeColorOverwrite);
     renderer->setTotalHalfEdgeThickness(this->totalHalfEdgeThickness);
     renderer->setEdgeFadeThickness(this->edgeFadeThickness);
     this->renderer->resize(cam.pixel_width, cam.pixel_height);

--- a/src/glview/GLView.cc
+++ b/src/glview/GLView.cc
@@ -46,7 +46,8 @@ void GLView::setRenderer(Renderer *r)
 {
   renderer = r;
   if (this->renderer) {
-renderer->setTotalHalfEdgeThickness(this->totalHalfEdgeThickness);
+    renderer->setTotalHalfEdgeThickness(this->totalHalfEdgeThickness);
+    renderer->setEdgeFadeThickness(this->edgeFadeThickness);
     this->renderer->resize(cam.pixel_width, cam.pixel_height);
   }
 }
@@ -771,25 +772,22 @@ void GLView::decodeMarkerValue(double i, double l, int size_div_sm)
 }
 
 void GLView::setTotalHalfEdgeThickness(float value){
-   this->totalHalfEdgeThickness = value;
+  this->totalHalfEdgeThickness = value;
   if (auto renderer = this->getRenderer()) {
     renderer->setTotalHalfEdgeThickness(value);
-    //update();
   }
 }
 
 void GLView::setEdgeFadeThickness(float value){
-   this->totalHalfEdgeThickness = value;
+  this->edgeFadeThickness = value;
   if (auto renderer = this->getRenderer()) {
     renderer->setEdgeFadeThickness(value);
-    //update();
   }
 }
 
 void GLView::setEdgeColorOverwrite(bool flag){
   edgeColorOverwrite = flag;
   renderer->setEdgeColorOverwrite(flag);
-  //update();
 }
 
 void GLView::setEdgeColor(float red, float green, float blue){
@@ -797,5 +795,4 @@ void GLView::setEdgeColor(float red, float green, float blue){
   edgeColor[1] = green;
   edgeColor[2] = blue;
   renderer->setEdgeColor(red, green, blue);
-  //update();
 }

--- a/src/glview/GLView.cc
+++ b/src/glview/GLView.cc
@@ -778,6 +778,14 @@ void GLView::setTotalHalfEdgeThickness(float value){
   }
 }
 
+void GLView::setEdgeFadeThickness(float value){
+   this->totalHalfEdgeThickness = value;
+  if (auto renderer = this->getRenderer()) {
+    renderer->setEdgeFadeThickness(value);
+    //update();
+  }
+}
+
 void GLView::setEdgeColorOverwrite(bool flag){
   edgeColorOverwrite = flag;
   renderer->setEdgeColorOverwrite(flag);

--- a/src/glview/GLView.h
+++ b/src/glview/GLView.h
@@ -71,6 +71,8 @@ public:
   bool showcrosshairs;
   bool showscale;
 
+  void setTotalHalfEdgeThickness(float value);
+
 #ifdef ENABLE_OPENCSG
   bool is_opencsg_capable;
   bool has_shaders;
@@ -85,4 +87,6 @@ private:
   void showSmallaxes(const Color4f& col);
   void showScalemarkers(const Color4f& col);
   void decodeMarkerValue(double i, double l, int size_div_sm);
+
+  float totalHalfEdgeThickness = 1.414;
 };

--- a/src/glview/GLView.h
+++ b/src/glview/GLView.h
@@ -72,6 +72,8 @@ public:
   bool showscale;
 
   void setTotalHalfEdgeThickness(float value);
+  void setEdgeFadeThickness(float value);
+
   void setEdgeColorOverwrite(bool flag);
   void setEdgeColor(float red, float green, float blue);
 #ifdef ENABLE_OPENCSG

--- a/src/glview/GLView.h
+++ b/src/glview/GLView.h
@@ -76,6 +76,7 @@ public:
 
   void setEdgeColorOverwrite(bool flag);
   void setEdgeColor(float red, float green, float blue);
+
 #ifdef ENABLE_OPENCSG
   bool is_opencsg_capable;
   bool has_shaders;
@@ -92,6 +93,7 @@ private:
   void decodeMarkerValue(double i, double l, int size_div_sm);
 
   float totalHalfEdgeThickness = 1.414;
+  float edgeFadeThickness = 1.414;
   bool edgeColorOverwrite = false;
   float edgeColor[3];
 };

--- a/src/glview/GLView.h
+++ b/src/glview/GLView.h
@@ -72,7 +72,8 @@ public:
   bool showscale;
 
   void setTotalHalfEdgeThickness(float value);
-
+  void setEdgeColorOverwrite(bool flag);
+  void setEdgeColor(float red, float green, float blue);
 #ifdef ENABLE_OPENCSG
   bool is_opencsg_capable;
   bool has_shaders;
@@ -89,4 +90,6 @@ private:
   void decodeMarkerValue(double i, double l, int size_div_sm);
 
   float totalHalfEdgeThickness = 1.414;
+  bool edgeColorOverwrite = false;
+  float edgeColor[3];
 };

--- a/src/glview/Renderer.cc
+++ b/src/glview/Renderer.cc
@@ -307,11 +307,6 @@ void Renderer::render_surface(const PolySet& ps, csgmode_e csgmode, const Transf
 {
   PRINTD("Renderer render");
 
-  if(shaderinfo){
-    glUniform1f(shaderinfo->data.csg_rendering.totalHalfEdgeThickness, totalHalfEdgeThickness);
-    glUniform1f(shaderinfo->data.csg_rendering.edgeFadeThickness, edgeFadeThickness);
-  }
-
   bool mirrored = m.matrix().determinant() < 0;
 
   if (ps.getDimension() == 2) {

--- a/src/glview/Renderer.cc
+++ b/src/glview/Renderer.cc
@@ -116,6 +116,8 @@ Renderer::Renderer() : colorscheme(nullptr)
   renderer_shader.data.csg_rendering.color_area = glGetUniformLocation(edgeshader_prog, "color1"); // 1
   renderer_shader.data.csg_rendering.color_edge = glGetUniformLocation(edgeshader_prog, "color2"); // 2
   renderer_shader.data.csg_rendering.barycentric = glGetAttribLocation(edgeshader_prog, "barycentric"); // 3
+  renderer_shader.data.csg_rendering.totalHalfEdgeThickness = glGetUniformLocation(edgeshader_prog, "totalHalfEdgeThickness");
+  renderer_shader.data.csg_rendering.edgeFadeThickness = glGetUniformLocation(edgeshader_prog, "edgeFadeThickness");
 
   PRINTD("Renderer() end");
 }
@@ -296,6 +298,12 @@ static void gl_draw_triangle(const Renderer::shaderinfo_t *shaderinfo, const Vec
 void Renderer::render_surface(const PolySet& ps, csgmode_e csgmode, const Transform3d& m, const shaderinfo_t *shaderinfo) const
 {
   PRINTD("Renderer render");
+
+  if(shaderinfo){
+    glUniform1f(shaderinfo->data.csg_rendering.totalHalfEdgeThickness, totalHalfEdgeThickness);
+    glUniform1f(shaderinfo->data.csg_rendering.edgeFadeThickness, totalHalfEdgeThickness);
+  }
+
   bool mirrored = m.matrix().determinant() < 0;
 
   if (ps.getDimension() == 2) {
@@ -473,3 +481,7 @@ void Renderer::render_surface(const PolySet& ps, csgmode_e csgmode, const Transf
 void Renderer::render_edges(const PolySet& ps, csgmode_e csgmode) const {}
 
 #endif //NULLGL
+
+void Renderer::setTotalHalfEdgeThickness(float value){
+   this->totalHalfEdgeThickness = value;
+}

--- a/src/glview/Renderer.cc
+++ b/src/glview/Renderer.cc
@@ -19,6 +19,10 @@ Renderer::Renderer() : colorscheme(nullptr)
 {
   PRINTD("Renderer() start");
 
+  this->edgeColor[0] = 0.0;
+  this->edgeColor[1] = 0.0;
+  this->edgeColor[2] = 0.0;
+
   renderer_shader.progid = 0;
 
   // Setup default colors
@@ -172,7 +176,11 @@ void Renderer::setColor(const float color[4], const shaderinfo_t *shaderinfo) co
 #ifdef ENABLE_OPENCSG
   if (shaderinfo) {
     glUniform4f(shaderinfo->data.csg_rendering.color_area, c[0], c[1], c[2], c[3]);
-    glUniform4f(shaderinfo->data.csg_rendering.color_edge, (c[0] + 1) / 2, (c[1] + 1) / 2, (c[2] + 1) / 2, 1.0);
+    if(edgeColorOverwrite){
+      glUniform4f(shaderinfo->data.csg_rendering.color_edge, edgeColor[0], edgeColor[1], edgeColor[2], 1.0);
+    }else{
+      glUniform4f(shaderinfo->data.csg_rendering.color_edge, (c[0] + 1) / 2, (c[1] + 1) / 2, (c[2] + 1) / 2, 1.0);
+    }
   }
 #endif
 }
@@ -482,6 +490,18 @@ void Renderer::render_edges(const PolySet& ps, csgmode_e csgmode) const {}
 
 #endif //NULLGL
 
-void Renderer::setTotalHalfEdgeThickness(float value){
-   this->totalHalfEdgeThickness = value;
+void Renderer::setTotalHalfEdgeThickness(float value)
+{
+  this->totalHalfEdgeThickness = value;
 }
+
+void Renderer::setEdgeColorOverwrite(bool flag){
+  this->edgeColorOverwrite = flag;
+}
+  
+void Renderer::setEdgeColor(float red, float green, float blue)
+{
+   this->edgeColor[0] = red;
+   this->edgeColor[1] = green;
+   this->edgeColor[2] = blue;
+ }

--- a/src/glview/Renderer.cc
+++ b/src/glview/Renderer.cc
@@ -309,7 +309,7 @@ void Renderer::render_surface(const PolySet& ps, csgmode_e csgmode, const Transf
 
   if(shaderinfo){
     glUniform1f(shaderinfo->data.csg_rendering.totalHalfEdgeThickness, totalHalfEdgeThickness);
-    glUniform1f(shaderinfo->data.csg_rendering.edgeFadeThickness, totalHalfEdgeThickness);
+    glUniform1f(shaderinfo->data.csg_rendering.edgeFadeThickness, edgeFadeThickness);
   }
 
   bool mirrored = m.matrix().determinant() < 0;
@@ -493,6 +493,11 @@ void Renderer::render_edges(const PolySet& ps, csgmode_e csgmode) const {}
 void Renderer::setTotalHalfEdgeThickness(float value)
 {
   this->totalHalfEdgeThickness = value;
+}
+
+void Renderer::setEdgeFadeThickness(float value)
+{
+  this->edgeFadeThickness = value;
 }
 
 void Renderer::setEdgeColorOverwrite(bool flag){

--- a/src/glview/Renderer.h
+++ b/src/glview/Renderer.h
@@ -88,6 +88,8 @@ public:
   virtual void render_surface(const PolySet& geom, csgmode_e csgmode, const Transform3d& m, const shaderinfo_t *shaderinfo = nullptr) const;
   virtual void render_edges(const PolySet& geom, csgmode_e csgmode) const;
   virtual void setTotalHalfEdgeThickness(float value);
+  virtual void setEdgeColorOverwrite(bool flag);
+  virtual void setEdgeColor(float red, float green, float blue);
 
 protected:
   std::map<ColorMode, Color4f> colormap;
@@ -95,5 +97,7 @@ protected:
 
 private:
   shaderinfo_t renderer_shader;
+  bool edgeColorOverwrite = false;
   float totalHalfEdgeThickness = 1.414;
+  float edgeColor[3];
 };

--- a/src/glview/Renderer.h
+++ b/src/glview/Renderer.h
@@ -32,6 +32,8 @@ public:
         int color_edge;
         // barycentric coordinates of the current vertex
         int barycentric;
+        int totalHalfEdgeThickness;
+        int edgeFadeThickness;
       } csg_rendering;
       struct {
         int identifier;
@@ -85,6 +87,7 @@ public:
   virtual csgmode_e get_csgmode(const bool highlight_mode, const bool background_mode, const OpenSCADOperator type = OpenSCADOperator::UNION) const;
   virtual void render_surface(const PolySet& geom, csgmode_e csgmode, const Transform3d& m, const shaderinfo_t *shaderinfo = nullptr) const;
   virtual void render_edges(const PolySet& geom, csgmode_e csgmode) const;
+  virtual void setTotalHalfEdgeThickness(float value);
 
 protected:
   std::map<ColorMode, Color4f> colormap;
@@ -92,4 +95,5 @@ protected:
 
 private:
   shaderinfo_t renderer_shader;
+  float totalHalfEdgeThickness = 1.414;
 };

--- a/src/glview/Renderer.h
+++ b/src/glview/Renderer.h
@@ -85,8 +85,10 @@ public:
   virtual void setColorScheme(const ColorScheme& cs);
 
   virtual csgmode_e get_csgmode(const bool highlight_mode, const bool background_mode, const OpenSCADOperator type = OpenSCADOperator::UNION) const;
+
   virtual void render_surface(const PolySet& geom, csgmode_e csgmode, const Transform3d& m, const shaderinfo_t *shaderinfo = nullptr) const;
   virtual void render_edges(const PolySet& geom, csgmode_e csgmode) const;
+
   virtual void setTotalHalfEdgeThickness(float value);
   virtual void setEdgeFadeThickness(float value);
   virtual void setEdgeColorOverwrite(bool flag);

--- a/src/glview/Renderer.h
+++ b/src/glview/Renderer.h
@@ -97,11 +97,11 @@ public:
 protected:
   std::map<ColorMode, Color4f> colormap;
   const ColorScheme *colorscheme;
+  float totalHalfEdgeThickness = 1.414;
+  float edgeFadeThickness = 1.414;
 
 private:
   shaderinfo_t renderer_shader;
   bool edgeColorOverwrite = false;
-  float totalHalfEdgeThickness = 1.414;
-  float edgeFadeThickness = 1.414;
   float edgeColor[3];
 };

--- a/src/glview/Renderer.h
+++ b/src/glview/Renderer.h
@@ -88,6 +88,7 @@ public:
   virtual void render_surface(const PolySet& geom, csgmode_e csgmode, const Transform3d& m, const shaderinfo_t *shaderinfo = nullptr) const;
   virtual void render_edges(const PolySet& geom, csgmode_e csgmode) const;
   virtual void setTotalHalfEdgeThickness(float value);
+  virtual void setEdgeFadeThickness(float value);
   virtual void setEdgeColorOverwrite(bool flag);
   virtual void setEdgeColor(float red, float green, float blue);
 
@@ -99,5 +100,6 @@ private:
   shaderinfo_t renderer_shader;
   bool edgeColorOverwrite = false;
   float totalHalfEdgeThickness = 1.414;
+  float edgeFadeThickness = 1.414;
   float edgeColor[3];
 };

--- a/src/glview/preview/OpenCSGRenderer.cc
+++ b/src/glview/preview/OpenCSGRenderer.cc
@@ -389,7 +389,11 @@ void OpenCSGRenderer::renderCSGProducts(const std::shared_ptr<CSGProducts>& prod
 
       if (shaderinfo && shaderinfo->progid) {
         if (shaderinfo->type != EDGE_RENDERING ||
-            (shaderinfo->type == EDGE_RENDERING && showedges)) glUseProgram(shaderinfo->progid); GL_ERROR_CHECK();
+            (shaderinfo->type == EDGE_RENDERING && showedges)){
+               glUseProgram(shaderinfo->progid); GL_ERROR_CHECK();
+               glUniform1f(shaderinfo->data.csg_rendering.totalHalfEdgeThickness, totalHalfEdgeThickness);
+               glUniform1f(shaderinfo->data.csg_rendering.edgeFadeThickness, edgeFadeThickness);
+             }
       }
 
       for (const auto& csgobj : product.intersections) {
@@ -477,6 +481,9 @@ void OpenCSGRenderer::renderCSGProducts(const std::shared_ptr<CSGProducts>& prod
       if (shaderinfo && shaderinfo->progid) {
         GL_TRACE("glUseProgram(%d)", shaderinfo->progid);
         glUseProgram(shaderinfo->progid); GL_ERROR_CHECK();
+        
+        glUniform1f(shaderinfo->data.csg_rendering.totalHalfEdgeThickness, totalHalfEdgeThickness);
+        glUniform1f(shaderinfo->data.csg_rendering.edgeFadeThickness, edgeFadeThickness);
 
         if (shaderinfo->type == EDGE_RENDERING && showedges) {
           shader_attribs_enable();

--- a/src/gui/ViewportControl.cc
+++ b/src/gui/ViewportControl.cc
@@ -34,7 +34,6 @@ void ViewportControl::setMainWindow(MainWindow *mainWindow)
 {
   this->mainWindow = mainWindow;
   this->qglview = mainWindow->qglview;
-   this->qglview->setTotalHalfEdgeThickness(5.0);
 }
 
 bool ViewportControl::isLightTheme()

--- a/src/gui/ViewportControl.cc
+++ b/src/gui/ViewportControl.cc
@@ -203,12 +203,21 @@ bool ViewportControl::focusNextPrevChild(bool next){
 void ViewportControl::on_checkBoxOverwriteEdgeColor_stateChanged(int state){
   bool bState = (Qt::CheckState::Checked == state);
   this->qglview->setEdgeColorOverwrite(state);
+  this->qglview->update();
 }
 
 void ViewportControl::on_lineEditEdgeColor_textChanged(const QString &text){
   QColor color = QColor(text);
-    this->qglview->setEdgeColor(color.redF(), color.greenF(), color.blueF());
+  this->qglview->setEdgeColor(color.redF(), color.greenF(), color.blueF());
+  this->qglview->update();
 }
+
 void ViewportControl::on_doubleSpinBox_edge_valueChanged(double value){
-   this->qglview->setTotalHalfEdgeThickness((float) value);
+  this->qglview->setTotalHalfEdgeThickness((float) value);
+  this->qglview->update();
+}
+
+void ViewportControl::on_doubleSpinBox_edgeFade_valueChanged(double value){
+  this->qglview->setEdgeFadeThickness((float) value);
+  this->qglview->update();
 }

--- a/src/gui/ViewportControl.cc
+++ b/src/gui/ViewportControl.cc
@@ -34,6 +34,7 @@ void ViewportControl::setMainWindow(MainWindow *mainWindow)
 {
   this->mainWindow = mainWindow;
   this->qglview = mainWindow->qglview;
+   this->qglview->setTotalHalfEdgeThickness(5.0);
 }
 
 bool ViewportControl::isLightTheme()
@@ -197,4 +198,8 @@ bool ViewportControl::focusNextPrevChild(bool next){
         }
     }
     return true;
+}
+
+void ViewportControl::on_doubleSpinBox_edge_valueChanged(double value){
+   this->qglview->setTotalHalfEdgeThickness((float) value);
 }

--- a/src/gui/ViewportControl.cc
+++ b/src/gui/ViewportControl.cc
@@ -208,6 +208,7 @@ void ViewportControl::on_checkBoxOverwriteEdgeColor_stateChanged(int state){
 void ViewportControl::on_lineEditEdgeColor_textChanged(const QString &text){
   QColor color = QColor(text);
   this->qglview->setEdgeColor(color.redF(), color.greenF(), color.blueF());
+  checkBoxOverwriteEdgeColor->setCheckState(Qt::CheckState::Checked);
   this->qglview->update();
 }
 

--- a/src/gui/ViewportControl.cc
+++ b/src/gui/ViewportControl.cc
@@ -200,6 +200,15 @@ bool ViewportControl::focusNextPrevChild(bool next){
     return true;
 }
 
+void ViewportControl::on_checkBoxOverwriteEdgeColor_stateChanged(int state){
+  bool bState = (Qt::CheckState::Checked == state);
+  this->qglview->setEdgeColorOverwrite(state);
+}
+
+void ViewportControl::on_lineEditEdgeColor_textChanged(const QString &text){
+  QColor color = QColor(text);
+    this->qglview->setEdgeColor(color.redF(), color.greenF(), color.blueF());
+}
 void ViewportControl::on_doubleSpinBox_edge_valueChanged(double value){
    this->qglview->setTotalHalfEdgeThickness((float) value);
 }

--- a/src/gui/ViewportControl.h
+++ b/src/gui/ViewportControl.h
@@ -31,6 +31,7 @@ private slots:
   void updateCamera();
   void updateViewportControlHints();
   void requestResize();
+  void on_doubleSpinBox_edge_valueChanged(double value);
 
 protected:
   void resizeEvent(QResizeEvent *event) override;

--- a/src/gui/ViewportControl.h
+++ b/src/gui/ViewportControl.h
@@ -32,6 +32,8 @@ private slots:
   void updateViewportControlHints();
   void requestResize();
   void on_doubleSpinBox_edge_valueChanged(double value);
+  void on_checkBoxOverwriteEdgeColor_stateChanged(int state);
+  void on_lineEditEdgeColor_textChanged(const QString &text);
 
 protected:
   void resizeEvent(QResizeEvent *event) override;

--- a/src/gui/ViewportControl.h
+++ b/src/gui/ViewportControl.h
@@ -32,6 +32,7 @@ private slots:
   void updateViewportControlHints();
   void requestResize();
   void on_doubleSpinBox_edge_valueChanged(double value);
+  void on_doubleSpinBox_edgeFade_valueChanged(double value);
   void on_checkBoxOverwriteEdgeColor_stateChanged(int state);
   void on_lineEditEdgeColor_textChanged(const QString &text);
 

--- a/src/gui/ViewportControl.ui
+++ b/src/gui/ViewportControl.ui
@@ -113,6 +113,19 @@
      </layout>
     </widget>
    </item>
+   <item row="4" column="1">
+    <spacer name="verticalSpacer">
+     <property name="orientation">
+      <enum>Qt::Vertical</enum>
+     </property>
+     <property name="sizeHint" stdset="0">
+      <size>
+       <width>20</width>
+       <height>40</height>
+      </size>
+     </property>
+    </spacer>
+   </item>
    <item row="0" column="1">
     <widget class="QGroupBox" name="GroupBoxSize">
      <property name="title">
@@ -164,17 +177,23 @@
     </widget>
    </item>
    <item row="3" column="1">
-    <spacer name="verticalSpacer">
-     <property name="orientation">
-      <enum>Qt::Vertical</enum>
+    <widget class="QGroupBox" name="groupBox">
+     <property name="title">
+      <string>Edge</string>
      </property>
-     <property name="sizeHint" stdset="0">
-      <size>
-       <width>20</width>
-       <height>40</height>
-      </size>
-     </property>
-    </spacer>
+     <layout class="QFormLayout" name="formLayout">
+      <item row="0" column="0">
+       <widget class="QDoubleSpinBox" name="doubleSpinBox_edge"/>
+      </item>
+      <item row="0" column="1">
+       <widget class="QLabel" name="label_edge">
+        <property name="text">
+         <string>TotalHalfEdgeThickness</string>
+        </property>
+       </widget>
+      </item>
+     </layout>
+    </widget>
    </item>
   </layout>
   <action name="actionRowSelected">

--- a/src/gui/ViewportControl.ui
+++ b/src/gui/ViewportControl.ui
@@ -179,7 +179,7 @@
    <item row="3" column="1">
     <widget class="QGroupBox" name="groupBoxEdge">
      <property name="title">
-      <string>Edge</string>
+      <string>Edge setting for preview</string>
      </property>
      <layout class="QFormLayout" name="formLayout">
       <item row="1" column="0">
@@ -234,6 +234,9 @@
        <widget class="QDoubleSpinBox" name="doubleSpinBox_edgeFade">
         <property name="decimals">
          <number>3</number>
+        </property>
+        <property name="minimum">
+         <double>0.010000000000000</double>
         </property>
         <property name="value">
          <double>1.414000000000000</double>

--- a/src/gui/ViewportControl.ui
+++ b/src/gui/ViewportControl.ui
@@ -190,7 +190,21 @@
        </widget>
       </item>
       <item row="1" column="1">
-       <widget class="QDoubleSpinBox" name="doubleSpinBox_edge"/>
+       <widget class="QDoubleSpinBox" name="doubleSpinBox_edge">
+        <property name="decimals">
+         <number>3</number>
+        </property>
+        <property name="value">
+         <double>1.414000000000000</double>
+        </property>
+       </widget>
+      </item>
+      <item row="2" column="0">
+       <widget class="QLabel" name="label_edge_3">
+        <property name="text">
+         <string>edgeFadeThickness</string>
+        </property>
+       </widget>
       </item>
       <item row="3" column="0">
        <widget class="QLabel" name="label_edge_2">
@@ -215,6 +229,16 @@
       </item>
       <item row="4" column="1">
        <widget class="QLineEdit" name="lineEditEdgeColor"/>
+      </item>
+      <item row="2" column="1">
+       <widget class="QDoubleSpinBox" name="doubleSpinBox_edgeFade">
+        <property name="decimals">
+         <number>3</number>
+        </property>
+        <property name="value">
+         <double>1.414000000000000</double>
+        </property>
+       </widget>
       </item>
      </layout>
     </widget>

--- a/src/gui/ViewportControl.ui
+++ b/src/gui/ViewportControl.ui
@@ -177,20 +177,44 @@
     </widget>
    </item>
    <item row="3" column="1">
-    <widget class="QGroupBox" name="groupBox">
+    <widget class="QGroupBox" name="groupBoxEdge">
      <property name="title">
       <string>Edge</string>
      </property>
      <layout class="QFormLayout" name="formLayout">
-      <item row="0" column="0">
-       <widget class="QDoubleSpinBox" name="doubleSpinBox_edge"/>
-      </item>
-      <item row="0" column="1">
+      <item row="1" column="0">
        <widget class="QLabel" name="label_edge">
         <property name="text">
          <string>TotalHalfEdgeThickness</string>
         </property>
        </widget>
+      </item>
+      <item row="1" column="1">
+       <widget class="QDoubleSpinBox" name="doubleSpinBox_edge"/>
+      </item>
+      <item row="3" column="0">
+       <widget class="QLabel" name="label_edge_2">
+        <property name="text">
+         <string>Overwrite Edge Color</string>
+        </property>
+       </widget>
+      </item>
+      <item row="3" column="1">
+       <widget class="QCheckBox" name="checkBoxOverwriteEdgeColor">
+        <property name="text">
+         <string/>
+        </property>
+       </widget>
+      </item>
+      <item row="4" column="0">
+       <widget class="QLabel" name="label">
+        <property name="text">
+         <string>Edge Color</string>
+        </property>
+       </widget>
+      </item>
+      <item row="4" column="1">
+       <widget class="QLineEdit" name="lineEditEdgeColor"/>
       </item>
      </layout>
     </widget>


### PR DESCRIPTION
[demonstration](https://www.youtube.com/watch?v=tUHdCCiM-sU)

This feature can be used for high dpi screen, artistic effect [(example)](https://www.youtube.com/watch?v=mSmYnRA4sY4) and/or to find issues in the model by offering better contrast.

todo
   * [ ] wait for #4261
   * [ ] update the UI File
   * [ ] is there a way to have the constant 1.414 in fewer places?

Currently, this feature is not supported in command line and thus the automated testframework.