### PR TITLE
Fix leaking xsessions in export_png.cc

### DIFF
--- a/src/io/export_png.cc
+++ b/src/io/export_png.cc
@@ -19,9 +19,9 @@ static void setupCamera(Camera& cam, const BoundingBox& bbox)
 bool export_png(const shared_ptr<const Geometry>& root_geom, const ViewOptions& options, Camera& camera, std::ostream& output)
 {
   PRINTD("export_png geom");
-  OffscreenView *glview;
+  std::unique_ptr<OffscreenView> glview;
   try {
-    glview = new OffscreenView(camera.pixel_width, camera.pixel_height);
+    glview = std::make_unique<OffscreenView>(camera.pixel_width, camera.pixel_height);
   } catch (int error) {
     fprintf(stderr, "Can't create OpenGL OffscreenView. Code: %i.\n", error);
     return false;
@@ -41,7 +41,6 @@ bool export_png(const shared_ptr<const Geometry>& root_geom, const ViewOptions& 
   glview->setShowEdges(options["edges"]);
   glview->paintGL();
   glview->save(output);
-  delete glview;
   return true;
 }
 

--- a/src/io/export_png.cc
+++ b/src/io/export_png.cc
@@ -41,6 +41,7 @@ bool export_png(const shared_ptr<const Geometry>& root_geom, const ViewOptions& 
   glview->setShowEdges(options["edges"]);
   glview->paintGL();
   glview->save(output);
+  delete glview;
   return true;
 }
 


### PR DESCRIPTION
Found this when generating an animation resulted in the error:
> Maximum number of clients reached
> Unable to open a connection to the X server.
> DISPLAY=:0
> Can't create OpenGL OffscreenView. Code: -1.