### PR TITLE
Make hidapi findable on macOS. Fixes #4194

### DIFF
--- a/cmake/Modules/FindHidAPI.cmake
+++ b/cmake/Modules/FindHidAPI.cmake
@@ -1,12 +1,12 @@
-find_package(PkgConfig QUIET)
-PKG_CHECK_MODULES(PC_HIDAPI QUIET hidapi-libusb)
+find_package(PkgConfig)
+pkg_search_module(PC_HIDAPI QUIET hidapi hidapi-libusb)
 
 find_path(HIDAPI_INCLUDE_DIR NAMES hidapi.h
 	HINTS
 	${PC_HIDAPI_INCLUDEDIR}
 	${PC_HIDAPI_INCLUDE_DIRS})
 
-find_library(HIDAPI_LIBRARY NAMES hidapi-libusb
+find_library(HIDAPI_LIBRARY NAMES hidapi hidapi-libusb
 	HINTS
 	${PC_HIDAPI_LIBDIR}
 	${PC_HIDAPI_LIBRARY_DIRS})


### PR DESCRIPTION
Verified that this correctly detects HID devices in the GUI.
I don't have a compatible HID device to test with, but this at least allows people to try.