### PR TITLE
implement new scale and translate parameter to rotate_extrude

### DIFF
--- a/src/core/RotateExtrudeNode.cc
+++ b/src/core/RotateExtrudeNode.cc
@@ -47,7 +47,7 @@ static std::shared_ptr<AbstractNode> builtin_rotate_extrude(const ModuleInstanti
 
   Parameters parameters = Parameters::parse(std::move(arguments), inst->location(),
                                             {"file", "layer", "origin", "scale"},
-                                            {"convexity", "angle"}
+                                            {"convexity", "angle", "translate"}
                                             );
 
   node->fn = parameters["$fn"].toDouble();
@@ -71,12 +71,30 @@ static std::shared_ptr<AbstractNode> builtin_rotate_extrude(const ModuleInstanti
   node->scale = parameters["scale"].toDouble();
   node->angle = 360;
   parameters["angle"].getFiniteDouble(node->angle);
+  node->scale_x = node->scale_y = 1;
+  bool scaleOK = parameters["scale"].getFiniteDouble(node->scale_x);
+  scaleOK &= parameters["scale"].getFiniteDouble(node->scale_y);
+  scaleOK |= parameters["scale"].getVec2(node->scale_x, node->scale_y, true);
+  if (!node->filename.empty() && (node->scale_x != 1 || node->scale_y != 1)) {
+    LOG(message_group::Warning, inst->location(), parameters.documentRoot(),
+        "rotate_extrude(..., scale=%1$s) interpreted in deprecated mode", parameters["scale"].toEchoStringNoThrow());
+    node->scale_x = node->scale_y = 1;
+  } else if ((parameters["scale"].isDefined()) && (!scaleOK || !std::isfinite(node->scale_x) || !std::isfinite(node->scale_y))) {
+    LOG(message_group::Warning, inst->location(), parameters.documentRoot(), "rotate_extrude(..., scale=%1$s) could not be converted", parameters["scale"].toEchoStringNoThrow());
+  }
+  node->trans_x = node->trans_y = 0;
+  bool transOK = parameters["translate"].getFiniteDouble(node->trans_x);
+  transOK &= parameters["translate"].getFiniteDouble(node->trans_y);
+  transOK |= parameters["translate"].getVec2(node->trans_x, node->trans_y, true);
+  if ((parameters["translate"].isDefined()) && (!transOK || !std::isfinite(node->trans_x) || !std::isfinite(node->trans_y))) {
+    LOG(message_group::Warning, inst->location(), parameters.documentRoot(), "rotate_extrude(..., translate=%1$s) could not be converted", parameters["translate"].toEchoStringNoThrow());
+  }
 
   if (node->convexity <= 0) node->convexity = 2;
 
   if (node->scale <= 0) node->scale = 1;
 
-  if ((node->angle <= -360) || (node->angle > 360)) node->angle = 360;
+  if (node->scale_x == 1 && node->scale_y == 1 && node->trans_x == 0 && node->trans_y == 0 && ((node->angle <= -360) || (node->angle > 360))) node->angle = 360;
 
   if (node->filename.empty()) {
     children.instantiate(node);
@@ -105,7 +123,18 @@ std::string RotateExtrudeNode::toString() const
     ;
   }
   stream <<
-    "angle = " << this->angle << ", "
+    "angle = " << this->angle << ", ";
+  if (this->scale_x != this->scale_y) {
+    stream << "scale = [" << this->scale_x << ", " << this->scale_y << "], ";
+  } else if (this->scale_x != 1.0) {
+    stream << "scale = " << this->scale_x << ", ";
+  }
+  if (this->trans_x != this->trans_y) {
+    stream << "translate = [" << this->trans_x << ", " << this->trans_y << "], ";
+  } else if (this->trans_x != 0.0) {
+    stream << "translate = " << this->trans_x << ", ";
+  }
+  stream <<
     "convexity = " << this->convexity << ", "
     "$fn = " << this->fn << ", $fa = " << this->fa << ", $fs = " << this->fs << ")";
 
@@ -118,6 +147,6 @@ void register_builtin_dxf_rotate_extrude()
 
   Builtins::init("rotate_extrude", new BuiltinModule(builtin_rotate_extrude),
   {
-    "rotate_extrude(angle = 360, convexity = 2)",
+    "rotate_extrude(angle = 360, scale = 1, translate = 0, convexity = 2)",
   });
 }

--- a/src/core/RotateExtrudeNode.h
+++ b/src/core/RotateExtrudeNode.h
@@ -12,13 +12,15 @@ public:
     fn = fs = fa = 0;
     origin_x = origin_y = scale = 0;
     angle = 360;
+    scale_x = scale_y = 1;
+    trans_x = trans_y = 0;
   }
   std::string toString() const override;
   std::string name() const override { return "rotate_extrude"; }
 
   int convexity;
   double fn, fs, fa;
