### PR TITLE
Upgrade harfbuzz to 2.8.2 to fix compilation error

### DIFF
--- a/scripts/macosx-build-dependencies.sh
+++ b/scripts/macosx-build-dependencies.sh
@@ -45,7 +45,7 @@ PACKAGES=(
     "libffi REMOVE"
     "freetype 2.9.1"
     "ragel REMOVE"
-    "harfbuzz 2.3.1"
+    "harfbuzz 2.8.2"
     "libzip 1.8.0"
     "libxml2 REMOVE"
     "libuuid 1.6.2"
@@ -767,10 +767,10 @@ build_harfbuzz()
   echo "Building harfbuzz $version..."
   cd "$BASEDIR"/src
   rm -rf "harfbuzz-$version"
-  if [ ! -f "harfbuzz-$version.tar.gz" ]; then
-    curl -LO "https://www.freedesktop.org/software/harfbuzz/release/harfbuzz-$version.tar.bz2"
+  if [ ! -f "harfbuzz-$version.tar.xz" ]; then
+      curl -LO "https://github.com/harfbuzz/harfbuzz/releases/download/$version/harfbuzz-$version.tar.xz"
   fi
-  tar xzf "harfbuzz-$version.tar.bz2"
+  tar xzf "harfbuzz-$version.tar.xz"
   cd "harfbuzz-$version"
 
   # Build each arch separately


### PR DESCRIPTION
The current harfbuzz-2.3.1 fails to build on M1 on macOS 12.6.1, Xcode 13.4.1.

See https://github.com/harfbuzz/harfbuzz/pull/2995