### PR TITLE
Remove support for OpenGL < 2

### DIFF
--- a/src/glview/GLView.cc
+++ b/src/glview/GLView.cc
@@ -7,11 +7,6 @@
 #include "degree_trig.h"
 #include <cmath>
 #include <cstdio>
-#ifdef _WIN32
-#include <GL/wglew.h>
-#elif !defined(__APPLE__)
-#include <GL/glxew.h>
-#endif
 
 #ifdef ENABLE_OPENCSG
 #include <opencsg.h>
@@ -32,7 +27,6 @@ GLView::GLView()
 #ifdef ENABLE_OPENCSG
   is_opencsg_capable = false;
   has_shaders = false;
-  opencsg_support = true;
   static int sId = 0;
   this->opencsg_id = sId++;
 #endif
@@ -195,33 +189,12 @@ void glCompileCheck(GLuint shader) {
 
 void GLView::enable_opencsg_shaders()
 {
-  const char *openscad_disable_gl20_env = getenv("OPENSCAD_DISABLE_GL20");
-  if (openscad_disable_gl20_env && !strcmp(openscad_disable_gl20_env, "0")) {
-    openscad_disable_gl20_env = nullptr;
-  }
-
   // All OpenGL 2 contexts are OpenCSG capable
   if (GLEW_VERSION_2_0) {
-    if (!openscad_disable_gl20_env) {
-      this->is_opencsg_capable = true;
-      this->has_shaders = true;
-    }
+		this->is_opencsg_capable = true;
+		this->has_shaders = true;
   }
-#ifndef GLEW_EGL
-  // If OpenGL < 2, check for extensions
-  else if (GLEW_ARB_framebuffer_object || (GLEW_EXT_framebuffer_object && GLEW_EXT_packed_depth_stencil)
-#ifdef _WIN32
-           || (WGLEW_ARB_pbuffer && WGLEW_ARB_pixel_format)
-#elif !defined(__APPLE__)
-           // not supported by GLEW when built with EGL
-           || (GLXEW_SGIX_pbuffer && GLXEW_SGIX_fbconfig)
-#endif
-           ) {
-    this->is_opencsg_capable = true;
-  }
-#endif // ifndef GLEW_EGL
-
-  if (!GLEW_VERSION_2_0 || !this->is_opencsg_capable) {
+  else {
     display_opencsg_warning();
   }
 }

--- a/src/glview/GLView.h
+++ b/src/glview/GLView.h
@@ -75,7 +75,6 @@ public:
   bool has_shaders;
   void enable_opencsg_shaders();
   virtual void display_opencsg_warning() = 0;
-  bool opencsg_support;
   int opencsg_id;
 #endif
 private:

--- a/src/gui/OpenCSGWarningDialog.cc
+++ b/src/gui/OpenCSGWarningDialog.cc
@@ -9,11 +9,6 @@ OpenCSGWarningDialog::OpenCSGWarningDialog(QWidget *)
           Preferences::inst()->openCSGWarningBox, SLOT(setChecked(bool)));
   connect(this->showBox, SIGNAL(toggled(bool)),
           Preferences::inst(), SLOT(on_openCSGWarningBox_toggled(bool)));
-
-  connect(this->enableOpenCSGBox, SIGNAL(toggled(bool)),
-          Preferences::inst()->enableOpenCSGBox, SLOT(setChecked(bool)));
-  connect(this->enableOpenCSGBox, SIGNAL(toggled(bool)),
-          Preferences::inst(), SLOT(on_enableOpenCSGBox_toggled(bool)));
 }
 
 void OpenCSGWarningDialog::setText(const QString& text)

--- a/src/gui/OpenCSGWarningDialog.ui
+++ b/src/gui/OpenCSGWarningDialog.ui
@@ -29,16 +29,6 @@ p, li { white-space: pre-wrap; }
     </widget>
    </item>
    <item>
-    <widget class="QCheckBox" name="enableOpenCSGBox">
-     <property name="text">
-      <string>Enable OpenCSG</string>
-     </property>
-     <property name="checked">
-      <bool>true</bool>
-     </property>
-    </widget>
-   </item>
-   <item>
     <layout class="QHBoxLayout" name="horizontalLayout">
      <item>
       <widget class="QCheckBox" name="showBox">

