### PR TITLE
round up number of fragments in rotate_extrude

### DIFF
--- a/src/geometry/GeometryEvaluator.cc
+++ b/src/geometry/GeometryEvaluator.cc
@@ -1254,7 +1254,7 @@ static Geometry *rotatePolygon(const RotateExtrudeNode& node, const Polygon2d& p
       }
     }
   }
-  fragments = (unsigned int)fmax(Calc::get_fragments_from_r(max_x - min_x, node.fn, node.fs, node.fa) * std::abs(node.angle) / 360, 1);
+  fragments = (unsigned int)std::ceil(fmax(Calc::get_fragments_from_r(max_x - min_x, node.fn, node.fs, node.fa) * std::abs(node.angle) / 360, 1));
 
   bool flip_faces = (min_x >= 0 && node.angle > 0 && node.angle != 360) || (min_x < 0 && (node.angle < 0 || node.angle == 360));
 


### PR DESCRIPTION
The old code rounded down the number of fragments in rotate extrude, which lead to weird results when working with a low number of $fn. By rounding up that number we always at least get the number of fragments needed to span a real body when working with degrees > 180.