### PR TITLE
fixed overwrite of feature enable from commandline

### DIFF
--- a/src/gui/Preferences.cc
+++ b/src/gui/Preferences.cc
@@ -327,7 +327,12 @@ void Preferences::setupFeaturesPage()
     cb->setFont(bold_font);
     // synchronize Qt settings with the feature settings
     bool value = getValue(featurekey).toBool();
-    feature->enable(value);
+    if( !feature->is_enabled() ) {
+      feature->enable(value); // only if not already set from command-line
+    } else {
+      value = feature->is_enabled(); // otherwise sync QT with command-line request
+    }
+
     cb->setChecked(value);
     cb->setProperty(featurePropertyName, QVariant::fromValue<Feature *>(feature));
     connect(cb, SIGNAL(toggled(bool)), this, SLOT(featuresCheckBoxToggled(bool)));


### PR DESCRIPTION
Hi, I think i've found an issue in the Feature functionality.
If you run openscad with "--enable <a functionality disabled in preferences>" the `setupFeaturesPage ` method in Preferences.cc execution actually resets the value to false and so it remains disabled.

This change syncs the QT value to the command line value requested as one would expect.