### PR TITLE
[fast-csg] Simplify experimental features.

### DIFF
--- a/src/Feature.cc
+++ b/src/Feature.cc
@@ -32,14 +32,8 @@ Feature::list_t Feature::feature_list;  // Double-listed values. --^
  * const Features listed below.
  */
 const Feature Feature::ExperimentalFastCsg("fast-csg", "Enable much faster CSG operations with corefinement instead of nef when possible.");
-const Feature Feature::ExperimentalFastCsgTrustCorefinement("fast-csg-trust-corefinement", "Speed up fast-csg by trusting corefinement functions to tell us the cases they don't support, rather than proactively avoiding these with costly checks.");
+const Feature Feature::ExperimentalFastCsgSafer("fast-csg-safer", "Don't use corefinement in cases it doesn't supports and risks crashing. This will fallback to slower operations on Nef polyhedra.");
 const Feature Feature::ExperimentalFastCsgDebug("fast-csg-debug", "Debug mode for fast-csg: adds logs with extra costly checks and dumps .off files with the last corefinement operands.");
-#if FAST_CSG_KERNEL_IS_LAZY
-const Feature Feature::ExperimentalFastCsgExact("fast-csg-exact", "Force lazy numbers to exact after each CSG operation.");
-const Feature Feature::ExperimentalFastCsgExactCorefinementCallback("fast-csg-exact-callbacks", "Same as fast-csg-exact but even forces exact numbers inside corefinement callbacks rather than at the end of each operation.");
-#endif // FAST_CSG_KERNEL_IS_LAZY
-const Feature Feature::ExperimentalFastCsgRemesh("fast-csg-remesh", "Simplify results of fast-csg to avoid explosively slow renders (adds a bit of overhead as uses corefinement callbacks)");
-const Feature Feature::ExperimentalFastCsgRemeshPredictibly("fast-csg-remesh-predictibly", "Same as fast-csg-remesh but ensuring it remeshes faces starting from a predictable vertex. Slower but good for tests.");
 const Feature Feature::ExperimentalManifold("manifold", "Use the Manifold library (https://github.com/elalish/manifold) for CSG operations instead of CGAL.");
 const Feature Feature::ExperimentalRoof("roof", "Enable <code>roof</code>");
 const Feature Feature::ExperimentalInputDriverDBus("input-driver-dbus", "Enable DBus input drivers (requires restart)");
