### PR TITLE
add dict() builtin function with example

### DIFF
--- a/examples/Advanced/dict_split_definition_instantiation.scad
+++ b/examples/Advanced/dict_split_definition_instantiation.scad
@@ -1,0 +1,102 @@
+// dict_split_definition_instantiation.scad - usage of dict()
+
+// dict() construct an associative array, where keys are strings. One of
+// possible usages is to separate definition of the model from its
+// instantiation. The model defintion then can be used elsewhere, for example
+// to define mounting holes or attachment points, as shown in this example.
+
+// The example could be split into three source files, as the modules are
+// supposed to not know about each other. However, for simplicity, the files
+// were fused into one and the content split by markers.
+
+
+$fn = 32;
+
+/* ---------------------- BOX MODULE DEFINITION ---------------------------- */
+
+function box_definition(length, width, height)
+    = dict(
+        length = length,
+        width = width,
+        height = height,
+    );
+
+module box_instance(definition) {
+    translate([-definition.length/2, -definition.width/2, 0])
+        difference() {
+            cube([definition.length, definition.width, definition.height]);
+            translate([4, definition.width/2, -0.01])
+                cylinder(r=2, h=definition.height+0.02);
+            translate([definition.length-4, definition.width/2, -0.01])
+                cylinder(r=2, h=definition.height+0.02);
+        }
+}
+
+module at_box_mounting_holes(definition) {
+    translate([-definition.length/2, -definition.width/2, 0]) {
+        translate([4, definition.width/2, 0])
+            children();
+        translate([definition.length-4, definition.width/2, 0])
+            children();
+    }
+}
+
+
+/* --------------------- HOLDER MODULE DEFINITION -------------------------- */
+
+function holder_definition(base_length, arm_length, arm_angle)
+    = dict(
+        base_length = base_length,
+        arm_length = arm_length,
+        arm_angle = arm_angle,
+    );
+
+module holder_instance(definition) {
+    cube([10, 10, definition.base_length]);
+    translate([5, 0, definition.base_length]) {
+        rotate([-90, 0, 0])
+            cylinder(d=10, h=20);
+        rotate([0, definition.arm_angle, 0])
+            translate([-5, 10, 0]) {
+                cube([10, 10, definition.arm_length]);
+
+                translate([5, 5, definition.arm_length+5])
+                    cube([50, 50, 10], center=true);
+            }
+    }
+
+}
+
+module at_holder_payload(definition) {
+    translate([5, 0, definition.base_length])
+        rotate([0, definition.arm_angle, 0])
+            translate([-5, 10, 0])
+                translate([5, 5, definition.arm_length+10])
+                    children();
+}
+
+
+/* ------------------------------ HELPERS ---------------------------------- */
+
+module m3_hole(depth) {
+    translate([0, 0, -depth])
+        cylinder(d=3, h=depth+0.01);
+}
+
+/* -------------------------- ASSEMBLY MODULE ------------------------------ */
+
+// define both models, but don't instantiate them yet
+holder1 = holder_definition(100, 50, 40);
+box1 = box_definition(30, 40, 20);
+
+// instantiate holder and cut mounting holes for the box
+difference() {
+    color("green") holder_instance(holder1);
+    at_holder_payload(holder1)
+        at_box_mounting_holes(box1)
+            m3_hole(depth=12);
+}
+
+// instantiate box attached to the holder
+at_holder_payload(holder1)
+    color("blue") box_instance(box1);

--- a/src/core/builtin_functions.cc
+++ b/src/core/builtin_functions.cc
@@ -939,6 +939,27 @@ Value builtin_import(Arguments arguments, const Location& loc)
   return import_json(file, arguments.session(), loc);
 }
 
+Value builtin_dict(const std::shared_ptr<const Context>& context, const FunctionCall *call)
+{
+  ObjectType obj(context->session());
+
+  std::set<std::string> seen;
+  for (const auto& argument : call->arguments) {
+    Value value = argument->getExpr()->evaluate(context);
+    if (argument->getName().empty()) {
+	
+      LOG(message_group::Warning, call->location(), context->documentRoot(), "Assignment without variable name %1$s", value.toEchoStringNoThrow());
+    } else if (seen.find(argument->getName()) != seen.end()) {
+      LOG(message_group::Warning, call->location(), context->documentRoot(), "Ignoring duplicate variable assignment %1$s = %2$s", argument->getName(), value.toEchoStringNoThrow());
+    } else {
+      obj.set(argument->getName(), std::move(value));
+      seen.insert(argument->getName());
+    }
+  }
+
+  return std::move(obj);
+}
+
 void register_builtin_functions()
 {
   Builtins::init("abs", new BuiltinFunction(&builtin_abs),
@@ -1160,5 +1181,10 @@ void register_builtin_functions()
   Builtins::init("import", new BuiltinFunction(&builtin_import, &Feature::ExperimentalImportFunction),
   {
     "import(file) -> object",
+  });
+
+  Builtins::init("dict", new BuiltinFunction(&builtin_dict),
+  {
+    "dict(param=value, ...) -> object",
   });
 }


### PR DESCRIPTION
dict() is a variable parameter function (all arguments must be named)
that constucts ObjectType with attributes corresponding to given
arguments. See the attached example comments for dict() purpose.

The pull request closes #4203 and partially addresses #3088 (see [this comment](https://github.com/openscad/openscad/issues/3088#issuecomment-539626365)).
I added only a function in order to not introduce any new syntax.