### PR TITLE
Copy over the Save As's manual overwrite check to Save a Copy

### DIFF
--- a/src/gui/TabManager.cc
+++ b/src/gui/TabManager.cc
@@ -729,6 +729,16 @@ bool TabManager::saveACopy(EditorInterface *edt)
 
   if (QFileInfo(filename).suffix().isEmpty()) {
     filename.append(".scad");
+
+    // Manual overwrite check since Qt doesn't do it, when using the
+    // defaultSuffix property
+    const QFileInfo info(filename);
+    if (info.exists()) {
+        const auto text = QString(_("%1 already exists.\nDo you want to replace it?")).arg(info.fileName());
+        if (QMessageBox::warning(par, par->windowTitle(), text, QMessageBox::Yes | QMessageBox::No, QMessageBox::No) != QMessageBox::Yes) {
+        return false;
+        }
+    }
   }
 
   return save(edt, filename);


### PR DESCRIPTION
Closes #4397 

I did some manual local tests and it appears that Save a Copy is functioning as expected now. However, it would help if someone else can do their own checks as well before this is merged.