@@ -50,7 +44,7 @@ const Feature Feature::ExperimentalVxORenderersDirect("vertex-object-renderers-d
 const Feature Feature::ExperimentalVxORenderersPrealloc("vertex-object-renderers-prealloc", "Enable preallocating buffers in vertex object renderers");
 const Feature Feature::ExperimentalTextMetricsFunctions("textmetrics", "Enable the <code>textmetrics()</code> and <code>fontmetrics()</code> functions.");
 const Feature Feature::ExperimentalImportFunction("import-function", "Enable import function returning data instead of geometry.");
-const Feature Feature::ExperimentalSortStl("sort-stl", "Sort the STL output for predictable, diffable results.");
+const Feature Feature::ExperimentalPredictibleOutput("predictible-output", "Attempt to produce predictible, diffable outputs (e.g. sorting the STL, or remeshing in a determined order)");
 
 Feature::Feature(const std::string& name, std::string description)
   : name(name), description(std::move(description))

--- a/src/Feature.h
+++ b/src/Feature.h
@@ -15,12 +15,8 @@ public:
   using iterator = list_t::iterator;
 
   static const Feature ExperimentalFastCsg;
-  static const Feature ExperimentalFastCsgTrustCorefinement;
+  static const Feature ExperimentalFastCsgSafer;
   static const Feature ExperimentalFastCsgDebug;
-  static const Feature ExperimentalFastCsgExact;
-  static const Feature ExperimentalFastCsgExactCorefinementCallback;
-  static const Feature ExperimentalFastCsgRemesh;
-  static const Feature ExperimentalFastCsgRemeshPredictibly;
   static const Feature ExperimentalManifold;
   static const Feature ExperimentalRoof;
   static const Feature ExperimentalInputDriverDBus;
@@ -31,7 +27,7 @@ public:
   static const Feature ExperimentalVxORenderersPrealloc;
   static const Feature ExperimentalTextMetricsFunctions;
   static const Feature ExperimentalImportFunction;
-  static const Feature ExperimentalSortStl;
+  static const Feature ExperimentalPredictibleOutput;
 
   [[nodiscard]] const std::string& get_name() const;
   [[nodiscard]] const std::string& get_description() const;

--- a/src/geometry/cgal/CGALHybridPolyhedron.cc
+++ b/src/geometry/cgal/CGALHybridPolyhedron.cc
@@ -184,7 +184,7 @@ void CGALHybridPolyhedron::operator-=(CGALHybridPolyhedron& other)
 
 bool CGALHybridPolyhedron::canCorefineWith(const CGALHybridPolyhedron& other) const
 {
-  if (Feature::ExperimentalFastCsgTrustCorefinement.is_enabled()) {
+  if (!Feature::ExperimentalFastCsgSafer.is_enabled()) {
     return true;
   }
   const char *reasonWontCorefine = nullptr;
@@ -194,8 +194,7 @@ bool CGALHybridPolyhedron::canCorefineWith(const CGALHybridPolyhedron& other) co
     reasonWontCorefine = "non manifoldness detected";
   }
   if (reasonWontCorefine) {
-    LOG("[fast-csg] Performing safer but slower nef operation instead of corefinement because %1$s. "
-        "(can override with fast-csg-trust-corefinement)",
+    LOG("[fast-csg] Performing safer but slower nef operation instead of corefinement because %1$s.",
         reasonWontCorefine);
   }
   return !reasonWontCorefine;

--- a/src/geometry/cgal/cgalutils-coplanar-faces-remesher.h
+++ b/src/geometry/cgal/cgalutils-coplanar-faces-remesher.h
@@ -69,7 +69,7 @@ public:
 
     auto facesBefore = tm.number_of_faces();
     auto verbose = Feature::ExperimentalFastCsgDebug.is_enabled();
-    auto predictibleRemesh = Feature::ExperimentalFastCsgRemeshPredictibly.is_enabled();
+    auto predictibleRemesh = Feature::ExperimentalPredictibleOutput.is_enabled();
 
     class PatchData
     {

--- a/src/geometry/cgal/cgalutils-corefine.cc
+++ b/src/geometry/cgal/cgalutils-corefine.cc
@@ -5,55 +5,6 @@
 
 namespace CGALUtils {
 
-#if FAST_CSG_KERNEL_IS_LAZY
-
-/*! Visitor that forces exact numbers for the vertices of all the faces created during corefinement.
- */
-template <typename TriangleMesh>
-struct ExactLazyNumbersVisitor
-  : public PMP::Corefinement::Default_visitor<TriangleMesh> {
-  using GT = boost::graph_traits<TriangleMesh>;
-  using face_descriptor = typename GT::face_descriptor;
-  using halfedge_descriptor = typename GT::halfedge_descriptor;
-  using vertex_descriptor = typename GT::vertex_descriptor;
-
-#if CGAL_VERSION_NR >= CGAL_VERSION_NUMBER(5, 4, 0)
-  void new_vertex_added(std::size_t /*i_id*/, vertex_descriptor v, const TriangleMesh& tm) {
-    auto& pt = tm.point(v);
-    CGAL::exact(pt.x());
-    CGAL::exact(pt.y());
-    CGAL::exact(pt.z());
-  }
-#else
-  face_descriptor split_face;
-  std::vector<face_descriptor> created_faces;
-
-  void before_subface_creations(face_descriptor f_split, TriangleMesh& tm)
-  {
-    split_face = f_split;
-    created_faces.clear();
-  }
-
-  void after_subface_creations(TriangleMesh& mesh)
-  {
-    for (auto& fi : created_faces) {
-      CGAL::Vertex_around_face_iterator<TriangleMesh> vbegin, vend;
-      for (boost::tie(vbegin, vend) = vertices_around_face(mesh.halfedge(fi), mesh); vbegin != vend;
-           ++vbegin) {
-        auto& v = mesh.point(*vbegin);
-        CGAL::exact(v.x());
-        CGAL::exact(v.y());
-        CGAL::exact(v.z());
-      }
-    }
-    created_faces.clear();
-  }
-  void after_subface_created(face_descriptor fi, TriangleMesh& tm) { created_faces.push_back(fi); }
-#endif // if CGAL_VERSION_NR >= CGAL_VERSION_NUMBER(5, 4, 0)
-};
-
-#endif// FAST_CSG_KERNEL_IS_LAZY
-
 #define COREFINEMENT_FUNCTION(functionName, cgalFunctionName) \
         template <class TriangleMesh> \
         bool functionName(TriangleMesh &lhs, TriangleMesh &rhs, TriangleMesh &out) \

--- a/src/geometry/cgal/cgalutils-corefine.cc
+++ b/src/geometry/cgal/cgalutils-corefine.cc
@@ -58,20 +58,11 @@ struct ExactLazyNumbersVisitor
         template <class TriangleMesh> \
         bool functionName(TriangleMesh &lhs, TriangleMesh &rhs, TriangleMesh &out) \
         { \
-          auto remesh = Feature::ExperimentalFastCsgRemesh.is_enabled() || Feature::ExperimentalFastCsgRemeshPredictibly.is_enabled(); \
-          auto exactCallback = Feature::ExperimentalFastCsgExactCorefinementCallback.is_enabled(); \
-          if (exactCallback && !remesh) { \
-            auto param = PMP::parameters::visitor(ExactLazyNumbersVisitor<TriangleMesh>()); \
-            return cgalFunctionName(lhs, rhs, out, param, param); \
-          } else if (remesh) { \
-            CorefinementVisitor<TriangleMesh> visitor(lhs, rhs, out, exactCallback); \
-            auto param = PMP::parameters::visitor(visitor); \
-            auto result = cgalFunctionName(lhs, rhs, out, param, param, param); \
-            visitor.remeshSplitFaces(out); \
-            return result; \
-          } else { \
-            return cgalFunctionName(lhs, rhs, out); \
-          } \
+          CorefinementVisitor<TriangleMesh> visitor(lhs, rhs, out); \
+          auto param = PMP::parameters::visitor(visitor); \
+          auto result = cgalFunctionName(lhs, rhs, out, param, param, param); \
+          visitor.remeshSplitFaces(out); \
+          return result; \
         }
 
 COREFINEMENT_FUNCTION(corefineAndComputeUnion, PMP::corefine_and_compute_union);

--- a/src/geometry/cgal/cgalutils-mesh.cc
+++ b/src/geometry/cgal/cgalutils-mesh.cc
@@ -124,13 +124,8 @@ void cleanupMesh(CGAL_HybridMesh& mesh, bool is_corefinement_result)
 {
   mesh.collect_garbage();
 #if FAST_CSG_KERNEL_IS_LAZY
-  // If exact corefinement callbacks are enabled, no need to make numbers exact here again.
-  auto make_exact =
-    Feature::ExperimentalFastCsgExactCorefinementCallback.is_enabled()
-      ? !is_corefinement_result
-      : Feature::ExperimentalFastCsgExact.is_enabled();
-
-  if (make_exact) {
+  // Don't make exact again if exact corefinement callbacks already did the job.
+  if (!is_corefinement_result) {
     for (auto v : mesh.vertices()) {
       auto& pt = mesh.point(v);
       CGAL::exact(pt.x());

--- a/src/io/export_stl.cc
+++ b/src/io/export_stl.cc
@@ -142,7 +142,7 @@ uint64_t append_stl(const PolySet& ps, std::ostream& output, bool binary)
       }
     };
 
-  if (Feature::ExperimentalSortStl.is_enabled()) {
+  if (Feature::ExperimentalPredictibleOutput.is_enabled()) {
     Export::ExportMesh exportMesh { triangulated };
     exportMesh.foreach_triangle([&](const auto& pts) {
         processTriangle({ toVector(pts[0]), toVector(pts[1]), toVector(pts[2]) });

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -362,9 +362,9 @@ function(add_cmdline_test TESTCMD_BASENAME)
     if (NOT SCADFILE IN_LIST SCADFILES_WITH_DIFFERENT_FAST_CSG_EXPECTATIONS
         AND NOT SCADFILE IN_LIST SCADFILES_FAILING_WITH_FAST_CSG
         AND NOT TEST_FULLNAME IN_LIST TESTS_FAILING_WITH_FAST_CSG)
-      set(EXPERIMENTAL_OPTION ${EXPERIMENTAL_OPTION} "--enable=fast-csg" "--enable=fast-csg-remesh")
-      if (NOT SCADFILE IN_LIST FAST_CSG_TRUST_FAILING_SCADFILES)
-        set(EXPERIMENTAL_OPTION ${EXPERIMENTAL_OPTION} "--enable=fast-csg-trust-corefinement")
+      set(EXPERIMENTAL_OPTION ${EXPERIMENTAL_OPTION} "--enable=fast-csg")
+      if (SCADFILE IN_LIST FAST_CSG_SAFER_NEEDED)
+        set(EXPERIMENTAL_OPTION ${EXPERIMENTAL_OPTION} "--enable=fast-csg-safer")
       endif()
     endif()
 
@@ -829,7 +829,7 @@ list(APPEND SCADFILES_FAILING_WITH_FAST_CSG
   # Needs investigation:
   ${TEST_SCAD_DIR}/3D/issues/issue1246.scad
 )
-list(APPEND FAST_CSG_TRUST_FAILING_SCADFILES
+list(APPEND FAST_CSG_SAFER_NEEDED
   ${TEST_SCAD_DIR}/3D/features/edge-cases.scad
 )
 
@@ -1173,7 +1173,7 @@ add_cmdline_test(lazyunion-dxfpngtest  SCRIPT ${EX_IM_PNGTEST_PY} SUFFIX png FIL
 add_cmdline_test(lazyunion-svgpngtest  SCRIPT ${EX_IM_PNGTEST_PY} SUFFIX png FILES ${LAZYUNION_2D_FILES} EXPECTEDDIR lazyunion-cgalpng     ARGS ${OPENSCAD_ARG} --format=SVG --enable=lazy-union --render=cgal)
 
 add_cmdline_test(manifold-cgalpng             OPENSCAD SUFFIX png FILES ${SCADFILES_WITH_DIFFERENT_MANIFOLD_EXPECTATIONS} ARGS --enable=manifold --render)
-add_cmdline_test(fastcsg-cgalpng              OPENSCAD SUFFIX png FILES ${SCADFILES_WITH_DIFFERENT_FAST_CSG_EXPECTATIONS} ARGS --enable=fast-csg --enable=fast-csg-remesh --enable=fast-csg-trust-corefinement --render)
+add_cmdline_test(fastcsg-cgalpng              OPENSCAD SUFFIX png FILES ${SCADFILES_WITH_DIFFERENT_FAST_CSG_EXPECTATIONS} ARGS --enable=fast-csg --render)
 add_cmdline_test(fastcsg-lazyunion-cgalpng    OPENSCAD SUFFIX png FILES ${FASTCSG_LAZYUNION_FILES} ARGS --enable=lazy-union --render)
 add_cmdline_test(fastcsg-lazyunion-amfpngtest SCRIPT ${EX_IM_PNGTEST_PY} SUFFIX png FILES ${FASTCSG_LAZYUNION_FILES} EXPECTEDDIR fastcsg-lazyunion-monotonepngtest ARGS --enable=lazy-union ${OPENSCAD_ARG} --format=AMF)
 add_cmdline_test(fastcsg-lazyunion-3mfpngtest SCRIPT ${EX_IM_PNGTEST_PY} SUFFIX png FILES ${FASTCSG_LAZYUNION_FILES} EXPECTEDDIR fastcsg-lazyunion-monotonepngtest ARGS --enable=lazy-union ${OPENSCAD_ARG} --format=3MF)
@@ -1190,8 +1190,8 @@ list(APPEND FASTCSG_REMESH_FILES
   ${TEST_SCAD_DIR}/experimental/fastcsg-remesh-cube-2.scad
 )
 
-add_cmdline_test(remesh-cgalpng OPENSCAD SUFFIX png FILES ${FASTCSG_REMESH_FILES} ARGS --enable=fast-csg --enable=fast-csg-remesh --enable=fast-csg-trust-corefinement --render)
-add_cmdline_test(remesh-stl     OPENSCAD SUFFIX stl FILES ${FASTCSG_REMESH_FILES} ARGS --enable=sort-stl --enable=fast-csg --enable=fast-csg-remesh-predictibly --enable=fast-csg-trust-corefinement --render)
+add_cmdline_test(remesh-cgalpng OPENSCAD SUFFIX png FILES ${FASTCSG_REMESH_FILES} ARGS --enable=fast-csg --render)
+add_cmdline_test(remesh-stl     OPENSCAD SUFFIX stl FILES ${FASTCSG_REMESH_FILES} ARGS --enable=predictible-output --enable=fast-csg --render)
 
 # Trivial Export/Import files
 # This sanity-checks bidirectional file format import/export
@@ -1208,8 +1208,8 @@ add_cmdline_test(pdfexporttest SCRIPT ${EXPORT_PNGTEST_PY} SUFFIX png FILES ${SC
 
 # Corner-case Export/Import tests
 add_cmdline_test(monotonepngtest OPENSCAD SUFFIX png FILES ${EXPORT3D_CGAL_TEST_FILES} ${EXPORT3D_CGALCGAL_TEST_FILES} ARGS --colorscheme=Monotone --render)
-add_cmdline_test(stlexport             OPENSCAD SUFFIX stl FILES ${EXPORT_STL_TEST_FILES} ARGS --enable=sort-stl --render)
-add_cmdline_test(manifold-stlexport    OPENSCAD SUFFIX stl FILES ${EXPORT_STL_TEST_FILES} ARGS --enable=sort-stl --enable=manifold --render)
+add_cmdline_test(stlexport             OPENSCAD SUFFIX stl FILES ${EXPORT_STL_TEST_FILES} ARGS --enable=predictible-output --render)
+add_cmdline_test(manifold-stlexport    OPENSCAD SUFFIX stl FILES ${EXPORT_STL_TEST_FILES} ARGS --enable=predictible-output --enable=manifold --render)
 add_cmdline_test(objexport             OPENSCAD SUFFIX obj FILES ${EXPORT_OBJ_TEST_FILES} ARGS --render)
 add_cmdline_test(3mfexport             OPENSCAD ARGS SUFFIX 3mf FILES ${EXPORT_3MF_TEST_FILES})
 


### PR DESCRIPTION
There's been too many features for too long, time to tidy things up!

- `fast-csg` now implies former `fast-csg-remesh`, `fast-csg-exact`, `fast-csg-exact-callbacks`, `fast-csg-trust-corefinement`
- `fast-csg-safer` is same as formerly not enabling `fast-csg-trust-corefinement`
- `predictible-output` implies former `sort-stl` and `fast-csg-remesh-predictibly`

These might be the last days of [fast-csg](https://github.com/openscad/openscad/pull/3641) anyway 😅 (see https://github.com/openscad/openscad/pull/4533).