### PR TITLE
Add TBB to uni-get-dependencies.sh so it makes it to the AppImage

### DIFF
--- a/scripts/uni-get-dependencies.sh
+++ b/scripts/uni-get-dependencies.sh
@@ -11,7 +11,7 @@ get_fedora_deps_yum()
   boost-devel mpfr-devel gmp-devel glew-devel CGAL-devel gcc gcc-c++ pkgconfig \
   opencsg-devel git libXmu-devel curl imagemagick ImageMagick glib2-devel make \
   xorg-x11-server-Xvfb gettext qscintilla-qt5-devel \
-  mesa-dri-drivers double-conversion-devel
+  mesa-dri-drivers double-conversion-devel tbb-devel
 }
 
 get_fedora_deps_dnf()
@@ -22,7 +22,7 @@ get_fedora_deps_dnf()
   opencsg-devel git libXmu-devel curl ImageMagick glib2-devel make \
   xorg-x11-server-Xvfb gettext qscintilla-qt5-devel \
   mesa-dri-drivers libzip-devel ccache qt5-qtmultimedia-devel qt5-qtsvg-devel \
-  double-conversion-devel
+  double-conversion-devel tbb-devel
  dnf -y install libxml2-devel
  dnf -y install libffi-devel
  dnf -y install redhat-rpm-config
@@ -36,7 +36,8 @@ get_qomo_deps()
 get_altlinux_deps()
 {
  for i in boost-devel boost-filesystem-devel gcc4.5 gcc4.5-c++ boost-program_options-devel \
-  boost-thread-devel boost-system-devel boost-regex-devel eigen3 libmpfr libgmp libgmp_cxx-devel qt5-devel libcgal-devel git-core \
+  boost-thread-devel boost-system-devel boost-regex-devel eigen3 \
+  libmpfr libgmp libgmp_cxx-devel qt5-devel libcgal-devel git-core tbb-devel \
   libglew-devel flex bison curl imagemagick gettext glib2-devel; do apt-get install $i; done
 }
 
@@ -45,14 +46,15 @@ get_freebsd_deps()
  pkg_add -r bison boost-libs cmake git bash eigen3 flex gmake gmp mpfr \
   xorg libGLU libXmu libXi xorg-vfbserver glew \
   qt5-core qt5-gui qt5-buildtools qt5-opengl qt5-qmake \
-  opencsg cgal curl imagemagick glib2-devel gettext libdouble-conversion-3.0.0
+  opencsg cgal curl imagemagick glib2-devel gettext libdouble-conversion-3.0.0 \
+  devel/onetbb
 }
 
 get_netbsd_deps()
 {
  pkgin install bison boost cmake git bash eigen3 flex gmake gmp mpfr \
   qt5 glew cgal opencsg python27 curl \
-  ImageMagick glib2 gettext
+  ImageMagick glib2 gettext threadingbuildingblocks
 }
 
 get_opensuse_deps()
@@ -63,7 +65,7 @@ get_opensuse_deps()
   qscintilla-qt5-devel libqt5-qtbase-devel libQt5OpenGL-devel \
   xvfb-run libzip-devel libqt5-qtmultimedia-devel libqt5-qtsvg-devel \
   double-conversion-devel libboost_filesystem-devel libboost_regex-devel \
-  libboost_program_options-devel
+  libboost_program_options-devel tbb
  # qscintilla-qt5-devel replaces libqscintilla_qt5-devel
  # but openscad compiles with both
  zypper install libeigen3-devel
@@ -92,7 +94,7 @@ get_mageia_deps()
  urpmi task-c-devel task-c++-devel libqt5-devel libgmp-devel \
   libmpfr-devel libboost-devel eigen3-devel libglew-devel bison flex \
   cmake imagemagick glib2-devel python curl git x11-server-xvfb gettext \
-  double-conversion-devel
+  double-conversion-devel tbb
 }
 
 get_debian_deps()
@@ -103,7 +105,7 @@ get_debian_deps()
   libmpfr-dev libboost-dev libglew-dev libcairo2-dev \
   libeigen3-dev libcgal-dev libopencsg-dev libgmp3-dev libgmp-dev \
   imagemagick libfreetype6-dev libdouble-conversion-dev \
-  gtk-doc-tools libglib2.0-dev gettext xvfb pkg-config ragel
+  gtk-doc-tools libglib2.0-dev gettext xvfb pkg-config ragel libtbb-dev
  apt-get -y install libxi-dev libfontconfig-dev libzip-dev
 }
 
@@ -138,7 +140,7 @@ get_arch_deps()
 	base-devel gcc bison flex make libzip \
 	qt5 qscintilla-qt5 cgal gmp mpfr boost opencsg \
 	glew eigen glib2 fontconfig freetype2 harfbuzz \
-	double-conversion imagemagick
+	double-conversion imagemagick tbb
 }
 
 get_ubuntu_16_deps()
@@ -162,7 +164,7 @@ get_solus_deps()
 	opencsg-devel glew-devel eigen3 \
 	fontconfig-devel freetype2-devel harfbuzz-devel libzip-devel \
 	double-conversion-devel \
-	bison flex
+	bison flex intel-tbb-devel
 }
 
 unknown()


### PR DESCRIPTION
Hey @t-paul, didn't realize the app image was built using that script, might need another update sorry!

(context: https://github.com/openscad/openscad/pull/4533)

Edit: Now I see the [latest workflow](https://app.circleci.com/pipelines/github/openscad/openscad/3399/workflows/f388688a-cce4-4fc6-bcbe-de70c00e5335/jobs/13941) succeeded, maybe you already added the dep to the image 🥳