### PR TITLE
Adjust 3mf regression test

### DIFF
--- a/tests/regression/3mfexport/3mf-export-expected.3mf
+++ b/tests/regression/3mfexport/3mf-export-expected.3mf
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<model xmlns="http://schemas.microsoft.com/3dmanufacturing/core/2015/02" unit="millimeter" xml:lang="en-US" xmlns:m="http://schemas.microsoft.com/3dmanufacturing/material/2015/02" xmlns:p="http://schemas.microsoft.com/3dmanufacturing/production/2015/06" xmlns:b="http://schemas.microsoft.com/3dmanufacturing/beamlattice/2017/02" xmlns:s="http://schemas.microsoft.com/3dmanufacturing/slice/2015/07">
+<model unit="millimeter" xml:lang="en-US" >
 	<resources>
 		<object id="1" name="OpenSCAD Model" type="model" p:UUID="XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXX">
 			<mesh>

--- a/tests/test_cmdline_tool.py
+++ b/tests/test_cmdline_tool.py
@@ -228,6 +228,8 @@ def post_process_3mf(filename):
     from zipfile import ZipFile
     xml_content = ZipFile(filename).read("3D/3dmodel.model")
     xml_content = re.sub('UUID="[^"]*"', 'UUID="XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXX"', xml_content.decode('utf-8'))
+    # ignore schema identifiers as they may differ between lib3MF versions
+    xml_content = re.sub('xmlns[^"]*\"[^"]*\"\ ?', '', xml_content)
     # add tag end whitespace for lib3mf 2.0 output files
     xml_content = re.sub('\"/>', '\" />', xml_content)
     with open(filename, 'wb') as xml_file:


### PR DESCRIPTION
Adjust regressing testing of 3mf files to account for variations in xmlns schemas to account for differences between V1.x and V2.x.