-  double origin_x, origin_y, scale, angle;
+  double origin_x, origin_y, scale, angle, scale_x, scale_y, trans_x, trans_y;
   Filename filename;
   std::string layername;
 };

--- a/src/geometry/GeometryEvaluator.cc
+++ b/src/geometry/GeometryEvaluator.cc
@@ -1212,20 +1212,20 @@ Response GeometryEvaluator::visit(State& state, const LinearExtrudeNode& node)
   return Response::ContinueTraversal;
 }
 
-static void fill_ring(std::vector<Vector3d>& ring, const Outline2d& o, double a, bool flip)
+static void fill_ring(std::vector<Vector3d>& ring, const Outline2d& o, double a, double sx, double sy, double tx, double ty, bool flip)
 {
   if (flip) {
     unsigned int l = o.vertices.size() - 1;
     for (unsigned int i = 0; i < o.vertices.size(); ++i) {
-      ring[i][0] = o.vertices[l - i][0] * sin_degrees(a);
-      ring[i][1] = o.vertices[l - i][0] * cos_degrees(a);
-      ring[i][2] = o.vertices[l - i][1];
+      ring[i][0] = (o.vertices[l - i][0] * sx + tx) * sin_degrees(a);
+      ring[i][1] = (o.vertices[l - i][0] * sx + tx) * cos_degrees(a);
+      ring[i][2] = o.vertices[l - i][1] * sy + ty;
     }
   } else {
     for (unsigned int i = 0; i < o.vertices.size(); ++i) {
-      ring[i][0] = o.vertices[i][0] * sin_degrees(a);
-      ring[i][1] = o.vertices[i][0] * cos_degrees(a);
-      ring[i][2] = o.vertices[i][1];
+      ring[i][0] = (o.vertices[i][0] * sx + tx) * sin_degrees(a);
+      ring[i][1] = (o.vertices[i][0] * sx + tx) * cos_degrees(a);
+      ring[i][2] = o.vertices[i][1] * sy + ty;
     }
   }
 }
@@ -1262,6 +1262,8 @@ static std::unique_ptr<Geometry> rotatePolygon(const RotateExtrudeNode& node, co
     for (const auto& v : o.vertices) {
       min_x = fmin(min_x, v[0]);
       max_x = fmax(max_x, v[0]);
+      min_x = fmin(min_x, v[0] * node.scale_x + node.trans_x);
+      max_x = fmax(max_x, v[0] * node.scale_x + node.trans_x);
     }
   }
 
