### PR TITLE
Fixes for many clang-tidy `bugprone-*` checks

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,11 +1,16 @@
 Checks: '
   -*,
-  modernize-*,
-    -modernize-use-trailing-return-type,
-    -modernize-avoid-c-arrays,
-    -modernize-use-nodiscard,
+  bugprone-*,
+    -bugprone-easily-swappable-parameters,
+    -bugprone-exception-escape,
+    -bugprone-narrowing-conversions,
+    -bugprone-reserved-identifier,
   clang-analyzer-*,
     -clang-analyzer-cplusplus.NewDelete,
     -clang-analyzer-cplusplus.NewDeleteLeaks,
+  modernize-*,
+    -modernize-avoid-c-arrays,
+    -modernize-use-nodiscard,
+    -modernize-use-trailing-return-type,
 '
 WarningsAsErrors: ''

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -4,7 +4,6 @@ Checks: '
     -bugprone-easily-swappable-parameters,
     -bugprone-exception-escape,
     -bugprone-narrowing-conversions,
-    -bugprone-reserved-identifier,
   clang-analyzer-*,
     -clang-analyzer-cplusplus.NewDelete,
     -clang-analyzer-cplusplus.NewDeleteLeaks,

--- a/src/LibraryInfo.cc
+++ b/src/LibraryInfo.cc
@@ -22,7 +22,7 @@
 #define GCC_INT_VERSION (__GNUC__ * 10000 + __GNUC_MINOR__ * 100)
 #if GCC_INT_VERSION > 40600 || defined(__clang__)
 #include <cxxabi.h>
-#define __openscad_info_demangle__ 1
+#define openscad_info_demangle_ 1
 #endif // GCC_INT_VERSION
 #endif // GNUG
 #endif // ENABLE_CGAL
@@ -97,7 +97,7 @@ std::string LibraryInfo::info()
   std::string cgal_3d_kernel = typeid(CGAL_Kernel3).name();
   std::string cgal_2d_kernel = typeid(CGAL_Kernel2).name();
   std::string cgal_2d_kernelEx = typeid(CGAL_ExactKernel2).name();
-#if defined(__openscad_info_demangle__)
+#if defined(openscad_info_demangle_)
   int status;
   cgal_3d_kernel = std::string(abi::__cxa_demangle(cgal_3d_kernel.c_str(), nullptr, nullptr, &status) );
   cgal_2d_kernel = std::string(abi::__cxa_demangle(cgal_2d_kernel.c_str(), nullptr, nullptr, &status) );

--- a/src/core/BuiltinContext.cc
+++ b/src/core/BuiltinContext.cc
@@ -1,3 +1,4 @@
+// NOLINTNEXTLINE(bugprone-reserved-identifier)
 #define _USE_MATH_DEFINES
 #include <cmath>
 

--- a/src/core/CgalAdvNode.h
+++ b/src/core/CgalAdvNode.h
@@ -15,12 +15,11 @@ class CgalAdvNode : public AbstractNode
 public:
   VISITABLE();
   CgalAdvNode(const ModuleInstantiation *mi, CgalAdvType type) : AbstractNode(mi), type(type) {
-    convexity = 1;
   }
   std::string toString() const override;
   std::string name() const override;
 
-  unsigned int convexity;
+  unsigned int convexity{1};
   Vector3d newsize;
   Eigen::Matrix<bool, 3, 1> autosize;
   CgalAdvType type;

--- a/src/core/FreetypeRenderer.cc
+++ b/src/core/FreetypeRenderer.cc
@@ -40,7 +40,7 @@
 #include "calc.h"
 
 #include FT_OUTLINE_H
-
+// NOLINTNEXTLINE(bugprone-macro-parentheses)
 #define SCRIPT_UNTAG(tag)   ((uint8_t)((tag) >> 24)) % ((uint8_t)((tag) >> 16)) % ((uint8_t)((tag) >> 8)) % ((uint8_t)(tag))
 
 static inline Vector2d get_scaled_vector(const FT_Vector *ft_vector, double scale) {

--- a/src/core/FreetypeRenderer.cc
+++ b/src/core/FreetypeRenderer.cc
@@ -252,7 +252,7 @@ void FreetypeRenderer::Params::detect_properties()
   // by using a fraction of the number of full circle segments
   // the resolution will be better matching the detail level of
   // other objects.
-  auto text_segments = std::max(floor(segments / 8) + 1, 2.0);
+  auto text_segments = std::max(segments / 8 + 1, 2);
   set_segments(text_segments);
 }
 

--- a/src/core/FreetypeRenderer.h
+++ b/src/core/FreetypeRenderer.h
@@ -56,7 +56,7 @@ public:
     void set_fs(double fs) {
       this->fs = fs;
     }
