### PR TITLE
Feature multicore geometry

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -739,6 +739,7 @@ set(CGAL_SOURCES
   src/geometry/GeometryEvaluator.cc
   src/geometry/cgal/cgalutils.cc
   src/geometry/cgal/cgalutils-applyops.cc
+  src/geometry/cgal/cgalutils-applyops-multicore.cc
   src/geometry/cgal/cgalutils-applyops-hybrid.cc
   src/geometry/cgal/cgalutils-applyops-hybrid-minkowski.cc
   src/geometry/cgal/cgalutils-closed.cc

--- a/src/Feature.cc
+++ b/src/Feature.cc
@@ -50,6 +50,8 @@ const Feature Feature::ExperimentalTextMetricsFunctions("textmetrics", "Enable t
 const Feature Feature::ExperimentalImportFunction("import-function", "Enable import function returning data instead of geometry.");
 const Feature Feature::ExperimentalSortStl("sort-stl", "Sort the STL output for predictable, diffable results.");
 
+const Feature Feature::ExperimentalMulticore("multicore-ops", "Enable multicore parallelization of operations on geometry sets");
+
 Feature::Feature(const std::string& name, const std::string& description)
   : enabled(false), name(name), description(description)
 {

--- a/src/Feature.h
+++ b/src/Feature.h
@@ -32,6 +32,8 @@ public:
   static const Feature ExperimentalImportFunction;
   static const Feature ExperimentalSortStl;
 
+  static const Feature ExperimentalMulticore;
+
   const std::string& get_name() const;
   const std::string& get_description() const;
 

--- a/src/geometry/cgal/cgalutils-applyops-multicore.cc
+++ b/src/geometry/cgal/cgalutils-applyops-multicore.cc
@@ -13,40 +13,98 @@
 #include "node.h"
 #include "progress.h"
 
-void applyUnion3DMulticoreWorker(Geometry::Geometries::iterator chbegin,
-																 Geometry::Geometries::iterator chend,
-																 shared_ptr<const Geometry>* partialResult );
+#include <list>
+#include <thread>
 
 namespace CGALUtils {
+
+void applyUnion3DMulticoreWorker(Geometry::Geometries::iterator& chbegin,
+																 Geometry::Geometries::iterator& chend,
+																 shared_ptr<const Geometry>& partialResult );
+
+void applyOperator3DMulticoreWorker(const Geometry::Geometries& children,
+																		OpenSCADOperator op, shared_ptr<const Geometry> partialResult );
+
+void applyHullMulticoreWorker(const Geometry::Geometries& childrens, PolySet& result, bool& continueExec );
 
 shared_ptr<const Geometry> applyUnion3DMulticore(
   Geometry::Geometries::iterator chbegin,
   Geometry::Geometries::iterator chend)
 {
-	applyUnion3DMulticoreWorker(chbegin, chend, NULL);
-  return nullptr;
+//	int numElements = std::distance( chbegin, chend );
+//	unsigned int numCores = std::thread::hardware_concurrency();
+//
+//	if( numElements < numCores * 2 ) {
+//		// needs at least two elements per core, if  not then fallback basic
+//		return applyBasicUnion3D( chbegin, chend );
+//	}
+
+	shared_ptr<const Geometry> partialResult;
+	std::thread t1( applyUnion3DMulticoreWorker, std::ref(chbegin), std::ref(chend), std::ref(partialResult) );
+
+	t1.join();
+
+  return partialResult;
 }
 
 shared_ptr<const Geometry> applyOperator3DMulticore(
   const Geometry::Geometries& children, 
   OpenSCADOperator op)
 {
-  return nullptr;
+	//	int numElements = std::distance( chbegin, chend );
+	//	unsigned int numCores = std::thread::hardware_concurrency();
+	//
+	//	if( numElements < numCores * 2 ) {
+	//		// needs at least two elements per core, if  not then fallback basic
+	//		return applyBasicUnion3D( chbegin, chend );
+	//	}
+
+	shared_ptr<const Geometry> partialResult;
+	std::thread t1( applyOperator3DMulticoreWorker, std::ref(children), op, std::ref(partialResult) );
+
+	t1.join();
+
+	return partialResult;
 }
 
 bool applyHullMulticore(const Geometry::Geometries& children, PolySet& result)
 {
-  return false;
+	//	int numElements = std::distance( chbegin, chend );
+	//	unsigned int numCores = std::thread::hardware_concurrency();
+	//
+	//	if( numElements < numCores * 2 ) {
+	//		// needs at least two elements per core, if  not then fallback basic
+	//		return applyBasicUnion3D( chbegin, chend );
+	//	}
+
+	bool resultFlag = false;
+	std::thread t1( applyHullMulticoreWorker, std::ref(children), std::ref(result), std::ref(resultFlag) );
+
+	t1.join();
+
+	return resultFlag;
+}
+
+void applyUnion3DMulticoreWorker(Geometry::Geometries::iterator& chbegin,
+																 Geometry::Geometries::iterator& chend,
+																 shared_ptr<const Geometry>& partialResult )
+{
+	shared_ptr<const Geometry> tmpResult = applyBasicUnion3D(chbegin, chend);
+	partialResult.swap( tmpResult );
+}
+
+void applyOperator3DMulticoreWorker(const Geometry::Geometries& children,
+																		OpenSCADOperator op, shared_ptr<const Geometry> partialResult )
+{
+	shared_ptr<const Geometry> tmpResult = applyBasicOperator3D(children, op);
+	partialResult.swap( tmpResult );
+}
+
+void applyHullMulticoreWorker(const Geometry::Geometries& children, PolySet& result, bool& continueExec )
+{
+	continueExec = applyBasicHull(children, result);
 }
 
 }  // namespace CGALUtils
-
-void applyUnion3DMulticoreWorker(Geometry::Geometries::iterator chbegin,
-																 Geometry::Geometries::iterator chend,
-																 shared_ptr<const Geometry>* partialResult )
-{
-
-}
-
 
 #endif // ENABLE_CGAL

--- a/src/geometry/cgal/cgalutils-applyops-multicore.cc
+++ b/src/geometry/cgal/cgalutils-applyops-multicore.cc
@@ -133,12 +133,17 @@ shared_ptr<const Geometry> applyOperator3DMulticore(  const Geometry::Geometries
 
     shared_ptr<const Geometry> result;
     applyMulticoreWorker( 1, children.begin(), children.end(), result,
-          [&](const Geometry::Geometries::const_iterator& itbegin, const Geometry::Geometries::const_iterator& itend, shared_ptr<const Geometry>& partialResult)
-          {
-              Geometry::Geometries list( itbegin, itend );
-              auto operationGeom = applyBasicOperator3D(list, op );
+      [&](const Geometry::Geometries::const_iterator& itbegin, const Geometry::Geometries::const_iterator& itend, shared_ptr<const Geometry>& partialResult)
+      {
+          Geometry::Geometries list( itbegin, itend );
+          if( op == OpenSCADOperator::MINKOWSKI ) {
+              auto operationGeom = applyBasicMinkowski( list );
               partialResult.swap(operationGeom );
-          } );
+              return;
+          }
+          auto operationGeom = applyBasicOperator3D(list, op );
+          partialResult.swap(operationGeom );
+      } );
 
     std::cout << timeSinceEpochMs() - start << "End Operator Multicore " << std::endl;
     return result;

--- a/src/geometry/cgal/cgalutils-applyops-multicore.cc
+++ b/src/geometry/cgal/cgalutils-applyops-multicore.cc
@@ -1,0 +1,52 @@
+// this file is split into many separate cgalutils* files
+// in order to workaround gcc 4.9.1 crashing on systems with only 2GB of RAM
+
+// remove this at last commit (vscode limitation)
+#ifndef ENABLE_CGAL
+  #define ENABLE_CGAL
+#endif
+
+#ifdef ENABLE_CGAL
+
+#include "cgalutils.h"
+#include "CGALHybridPolyhedron.h"
+#include "node.h"
+#include "progress.h"
+
+void applyUnion3DMulticoreWorker(Geometry::Geometries::iterator chbegin,
+																 Geometry::Geometries::iterator chend,
+																 shared_ptr<const Geometry>* partialResult );
+
+namespace CGALUtils {
+
+shared_ptr<const Geometry> applyUnion3DMulticore(
+  Geometry::Geometries::iterator chbegin,
+  Geometry::Geometries::iterator chend)
+{
+	applyUnion3DMulticoreWorker(chbegin, chend, NULL);
+  return nullptr;
+}
+
+shared_ptr<const Geometry> applyOperator3DMulticore(
+  const Geometry::Geometries& children, 
+  OpenSCADOperator op)
+{
+  return nullptr;
+}
+
+bool applyHullMulticore(const Geometry::Geometries& children, PolySet& result)
+{
+  return false;
+}
+
+}  // namespace CGALUtils
+
+void applyUnion3DMulticoreWorker(Geometry::Geometries::iterator chbegin,
+																 Geometry::Geometries::iterator chend,
+																 shared_ptr<const Geometry>* partialResult )
+{
+
+}
+
+
+#endif // ENABLE_CGAL

--- a/src/geometry/cgal/cgalutils-applyops-multicore.cc
+++ b/src/geometry/cgal/cgalutils-applyops-multicore.cc
@@ -15,12 +15,21 @@
 
 #include <list>
 #include <thread>
+#include <chrono>
+
+using namespace std::chrono;
 
 namespace CGALUtils {
 
-void applyUnion3DMulticoreWorker(Geometry::Geometries::iterator& chbegin,
-																 Geometry::Geometries::iterator& chend,
-																 shared_ptr<const Geometry>& partialResult );
+uint64_t timeSinceEpochMs() {
+	using namespace std::chrono;
+	return duration_cast<milliseconds>(system_clock::now().time_since_epoch()).count();
+};
+
+void applyUnion3DMulticoreWorker( int index,
+		Geometry::Geometries::iterator& chbegin,
+	 Geometry::Geometries::iterator& chend,
+	 shared_ptr<const Geometry>& partialResult );
 
 void applyOperator3DMulticoreWorker(const Geometry::Geometries& children,
 																		OpenSCADOperator op, shared_ptr<const Geometry> partialResult );
@@ -31,7 +40,9 @@ shared_ptr<const Geometry> applyUnion3DMulticore(
   Geometry::Geometries::iterator chbegin,
   Geometry::Geometries::iterator chend)
 {
-//	int numElements = std::distance( chbegin, chend );
+	uint64_t start  = timeSinceEpochMs();
+
+	int numElements = std::distance( chbegin, chend );
 //	unsigned int numCores = std::thread::hardware_concurrency();
 //
 //	if( numElements < numCores * 2 ) {
@@ -39,12 +50,70 @@ shared_ptr<const Geometry> applyUnion3DMulticore(
 //		return applyBasicUnion3D( chbegin, chend );
 //	}
 
-	shared_ptr<const Geometry> partialResult;
-	std::thread t1( applyUnion3DMulticoreWorker, std::ref(chbegin), std::ref(chend), std::ref(partialResult) );
+	// re-order by facets so that there's some load balancing among threads
+	Geometry::Geometries balancedList( chbegin, chend );
+	balancedList.sort([](const Geometry::GeometryItem& poly1, const Geometry::GeometryItem& poly2)
+										{
+											return poly1.second->numFacets() < poly2.second->numFacets();
+										});
+
+	std::cout << timeSinceEpochMs() - start << " Main Elements: " << numElements << std::endl;
+	Geometry::Geometries::iterator chmiddle1 = chbegin;
+	std::advance( chmiddle1, numElements / 4 );
+	Geometry::Geometries::iterator chmiddle2 = chmiddle1;
+	std::advance( chmiddle2, numElements / 4 );
+	Geometry::Geometries::iterator chmiddle3 = chmiddle2;
+	std::advance( chmiddle3, numElements / 4 );
+
+	shared_ptr<const Geometry> partialResultLeft;
+	std::thread t1( applyUnion3DMulticoreWorker, 1, std::ref(chbegin), std::ref(chmiddle1), std::ref(partialResultLeft) );
+
+	shared_ptr<const Geometry> partialResultRight;
+	std::thread t2( applyUnion3DMulticoreWorker, 2, std::ref(chmiddle1), std::ref(chmiddle2), std::ref(partialResultRight) );
+
+	shared_ptr<const Geometry> partialResultLeft2;
+	std::thread t3( applyUnion3DMulticoreWorker, 3, std::ref(chmiddle2), std::ref(chmiddle3), std::ref(partialResultLeft2) );
+
+	shared_ptr<const Geometry> partialResultRight2;
+	std::thread t4( applyUnion3DMulticoreWorker, 4, std::ref(chmiddle3), std::ref(chend), std::ref(partialResultRight2) );
 
 	t1.join();
+	t2.join();
+	t3.join();
+	t4.join();
 
-  return partialResult;
+	Geometry::Geometries partials;
+	partials.push_back(std::make_pair(nullptr, partialResultRight));
+	partials.push_back(std::make_pair(nullptr, partialResultLeft));
+
+	Geometry::Geometries::iterator chstart2 = partials.begin();
+	Geometry::Geometries::iterator chend2 = partials.end();
+	shared_ptr<const Geometry> partialResultUnion1;
+	std::thread u1( applyUnion3DMulticoreWorker, 5, std::ref(chstart2), std::ref(chend2), std::ref(partialResultUnion1) );
+
+	Geometry::Geometries partials2;
+	partials2.push_back(std::make_pair(nullptr, partialResultRight2));
+	partials2.push_back(std::make_pair(nullptr, partialResultLeft2));
+
+	Geometry::Geometries::iterator chstart3 = partials2.begin();
+	Geometry::Geometries::iterator chend3 = partials2.end();
+	shared_ptr<const Geometry> partialResultUnion2;
+
+	std::thread u2( applyUnion3DMulticoreWorker, 6, std::ref(chstart3), std::ref(chend3), std::ref(partialResultUnion2) );
+
+	u1.join();
+	u2.join();
+
+	std::cout << timeSinceEpochMs() - start << " 2nd Partials Finished" << std::endl;
+
+	Geometry::Geometries unionData;
+	unionData.push_back(std::make_pair(nullptr, partialResultUnion1));
+	unionData.push_back(std::make_pair(nullptr, partialResultUnion2));
+
+	auto finalUnion = applyBasicUnion3D( unionData.begin(), unionData.end() );
+	std::cout << timeSinceEpochMs() - start << " Finished" << std::endl;
+
+	return finalUnion;
 }
 
 shared_ptr<const Geometry> applyOperator3DMulticore(
@@ -85,12 +154,24 @@ bool applyHullMulticore(const Geometry::Geometries& children, PolySet& result)
 	return resultFlag;
 }
 
-void applyUnion3DMulticoreWorker(Geometry::Geometries::iterator& chbegin,
-																 Geometry::Geometries::iterator& chend,
-																 shared_ptr<const Geometry>& partialResult )
+void applyUnion3DMulticoreWorker( int index,
+		Geometry::Geometries::iterator& chbegin,
+		 Geometry::Geometries::iterator& chend,
+		 shared_ptr<const Geometry>& partialResult )
 {
+	for( auto ch = chbegin; ch != chend; ch++ ) {
+		std::cout<< "[" << index << "] Facets: " << ch->second->numFacets() << std::endl;
+	}
+
+	uint64_t start = timeSinceEpochMs();
+	int numElements = std::distance( chbegin, chend );
+	std::cout << timeSinceEpochMs() - start << "["<< index << "] Elements: " << numElements << std::endl;
 	shared_ptr<const Geometry> tmpResult = applyBasicUnion3D(chbegin, chend);
+
+	std::cout << timeSinceEpochMs() - start << "["<< index << "] Swap" << std::endl;
 	partialResult.swap( tmpResult );
+
+	std::cout << timeSinceEpochMs() - start << "["<< index << "] Finished" << std::endl;
 }
 
 void applyOperator3DMulticoreWorker(const Geometry::Geometries& children,

--- a/src/geometry/cgal/cgalutils-applyops.cc
+++ b/src/geometry/cgal/cgalutils-applyops.cc
@@ -260,7 +260,10 @@ bool applyBasicHull(const Geometry::Geometries& children, PolySet& result)
 shared_ptr<const Geometry> applyMinkowski(const Geometry::Geometries& children)
 {
 	if (Feature::ExperimentalMulticore.is_enabled()) {
-		return applyOperator3DMulticore(children, OpenSCADOperator::MINKOWSKI);
+        if (Feature::ExperimentalFastCsg.is_enabled()) {
+            return applyOperator3DMulticore<CGALHybridPolyhedron>(children, OpenSCADOperator::MINKOWSKI);
+        }
+		return applyOperator3DMulticore<const Geometry>(children, OpenSCADOperator::MINKOWSKI);
 	}
 	if (Feature::ExperimentalFastCsg.is_enabled()) {
 		return applyMinkowskiHybrid(children);

--- a/src/geometry/cgal/cgalutils-applyops.cc
+++ b/src/geometry/cgal/cgalutils-applyops.cc
@@ -1,6 +1,10 @@
 // this file is split into many separate cgalutils* files
 // in order to workaround gcc 4.9.1 crashing on systems with only 2GB of RAM
 
+// remove this at last commit (vscode limitation)
+#ifndef ENABLE_CGAL
+  #define ENABLE_CGAL
+#endif
 #ifdef ENABLE_CGAL
 
 #include "cgal.h"
@@ -33,16 +37,23 @@
 
 namespace CGALUtils {
 
+shared_ptr<const Geometry> applyOperator3D(const Geometry::Geometries& children, OpenSCADOperator op) {
+	if (Feature::ExperimentalMulticore.is_enabled()) {
+		return applyOperator3DMulticore(children, op);
+	}
+	if (Feature::ExperimentalFastCsg.is_enabled()) {
+		return applyOperator3DHybrid(children, op);
+	}
+
+	return applyBasicOperator3D( children, op );
+}
+
 /*!
    Applies op to all children and returns the result.
    The child list should be guaranteed to contain non-NULL 3D or empty Geometry objects
  */
-shared_ptr<const Geometry> applyOperator3D(const Geometry::Geometries& children, OpenSCADOperator op)
+shared_ptr<const Geometry> applyBasicOperator3D(const Geometry::Geometries& children, OpenSCADOperator op)
 {
-  if (Feature::ExperimentalFastCsg.is_enabled()) {
-    return applyOperator3DHybrid(children, op);
-  }
-
   CGAL_Nef_polyhedron *N = nullptr;
 
   assert(op != OpenSCADOperator::UNION && "use applyUnion3D() instead of applyOperator3D()");
@@ -106,12 +117,21 @@ shared_ptr<const Geometry> applyOperator3D(const Geometry::Geometries& children,
 }
 
 shared_ptr<const Geometry> applyUnion3D(
+		Geometry::Geometries::iterator chbegin, Geometry::Geometries::iterator chend)
+{
+	if (Feature::ExperimentalMulticore.is_enabled()) {
+		return applyUnion3DMulticore(chbegin, chend);
+	}
+	if (Feature::ExperimentalFastCsg.is_enabled()) {
+		return applyUnion3DHybrid(chbegin, chend);
+	}
+
+	return applyBasicUnion3D(chbegin, chend);
+}
+
+shared_ptr<const Geometry> applyBasicUnion3D(
   Geometry::Geometries::iterator chbegin, Geometry::Geometries::iterator chend)
 {
-  if (Feature::ExperimentalFastCsg.is_enabled()) {
-    return applyUnion3DHybrid(chbegin, chend);
-  }
-
   typedef std::pair<shared_ptr<const CGAL_Nef_polyhedron>, int> QueueConstItem;
   struct QueueItemGreater {
     // stable sort for priority_queue by facets, then progress mark
@@ -158,9 +178,16 @@ shared_ptr<const Geometry> applyUnion3D(
   return nullptr;
 }
 
-
-
 bool applyHull(const Geometry::Geometries& children, PolySet& result)
+{
+	if (Feature::ExperimentalMulticore.is_enabled()) {
+		return applyHullMulticore(children, result);
+	}
+
+	return applyBasicHull(children, result);
+}
+
+bool applyBasicHull(const Geometry::Geometries& children, PolySet& result)
 {
   typedef CGAL::Epick K;
   // Collect point cloud
@@ -227,14 +254,23 @@ bool applyHull(const Geometry::Geometries& children, PolySet& result)
 }
 
 
+shared_ptr<const Geometry> applyMinkowski(const Geometry::Geometries& children)
+{
+	if (Feature::ExperimentalMulticore.is_enabled()) {
+		return applyOperator3DMulticore(children, OpenSCADOperator::MINKOWSKI);
+	}
+	if (Feature::ExperimentalFastCsg.is_enabled()) {
+		return applyMinkowskiHybrid(children);
+	}
+
+	return applyBasicMinkowski( children );
+}
+
 /*!
    children cannot contain nullptr objects
  */
-shared_ptr<const Geometry> applyMinkowski(const Geometry::Geometries& children)
+shared_ptr<const Geometry> applyBasicMinkowski(const Geometry::Geometries& children)
 {
-  if (Feature::ExperimentalFastCsg.is_enabled()) {
-    return applyMinkowskiHybrid(children);
-  }
   CGAL::Timer t, t_tot;
   assert(children.size() >= 2);
   Geometry::Geometries::const_iterator it = children.begin();

--- a/src/geometry/cgal/cgalutils-applyops.cc
+++ b/src/geometry/cgal/cgalutils-applyops.cc
@@ -117,7 +117,7 @@ shared_ptr<const Geometry> applyBasicOperator3D(const Geometry::Geometries& chil
 }
 
 shared_ptr<const Geometry> applyUnion3D(
-		Geometry::Geometries::iterator chbegin, Geometry::Geometries::iterator chend)
+		const Geometry::Geometries::const_iterator& chbegin, const Geometry::Geometries::const_iterator& chend)
 {
 	if (Feature::ExperimentalMulticore.is_enabled()) {
 		return applyUnion3DMulticore(chbegin, chend);
@@ -130,7 +130,7 @@ shared_ptr<const Geometry> applyUnion3D(
 }
 
 shared_ptr<const Geometry> applyBasicUnion3D(
-  Geometry::Geometries::iterator chbegin, Geometry::Geometries::iterator chend)
+        const Geometry::Geometries::const_iterator& chbegin, const Geometry::Geometries::const_iterator& chend)
 {
   typedef std::pair<shared_ptr<const CGAL_Nef_polyhedron>, int> QueueConstItem;
   struct QueueItemGreater {

--- a/src/geometry/cgal/cgalutils-applyops.cc
+++ b/src/geometry/cgal/cgalutils-applyops.cc
@@ -120,7 +120,10 @@ shared_ptr<const Geometry> applyUnion3D(
 		const Geometry::Geometries::const_iterator& chbegin, const Geometry::Geometries::const_iterator& chend)
 {
 	if (Feature::ExperimentalMulticore.is_enabled()) {
-		return applyUnion3DMulticore(chbegin, chend);
+        if (Feature::ExperimentalFastCsg.is_enabled()) {
+            return applyUnion3DMulticore<CGALHybridPolyhedron>(chbegin, chend);
+        }
+		return applyUnion3DMulticore<const Geometry>(chbegin, chend);
 	}
 	if (Feature::ExperimentalFastCsg.is_enabled()) {
 		return applyUnion3DHybrid(chbegin, chend);

--- a/src/geometry/cgal/cgalutils.h
+++ b/src/geometry/cgal/cgalutils.h
@@ -47,6 +47,7 @@ shared_ptr<CGALHybridPolyhedron> applyUnion3DHybrid(
   const Geometry::Geometries::const_iterator& chbegin,
   const Geometry::Geometries::const_iterator& chend);
 
+template<class T>
 shared_ptr<const Geometry> applyOperator3DMulticore(const Geometry::Geometries& children, OpenSCADOperator op);
 template<class T>
 shared_ptr<const Geometry> applyUnion3DMulticore(const Geometry::Geometries::const_iterator& chbegin,

--- a/src/geometry/cgal/cgalutils.h
+++ b/src/geometry/cgal/cgalutils.h
@@ -31,16 +31,27 @@ Result vector_convert(V const& v) {
 namespace CGALUtils {
 
 bool applyHull(const Geometry::Geometries& children, PolySet& P);
+bool applyBasicHull(const Geometry::Geometries& children, PolySet& P);
+bool applyHullMulticore(const Geometry::Geometries& children, PolySet& result);
+
 template <typename K>
 bool is_weakly_convex(const CGAL::Polyhedron_3<K>& p);
 template <typename K>
 bool is_weakly_convex(const CGAL::Surface_mesh<CGAL::Point_3<K>>& m);
 shared_ptr<const Geometry> applyOperator3D(const Geometry::Geometries& children, OpenSCADOperator op);
 shared_ptr<const Geometry> applyUnion3D(Geometry::Geometries::iterator chbegin, Geometry::Geometries::iterator chend);
+
 shared_ptr<CGALHybridPolyhedron> applyOperator3DHybrid(const Geometry::Geometries& children, OpenSCADOperator op);
 shared_ptr<CGALHybridPolyhedron> applyUnion3DHybrid(
   const Geometry::Geometries::const_iterator& chbegin,
   const Geometry::Geometries::const_iterator& chend);
+
+shared_ptr<const Geometry> applyOperator3DMulticore(const Geometry::Geometries& children, OpenSCADOperator op);
+shared_ptr<const Geometry> applyUnion3DMulticore(Geometry::Geometries::iterator chbegin, Geometry::Geometries::iterator chend);
+
+shared_ptr<const Geometry> applyBasicOperator3D(const Geometry::Geometries& children, OpenSCADOperator op);
+shared_ptr<const Geometry> applyBasicUnion3D(Geometry::Geometries::iterator chbegin, Geometry::Geometries::iterator chend);
+
 //FIXME: Old, can be removed:
 //void applyBinaryOperator(CGAL_Nef_polyhedron &target, const CGAL_Nef_polyhedron &src, OpenSCADOperator op);
 Polygon2d *project(const CGAL_Nef_polyhedron& N, bool cut);
@@ -52,6 +63,7 @@ CGAL_Iso_cuboid_3 createIsoCuboidFromBoundingBox(const BoundingBox& bbox);
 bool is_approximately_convex(const PolySet& ps);
 shared_ptr<const Geometry> applyMinkowski(const Geometry::Geometries& children);
 shared_ptr<const Geometry> applyMinkowskiHybrid(const Geometry::Geometries& children);
+shared_ptr<const Geometry> applyBasicMinkowski(const Geometry::Geometries& children);
 
 template <typename Polyhedron> bool createPolySetFromPolyhedron(const Polyhedron& p, PolySet& ps);
 template <class InputKernel, class OutputKernel>

--- a/src/geometry/cgal/cgalutils.h
+++ b/src/geometry/cgal/cgalutils.h
@@ -48,6 +48,7 @@ shared_ptr<CGALHybridPolyhedron> applyUnion3DHybrid(
   const Geometry::Geometries::const_iterator& chend);
 
 shared_ptr<const Geometry> applyOperator3DMulticore(const Geometry::Geometries& children, OpenSCADOperator op);
+template<class T>
 shared_ptr<const Geometry> applyUnion3DMulticore(const Geometry::Geometries::const_iterator& chbegin,
                                                  const Geometry::Geometries::const_iterator& chend);
 

--- a/src/geometry/cgal/cgalutils.h
+++ b/src/geometry/cgal/cgalutils.h
@@ -39,7 +39,8 @@ bool is_weakly_convex(const CGAL::Polyhedron_3<K>& p);
 template <typename K>
 bool is_weakly_convex(const CGAL::Surface_mesh<CGAL::Point_3<K>>& m);
 shared_ptr<const Geometry> applyOperator3D(const Geometry::Geometries& children, OpenSCADOperator op);
-shared_ptr<const Geometry> applyUnion3D(Geometry::Geometries::iterator chbegin, Geometry::Geometries::iterator chend);
+shared_ptr<const Geometry> applyUnion3D(const Geometry::Geometries::const_iterator& chbegin,
+                                        const Geometry::Geometries::const_iterator& chend);
 
 shared_ptr<CGALHybridPolyhedron> applyOperator3DHybrid(const Geometry::Geometries& children, OpenSCADOperator op);
 shared_ptr<CGALHybridPolyhedron> applyUnion3DHybrid(
@@ -47,10 +48,12 @@ shared_ptr<CGALHybridPolyhedron> applyUnion3DHybrid(
   const Geometry::Geometries::const_iterator& chend);
 
 shared_ptr<const Geometry> applyOperator3DMulticore(const Geometry::Geometries& children, OpenSCADOperator op);
-shared_ptr<const Geometry> applyUnion3DMulticore(Geometry::Geometries::iterator chbegin, Geometry::Geometries::iterator chend);
+shared_ptr<const Geometry> applyUnion3DMulticore(const Geometry::Geometries::const_iterator& chbegin,
+                                                 const Geometry::Geometries::const_iterator& chend);
 
 shared_ptr<const Geometry> applyBasicOperator3D(const Geometry::Geometries& children, OpenSCADOperator op);
-shared_ptr<const Geometry> applyBasicUnion3D(Geometry::Geometries::iterator chbegin, Geometry::Geometries::iterator chend);
+shared_ptr<const Geometry> applyBasicUnion3D(const Geometry::Geometries::const_iterator& chbegin,
+                                             const Geometry::Geometries::const_iterator& chend);
 
 //FIXME: Old, can be removed:
 //void applyBinaryOperator(CGAL_Nef_polyhedron &target, const CGAL_Nef_polyhedron &src, OpenSCADOperator op);


### PR DESCRIPTION
This change responds to #391.

It creates a new feature called "multicore-ops" and allows the multithread execution of the geometry collecting operations:
* Union
* Subtraction
* Hull 
* Minkowsky

It supports both standard (Nef) and hybrid polygon operations (when the corresponding feature is also enabled).

The subdivision of work is simple divide-and-conquer:
1) if the subdivision reaches the maximum number of executors or the list cannot be subdivided further then the operation is applied and returned
2) if not then two balanced lists of geometries are generated
3) the two threads are launched recursively and awaited for their result
4) the operation is then applied on the two partial results and returned to the parent thread

From my tests i've found that the Nef objects do not significantly benefit from the change (because the last operation still dominates the running time and cannot be simplified via threading), while the hybrid operations do seem to have a certain boost.

I cannot give precise measurements because i've develop this in a virtual machine so my timings are not really indicative.

A word of caution: this is not a silver bullet to improve performance, the scaling is _by geometry_ not _by facets_ so there could be anomalous scenarios where the added operations can slow down significantly the entire operation

If there is anything else to document or explain, please let me know.
