### PR TITLE
Enable autocomplete for words in the document.

### DIFF
--- a/src/gui/ScintillaEditor.cc
+++ b/src/gui/ScintillaEditor.cc
@@ -327,7 +327,7 @@ void ScintillaEditor::setupAutoComplete(const bool forceOff)
   const bool enable = configValue && !forceOff;
 
   if (enable) {
-    qsci->setAutoCompletionSource(QsciScintilla::AcsAPIs);
+    qsci->setAutoCompletionSource(QsciScintilla::AcsAll);
     qsci->setAutoCompletionFillupsEnabled(false);
     qsci->setAutoCompletionFillups("(");
     qsci->setCallTipsVisible(10);


### PR DESCRIPTION
Currently builtin editor does autocompletion for
builtin APIs only. This patch enables autocompletion for all words in the document, thus allowing to
autocomplete variable names, which greatly increases editing comfort and speed.