-    void set_segments(double segments) {
+    void set_segments(unsigned int segments) {
       this->segments = segments;
     }
     void set_text(const std::string& text) {
@@ -105,7 +105,8 @@ public:
              << ", $fs = " << params.fs;
     }
 private:
-    double size, spacing, fn, fa, fs, segments;
+    double size, spacing, fn, fa, fs;
+    unsigned int segments;
     std::string text, font, direction, language, script, halign, valign;
     Location loc = Location::NONE;
     std::string documentPath = "";

--- a/src/core/SurfaceNode.cc
+++ b/src/core/SurfaceNode.cc
@@ -137,7 +137,7 @@ void SurfaceNode::convert_image(img_data_t& data, std::vector<uint8_t>& img, uns
   double min_val = 200;
   for (unsigned int y = 0; y < height; ++y) {
     for (unsigned int x = 0; x < width; ++x) {
-      long idx = 4 * (y * width + x);
+      long idx = 4l * (y * width + x);
       double pixel = 0.2126 * img[idx] + 0.7152 * img[idx + 1] + 0.0722 * img[idx + 2];
       double z = 100.0 / 255 * (invert ? 1 - pixel : pixel);
       data[ x + (width * (height - 1 - y)) ] = z;

--- a/src/core/TextNode.cc
+++ b/src/core/TextNode.cc
@@ -46,6 +46,7 @@ static std::shared_ptr<AbstractNode> builtin_text(const ModuleInstantiation *ins
 
   auto node = std::make_shared<TextNode>(inst);
 
+  auto *session = arguments.session();
   Parameters parameters = Parameters::parse(std::move(arguments), inst->location(),
                                             {"text", "size", "font"},
                                             {"direction", "language", "script", "halign", "valign", "spacing"}
@@ -53,8 +54,7 @@ static std::shared_ptr<AbstractNode> builtin_text(const ModuleInstantiation *ins
   parameters.set_caller("text");
 
   node->params.set_loc(inst->location());
-  node->params.set_documentPath(arguments.documentRoot());
-
+  node->params.set_documentPath(session->documentRoot());
   node->params.set(parameters);
   node->params.detect_properties();
 

--- a/src/core/TransformNode.cc
+++ b/src/core/TransformNode.cc
@@ -89,19 +89,19 @@ std::shared_ptr<AbstractNode> builtin_rotate(const ModuleInstantiation *inst, Ar
     switch (vec_a.size()) {
     default:
       ok &= false;
-    /* fallthrough */
+      [[fallthrough]];
     case 3:
       ok &= vec_a[2].getDouble(a);
       ok &= !std::isinf(a) && !std::isnan(a);
       sz = sin_degrees(a);
       cz = cos_degrees(a);
-    /* fallthrough */
+      [[fallthrough]];
     case 2:
       ok &= vec_a[1].getDouble(a);
       ok &= !std::isinf(a) && !std::isnan(a);
       sy = sin_degrees(a);
       cy = cos_degrees(a);
-    /* fallthrough */
+      [[fallthrough]];
     case 1:
       ok &= vec_a[0].getDouble(a);
       ok &= !std::isinf(a) && !std::isnan(a);

--- a/src/core/Value.cc
+++ b/src/core/Value.cc
@@ -50,23 +50,23 @@ const VectorType VectorType::EMPTY(nullptr);
 const RangeType RangeType::EMPTY{0, 0, 0};
 
 /* Define values for double-conversion library. */
-#define DC_BUFFER_SIZE 128
+#define DC_BUFFER_SIZE (128)
 #define DC_FLAGS (double_conversion::DoubleToStringConverter::UNIQUE_ZERO | double_conversion::DoubleToStringConverter::EMIT_POSITIVE_EXPONENT_SIGN)
 #define DC_INF "inf"
 #define DC_NAN "nan"
 #define DC_EXP 'e'
-#define DC_DECIMAL_LOW_EXP -6
-#define DC_DECIMAL_HIGH_EXP 21
-#define DC_MAX_LEADING_ZEROES 5
-#define DC_MAX_TRAILING_ZEROES 0
+#define DC_DECIMAL_LOW_EXP (-6)
+#define DC_DECIMAL_HIGH_EXP (21)
+#define DC_MAX_LEADING_ZEROES (5)
+#define DC_MAX_TRAILING_ZEROES (0)
 
 /* WARNING: using values > 8 will significantly slow double to string
  * conversion, defeating the purpose of using double-conversion library */
-#define DC_PRECISION_REQUESTED 6
+#define DC_PRECISION_REQUESTED (6)
 
 //private definitions used by trimTrailingZeroesHelper
-#define TRIM_TRAILINGZEROES_DONE 0
-#define TRIM_TRAILINGZEROES_CONTINUE 1
+#define TRIM_TRAILINGZEROES_DONE (0)
+#define TRIM_TRAILINGZEROES_CONTINUE (1)
 
 //process parameter buffer from the end to start to find out where the zeroes are located (if any).
 //parameter pos shall be the pos in buffer where '\0' is located.

--- a/src/core/Value.cc
+++ b/src/core/Value.cc
@@ -1340,7 +1340,7 @@ const Value& ObjectType::get(const std::string& key) const
 
 void ObjectType::set(const std::string& key, Value&& value)
 {
-  ptr->map.emplace(key, std::move(value));
+  ptr->map.emplace(key, value.clone());
   ptr->keys.emplace_back(key);
   ptr->values.emplace_back(std::move(value));
 }

--- a/src/core/Value.cc
+++ b/src/core/Value.cc
@@ -1245,7 +1245,6 @@ RangeType::iterator::iterator(const RangeType& range, iter_state state) : range(
 {
   if (std::isnan(range.begin_val) || std::isnan(range.end_val) ||
       std::isnan(range.step_val) || range.step_val == 0) {
-    state = iter_state::RANGE_END;
     i_step = num_values;
   }
   update_state();

--- a/src/core/Value.h
+++ b/src/core/Value.h
@@ -43,12 +43,11 @@ private:
   double begin_val;
   double step_val;
   double end_val;
+  enum class iter_state { RANGE_BEGIN, RANGE_RUNNING, RANGE_END };
 
 public:
   static constexpr uint32_t MAX_RANGE_STEPS = 10000;
   static const RangeType EMPTY;
-
-  enum class type_t { RANGE_TYPE_BEGIN, RANGE_TYPE_RUNNING, RANGE_TYPE_END };
 
   class iterator
   {
@@ -59,7 +58,7 @@ public:
     using difference_type = void; // type used by operator-(iterator), not implemented for forward iterator
     using reference = value_type; // type used by operator*(), not actually a reference
     using pointer = void;     // type used by operator->(), not implemented
-    iterator(const RangeType& range, type_t type);
+    iterator(const RangeType& range, iter_state type);
     iterator& operator++();
     reference operator*();
     bool operator==(const iterator& other) const;
@@ -67,10 +66,10 @@ public:
 private:
     const RangeType& range;
     double val;
-    type_t type;
+    iter_state state;
     const uint32_t num_values;
     uint32_t i_step;
-    void update_type();
+    void update_state();
   };
 
   RangeType(const RangeType&) = delete;       // never copy, move instead
@@ -148,8 +147,8 @@ private:
   [[nodiscard]] double step_value() const { return step_val; }
   [[nodiscard]] double end_value() const { return end_val; }
 
-  [[nodiscard]] iterator begin() const { return {*this, type_t::RANGE_TYPE_BEGIN}; }
-  [[nodiscard]] iterator end() const { return {*this, type_t::RANGE_TYPE_END}; }
+  [[nodiscard]] iterator begin() const { return {*this, iter_state::RANGE_BEGIN}; }
+  [[nodiscard]] iterator end() const { return {*this, iter_state::RANGE_END}; }
 
   /// return number of values, max uint32_t value if step is 0 or range is infinite
   [[nodiscard]] uint32_t numValues() const;
@@ -587,7 +586,7 @@ public:
   [[nodiscard]] std::string toString() const;
   [[nodiscard]] std::string toEchoString() const;
   [[nodiscard]] std::string toEchoStringNoThrow() const; //use this for warnings
-  const UndefType& toUndef();
+  [[nodiscard]] const UndefType& toUndef() const;
   [[nodiscard]] std::string toUndefString() const;
   [[nodiscard]] std::string chrString() const;
   bool getVec2(double& x, double& y, bool ignoreInfinite = false) const;

--- a/src/core/Value.h
+++ b/src/core/Value.h
@@ -248,7 +248,7 @@ private:
 
   [[nodiscard]] glong get_utf8_strlen() const {
     if (str_ptr->u8len == str_utf8_t::LENGTH_UNKNOWN) {
-      str_ptr->u8len = g_utf8_strlen(str_ptr->u8str.c_str(), str_ptr->u8str.size());
+      str_ptr->u8len = g_utf8_strlen(str_ptr->u8str.c_str(), static_cast<gssize>(str_ptr->u8str.size()));
     }
     return str_ptr->u8len;
   }
@@ -452,7 +452,7 @@ public:
           }
           check_and_push();
         } else { // vo->vec is flat
-          it = vo->vec.begin() + index;
+          it = vo->vec.begin() + static_cast<vec_t::iterator::difference_type>(index);
         }
         return *this;
       }

--- a/src/core/builtin_functions.cc
+++ b/src/core/builtin_functions.cc
@@ -782,6 +782,7 @@ Value builtin_cross(Arguments arguments, const Location& loc)
 
 Value builtin_textmetrics(Arguments arguments, const Location& loc)
 {
+  auto *session = arguments.session();
   Parameters parameters = Parameters::parse(std::move(arguments), loc,
                                             { "text", "size", "font" },
                                             { "direction", "language", "script", "halign", "valign", "spacing" }
@@ -790,7 +791,7 @@ Value builtin_textmetrics(Arguments arguments, const Location& loc)
 
   FreetypeRenderer::Params ftparams;
   ftparams.set_loc(loc);
-  ftparams.set_documentPath(arguments.documentRoot());
+  ftparams.set_documentPath(session->documentRoot());
   ftparams.set(parameters);
   ftparams.detect_properties();
 
@@ -801,25 +802,25 @@ Value builtin_textmetrics(Arguments arguments, const Location& loc)
 
   // The bounding box, ascent/descent, and offset values will be zero
   // if the text consists of nothing but whitespace.
-  VectorType bbox_pos(arguments.session());
+  VectorType bbox_pos(session);
   bbox_pos.emplace_back(metrics.bbox_x);
   bbox_pos.emplace_back(metrics.bbox_y);
 
-  VectorType bbox_dims(arguments.session());
+  VectorType bbox_dims(session);
   bbox_dims.emplace_back(metrics.bbox_w);
   bbox_dims.emplace_back(metrics.bbox_h);
 
-  VectorType offset(arguments.session());
+  VectorType offset(session);
   offset.emplace_back(metrics.x_offset);
   offset.emplace_back(metrics.y_offset);
 
   // The advance values are valid whether or not the text
   // is whitespace.
-  VectorType advance(arguments.session());
+  VectorType advance(session);
   advance.emplace_back(metrics.advance_x);
   advance.emplace_back(metrics.advance_y);
 
-  ObjectType text_metrics(arguments.session());
+  ObjectType text_metrics(session);
   text_metrics.set("position", std::move(bbox_pos));
   text_metrics.set("size", std::move(bbox_dims));
   text_metrics.set("ascent", metrics.ascent);
@@ -831,6 +832,7 @@ Value builtin_textmetrics(Arguments arguments, const Location& loc)
 
 Value builtin_fontmetrics(Arguments arguments, const Location& loc)
 {
+  auto *session = arguments.session();
   Parameters parameters = Parameters::parse(std::move(arguments), loc,
                                             { "size", "font" }
                                             );
@@ -838,7 +840,7 @@ Value builtin_fontmetrics(Arguments arguments, const Location& loc)
 
   FreetypeRenderer::Params ftparams;
   ftparams.set_loc(loc);
-  ftparams.set_documentPath(arguments.documentRoot());
+  ftparams.set_documentPath(session->documentRoot());
   ftparams.set(parameters);
   ftparams.detect_properties();
 
@@ -847,19 +849,19 @@ Value builtin_fontmetrics(Arguments arguments, const Location& loc)
     return Value::undefined.clone();
   }
 
-  ObjectType nominal(arguments.session());
+  ObjectType nominal(session);
   nominal.set("ascent", metrics.nominal_ascent);
   nominal.set("descent", metrics.nominal_descent);
 
-  ObjectType max(arguments.session());
+  ObjectType max(session);
   max.set("ascent", metrics.max_ascent);
   max.set("descent", metrics.max_descent);
 
-  ObjectType font(arguments.session());
+  ObjectType font(session);
   font.set("family", metrics.family_name);
   font.set("style", metrics.style_name);
 
-  ObjectType font_metrics(arguments.session());
+  ObjectType font_metrics(session);
   font_metrics.set("nominal", nominal);
   font_metrics.set("max", max);
   font_metrics.set("interline", metrics.interline);

--- a/src/core/builtin_functions.cc
+++ b/src/core/builtin_functions.cc
@@ -661,10 +661,9 @@ Value builtin_search(Arguments arguments, const Location& loc)
         }
         ++j;
       }
-      if (num_returns_per_match == 1 && matchCount == 0) {
-        returnvec.emplace_back(std::move(resultvec));
-      }
-      if (num_returns_per_match == 0 || num_returns_per_match > 1) {
+      if ((num_returns_per_match == 1 && matchCount == 0) ||
+          num_returns_per_match == 0 ||
+          num_returns_per_match > 1) {
         returnvec.emplace_back(std::move(resultvec));
       }
     }

--- a/src/core/customizer/ParameterObject.cc
+++ b/src/core/customizer/ParameterObject.cc
@@ -152,7 +152,8 @@ bool VectorParameter::importValue(boost::property_tree::ptree encodedValue, bool
 {
   std::vector<double> decoded;
 
-  std::string encoded = boost::algorithm::replace_all_copy(encodedValue.data(), " ", "");
+  // NOLINTBEGIN(*NewDeleteLeaks) LLVM bug https://github.com/llvm/llvm-project/issues/40486
+  std::string encoded = boost::algorithm::erase_all_copy(encodedValue.data(), " ");
   if (encoded.size() < 2 || encoded[0] != '[' || encoded[encoded.size() - 1] != ']') {
     return false;
   }
@@ -161,6 +162,7 @@ bool VectorParameter::importValue(boost::property_tree::ptree encodedValue, bool
 
   std::vector<std::string> items;
   boost::algorithm::split(items, encoded, boost::algorithm::is_any_of(","));
+  // NOLINTEND(*NewDeleteLeaks)
 
   for (const std::string& item : items) {
     std::stringstream stream(item);

--- a/src/core/parsersettings.cc
+++ b/src/core/parsersettings.cc
@@ -75,7 +75,7 @@ static bool check_valid(const fs::path& p, const std::vector<std::string> *openf
    Returns the absolute path to a valid file, or an empty path if no
    valid files could be found.
  */
-fs::path _find_valid_path(const fs::path& sourcepath,
+inline fs::path find_valid_path_(const fs::path& sourcepath,
                           const fs::path& localpath,
                           const std::vector<std::string> *openfilenames)
 {
@@ -95,7 +95,7 @@ fs::path find_valid_path(const fs::path& sourcepath,
                          const fs::path& localpath,
                          const std::vector<std::string> *openfilenames)
 {
-  return {_find_valid_path(sourcepath, localpath, openfilenames).generic_string()};
+  return {find_valid_path_(sourcepath, localpath, openfilenames).generic_string()};
 }
 
 

--- a/src/core/progress.cc
+++ b/src/core/progress.cc
@@ -2,7 +2,7 @@
 #include "node.h"
 
 int progress_report_count;
-int _progress_mark;
+int progress_mark_;
 void (*progress_report_f)(const std::shared_ptr<const AbstractNode> &, void *, int);
 void *progress_report_userdata;
 
@@ -24,12 +24,12 @@ void progress_report_fin()
 void progress_update(const std::shared_ptr<const AbstractNode> &node, int mark)
 {
   if (progress_report_f) {
-    _progress_mark = mark;
-    progress_report_f(node, progress_report_userdata, _progress_mark);
+    progress_mark_ = mark;
+    progress_report_f(node, progress_report_userdata, progress_mark_);
   }
 }
 
 void progress_tick()
 {
-  if (progress_report_f) progress_report_f(std::shared_ptr<const AbstractNode>(), progress_report_userdata, ++_progress_mark);
+  if (progress_report_f) progress_report_f(std::shared_ptr<const AbstractNode>(), progress_report_userdata, ++progress_mark_);
 }

--- a/src/geometry/ClipperUtils.cc
+++ b/src/geometry/ClipperUtils.cc
@@ -48,7 +48,8 @@ ClipperLib::Paths fromPolygon2d(const Polygon2d& poly, int pow2)
 AutoScaled<ClipperLib::Paths> fromPolygon2d(const Polygon2d& poly)
 {
   auto b = poly.getBoundingBox();
-  return {fromPolygon2d(poly, ClipperUtils::getScalePow2(b)), std::move(b)};
+  auto scale = ClipperUtils::getScalePow2(b);
+  return {fromPolygon2d(poly, scale), std::move(b)};
 }
 
 ClipperLib::PolyTree sanitize(const ClipperLib::Paths& paths)

--- a/src/geometry/Geometry.h
+++ b/src/geometry/Geometry.h
@@ -22,6 +22,10 @@ public:
   using Geometries = std::list<GeometryItem>;
 
   Geometry() = default;
+  Geometry(const Geometry&) = default;
+  Geometry& operator=(const Geometry&) = default;
+  Geometry(Geometry&&) = default;
+  Geometry& operator=(Geometry&&) = default;
   virtual ~Geometry() = default;
 
   [[nodiscard]] virtual size_t memsize() const = 0;

--- a/src/geometry/GeometryCache.cc
+++ b/src/geometry/GeometryCache.cc
@@ -45,12 +45,12 @@ size_t GeometryCache::totalCost() const
 
 size_t GeometryCache::maxSizeMB() const
 {
-  return this->cache.maxCost() / (1024 * 1024);
+  return this->cache.maxCost() / (1024ul * 1024ul);
 }
 
 void GeometryCache::setMaxSizeMB(size_t limit)
 {
-  this->cache.setMaxCost(limit * 1024 * 1024);
+  this->cache.setMaxCost(limit * 1024ul * 1024ul);
 }
 
 void GeometryCache::print()

--- a/src/geometry/GeometryCache.h
+++ b/src/geometry/GeometryCache.h
@@ -7,7 +7,7 @@
 class GeometryCache
 {
 public:
-  GeometryCache(size_t memorylimit = 100 *1024 *1024) : cache(memorylimit) {}
+  GeometryCache(size_t memorylimit = 100ul * 1024ul * 1024ul) : cache(memorylimit) {}
 
   static GeometryCache *instance() { if (!inst) inst = new GeometryCache; return inst; }
 

--- a/src/geometry/GeometryEvaluator.cc
+++ b/src/geometry/GeometryEvaluator.cc
@@ -1529,7 +1529,7 @@ Response GeometryEvaluator::visit(State& state, const AbstractIntersectionNode& 
 
 static Geometry *roofOverPolygon(const RoofNode& node, const Polygon2d& poly)
 {
-  PolySet *roof;
+  PolySet *roof = nullptr;
   if (node.method == "voronoi") {
     roof = roof_vd::voronoi_diagram_roof(poly, node.fa, node.fs);
     roof->setConvexity(node.convexity);

--- a/src/geometry/IndexedMesh.cc
+++ b/src/geometry/IndexedMesh.cc
@@ -68,9 +68,9 @@ void IndexedMesh::append_geometry(const shared_ptr<const Geometry>& geom)
   } else if (const auto hybrid = dynamic_pointer_cast<const CGALHybridPolyhedron>(geom)) {
     // TODO(ochafik): Implement append_geometry(Surface_mesh) instead of converting to PolySet
     mesh.append_geometry(hybrid->toPolySet());
-  } else if (dynamic_pointer_cast<const Polygon2d>(geom)) {
+  } else if (dynamic_pointer_cast<const Polygon2d>(geom)) { // NOLINT(bugprone-branch-clone)
     assert(false && "Unsupported file format");
-  } else {
+  } else { // NOLINT(bugprone-branch-clone)
     assert(false && "Not implemented");
   }
 }

--- a/src/geometry/Reindexer.h
+++ b/src/geometry/Reindexer.h
@@ -39,8 +39,8 @@ public:
   /*!
      Reserve the requested size for the new element map
    */
-  void reserve(std::size_t __n) {
-    return this->map.reserve(__n);
+  void reserve(std::size_t n) {
+    return this->map.reserve(n);
   }
 
   /*!

--- a/src/geometry/cgal/CGALCache.cc
+++ b/src/geometry/cgal/CGALCache.cc
@@ -47,12 +47,12 @@ size_t CGALCache::totalCost() const
 
 size_t CGALCache::maxSizeMB() const
 {
-  return this->cache.maxCost() / (1024 * 1024);
+  return this->cache.maxCost() / (1024ul * 1024ul);
 }
 
 void CGALCache::setMaxSizeMB(size_t limit)
 {
-  this->cache.setMaxCost(limit * 1024 * 1024);
+  this->cache.setMaxCost(limit * 1024ul * 1024ul);
 }
 
 void CGALCache::clear()

--- a/src/geometry/cgal/CGALCache.h
+++ b/src/geometry/cgal/CGALCache.h
@@ -10,7 +10,7 @@ class Geometry;
 class CGALCache
 {
 public:
-  CGALCache(size_t limit = 100 *1024 *1024);
+  CGALCache(size_t limit = 100ul *1024ul *1024ul);
 
   static CGALCache *instance() { if (!inst) inst = new CGALCache; return inst; }
   static bool acceptsGeometry(const shared_ptr<const Geometry>& geom);

--- a/src/geometry/cgal/CGALHybridPolyhedron.cc
+++ b/src/geometry/cgal/CGALHybridPolyhedron.cc
@@ -118,12 +118,14 @@ shared_ptr<const PolySet> CGALHybridPolyhedron::toPolySet() const
     if (CGALUtils::createPolySetFromMesh(*mesh, *ps)) {
       assert(false && "Error from CGALUtils::createPolySetFromNefPolyhedron3");
     }
+    ps->setConvexity(convexity);
     return ps;
   } else if (auto nef = getNefPolyhedron()) {
     auto ps = make_shared<PolySet>(3, /* convex */ unknown);
     if (CGALUtils::createPolySetFromNefPolyhedron3(*nef, *ps)) {
       assert(false && "Error from CGALUtils::createPolySetFromNefPolyhedron3");
     }
+    ps->setConvexity(convexity);
     return ps;
   } else {
     assert(!"Bad hybrid polyhedron state");

--- a/src/geometry/cgal/CGALHybridPolyhedron.cc
+++ b/src/geometry/cgal/CGALHybridPolyhedron.cc
@@ -20,16 +20,16 @@ CGALHybridPolyhedron::CGALHybridPolyhedron(const shared_ptr<CGAL_HybridMesh>& me
 {
   assert(mesh);
   data = mesh;
-
 }
 
-CGALHybridPolyhedron::CGALHybridPolyhedron(const CGALHybridPolyhedron& other)
+CGALHybridPolyhedron::CGALHybridPolyhedron(const CGALHybridPolyhedron& other) : Geometry(other)
 {
   *this = other;
 }
 
 CGALHybridPolyhedron& CGALHybridPolyhedron::operator=(const CGALHybridPolyhedron& other)
 {
+  Geometry::operator=(other);
   if (auto nef = other.getNefPolyhedron()) {
     data = make_shared<CGAL_HybridNef>(*nef);
   } else if (auto mesh = other.getMesh()) {
@@ -40,7 +40,7 @@ CGALHybridPolyhedron& CGALHybridPolyhedron::operator=(const CGALHybridPolyhedron
   return *this;
 }
 
-CGALHybridPolyhedron::CGALHybridPolyhedron()
+CGALHybridPolyhedron::CGALHybridPolyhedron() : Geometry()
 {
   data = make_shared<CGAL_HybridMesh>();
 }
@@ -48,15 +48,15 @@ CGALHybridPolyhedron::CGALHybridPolyhedron()
 std::shared_ptr<CGAL_HybridNef> CGALHybridPolyhedron::getNefPolyhedron() const
 {
   return std::holds_alternative<shared_ptr<CGAL_HybridNef>>(data) ?
-    std::get<shared_ptr<CGAL_HybridNef>>(data) :
-    nullptr;
+         std::get<shared_ptr<CGAL_HybridNef>>(data) :
+         nullptr;
 }
 
 std::shared_ptr<CGAL_HybridMesh> CGALHybridPolyhedron::getMesh() const
 {
   return std::holds_alternative<shared_ptr<CGAL_HybridMesh>>(data) ?
-    std::get<shared_ptr<CGAL_HybridMesh>>(data) :
-    nullptr;
+         std::get<shared_ptr<CGAL_HybridMesh>>(data) :
+         nullptr;
 }
 
 bool CGALHybridPolyhedron::isEmpty() const

--- a/src/geometry/cgal/CGAL_Nef_polyhedron.cc
+++ b/src/geometry/cgal/CGAL_Nef_polyhedron.cc
@@ -12,7 +12,7 @@ CGAL_Nef_polyhedron::CGAL_Nef_polyhedron(const CGAL_Nef_polyhedron3 *p)
 // Copy constructor only performs shallow copies, so all modifying functions
 // must reset p3 with a new CGAL_Nef_polyhedron3 object, to prevent cache corruption.
 // This is also partly enforced by p3 pointing to a const object.
-CGAL_Nef_polyhedron::CGAL_Nef_polyhedron(const CGAL_Nef_polyhedron& src)
+CGAL_Nef_polyhedron::CGAL_Nef_polyhedron(const CGAL_Nef_polyhedron& src) : Geometry(src)
 {
   if (src.p3) this->p3 = src.p3;
 }

--- a/src/geometry/linalg.cc
+++ b/src/geometry/linalg.cc
@@ -68,20 +68,20 @@ using Py_uhash_t = uint32_t;
 using Float_t = double;
 Py_hash_t hash_floating_point(Float_t v)
 {
-  int _PyHASH_BITS = 31;
-  //if (sizeof(Py_uhash_t)==8) _PyHASH_BITS=61;
+  static constexpr int PyHASH_BITS = 31;
+  //if (sizeof(Py_uhash_t)==8) PyHASH_BITS=61;
 
-  Py_uhash_t _PyHASH_MODULUS = (((Py_uhash_t)1 << _PyHASH_BITS) - 1);
-  Py_uhash_t _PyHASH_INF = 314159;
-  Py_uhash_t _PyHASH_NAN = 0;
+  static constexpr Py_uhash_t PyHASH_MODULUS = (((Py_uhash_t)1 << PyHASH_BITS) - 1);
+  static constexpr Py_uhash_t PyHASH_INF = 314159;
+  static constexpr Py_uhash_t PyHASH_NAN = 0;
 
   int e, sign;
   Float_t m;
   Py_uhash_t x, y;
 
   if (!std::isfinite(v)) {
-    if (std::isinf(v)) return v > 0 ? _PyHASH_INF : -_PyHASH_INF;
-    else return _PyHASH_NAN;
+    if (std::isinf(v)) return v > 0 ? PyHASH_INF : -PyHASH_INF;
+    else return PyHASH_NAN;
   }
 
   m = frexp(v, &e);
@@ -96,18 +96,18 @@ Py_hash_t hash_floating_point(Float_t v)
      and hexadecimal floating point. */
   x = 0;
   while (m) {
-    x = ((x << 28) & _PyHASH_MODULUS) | x >> (_PyHASH_BITS - 28);
+    x = ((x << 28) & PyHASH_MODULUS) | x >> (PyHASH_BITS - 28);
     m *= 268435456.0; // 2**28
     e -= 28;
     y = (Py_uhash_t)m; /* pull out integer part */
     m -= y;
     x += y;
-    if (x >= _PyHASH_MODULUS) x -= _PyHASH_MODULUS;
+    if (x >= PyHASH_MODULUS) x -= PyHASH_MODULUS;
   }
 
-  /* adjust for the exponent;  first reduce it modulo _PyHASH_BITS */
-  e = e >= 0 ? e % _PyHASH_BITS : _PyHASH_BITS - 1 - ((-1 - e) % _PyHASH_BITS);
-  x = ((x << e) & _PyHASH_MODULUS) | x >> (_PyHASH_BITS - e);
+  /* adjust for the exponent;  first reduce it modulo PyHASH_BITS */
+  e = e >= 0 ? e % PyHASH_BITS : PyHASH_BITS - 1 - ((-1 - e) % PyHASH_BITS);
+  x = ((x << e) & PyHASH_MODULUS) | x >> (PyHASH_BITS - e);
 
   x = x * sign;
   return (Py_hash_t)x;

--- a/src/geometry/linalg.h
+++ b/src/geometry/linalg.h
@@ -53,7 +53,10 @@ public:
   Color4f(float r, float g, float b, float a = 1.0f) : Eigen::Matrix<float, 4, 1, Eigen::DontAlign>(r, g, b, a) { }
 
   void setRgb(int r, int g, int b, int a = 255) {
-    *this << r / 255.0f, g / 255.0f, b / 255.0f, a / 255.0f;
+    *this << static_cast<float>(r) / 255.0f,
+             static_cast<float>(g) / 255.0f,
+             static_cast<float>(b) / 255.0f,
+             static_cast<float>(a) / 255.0f;
   }
 
   [[nodiscard]] bool isValid() const { return this->minCoeff() >= 0.0f; }

--- a/src/geometry/roof_vd.cc
+++ b/src/geometry/roof_vd.cc
@@ -1,6 +1,7 @@
 // This file is a part of openscad. Everything implied is implied.
 // Author: Alexey Korepanov <kaikaikai@yandex.ru>
 
+// NOLINTNEXTLINE(bugprone-reserved-identifier)
 #define _USE_MATH_DEFINES
 #include <cmath>
 

--- a/src/glview/GLView.cc
+++ b/src/glview/GLView.cc
@@ -214,23 +214,18 @@ void GLView::enable_opencsg_shaders()
       this->has_shaders = true;
     }
   }
-
 #ifndef GLEW_EGL
-
   // If OpenGL < 2, check for extensions
-  else {
-    if (GLEW_ARB_framebuffer_object) this->is_opencsg_capable = true;
-    else if (GLEW_EXT_framebuffer_object && GLEW_EXT_packed_depth_stencil) {
-      this->is_opencsg_capable = true;
-    }
+  else if (GLEW_ARB_framebuffer_object || (GLEW_EXT_framebuffer_object && GLEW_EXT_packed_depth_stencil)
 #ifdef _WIN32
-    else if (WGLEW_ARB_pbuffer && WGLEW_ARB_pixel_format) this->is_opencsg_capable = true;
+           || (WGLEW_ARB_pbuffer && WGLEW_ARB_pixel_format)
 #elif !defined(__APPLE__)
-    // not supported by GLEW when built with EGL
-    else if (GLXEW_SGIX_pbuffer && GLXEW_SGIX_fbconfig) this->is_opencsg_capable = true;
+          // not supported by GLEW when built with EGL
+           || (GLXEW_SGIX_pbuffer && GLXEW_SGIX_fbconfig)
 #endif
+  ) {
+    this->is_opencsg_capable = true;
   }
-
 #endif // ifndef GLEW_EGL
 
   if (!GLEW_VERSION_2_0 || !this->is_opencsg_capable) {

--- a/src/glview/Renderer.cc
+++ b/src/glview/Renderer.cc
@@ -177,12 +177,7 @@ Color4f Renderer::setColor(ColorMode colormode, const float color[4], const shad
   PRINTD("setColor b");
   Color4f basecol;
   if (getColor(colormode, basecol)) {
-    if (colormode == ColorMode::BACKGROUND) {
-      basecol = {color[0] >= 0 ? color[0] : basecol[0],
-                 color[1] >= 0 ? color[1] : basecol[1],
-                 color[2] >= 0 ? color[2] : basecol[2],
-                 color[3] >= 0 ? color[3] : basecol[3]};
-    } else if (colormode != ColorMode::HIGHLIGHT) {
+    if (colormode == ColorMode::BACKGROUND || colormode != ColorMode::HIGHLIGHT) {
       basecol = {color[0] >= 0 ? color[0] : basecol[0],
                  color[1] >= 0 ? color[1] : basecol[1],
                  color[2] >= 0 ? color[2] : basecol[2],

--- a/src/glview/VBORenderer.cc
+++ b/src/glview/VBORenderer.cc
@@ -48,12 +48,7 @@ bool VBORenderer::getShaderColor(Renderer::ColorMode colormode, const Color4f& c
 {
   Color4f basecol;
   if (Renderer::getColor(colormode, basecol)) {
-    if (colormode == ColorMode::BACKGROUND) {
-      basecol = Color4f(color[0] >= 0 ? color[0] : basecol[0],
-                        color[1] >= 0 ? color[1] : basecol[1],
-                        color[2] >= 0 ? color[2] : basecol[2],
-                        color[3] >= 0 ? color[3] : basecol[3]);
-    } else if (colormode != ColorMode::HIGHLIGHT) {
+    if (colormode == ColorMode::BACKGROUND || colormode != ColorMode::HIGHLIGHT) {
       basecol = Color4f(color[0] >= 0 ? color[0] : basecol[0],
                         color[1] >= 0 ? color[1] : basecol[1],
                         color[2] >= 0 ? color[2] : basecol[2],

--- a/src/glview/VBORenderer.h
+++ b/src/glview/VBORenderer.h
@@ -1,5 +1,4 @@
-#ifndef __VBORENDERER_H__
-#define __VBORENDERER_H__
+#pragma once
 
 #include "Renderer.h"
 #include "system-gl.h"
@@ -80,5 +79,3 @@ private:
     BARYCENTRIC_ATTRIB
   };
 };
-
-#endif // __VBORENDERER_H__

--- a/src/glview/VertexArray.h
+++ b/src/glview/VertexArray.h
@@ -1,8 +1,5 @@
 #pragma once
 
-#ifndef __VERTEX_H__
-#define __VERTEX_H__
-
 #include <unordered_map>
 #include <boost/functional/hash.hpp>
 
@@ -499,5 +496,3 @@ private:
   VertexData elements_;
   ElementsMap elements_map_;
 };
-
-#endif // __VERTEX_H__

--- a/src/glview/cgal/CGAL_OGL_VBO_helper.h
+++ b/src/glview/cgal/CGAL_OGL_VBO_helper.h
@@ -76,7 +76,7 @@ public:
                               0, 1, 0.0, 1, 2, true);
   }
 
-  using TessUserData = struct _TessUserData {
+  struct TessUserData {
     GLenum which;
     GLdouble *normal;
     CGAL::Color color;

--- a/src/gui/ErrorLog.cc
+++ b/src/gui/ErrorLog.cc
@@ -118,8 +118,8 @@ void ErrorLog::on_errorLogComboBox_currentIndexChanged(const QString& group)
   errorLogModel->clear();
   initGUI();
   for (auto& lastMessage : lastMessages) {
-    if (group == QString::fromStdString("All")) showtheErrorInGUI(lastMessage);
-    else if (group == QString::fromStdString(getGroupName(lastMessage.group))) {
+    if (group == QString::fromStdString("All") ||
+        group == QString::fromStdString(getGroupName(lastMessage.group))) {
       showtheErrorInGUI(lastMessage);
     }
   }

--- a/src/gui/MainWindow.cc
+++ b/src/gui/MainWindow.cc
@@ -1303,7 +1303,7 @@ void MainWindow::compileCSG()
     LOG(message_group::None, Location::NONE, "", "Compiling design (CSG Products normalization)...");
     this->processEvents();
 
-    size_t normalizelimit = 2 * Preferences::inst()->getValue("advanced/openCSGLimit").toUInt();
+    size_t normalizelimit = 2ul * Preferences::inst()->getValue("advanced/openCSGLimit").toUInt();
     CSGTreeNormalizer normalizer(normalizelimit);
 
     if (this->csgRoot) {

--- a/src/gui/Preferences.cc
+++ b/src/gui/Preferences.cc
@@ -116,11 +116,11 @@ void Preferences::init() {
   // Setup default settings
   this->defaultmap["advanced/opencsg_show_warning"] = true;
   this->defaultmap["advanced/enable_opencsg_opengl1x"] = true;
-  this->defaultmap["advanced/polysetCacheSize"] = qulonglong(GeometryCache::instance()->maxSizeMB()) * 1024 * 1024;
-  this->defaultmap["advanced/polysetCacheSizeMB"] = getValue("advanced/polysetCacheSize").toULongLong() / (1024 * 1024); // carry over old settings if they exist
+  this->defaultmap["advanced/polysetCacheSize"] = qulonglong(GeometryCache::instance()->maxSizeMB()) * 1024ul * 1024ul;
+  this->defaultmap["advanced/polysetCacheSizeMB"] = getValue("advanced/polysetCacheSize").toULongLong() / (1024ul * 1024ul); // carry over old settings if they exist
 #ifdef ENABLE_CGAL
-  this->defaultmap["advanced/cgalCacheSize"] = qulonglong(CGALCache::instance()->maxSizeMB()) * 1024 * 1024;
-  this->defaultmap["advanced/cgalCacheSizeMB"] = getValue("advanced/cgalCacheSize").toULongLong() / (1024 * 1024); // carry over old settings if they exist
+  this->defaultmap["advanced/cgalCacheSize"] = qulonglong(CGALCache::instance()->maxSizeMB()) * 1024ul * 1024ul;
+  this->defaultmap["advanced/cgalCacheSizeMB"] = getValue("advanced/cgalCacheSize").toULongLong() / (1024ul * 1024ul); // carry over old settings if they exist
 #endif
   this->defaultmap["advanced/openCSGLimit"] = RenderSettings::inst()->openCSGTermLimit;
   this->defaultmap["advanced/forceGoldfeather"] = false;

--- a/src/gui/PrintService.h
+++ b/src/gui/PrintService.h
@@ -42,7 +42,7 @@ public:
   const QString getService() const { return service; }
   const QString getDisplayName() const { return displayName; }
   const QString getApiUrl() const { return apiUrl; }
-  long getFileSizeLimit() const { return fileSizeLimitMB * 1024 * 1024; }
+  long getFileSizeLimit() const { return fileSizeLimitMB * 1024ul * 1024ul; }
   long getFileSizeLimitMB() const { return fileSizeLimitMB; }
   const QString getInfoHtml() const { return infoHtml; }
   const QString getInfoUrl() const { return infoUrl; }

--- a/src/gui/ScintillaEditor.cc
+++ b/src/gui/ScintillaEditor.cc
@@ -136,6 +136,7 @@ ScintillaEditor::ScintillaEditor(QWidget *parent) : EditorInterface(parent)
   // key bindings, as well as some minor scintilla bugs
   //
   QsciCommand *c;
+  // NOLINTBEGIN(bugprone-suspicious-enum-usage)
 #ifdef Q_OS_MAC
   // Alt-Backspace should delete left word (Alt-Delete already deletes right word)
   c = qsci->standardCommands()->find(QsciCommand::DeleteWordLeft);
@@ -169,6 +170,7 @@ ScintillaEditor::ScintillaEditor(QWidget *parent) : EditorInterface(parent)
   connect(shortcutAutocomplete, &QShortcut::activated, [ = ]() {
     qsci->autoCompleteFromAPIs();
   });
+  // NOLINTEND(bugprone-suspicious-enum-usage)
 
   scintillaLayout->setContentsMargins(0, 0, 0, 0);
   scintillaLayout->addWidget(qsci);

--- a/src/gui/input/HidApiInputDriver.cc
+++ b/src/gui/input/HidApiInputDriver.cc
@@ -78,8 +78,8 @@ static const struct device_id device_ids[] = {
 };
 
 #define HIDAPI_LOG(f) hidapi_log(boost::format(f))
+// NOLINTNEXTLINE(*macro-parentheses)
 #define HIDAPI_LOGP(f, a) hidapi_log(boost::format(f) % a)
-
 static void hidapi_log(boost::format format) {
   if (logstream) {
     const ch::system_clock::duration time = ch::system_clock::now() - logtime;

--- a/src/gui/parameter/ParameterWidget.cc
+++ b/src/gui/parameter/ParameterWidget.cc
@@ -67,9 +67,7 @@ void ParameterWidget::readFile(QString scadFile)
   assert(widgets.empty());
 
   QString jsonFile = getJsonFile(scadFile);
-  if (!boost::filesystem::exists(jsonFile.toStdString())) {
-    this->invalidJsonFile = QString();
-  } else if (this->sets.readFile(jsonFile.toStdString())) {
+  if (!boost::filesystem::exists(jsonFile.toStdString()) || this->sets.readFile(jsonFile.toStdString())) {
     this->invalidJsonFile = QString();
   } else {
     this->invalidJsonFile = jsonFile;

--- a/src/gui/qt-obsolete.h
+++ b/src/gui/qt-obsolete.h
@@ -5,7 +5,7 @@
 #endif
 
 #if (QT_VERSION < QT_VERSION_CHECK(5, 14, 0))
-#define Q_WHEEL_EVENT_POSITION(e) (e->pos())
+#define Q_WHEEL_EVENT_POSITION(e) ((e)->pos())
 #else
-#define Q_WHEEL_EVENT_POSITION(e) (e->position())
+#define Q_WHEEL_EVENT_POSITION(e) ((e)->position())
 #endif

--- a/src/gui/qtgettext.h
+++ b/src/gui/qtgettext.h
@@ -1,6 +1,4 @@
-#ifndef __openscad_qtgettext_h__
-#define __openscad_qtgettext_h__
-
+#pragma once
 // see doc/translation.txt
 
 // MinGW defines sprintf to libintl_sprintf which breaks usage of the
@@ -22,6 +20,3 @@ inline QString q_(const char *msgid, const char *msgctxt)
                            _(msgid)
                            );
 }
-
-#endif // ifndef __openscad_qtgettext_h__
-

--- a/src/io/DxfData.cc
+++ b/src/io/DxfData.cc
@@ -320,13 +320,7 @@ DxfData::DxfData(double fn, double fs, double fa,
       case 8:
         layer = data;
         break;
-      case 10:
-        if (in_blocks_section) {
-          xverts.push_back((boost::lexical_cast<double>(data)));
-        } else {
-          xverts.push_back((boost::lexical_cast<double>(data) - xorigin) * scale);
-        }
-        break;
+      case 10: [[fallthrough]];
       case 11:
         if (in_blocks_section) {
           xverts.push_back((boost::lexical_cast<double>(data)));
@@ -334,13 +328,7 @@ DxfData::DxfData(double fn, double fs, double fa,
           xverts.push_back((boost::lexical_cast<double>(data) - xorigin) * scale);
         }
         break;
-      case 20:
-        if (in_blocks_section) {
-          yverts.push_back((boost::lexical_cast<double>(data)));
-        } else {
-          yverts.push_back((boost::lexical_cast<double>(data) - yorigin) * scale);
-        }
-        break;
+      case 20: [[fallthrough]];
       case 21:
         if (in_blocks_section) {
           yverts.push_back((boost::lexical_cast<double>(data)));

--- a/src/io/DxfData.cc
+++ b/src/io/DxfData.cc
@@ -93,7 +93,7 @@ DxfData::DxfData(double fn, double fs, double fa,
   std::string current_block;
 
 #define ADD_LINE(_x1, _y1, _x2, _y2) do {                   \
-          double _p1x = _x1, _p1y = _y1, _p2x = _x2, _p2y = _y2;  \
+          double _p1x = (_x1), _p1y = (_y1), _p2x = (_x2), _p2y = (_y2);\
           if (!in_entities_section && !in_blocks_section)         \
           break;                                                \
           if (in_entities_section &&                              \

--- a/src/io/DxfData.cc
+++ b/src/io/DxfData.cc
@@ -24,6 +24,7 @@
  *
  */
 
+// NOLINTNEXTLINE(bugprone-reserved-identifier)
 #define _USE_MATH_DEFINES
 #include <cmath>
 

--- a/src/io/dxfdim.cc
+++ b/src/io/dxfdim.cc
@@ -142,6 +142,7 @@ Value builtin_dxf_dim(Arguments arguments, const Location& loc)
 
 Value builtin_dxf_cross(Arguments arguments, const Location& loc)
 {
+  auto *session = arguments.session();
   Parameters parameters = Parameters::parse(std::move(arguments), loc, {}, {"file", "layer", "origin", "scale", "name"});
 
   std::string rawFilename;
@@ -181,7 +182,7 @@ Value builtin_dxf_cross(Arguments arguments, const Location& loc)
 
   auto result = dxf_cross_cache.find(key);
   if (result != dxf_cross_cache.end()) {
-    VectorType ret(arguments.session());
+    VectorType ret(session);
     for (auto v : result->second) {
       ret.emplace_back(v);
     }
@@ -213,7 +214,7 @@ Value builtin_dxf_cross(Arguments arguments, const Location& loc)
 
       std::vector<double> value = {x, y};
       dxf_cross_cache.emplace(key, value);
-      VectorType ret(arguments.session());
+      VectorType ret(session);
       ret.emplace_back(x);
       ret.emplace_back(y);
       return {std::move(ret)};

--- a/src/io/export_3mf.cc
+++ b/src/io/export_3mf.cc
@@ -147,9 +147,9 @@ static bool append_3mf(const shared_ptr<const Geometry>& geom, PLib3MFModelMeshO
     PolySet triangulated(3);
     PolySetUtils::tessellate_faces(*ps, triangulated);
     return append_polyset(triangulated, model);
-  } else if (dynamic_pointer_cast<const Polygon2d>(geom)) {
+  } else if (dynamic_pointer_cast<const Polygon2d>(geom)) { // NOLINT(bugprone-branch-clone)
     assert(false && "Unsupported file format");
-  } else {
+  } else { // NOLINT(bugprone-branch-clone)
     assert(false && "Not implemented");
   }
 

--- a/src/io/export_amf.cc
+++ b/src/io/export_amf.cc
@@ -63,9 +63,9 @@ static size_t add_vertex(std::vector<vertex_str>& vertices, const Point& p) {
   if (vi == vertices.end()) {
     vertices.push_back(vs);
     return vertices.size() - 1;
-   } else {
+  } else {
     return std::distance(vertices.begin(), vi);
-   }
+  }
 }
 
 /*!
@@ -141,12 +141,12 @@ static void append_amf(const shared_ptr<const Geometry>& geom, std::ostream& out
     for (const auto& item : geomlist->getChildren()) {
       append_amf(item.second, output);
     }
-  } else if (geom->getDimension() != 3) {
-    assert(false && "Unsupported file format");
   } else if (auto N = CGALUtils::getNefPolyhedronFromGeometry(geom)) {
     // FIXME: Implement this without creating a Nef polyhedron
     if (!N->isEmpty()) append_amf(*N, output);
-  } else {
+  } else if (geom->getDimension() != 3) { // NOLINT(bugprone-branch-clone)
+    assert(false && "Unsupported file format");
+  } else { // NOLINT(bugprone-branch-clone)
     assert(false && "Not implemented");
   }
 }

--- a/src/io/export_dxf.cc
+++ b/src/io/export_dxf.cc
@@ -239,11 +239,11 @@ void export_dxf(const shared_ptr<const Geometry>& geom, std::ostream& output)
     for (const auto& item : geomlist->getChildren()) {
       export_dxf(item.second, output);
     }
-  } else if (dynamic_pointer_cast<const PolySet>(geom)) {
-    assert(false && "Unsupported file format");
   } else if (const auto poly = dynamic_pointer_cast<const Polygon2d>(geom)) {
     export_dxf(*poly, output);
-  } else {
+  } else if (dynamic_pointer_cast<const PolySet>(geom)) { // NOLINT(bugprone-branch-clone)
+    assert(false && "Unsupported file format");
+  } else { // NOLINT(bugprone-branch-clone)
     assert(false && "Export as DXF for this geometry type is not supported");
   }
 }

--- a/src/io/export_pdf.cc
+++ b/src/io/export_pdf.cc
@@ -152,11 +152,11 @@ void draw_geom(const shared_ptr<const Geometry>& geom, cairo_t *cr, bool& inpape
     for (const auto& item : geomlist->getChildren()) {
       draw_geom(item.second, cr, inpaper, pos);
     }
-  } else if (dynamic_pointer_cast<const PolySet>(geom)) {
-    assert(false && "Unsupported file format");
   } else if (const auto poly = dynamic_pointer_cast<const Polygon2d>(geom)) {
     draw_geom(*poly, cr, inpaper, pos);
-  } else {
+  } else if (dynamic_pointer_cast<const PolySet>(geom)) { //NOLINT(bugprone-branch-clone)
+    assert(false && "Unsupported file format");
+  } else { //NOLINT(bugprone-branch-clone)
     assert(false && "Export as PDF for this geometry type is not supported");
   }
 }

--- a/src/io/export_stl.cc
+++ b/src/io/export_stl.cc
@@ -213,9 +213,9 @@ uint64_t append_stl(const shared_ptr<const Geometry>& geom, std::ostream& output
     triangle_count += append_stl(*ps, output, binary);
   } else if (const auto hybrid = dynamic_pointer_cast<const CGALHybridPolyhedron>(geom)) {
     triangle_count += append_stl(*hybrid, output, binary);
-  } else if (dynamic_pointer_cast<const Polygon2d>(geom)) {
+  } else if (dynamic_pointer_cast<const Polygon2d>(geom)) { //NOLINT(bugprone-branch-clone)
     assert(false && "Unsupported file format");
-  } else {
+  } else { //NOLINT(bugprone-branch-clone)
     assert(false && "Not implemented");
   }
 

--- a/src/io/export_svg.cc
+++ b/src/io/export_svg.cc
@@ -56,11 +56,11 @@ static void append_svg(const shared_ptr<const Geometry>& geom, std::ostream& out
     for (const auto& item : geomlist->getChildren()) {
       append_svg(item.second, output);
     }
-  } else if (dynamic_pointer_cast<const PolySet>(geom)) {
-    assert(false && "Unsupported file format");
   } else if (const auto poly = dynamic_pointer_cast<const Polygon2d>(geom)) {
     append_svg(*poly, output);
-  } else {
+  } else if (dynamic_pointer_cast<const PolySet>(geom)) { // NOLINT(bugprone-branch-clone)
+    assert(false && "Unsupported file format");
+  } else { // NOLINT(bugprone-branch-clone)
     assert(false && "Export as SVG for this geometry type is not supported");
   }
 }

--- a/src/io/import_stl.cc
+++ b/src/io/import_stl.cc
@@ -13,7 +13,7 @@
 #error Byte order undefined or unknown. Currently only BOOST_ENDIAN_BIG_BYTE and BOOST_ENDIAN_LITTLE_BYTE are supported.
 #endif
 
-#define STL_FACET_NUMBYTES 4 * 3 * 4 + 2
+inline constexpr size_t STL_FACET_NUMBYTES = 4ul * 3ul * 4ul + 2ul;
 // as there is no 'float32_t' standard, we assume the systems 'float'
 // is a 'binary32' aka 'single' standard IEEE 32-bit floating point type
 union stl_facet {
@@ -28,7 +28,7 @@ union stl_facet {
   } data;
 };
 
-static_assert(offsetof(stl_facet::facet_data, attribute_byte_count) == 4 * 3 * 4,
+static_assert(offsetof(stl_facet::facet_data, attribute_byte_count) == 4ul * 3ul * 4ul,
               "Invalid padding in stl_facet");
 
 #if BOOST_ENDIAN_BIG_BYTE
@@ -92,7 +92,7 @@ PolySet *import_stl(const std::string& filename, const Location& loc) {
 #if BOOST_ENDIAN_BIG_BYTE
     uint32_byte_swap(facenum);
 #endif
-    if (file_size == static_cast<std::streamoff>(80 + 4 + 50 * facenum)) {
+    if (file_size == static_cast<std::streamoff>(80ul + 4ul + 50ul * facenum)) {
       binary = true;
     }
   }

--- a/src/io/import_stl.cc
+++ b/src/io/import_stl.cc
@@ -120,9 +120,7 @@ PolySet *import_stl(const std::string& filename, const Location& loc) {
       boost::trim(line);
       boost::smatch results;
 
-      if (line.length() == 0) {
-        continue;
-      } else if (boost::regex_search(line, ex_sfe)) {
+      if (line.length() == 0 || boost::regex_search(line, ex_sfe)) {
         continue;
       } else if (boost::regex_search(line, ex_outer)) {
         i = 0;

--- a/src/io/libsvg/libsvg.cc
+++ b/src/io/libsvg/libsvg.cc
@@ -140,11 +140,10 @@ void processNode(xmlTextReaderPtr reader, shapes_defs_list_t *defs_lookup_list, 
       in_defs = false;
     }
 
-    if (std::string("g") == name || std::string("svg") == name) {
-      stack.pop_back();
-    } else if (std::string("tspan") == name) {
-      stack.pop_back();
-    } else if (std::string("text") == name) {
+    if (std::string("g") == name ||
+        std::string("svg") == name ||
+        std::string("tspan") == name ||
+        std::string("text") == name) {
       stack.pop_back();
     }
 #if SVG_DEBUG

--- a/src/io/libsvg/line.h
+++ b/src/io/libsvg/line.h
@@ -37,8 +37,8 @@ private:
 public:
   line() = default;
 
-  [[nodiscard]] double get_x2() const { return x2; }
-  [[nodiscard]] double get_y2() const { return y2; }
+  [[nodiscard]] double get_x2() const { return x2; } // NOLINT(bugprone-virtual-near-miss)
+  [[nodiscard]] double get_y2() const { return y2; } // NOLINT(bugprone-virtual-near-miss)
 
   void set_attrs(attr_map_t& attrs, void *context) override;
   [[nodiscard]] const std::string dump() const override;

--- a/src/io/libsvg/rect.cc
+++ b/src/io/libsvg/rect.cc
@@ -88,7 +88,7 @@ const std::string rect::name("rect");
 void
 rect::set_attrs(attr_map_t& attrs, void *context)
 {
-  shape::set_attrs(attrs, context);
+  shape::set_attrs(attrs, context); // NOLINT(bugprone-parent-virtual-call)
   this->x = parse_double(attrs["x"]);
   this->y = parse_double(attrs["y"]);
   this->width = parse_double(attrs["width"]);

--- a/src/io/libsvg/text.h
+++ b/src/io/libsvg/text.h
@@ -43,8 +43,8 @@ public:
 
   [[nodiscard]] bool is_container() const override { return true; }
 
-  [[nodiscard]] double get_dx() const { return dx; }
-  [[nodiscard]] double get_dy() const { return dy; }
+  [[nodiscard]] double get_dx() const { return dx; } // NOLINT(bugprone-virtual-near-miss)
+  [[nodiscard]] double get_dy() const { return dy; } // NOLINT(bugprone-virtual-near-miss)
   [[nodiscard]] double get_rotate() const { return rotate; }
   [[nodiscard]] double get_text_length() const { return text_length; }
   [[nodiscard]] const std::string& get_font_family() const { return font_family; }

--- a/src/io/libsvg/tspan.h
+++ b/src/io/libsvg/tspan.h
@@ -43,8 +43,8 @@ public:
 
   [[nodiscard]] bool is_container() const override { return true; }
 
-  [[nodiscard]] double get_dx() const { return dx; }
-  [[nodiscard]] double get_dy() const { return dy; }
+  [[nodiscard]] double get_dx() const { return dx; } // NOLINT(bugprone-virtual-near-miss)
+  [[nodiscard]] double get_dy() const { return dy; } // NOLINT(bugprone-virtual-near-miss)
   [[nodiscard]] double get_rotate() const { return rotate; }
   [[nodiscard]] double get_text_length() const { return text_length; }
   [[nodiscard]] const std::string& get_font_family() const { return font_family; }

--- a/src/openscad.cc
+++ b/src/openscad.cc
@@ -860,6 +860,7 @@ struct CommaSeparatedVector
   friend std::istream& operator>>(std::istream& in, CommaSeparatedVector& value) {
     std::string token;
     in >> token;
+    // NOLINTNEXTLINE(*NewDeleteLeaks) LLVM bug https://github.com/llvm/llvm-project/issues/40486
     boost::split(value.values, token, boost::is_any_of(","));
     return in;
   }

--- a/src/platform/PlatformUtils.h
+++ b/src/platform/PlatformUtils.h
@@ -5,8 +5,8 @@
 #include <boost/filesystem.hpp>
 namespace fs = boost::filesystem;
 
-#define STACK_BUFFER_SIZE (128 * 1024)
-#define STACK_LIMIT_DEFAULT (STACKSIZE - STACK_BUFFER_SIZE)
+static constexpr size_t STACK_BUFFER_SIZE = 128ul * 1024ul;
+static constexpr size_t STACK_LIMIT_DEFAULT = size_t{STACKSIZE} - STACK_BUFFER_SIZE;
 
 namespace PlatformUtils {
 extern const char *OPENSCAD_FOLDER_NAME;

--- a/src/utils/boost-utils.cc
+++ b/src/utils/boost-utils.cc
@@ -97,9 +97,7 @@ boostfs_uncomplete(fs::path const p, fs::path const base)
       // write to output, ../ times the number of remaining elements in base;
       // this is how far we've had to come down the tree from base to get to the common root
       for (; base_it != base_end; ++base_it) {
-        if (*base_it == _dot) continue;
-        else if (*base_it == _sep) continue;
-
+        if (*base_it == _dot || *base_it == _sep) continue;
         output /= "../";
       }
 
@@ -108,8 +106,7 @@ boostfs_uncomplete(fs::path const p, fs::path const base)
       fs::path::iterator path_it_start = path_it;
       for (; path_it != path_end; ++path_it) {
         if (path_it != path_it_start) output /= "/";
-        if (*path_it == _dot) continue;
-        if (*path_it == _sep) continue;
+        if (*path_it == _dot || *path_it == _sep) continue;
         output /= *path_it;
       }
       break;

--- a/src/utils/calc.cc
+++ b/src/utils/calc.cc
@@ -24,6 +24,7 @@
  *
  */
 
+// NOLINTNEXTLINE(bugprone-reserved-identifier)
 #define _USE_MATH_DEFINES
 #include <cmath>
 #include <cassert>

--- a/src/utils/degree_trig.cc
+++ b/src/utils/degree_trig.cc
@@ -26,6 +26,7 @@
 //
 // Trigonometry function taking degrees, accurate for 30, 45, 60 and 90, etc.
 //
+// NOLINTNEXTLINE(bugprone-reserved-identifier)
 #define _USE_MATH_DEFINES
 #include <cmath>
 #include <limits>

--- a/src/utils/printutils.h
+++ b/src/utils/printutils.h
@@ -21,6 +21,11 @@
 #include <clocale>
 #include "AST.h"
 #include <set>
+
+// It seems standard practice to use underscore for gettext, even though it is reserved.
+// Not wanting to risk breaking translations by changing every usage of this,
+// I've opted to just disable the check in this case. - Hans L
+// NOLINTBEGIN(bugprone-reserved-identifier)
 inline char *_(const char *msgid) { return gettext(msgid); }
 inline const char *_(const char *msgid, const char *msgctxt) {
   /* The separator between msgctxt and msgid in a .mo file.  */
@@ -36,6 +41,7 @@ inline const char *_(const char *msgid, const char *msgctxt) {
     return translation;
   }
 }
+// NOLINTEND(bugprone-reserved-identifier)
 
 enum class message_group {
   Error, Warning, UI_Warning, Font_Warning, Export_Warning, Export_Error, UI_Error, Parser_Error, Trace, Deprecated, None, Echo

--- a/src/utils/printutils.h
+++ b/src/utils/printutils.h
@@ -118,8 +118,10 @@ void PRINT_NOCACHE(const Message& msgObj);
  */
 
 void PRINTDEBUG(const std::string& filename, const std::string& msg);
+// NOLINTBEGIN
 #define PRINTD(_arg) do { PRINTDEBUG(std::string(__FILE__), _arg); } while (0)
 #define PRINTDB(_fmt, _arg) do { try { PRINTDEBUG(std::string(__FILE__), str(boost::format(_fmt) % _arg)); } catch (const boost::io::format_error& e) { PRINTDEBUG(std::string(__FILE__), "bad PRINTDB usage"); } } while (0)
+// NOLINTEND
 
 std::string two_digit_exp_format(std::string doublestr);
 std::string two_digit_exp_format(double x);


### PR DESCRIPTION
Some counts of unique lines which failed `bugprone` checks before:
```
    336 [bugprone-narrowing-conversions]
     78 [bugprone-easily-swappable-parameters]
     19 [bugprone-branch-clone]
     19 [bugprone-reserved-identifier]
     14 [bugprone-implicit-widening-of-multiplication-result]
      9 [bugprone-macro-parentheses]
      7 [bugprone-use-after-move]
      6 [bugprone-virtual-near-miss]
      5 [bugprone-exception-escape]
      4 [bugprone-suspicious-enum-usage]
      2 [bugprone-copy-constructor-init]
      1 [bugprone-parent-virtual-call]
      1 [bugprone-misplaced-widening-cast]
      1 [bugprone-integer-division]
      1 [bugprone-forwarding-reference-overload]
```
after:
```
    330 [bugprone-narrowing-conversions]
     78 [bugprone-easily-swappable-parameters]
      5 [bugprone-exception-escape]
```

The remaining checks are disabled in the top-level `.clang-tidy` file:
 - `narrowing-conversions` were just too many to deal with
 - `easily-swappable-parameters`  This is triggered any time two or more parameters of the same type are adjacent in a function signature, for example anything of the form: `foo(T x,T y,T z)`.  I don't see any sensible way to avoid such occurrences.
 - `exception-escape` these should probably be looked into, but I'm not sure how to best handle them.  The offending lines are pasted below.
```
src/core/Context.h:27:3: warning: an exception may be thrown in function '~ContextHandle<T>' which should not throw exceptions [bugprone-exception-escape]
src/core/Context.h:40:18: warning: an exception may be thrown in function 'operator=' which should not throw exceptions [bugprone-exception-escape]
src/core/ContextMemoryManager.cc:350:23: warning: an exception may be thrown in function '~ContextMemoryManager' which should not throw exceptions [bugprone-exception-escape]
src/core/ContextMemoryManager.h:36:3: warning: an exception may be thrown in function '~ContextMemoryManager' which should not throw exceptions [bugprone-exception-escape]
src/openscad.cc:886:5: warning: an exception may be thrown in function 'main' which should not throw exceptions [bugprone-exception-escape]
```

