### PR TITLE
move range check outside loop in random_extrude

### DIFF
--- a/src/geometry/GeometryEvaluator.cc
+++ b/src/geometry/GeometryEvaluator.cc
@@ -1265,14 +1265,15 @@ static Geometry *rotatePolygon(const RotateExtrudeNode& node, const Polygon2d& p
     for (const auto& v : o.vertices) {
       min_x = fmin(min_x, v[0]);
       max_x = fmax(max_x, v[0]);
-
-      if ((max_x - min_x) > max_x && (max_x - min_x) > fabs(min_x)) {
-        LOG(message_group::Error, "all points for rotate_extrude() must have the same X coordinate sign (range is %1$.2f -> %2$.2f)", min_x, max_x);
-        delete ps;
-        return nullptr;
-      }
     }
   }
+
+  if ((max_x - min_x) > max_x && (max_x - min_x) > fabs(min_x)) {
+    LOG(message_group::Error, "all points for rotate_extrude() must have the same X coordinate sign (range is %1$.2f -> %2$.2f)", min_x, max_x);
+    delete ps;
+    return nullptr;
+  }
+
   fragments = (unsigned int)fmax(Calc::get_fragments_from_r(max_x - min_x, node.fn, node.fs, node.fa) * std::abs(node.angle) / 360, 1);
 
   bool flip_faces = (min_x >= 0 && node.angle > 0 && node.angle != 360) || (min_x < 0 && (node.angle < 0 || node.angle == 360));


### PR DESCRIPTION
We should move the range check outside the loop calculating min/max x coordinates. There are two reasons behind this:
1. With the old implementation a violation might get detected early without going through all loops but this approach makes the loop processing in the non-error case slower due to repeated testing. It is advisable to optimize for the non-error case of optimization for error case since the non-error case is the one users will execute normally.
2. With the old implementation the printed range is incorrect since it will only print the range of all the vertices processed so far instead of the full range as printed in the new implementation. This produces quite confusing values in the error case.