--- a/src/gui/Preferences.cc
+++ b/src/gui/Preferences.cc
@@ -115,7 +115,6 @@ void Preferences::init() {
 
   // Setup default settings
   this->defaultmap["advanced/opencsg_show_warning"] = true;
-  this->defaultmap["advanced/enable_opencsg_opengl1x"] = true;
   this->defaultmap["advanced/polysetCacheSize"] = qulonglong(GeometryCache::instance()->maxSizeMB()) * 1024ul * 1024ul;
   this->defaultmap["advanced/polysetCacheSizeMB"] = getValue("advanced/polysetCacheSize").toULongLong() / (1024ul * 1024ul); // carry over old settings if they exist
 #ifdef ENABLE_CGAL
@@ -435,13 +434,6 @@ Preferences::on_openCSGWarningBox_toggled(bool state)
 {
   QSettingsCached settings;
   settings.setValue("advanced/opencsg_show_warning", state);
-}
-
-void
-Preferences::on_enableOpenCSGBox_toggled(bool state)
-{
-  QSettingsCached settings;
-  settings.setValue("advanced/enable_opencsg_opengl1x", state);
 }
 
 void Preferences::on_cgalCacheSizeMBEdit_textChanged(const QString& text)
@@ -963,7 +955,6 @@ void Preferences::updateGUI()
   }
 
   BlockSignals<QCheckBox *>(this->openCSGWarningBox)->setChecked(getValue("advanced/opencsg_show_warning").toBool());
-  BlockSignals<QCheckBox *>(this->enableOpenCSGBox)->setChecked(getValue("advanced/enable_opencsg_opengl1x").toBool());
   BlockSignals<QLineEdit *>(this->cgalCacheSizeMBEdit)->setText(getValue("advanced/cgalCacheSizeMB").toString());
   BlockSignals<QLineEdit *>(this->polysetCacheSizeMBEdit)->setText(getValue("advanced/polysetCacheSizeMB").toString());
   BlockSignals<QLineEdit *>(this->opencsgLimitEdit)->setText(getValue("advanced/openCSGLimit").toString());

--- a/src/gui/Preferences.h
+++ b/src/gui/Preferences.h
@@ -33,7 +33,6 @@ public slots:
   void on_fontSize_currentIndexChanged(const QString&);
   void on_syntaxHighlight_activated(const QString&);
   void on_openCSGWarningBox_toggled(bool);
-  void on_enableOpenCSGBox_toggled(bool);
   void on_cgalCacheSizeMBEdit_textChanged(const QString&);
   void on_polysetCacheSizeMBEdit_textChanged(const QString&);
   void on_opencsgLimitEdit_textChanged(const QString&);

--- a/src/gui/Preferences.ui
+++ b/src/gui/Preferences.ui
@@ -1656,13 +1656,6 @@
                 </widget>
                </item>
                <item>
-                <widget class="QCheckBox" name="enableOpenCSGBox">
-                 <property name="text">
-                  <string>Enable for OpenGL 1.x</string>
-                 </property>
-                </widget>
-               </item>
-               <item>
                 <layout class="QHBoxLayout" name="horizontalLayout_4">
                  <item>
                   <widget class="QLabel" name="label_7">

--- a/src/gui/QGLView.cc
+++ b/src/gui/QGLView.cc
@@ -121,13 +121,7 @@ void QGLView::display_opencsg_warning_dialog()
 {
   auto dialog = new OpenCSGWarningDialog(this);
 
-  QString message;
-  if (this->is_opencsg_capable) {
-    message += _("Warning: You may experience OpenCSG rendering errors.\n\n");
-  } else {
-    message += _("Warning: Missing OpenGL capabilities for OpenCSG - OpenCSG has been disabled.\n\n");
-    dialog->enableOpenCSGBox->hide();
-  }
+  QString message = _("Warning: Missing OpenGL capabilities for OpenCSG - OpenCSG has been disabled.\n\n");
   message += _("It is highly recommended to use OpenSCAD on a system with "
                "OpenGL 2.0 or later.\n"
                "Your renderer information is as follows:\n");
@@ -138,10 +132,7 @@ void QGLView::display_opencsg_warning_dialog()
                               (const char *)glGetString(GL_VERSION));
 
   dialog->setText(message);
-  dialog->enableOpenCSGBox->setChecked(Preferences::inst()->getValue("advanced/enable_opencsg_opengl1x").toBool());
   dialog->exec();
-
-  opencsg_support = this->is_opencsg_capable && Preferences::inst()->getValue("advanced/enable_opencsg_opengl1x").toBool();
 }
 #endif // ifdef ENABLE_OPENCSG
 

--- a/src/gui/QGLView.h
+++ b/src/gui/QGLView.h
@@ -22,7 +22,7 @@ class QGLView : public QOpenGLWidget, public GLView
 public:
   QGLView(QWidget *parent = nullptr);
 #ifdef ENABLE_OPENCSG
-  bool hasOpenCSGSupport() { return this->opencsg_support; }
+  bool hasOpenCSGSupport() { return this->is_opencsg_capable; }
 #endif
   // Properties
   bool orthoMode() const { return (this->cam.projection == Camera::ProjectionType::ORTHOGONAL); }


### PR DESCRIPTION
I don't expect there to be any real usage of pre-OpenGL 2 devices in the wild, so proactively removing this to keep future code cleaner.