### PR TITLE
Update to github ci to migrate to node 16 compatible versions

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -29,7 +29,7 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
       with:
         # We must fetch at least the immediate parents so that if this is
         # a pull request then we can checkout the head.
@@ -40,7 +40,7 @@ jobs:
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v1
+      uses: github/codeql-action/init@v2
       with:
         languages: ${{ matrix.language }}
         # If you wish to specify custom queries, you can do so here or in a config file.
@@ -56,4 +56,4 @@ jobs:
       run: ./scripts/github-ci.sh build
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v1
+      uses: github/codeql-action/analyze@v2

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -24,7 +24,7 @@ jobs:
 
     steps:
     - name: Checkout
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
     - name: Submodules
       run: git submodule update --init --recursive
     - name: Install dependencies
@@ -34,7 +34,7 @@ jobs:
     - name: Build and test
       run: ./scripts/github-ci.sh build test coverage
     - name: Upload Test Result Report
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       if: ${{ always() }}
       with:
         name: Test Result Report (${{ matrix.os }})
@@ -42,7 +42,7 @@ jobs:
           b/tests/Testing/Temporary/*_report.html
           b/tests/Testing/Temporary/LastTest.log
     - name: Upload Code Coverage Report
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       with:
         name: Code Coverage Report (${{ matrix.os }})
         path: c/coverage*.html

--- a/.github/workflows/macos-release.yml
+++ b/.github/workflows/macos-release.yml
@@ -15,7 +15,7 @@ jobs:
       LIBRARIES_CACHE: libraries.tar.gz
     steps:
     - name: Checkout OpenSCAD
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
       with:
         submodules: 'recursive'
     - name: Install Homebrew packages
@@ -24,7 +24,7 @@ jobs:
         brew install automake meson
     - name: Cache Libraries
       id: cache-libraries
-      uses: actions/cache@v2
+      uses: actions/cache@v3
       with:
         path: ${{ env.OPENSCAD_LIBRARIES }}
         key: ${{ runner.os }}-libraries-1-${{ hashFiles('./scripts/macosx-build-dependencies.sh', '.github/workflows/macos-release.yml') }}
@@ -63,7 +63,7 @@ jobs:
       run: |
         ./scripts/macosx-sanity-check.py ./build/OpenSCAD.app/Contents/MacOS/OpenSCAD
     - name: Upload Artifacts
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       with:
         name: Build Artifacts
         path: ${{ runner.temp }}/out/

--- a/.github/workflows/macos-snapshot.yml.disabled
+++ b/.github/workflows/macos-snapshot.yml.disabled
@@ -15,7 +15,7 @@ jobs:
       LIBRARIES_CACHE: libraries.tar.gz
     steps:
     - name: Checkout OpenSCAD
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
       with:
         submodules: 'recursive'
     - name: Install Homebrew packages
@@ -24,7 +24,7 @@ jobs:
         brew install automake meson
     - name: Cache Libraries
       id: cache-libraries
-      uses: actions/cache@v2
+      uses: actions/cache@v3
       with:
         path: ${{ env.OPENSCAD_LIBRARIES }}
         key: ${{ runner.os }}-libraries2-${{ hashFiles('./scripts/macosx-build-dependencies.sh', '.github/workflows/macos-release.yml') }}
@@ -63,7 +63,7 @@ jobs:
       run: |
         ./scripts/macosx-sanity-check.py ./build/OpenSCAD.app/Contents/MacOS/OpenSCAD
     - name: Upload Artifacts
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       with:
         name: Build Artifacts
         path: ${{ runner.temp }}/out/

--- a/.github/workflows/macos-tests.yml
+++ b/.github/workflows/macos-tests.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: macos-latest
     steps:
     - name: Checkout
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
       with:
         submodules: 'recursive'
     - name: Install Homebrew packages
@@ -32,7 +32,7 @@ jobs:
         export NUMCPU=$(($(sysctl -n hw.ncpu) * 3 / 2))
         ctest -j$NUMCPU -E 'edges_view-options-tests|nef3_broken'
     - name: Upload Test Result Report
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       with:
         name: Test Result Report (MacOS)
         path: |

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -14,7 +14,7 @@ jobs:
         shell: msys2 {0}
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Setup MSYS2 Environment
         uses: msys2/setup-msys2@v2
         with:
@@ -37,7 +37,7 @@ jobs:
           cd tests
           ctest -j2 -E 'opencsgtest_issue1165|opencsgtest_issue1215|throwntogethertest_issue1089|throwntogethertest_issue1215|openscad-nonascii|import_3mf|3mfpngtest|3mfexport|pdfexporttest_centered'
       - name: Upload Test Result Report
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         if: ${{ always() }}
         with:
           name: Test Result Report (Windows)


### PR DESCRIPTION
inline with the blog entry below project CI is generating warnings relating to the soon to be deprecated node runtime.
project ci files checked for uses: clauses and updated where current imported actions were using node 12 runtime.
https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/

