### PR TITLE
Fix recent file list bug

### DIFF
--- a/src/gui/MainWindow.cc
+++ b/src/gui/MainWindow.cc
@@ -984,16 +984,14 @@ bool MainWindow::network_progress_func(const double permille)
   return (progresswidget && progresswidget->wasCanceled());
 }
 
-void MainWindow::updateRecentFiles(EditorInterface *edt)
+void MainWindow::updateRecentFiles(QString FileSavedOrOpened)
 {
   // Check that the canonical file path exists - only update recent files
   // if it does. Should prevent empty list items on initial open etc.
-  QFileInfo fileinfo(edt->filepath);
-  auto infoFileName = fileinfo.absoluteFilePath();
   QSettingsCached settings; // already set up properly via main.cpp
   auto files = settings.value("recentFileList").toStringList();
-  files.removeAll(infoFileName);
-  files.prepend(infoFileName);
+  files.removeAll(FileSavedOrOpened);
+  files.prepend(FileSavedOrOpened);
   while (files.size() > UIUtils::maxRecentFiles) files.removeLast();
   settings.setValue("recentFileList", files);
 

--- a/src/gui/MainWindow.h
+++ b/src/gui/MainWindow.h
@@ -143,7 +143,7 @@ private:
 
 public slots:
   void updateExportActions();
-  void updateRecentFiles(EditorInterface *edt);
+  void updateRecentFiles(QString FileSavedOrOpened );
   void updateRecentFileActions();
   void handleFileDrop(const QUrl& url);
 

--- a/src/gui/TabManager.cc
+++ b/src/gui/TabManager.cc
@@ -487,7 +487,7 @@ void TabManager::openTabFile(const QString& filename)
   if (knownFileType && cmd.isEmpty()) {
     setTabName(filename);
     editor->parameterWidget->readFile(fileinfo.absoluteFilePath());
-    par->updateRecentFiles(editor);
+    par->updateRecentFiles(filename);
   } else {
     setTabName(nullptr);
     editor->setPlainText(cmd.arg(filename));
@@ -680,7 +680,7 @@ bool TabManager::save(EditorInterface *edt, const QString path)
     edt->parameterWidget->saveFile(path);
     edt->setContentModified(false);
     edt->parameterWidget->setModified(false);
-    par->updateRecentFiles(edt);
+    par->updateRecentFiles(path);
   } else {
     saveError(file, _("Error saving design"), path);
   }


### PR DESCRIPTION
Fixes #3690

The source of this bug was that the 'filename' field in the editor interface object does not always hold the filename and path of the recently saved file.  

I change the call to `updaterRecentFiles()` argument from a pointer to the editor interface to a QString with the recent filename and path, which is available in both of the functions which call `updateRecentFiles()`. 