### PR TITLE
FreetypeRenderer::GlyphData destruction simplification

### DIFF
--- a/src/core/FreetypeRenderer.cc
+++ b/src/core/FreetypeRenderer.cc
@@ -368,6 +368,7 @@ FreetypeRenderer::ShapeResults::ShapeResults(
   hb_glyph_info_t *glyph_info = hb_buffer_get_glyph_infos(hb_buf, &glyph_count);
   hb_glyph_position_t *glyph_pos = hb_buffer_get_glyph_positions(hb_buf, &glyph_count);
 
+  glyph_array.reserve(glyph_count);
   for (unsigned int idx = 0; idx < glyph_count; ++idx) {
     FT_Error error;
     FT_UInt glyph_index = glyph_info[idx].codepoint;
@@ -389,8 +390,8 @@ FreetypeRenderer::ShapeResults::ShapeResults(
           glyph_index, idx, params.text);
       continue;
     }
-    const GlyphData *glyph_data = new GlyphData(glyph, idx, &glyph_pos[idx]);
-    glyph_array.push_back(glyph_data);
+
+    glyph_array.emplace_back(glyph, idx, &glyph_pos[idx]);
   }
 
   ascent = std::numeric_limits<double>::lowest();
@@ -402,9 +403,9 @@ FreetypeRenderer::ShapeResults::ShapeResults(
   bottom = std::numeric_limits<double>::max();
   top = std::numeric_limits<double>::lowest();
 
-  for (const auto glyph : glyph_array) {
+  for (const auto& glyph : glyph_array) {
     FT_BBox bbox;
-    FT_Glyph_Get_CBox(glyph->get_glyph(), FT_GLYPH_BBOX_GRIDFIT, &bbox);
+    FT_Glyph_Get_CBox(glyph.get_glyph(), FT_GLYPH_BBOX_GRIDFIT, &bbox);
 
     // Note that glyphs can extend left of their origin
     // and right of their advance-width, into the next
@@ -419,8 +420,8 @@ FreetypeRenderer::ShapeResults::ShapeResults(
       ascent = std::max(ascent, bbox.yMax / scale);
       descent = std::min(descent, bbox.yMin / scale);
 
-      double gxoff = glyph->get_x_offset();
-      double gyoff = glyph->get_y_offset();
+      const double gxoff = glyph.get_x_offset();
+      const double gyoff = glyph.get_y_offset();
 
       left = std::min(left,
                       advance_x + gxoff + bbox.xMin / scale);
@@ -433,8 +434,8 @@ FreetypeRenderer::ShapeResults::ShapeResults(
                         advance_y + gyoff + bbox.yMin / scale);
     }
 
-    advance_x += glyph->get_x_advance() * params.spacing;
-    advance_y += glyph->get_y_advance() * params.spacing;
+    advance_x += glyph.get_x_advance() * params.spacing;
+    advance_y += glyph.get_y_advance() * params.spacing;
   }
 
   // Right and left start out reversed.  If any ink is ever
@@ -560,16 +561,16 @@ std::vector<const Geometry *> FreetypeRenderer::render(const FreetypeRenderer::P
   }
 
   DrawingCallback callback(params.segments, params.size);
-  for (const auto glyph : sr.glyph_array) {
+  for (const auto& glyph : sr.glyph_array) {
     callback.start_glyph();
     callback.set_glyph_offset(
-      sr.x_offset + glyph->get_x_offset(),
-      sr.y_offset + glyph->get_y_offset());
-    FT_Outline outline = reinterpret_cast<FT_OutlineGlyph>(glyph->get_glyph())->outline;
+      sr.x_offset + glyph.get_x_offset(),
+      sr.y_offset + glyph.get_y_offset());
+    FT_Outline outline = reinterpret_cast<FT_OutlineGlyph>(glyph.get_glyph())->outline;
     FT_Outline_Decompose(&outline, &funcs, &callback);
 
-    double adv_x = glyph->get_x_advance() * params.spacing;
-    double adv_y = glyph->get_y_advance() * params.spacing;
+    double adv_x = glyph.get_x_advance() * params.spacing;
+    double adv_y = glyph.get_y_advance() * params.spacing;
     callback.add_glyph_advance(adv_x, adv_y);
     callback.finish_glyph();
   }

--- a/src/core/FreetypeRenderer.h
+++ b/src/core/FreetypeRenderer.h
@@ -174,25 +174,11 @@ public:
     double get_y_offset() const { return glyph_pos->y_offset / scale; }
     double get_x_advance() const { return glyph_pos->x_advance / scale; }
     double get_y_advance() const { return glyph_pos->y_advance / scale; }
+    ~GlyphData() { FT_Done_Glyph(glyph); }
 private:
     FT_Glyph glyph;
     unsigned int idx;
     hb_glyph_position_t *glyph_pos;
-  };
-
-  struct done_glyph {
-    void operator()(const GlyphData *glyph_data) {
-      FT_Done_Glyph(glyph_data->get_glyph());
-      delete glyph_data;
-    }
-  };
-
-  class GlyphArray : public std::vector<const GlyphData *>
-  {
-public:
-    virtual ~GlyphArray() {
-      std::for_each(begin(), end(), done_glyph());
-    }
   };
 
   class ShapeResults
@@ -203,7 +189,7 @@ public:
     // They have been downscaled from the 1e+5 unit size used for
     // when rendering from Freetype, and have not yet been scaled
     // back up to the desired font size.
-    GlyphArray glyph_array;
+    std::vector<GlyphData> glyph_array;
     double x_offset;
     double y_offset;
     double left;


### PR DESCRIPTION
- Avoiding redundant inheritance from `std::vector`
- Releasing resource in dtor, instead of external functor, should improve readability
- Straightforward memory allocation pattern: one chunk for all GlyphData of each `text` command. Technically I found a small difference in average runtime: from 34.5 to 33.9 seconds 734 symbols of 'Lorem ipsum" text, and J5040 CPU, but I believe it's not the main goal of this patch.