### PR TITLE
Remove qt5-default from CodeQL CI

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -51,7 +51,7 @@ jobs:
     - name: Install dependencies
       run: ./scripts/travis-ci-before-install-linux.sh bionic
     - name: Dependency fixup
-      run: sudo apt-get install qt5-default gettext
+      run: sudo apt-get install gettext
     - name: Build
       run: ./scripts/github-ci.sh build
 


### PR DESCRIPTION
OS has been updated from Ubuntu 20.04 to 22.04, which does not contain `qt5-default` package.