### PR TITLE
Run on macos-latest

### DIFF
--- a/.github/workflows/macos-tests.yml
+++ b/.github/workflows/macos-tests.yml
@@ -8,8 +8,8 @@ on:
 
 jobs:
   build:
-    runs-on: macos-11
-    name: macos-11
+    runs-on: macos-latest
+    name: macos-latest
     # If it's not done in 60 minutes, something is wrong.
     # Default is 6 hours, which is a bit long to wait.
     timeout-minutes: 60


### PR DESCRIPTION
The macOS runner was downgraded in #4490 to silence a hanging test (#4470). The hang was mitigated in #4501, so we can revert to macos-latest again.
