### PR TITLE
Allow touch-pad friendly 3D navigation

### DIFF
--- a/src/gui/QGLView.cc
+++ b/src/gui/QGLView.cc
@@ -278,6 +278,8 @@ void QGLView::mouseMoveEvent(QMouseEvent *event)
     if (event->buttons() & button_compare
 #ifdef Q_OS_MAC
         && !(event->modifiers() & Qt::MetaModifier)
+#elif !defined(_WIN32)
+       && !QApplication::keyboardModifiers().testFlag(Qt::ControlModifier)
 #endif
         ) {
       // Left button rotates in xz, Shift-left rotates in xy


### PR DESCRIPTION
issue #4297, only changes the behaviour of mouse/touchpad on Liunx systems:

This patch changes <ctrl> left mouse drag  to pan the 3d view, while &lt;ctrl>-&lt;shift> left mouse drag  zooms. Without this patch the view gets rotated in both cases.

This helps in particular with touchpads as Linux does not support right-click and drag with the touchpad in most windows managers.