### PR TITLE
Added object() function to make an object from arguments.

### DIFF
--- a/src/core/builtin_functions.cc
+++ b/src/core/builtin_functions.cc
@@ -427,6 +427,19 @@ Value builtin_concat(Arguments arguments, const Location& loc)
   return std::move(result);
 }
 
+Value builtin_object(Arguments arguments, const Location& loc)
+{
+  ObjectType result(arguments.session());
+  for (auto& argument : arguments) {
+    if (argument.name == boost::none) {
+      LOG(message_group::Warning, loc, arguments.documentRoot(), "object() argument is not named");
+    } else {
+      result.set(argument.name->c_str(), std::move(argument.value));
+    }
+  }
+  return std::move(result);
+}
+
 Value builtin_lookup(Arguments arguments, const Location& loc)
 {
   if (!check_arguments("lookup", arguments, loc, { Value::Type::NUMBER, Value::Type::VECTOR })) {
@@ -1084,6 +1097,11 @@ void register_builtin_functions()
   Builtins::init("concat", new BuiltinFunction(&builtin_concat),
   {
     "concat(number or string or vector, ...) -> vector",
+  });
+
+  Builtins::init("object", new BuiltinFunction(&builtin_object),
+  {
+    "object(key=value, ...) -> object",
   });
 
   Builtins::init("lookup", new BuiltinFunction(&builtin_lookup),


### PR DESCRIPTION
The `textmetrics()`, `fontmetrics()`, and `import("foo.json")` functions can return an Object type value that contains sub-values accessible via foo.bar syntax.  But creating a new object isn't available.  This PR adds an `object()` function that takes named args and makes them into object named sub-values.

```openscad
obj = object(foo=42, bar="fee", baz=[4,6,8]);
echo(obj.foo, obj.bar, obj.baz);
```

This also suggests an `newobj = obj_set(object, key=value, ...);` function that returns a copy of the given object, with new values set or overridden by the other given key=value arguments.  I have not implemented that in this PR as I am not clear enough on the function internals.
