### PR TITLE
Improve axis scale markers when view is off center.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 .uuid
 .vs/
 .vscode/
+.devcontainer/
 /*.scad
 **/out*.*
 *.dmg

--- a/src/glview/GLView.cc
+++ b/src/glview/GLView.cc
@@ -6,6 +6,7 @@
 #include "printutils.h"
 #include "Renderer.h"
 #include "degree_trig.h"
+#define _USE_MATH_DEFINES
 #include <cmath>
 #include "boost-utils.h"
 #ifdef _WIN32

--- a/src/glview/GLView.cc
+++ b/src/glview/GLView.cc
@@ -6,7 +6,6 @@
 #include "printutils.h"
 #include "Renderer.h"
 #include "degree_trig.h"
-#define _USE_MATH_DEFINES
 #include <cmath>
 #include "boost-utils.h"
 #ifdef _WIN32
@@ -609,7 +608,7 @@ bool GLView::frustumAxisInterstaction(const std::array<Eigen::Vector4d, 6>& plan
 
   for (auto i = 0; i < 6; ++i) {
     Eigen::Vector3d plane_xyz(planes[i].x(), planes[i].y(), planes[i].z());
-    auto angle = fabs(GLView::vectorToVectorAngle(plane_xyz, axis)) * 180.0 / M_PI;
+    auto angle = fabs(GLView::vectorToVectorAngle(plane_xyz, axis)) * M_RAD2DEG;
     if (angle < 2.0)
       continue;
 

--- a/src/glview/GLView.h
+++ b/src/glview/GLView.h
@@ -84,5 +84,9 @@ private:
   void showAxes(const Color4f& col);
   void showSmallaxes(const Color4f& col);
   void showScalemarkers(const Color4f& col);
+  std::array<Eigen::Vector4d, 6> getFrustumPlanes();
+  double vectorToVectorAngle(const Eigen::Vector3d& a, const Eigen::Vector3d& b);
+  bool frustumAxisInterstaction(const std::array<Eigen::Vector4d, 6>& planes, const Eigen::Vector3d axis, double& min_t, double& max_t);
+
   void decodeMarkerValue(double i, double l, int size_div_sm);
 };


### PR DESCRIPTION
This is my attempt to fix  #1206.
There is some more work to be done, see bellow.

Before this fix, centering the following cube:
```
translate([2000,-10,-10])
cube(20);
```
Looks like:
![openscad-bad](https://user-images.githubusercontent.com/819436/179364973-6d63edc4-855d-4820-8a49-44d92b5857ff.png)
Afterward it will look like:
![openscad-good](https://user-images.githubusercontent.com/819436/179364985-820427d0-4e0e-4465-9a5c-7214cda05cf0.png)

However, this fix is not complete.
I've made an effort to make minimal changes to current code structure to get this reviewed for basic concept before moving on to make bigger changes.
The main issue is that currently  the code treat all axis as equal, rendering the markers in one pass. It creates an issue when different lengths of axis are shown on screen(as my change try to find the global min&max over all axis) due to rendering of too much details and slowing the view to a crawl(at least on my oldish NVIDIA GTX 960), for example, in this view:
![openscad-slow](https://user-images.githubusercontent.com/819436/179365151-59734e55-be4c-4dff-b8e6-5bb157e98e4d.png)

Implementation details:

Introduce new functionality in GLView:
* Extraction of frustum planes from opengl.
* Calculating angle between vectors.
* Intersection of axis with frustum planes.

And use the new functionality to define&use min/max bounderies in
GLView::showScalemarkers to draw markers - instead of previous zoom
level usage.