### PR TITLE
Catch and log std::exception for compilation

### DIFF
--- a/src/gui/MainWindow.cc
+++ b/src/gui/MainWindow.cc
@@ -1103,7 +1103,7 @@ void MainWindow::compile(bool reload, bool forcedone)
     compileDone(didcompile | forcedone);
   } catch (const HardWarningException&) {
     exceptionCleanup();
-  } catch (std::exception &ex) {
+  } catch (const std::exception& ex) {
     UnknownExceptionCleanup(ex.what());
   } catch (...) {
     UnknownExceptionCleanup();

--- a/src/gui/MainWindow.cc
+++ b/src/gui/MainWindow.cc
@@ -1103,6 +1103,8 @@ void MainWindow::compile(bool reload, bool forcedone)
     compileDone(didcompile | forcedone);
   } catch (const HardWarningException&) {
     exceptionCleanup();
+  } catch (std::exception &ex) {
+    UnknownExceptionCleanup(ex.what());
   } catch (...) {
     UnknownExceptionCleanup();
   }
@@ -2335,9 +2337,14 @@ void MainWindow::exceptionCleanup(){
   if (designActionAutoReload->isChecked()) autoReloadTimer->start();
 }
 
-void MainWindow::UnknownExceptionCleanup(){
+void MainWindow::UnknownExceptionCleanup(std::string msg){
   setCurrentOutput(); // we need to show this error
-  LOG(message_group::Error, Location::NONE, "", "Parsing aborted by unknown exception");
+  if (msg.size() == 0) {
+    LOG(message_group::Error, Location::NONE, "", "Compilation aborted by unknown exception");
+  }
+  else {
+    LOG(message_group::Error, Location::NONE, "", "Compilation aborted by exception: %1$s", msg);
+  }
   LOG(message_group::None, Location::NONE, "", " ");
   GuiLocker::unlock();
   if (designActionAutoReload->isChecked()) autoReloadTimer->start();

--- a/src/gui/MainWindow.h
+++ b/src/gui/MainWindow.h
@@ -22,6 +22,7 @@
 #include "TabManager.h"
 #include "RenderStatistic.h"
 #include <memory>
+#include <string>
 
 #ifdef STATIC_QT_SVG_PLUGIN
 #include <QtPlugin>
@@ -112,7 +113,7 @@ public:
   void parseTopLevelDocument();
   void exceptionCleanup();
   void setLastFocus(QWidget *widget);
-  void UnknownExceptionCleanup();
+  void UnknownExceptionCleanup(std::string msg="");
 
   bool isLightTheme();
 

--- a/src/gui/TabManager.cc
+++ b/src/gui/TabManager.cc
@@ -501,6 +501,8 @@ void TabManager::openTabFile(const QString& filename)
       par->parseTopLevelDocument();
     } catch (const HardWarningException&) {
       par->exceptionCleanup();
+    } catch (std::exception& ex) {
+      par->UnknownExceptionCleanup(ex.what());
     } catch (...) {
       par->UnknownExceptionCleanup();
     }

--- a/src/gui/TabManager.cc
+++ b/src/gui/TabManager.cc
@@ -501,7 +501,7 @@ void TabManager::openTabFile(const QString& filename)
       par->parseTopLevelDocument();
     } catch (const HardWarningException&) {
       par->exceptionCleanup();
-    } catch (std::exception& ex) {
+    } catch (const std::exception& ex) {
       par->UnknownExceptionCleanup(ex.what());
     } catch (...) {
       par->UnknownExceptionCleanup();


### PR DESCRIPTION
In response to #4353, we really need to be catching std::exception and logging to the console its .what() message for exception throws during compilation, which this PR does.  The unknown exception remains as a fallback.