### PR TITLE
Add error check to userConfigPath on mac

### DIFF
--- a/src/platform/PlatformUtils-mac.mm
+++ b/src/platform/PlatformUtils-mac.mm
@@ -26,6 +26,9 @@ std::string PlatformUtils::userConfigPath()
 {
 	NSError *error;
 	NSURL *appSupportDir = [[NSFileManager defaultManager] URLForDirectory:NSApplicationSupportDirectory inDomain:NSUserDomainMask appropriateForURL:nil create:YES error:&error];
+	if (error) {
+		return "";
+	}
 	return std::string([[appSupportDir path] UTF8String]) + std::string("/") + PlatformUtils::OPENSCAD_FOLDER_NAME;
 }
 


### PR DESCRIPTION
This PR adds an error check to `userConfigPath` on MacOS. Without this, I was getting segfaults in some edge cases (like running openscad as a system user).

In the event of error, it returns an empty string, which is the same behavior as on Linux (in `PlatformUtils-posix.cc`).