### PR TITLE
Add missing include to SpaceNavInputDriver.cc

### DIFF
--- a/src/gui/input/SpaceNavInputDriver.cc
+++ b/src/gui/input/SpaceNavInputDriver.cc
@@ -31,6 +31,7 @@
 
 #include "input/SpaceNavInputDriver.h"
 #include "input/InputDriverManager.h"
+#include "utils/printutils.h"
 
 #include <spnav.h>
 #include <unistd.h>


### PR DESCRIPTION
Adds #include "utils/printutils.h" to fix build issue. 

Thanks Peepsalot on IRC for the actual fix!