### PR TITLE
Fix OpenCSG macOS patch

### DIFF
--- a/patches/OpenCSG-1.5.1-MacOSX-port.patch
+++ b/patches/OpenCSG-1.5.1-MacOSX-port.patch
@@ -1,8 +1,7 @@
-diff --git a/opencsg.pro b/opencsg.pro
-index b56e622..5cf2d6d 100644
 --- a/opencsg.pro
 +++ b/opencsg.pro
-@@ -1,2 +1,2 @@
+@@ -1,3 +1,3 @@
  TEMPLATE = subdirs
 -SUBDIRS  = src example
 +SUBDIRS  = src
+ CONFIG   += ordere


### PR DESCRIPTION
It was malformed and didn't get applied cleanly on macOS 13.