### PR TITLE
Set macOS timeout to 60 minutes

### DIFF
--- a/.github/workflows/macos-tests.yml
+++ b/.github/workflows/macos-tests.yml
@@ -10,6 +10,9 @@ jobs:
   build:
     runs-on: macos-11
     name: macos-11
+    # If it's not done in 60 minutes, something is wrong.
+    # Default is 6 hours, which is a bit long to wait.
+    timeout-minutes: 60
     steps:
     - name: Checkout
       uses: actions/checkout@v3


### PR DESCRIPTION
It's a bit wasteful to wait 6 hours for a hanging test to finish. Kill it after 1h; we can adjust this if it ever takes longer.