### PR TITLE
Rough distance measurement function

### DIFF
--- a/src/gui/QGLView.cc
+++ b/src/gui/QGLView.cc
@@ -174,6 +174,49 @@ void QGLView::mousePressEvent(QMouseEvent *event)
   last_mouse = event->globalPos();
 }
 
+bool firstPoint = true;
+
+void measureDist(GLdouble px, GLdouble py, GLdouble pz){
+  static float firstx, firsty, firstz;
+  float deltax, deltay, deltaz, deltadistance;
+  float secondx, secondy, secondz;
+  if(firstPoint){
+    firstx = px;
+    firsty = py;
+    firstz = pz;
+    glBegin(GL_LINES);
+    glVertex3f(firstx-1, firsty, firstz);
+    glVertex3f(firstx+1, firsty, firstz);
+    glVertex3f(firstx, firsty+1, firstz);
+    glVertex3f(firstx, firsty-1, firstz);
+    glVertex3f(firstx, firsty, firstz+1);
+    glVertex3f(firstx, firsty, firstz-1);
+    glEnd();
+    LOG(message_group::None, Location::NONE, "", "first point stored, select second point");
+    firstPoint = false;
+    return;
+  }else{
+    secondx = px;
+    secondy = py;
+    secondz = pz;
+    glBegin(GL_LINES);
+    glVertex3f(secondx-1, secondy, secondz);
+    glVertex3f(secondx+1, secondy, secondz);
+    glVertex3f(secondx, secondy+1, secondz);
+    glVertex3f(secondx, secondy-1, secondz);
+    glVertex3f(secondx, secondy, secondz+1);
+    glVertex3f(secondx, secondy, secondz-1);
+    glVertex3f(firstx, firsty, firstz);
+    glVertex3f(secondx, secondy, secondz);
+    glEnd(); 
+    deltax=px-firstx;
+    deltay=py-firsty;
+    deltaz=pz-firstz;
+    deltadistance=sqrt(pow(deltax,2)+pow(deltay,2)+pow(deltaz,2));
+    LOG(message_group::None, Location::NONE, "", "distance x=: %1$.4f  y=: %2$.4f   z=: %3$.4f  Total= %4$.4f",deltax,deltay,deltaz, deltadistance);
+    firstPoint = true;
+  }
+}
 /*
  * Voodoo warning...
  *
@@ -254,10 +297,15 @@ void QGLView::mouseDoubleClickEvent(QMouseEvent *event) {
   auto success = gluUnProject(x, y, z, modelview, projection, viewport, &px, &py, &pz);
 
   if (success == GL_TRUE) {
-    cam.object_trans -= Vector3d(px, py, pz);
-    update();
-    emit cameraChanged();
-  }
+    LOG(message_group::None, Location::NONE, "", "Model coordinates: x=: %1$.4f  y=: %2$.4f   z=: %3$.4f",px,py, pz);  //debugging
+    if ((QApplication::keyboardModifiers() & Qt::ShiftModifier) != 0) {
+      measureDist(px,py,pz);
+      }else{
+      cam.object_trans -= Vector3d(px, py, pz);
+      update();
+      emit cameraChanged();
+      }
+    }
   setGLContext(oldContext);
 }
 


### PR DESCRIPTION
This is a rough draft of a distance measurement function.  You can Shift-double-click at 2 points on the model and get an approximate distance in the Log. It works in the preview, and after a render.

How it works: The existing QGLView::mouseDoubleClickEvent(QMouseEvent *event) function provides the screen x and y coordinates of any doubleclick event and then finds the z cordinate with glReadPixels().  These x, y,and z are in screen coordinates which are no good for measuring, but that same event function converts these to model coordinates with gluUnProject().  You can use these model coordinates to measure, but they are only approximate, +/- a pixel width I think.  If you zoom in and click, you get higher accuracy.

The existing DoubleClickEvent function then moves the center of rotation of the model to the doubleclicked location.  I added an if/else at this point: if the shift key is held down while doubleclicking, it calls a new function: void measureDist(GLdouble px, GLdouble py, GLdouble pz), else it continues with the existing code.

The new measureDist() saves the coordinates on the first shift-doubleclick and puts a crosshairs on the location, then if you shift-doubleclick again, it subtracts the old coordinates from the new, does the pythagorean calculation and prints the result to the log.

It still needs a lot of work, but at this point I'd like some advice on if I am on a good track, or if anyone else is working on this or a better solution, or if anyone wants to help with this development. 