### PR TITLE
Added linear_extrude(1) to render 3D shape instead of 2D shape

### DIFF
--- a/examples/Advanced/module_recursion.scad
+++ b/examples/Advanced/module_recursion.scad
@@ -38,7 +38,7 @@ module tree(length, thickness, count, m = identity, r = 1) {
     }
 }
 
-tree(len, thickness, levels);
+linear_extrude(1) tree(len, thickness, levels);
 
 echo(version=version());
 // Written in 2015 by Torsten Paul <Torsten.Paul@gmx.de>

--- a/examples/Functions/list_comprehensions.scad
+++ b/examples/Functions/list_comprehensions.scad
@@ -7,9 +7,11 @@ module ngon(num, r) {
   polygon([for (i=[0:num-1], a=i*360/num) [ r*cos(a), r*sin(a) ]]);
 }
 
-ngon(3, 10);
-translate([20,0]) ngon(6, 8);
-translate([36,0]) ngon(10, 6);
+linear_extrude(1){
+	ngon(3, 10);
+	translate([20,0]) ngon(6, 8);
+	translate([36,0]) ngon(10, 6);
+}
 
 // More complex list comprehension:
 // Similar to ngon(), but uses an inner function to calculate
@@ -19,9 +21,11 @@ module rounded_ngon(num, r, rounding = 0) {
   polygon([for (a=[0:360-1]) v(a) + rounding*[cos(a),sin(a)]]);
 }
 
-translate([0,22]) rounded_ngon(3, 10, 5);
-translate([20,22]) rounded_ngon(6, 8, 4);
-translate([36,22]) rounded_ngon(10, 6, 3);
+linear_extrude(1){
+	translate([0,22]) rounded_ngon(3, 10, 5);
+	translate([20,22]) rounded_ngon(6, 8, 4);
+	translate([36,22]) rounded_ngon(10, 6, 3);
+}
 
 // Gear/star generator
 // Uses a list comprehension taking a list of radii to generate a star shape
@@ -30,9 +34,11 @@ module star(num, radii) {
   polygon([for (i=[0:num-1], a=i*360/num, r=radii[i%len(radii)]) [ r*cos(a), r*sin(a) ]]);
 }
 
-translate([0,44]) star(20, [6,10]);
-translate([20,44]) star(40, [6,8,8,6]);
-translate([36,44]) star(30, [3,4,5,6,5,4]);
+linear_extrude(1){
+	translate([0,44]) star(20, [6,10]);
+	translate([20,44]) star(40, [6,8,8,6]);
+	translate([36,44]) star(30, [3,4,5,6,5,4]);
+}
 
 echo(version=version());
 // Written by Marius Kintel <marius@kintel.net>

--- a/examples/Functions/polygon_areas.scad
+++ b/examples/Functions/polygon_areas.scad
@@ -1,12 +1,14 @@
 // polygon_areas.scad: Another recursion example 
 
 // Draw all geometry
-translate([0,20]) color("Red") text("Areas:", size=8, halign="center");
-translate([-44,0]) shapeWithArea(3, 10);
-translate([-22,0]) shapeWithArea(4, 10);
-translate([0,0]) shapeWithArea(6, 10);
-translate([22,0]) shapeWithArea(10, 10);
-translate([44,0]) shapeWithArea(360, 10);
+linear_extrude(1){
+	translate([0,20]) color("Red") text("Areas:", size=8, halign="center");
+	translate([-44,0]) shapeWithArea(3, 10);
+	translate([-22,0]) shapeWithArea(4, 10);
+	translate([0,0]) shapeWithArea(6, 10);
+	translate([22,0]) shapeWithArea(10, 10);
+	translate([44,0]) shapeWithArea(360, 10);
+}
 
 // One shape with corresponding text
 module shapeWithArea(num, r) {

--- a/examples/Functions/recursion.scad
+++ b/examples/Functions/recursion.scad
@@ -10,7 +10,7 @@
 // some time when OpenSCAD detects the endless recursive call.
 function factorial(n) = n == 0 ? 1 : factorial(n - 1) * n;
 
-color("cyan") text(str("6! = ", factorial(6)), halign = "center");
+linear_extrude(1) color("cyan") text(str("6! = ", factorial(6)), halign = "center");
 
 echo(version=version());
 // Written in 2015 by Torsten Paul <Torsten.Paul@gmx.de>


### PR DESCRIPTION
Updated examples to use linear_extrude so that F6 renders a 3D shape instead of a 2D shape