@@ -1272,9 +1274,11 @@ static std::unique_ptr<Geometry> rotatePolygon(const RotateExtrudeNode& node, co
 
   fragments = (unsigned int)std::ceil(fmax(Calc::get_fragments_from_r(max_x - min_x, node.fn, node.fs, node.fa) * std::abs(node.angle) / 360, 1));
 
-  bool flip_faces = (min_x >= 0 && node.angle > 0 && node.angle != 360) || (min_x < 0 && (node.angle < 0 || node.angle == 360));
+  bool full_loop = node.angle == 360 && node.scale_x == 1 && node.scale_y == 1 && node.trans_x == 0 && node.trans_y == 0;
 
-  if (node.angle != 360) {
+  bool flip_faces = (min_x >= 0 && node.angle > 0 && !full_loop) || (min_x < 0 && (node.angle < 0 || full_loop));
+
+  if (!full_loop) {
     auto ps_start = poly.tessellate(); // starting face
     Transform3d rot(angle_axis_degrees(90, Vector3d::UnitX()));
     ps_start->transform(rot);
@@ -1286,15 +1290,21 @@ static std::unique_ptr<Geometry> rotatePolygon(const RotateExtrudeNode& node, co
     }
     builder.appendPolySet(*ps_start);
 
-    auto ps_end = poly.tessellate();
-    Transform3d rot2(angle_axis_degrees(node.angle, Vector3d::UnitZ()) * angle_axis_degrees(90, Vector3d::UnitX()));
-    ps_end->transform(rot2);
-    if (flip_faces) {
-      for (auto& p : ps_end->indices) {
-        std::reverse(p.begin(), p.end());
+    if (node.scale_x != 0 && node.scale_y != 0) {
+      Polygon2d end_poly(poly);
+      Eigen::Affine2d trans(Eigen::Scaling(node.scale_x, node.scale_y));
+      end_poly.transform(trans);
+      auto ps_end = end_poly.tessellate();
+      translate_PolySet(*ps_end, Vector3d(node.trans_x, node.trans_y, 0));
+      Transform3d rot2(angle_axis_degrees(node.angle, Vector3d::UnitZ()) * angle_axis_degrees(90, Vector3d::UnitX()));
+      ps_end->transform(rot2);
+      if (flip_faces) {
+        for (auto& p : ps_end->indices) {
+          std::reverse(p.begin(), p.end());
+        }
       }
+      builder.appendPolySet(*ps_end);
     }
-    builder.appendPolySet(*ps_end);
   }
 
   for (const auto& o : poly.outlines()) {
@@ -1302,12 +1312,13 @@ static std::unique_ptr<Geometry> rotatePolygon(const RotateExtrudeNode& node, co
     rings[0].resize(o.vertices.size());
     rings[1].resize(o.vertices.size());
 
-    fill_ring(rings[0], o, (node.angle == 360) ? -90 : 90, flip_faces); // first ring
+    fill_ring(rings[0], o, full_loop ? -90 : 90, 1, 1, 0, 0, flip_faces); // first ring
     for (unsigned int j = 0; j < fragments; ++j) {
       double a;
-      if (node.angle == 360) a = -90 + ((j + 1) % fragments) * 360.0 / fragments; // start on the -X axis, for legacy support
+      if (full_loop) a = -90 + ((j + 1) % fragments) * 360.0 / fragments; // start on the -X axis, for legacy support
       else a = 90 - (j + 1) * node.angle / fragments; // start on the X axis
-      fill_ring(rings[(j + 1) % 2], o, a, flip_faces);
+      fill_ring(rings[(j + 1) % 2], o, a, 1 + (node.scale_x - 1) * (j + 1) / fragments, 1 + (node.scale_y - 1) * (j + 1) / fragments,
+		      node.trans_x * (j + 1) / fragments, node.trans_y * (j + 1) / fragments, flip_faces);
 
       for (size_t i = 0; i < o.vertices.size(); ++i) {
         builder.appendPolygon({


### PR DESCRIPTION
This implements two new vector parameters scale and translate to rotate_extrude with similar behavior that is known of twist in linear_extrude.

- scale: scale the base polygon along x and y axis in a linear way from [1,1] to the specified value from the start of the rotation to the end.  Since this parameter name was also used by the deprecated file importing function it is only available when not using file importing function.

- translate: translate the base polygon along x and y axis in a linear way from [0,0] to the specified value from the start of the rotation to the end.

This is an initial implementation working for me as a suggestion of how an interface and the implementation could look like. Given that I am not yet familiar with the OpenSCAD development community, I may have missed some interface or implementation guidelines. Feel free to point out name choices or design or implementation decisions that you don't like. I am open to adapting the code to the style usually applied.