### PR TITLE
Improve display name of github actions

### DIFF
--- a/.github/workflows/macos-release.yml
+++ b/.github/workflows/macos-release.yml
@@ -10,6 +10,7 @@ on:
 jobs:
   build:
     runs-on: macos-11
+    name: macos-11-release
     env:
       OPENSCAD_LIBRARIES: /Users/runner/work/openscad/libraries/install/
       LIBRARIES_CACHE: libraries.tar.gz

--- a/.github/workflows/macos-tests.yml
+++ b/.github/workflows/macos-tests.yml
@@ -9,6 +9,7 @@ on:
 jobs:
   build:
     runs-on: macos-latest
+    name: macos-latest
     steps:
     - name: Checkout
       uses: actions/checkout@v3

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -9,6 +9,7 @@ on:
 jobs:
   build:
     runs-on: windows-latest
+    name: windows-latest
     defaults:
       run:
         shell: msys2 {0}


### PR DESCRIPTION
A couple of existing actions are just displayed as "build"; this will show which platform the actions are for.