### PR TITLE
[DRAFT] Flatten CSG tree to let more lazy unions bubble up to the top

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -616,6 +616,7 @@ set(CORE_SOURCES
   src/core/SourceFile.cc
   src/core/SourceFileCache.cc
   src/core/StatCache.cc
+  src/core/TreeFlattener.cc
   src/core/UserModule.cc
   src/core/Tree.cc
   src/core/customizer/ParameterObject.cc

--- a/README.md
+++ b/README.md
@@ -283,3 +283,14 @@ Once built, you can run tests with `cd build/tests && ctest -j`.
 	#    ...
 	#    ./scripts/release-common.sh -snapshot -mingw64 -v "$OPENSCAD_VERSION"
 	```
+
+# Tree Flattener for better Lazy Unions and less transforms
+
+This is a rewrite of https://github.com/openscad/openscad/pull/3637 that:
+- Pushes down color and transform nodes
+- Flattens intersections and unions (treating list and group nodes as unions)
+
+It's the ideal companion to the experimental `lazy-union` feature as it lets many more unions bubble up to the top. For instance the following scene results in a lazy union of X bodies, with instant rendering (instead of X seconds, even with `fast-csg`).
+
+It's also a potentially good combo with the upcoming `manifold` rendering option (https://github.com/openscad/openscad/pull/4533) and generally for speed on larger models as it essentially computes the world transform of most leaf nodes and applies the transform once on each leaf (instead of applying many transforms along the tree). This means less operations, and less loss of precision (esp. w/ Manifold, which stores vertex coordinates in single precision floats).
+

--- a/src/Feature.cc
+++ b/src/Feature.cc
@@ -40,6 +40,7 @@ const Feature Feature::ExperimentalFastCsgExactCorefinementCallback("fast-csg-ex
 #endif // FAST_CSG_KERNEL_IS_LAZY
 const Feature Feature::ExperimentalFastCsgRemesh("fast-csg-remesh", "Simplify results of fast-csg to avoid explosively slow renders (adds a bit of overhead as uses corefinement callbacks)");
 const Feature Feature::ExperimentalFastCsgRemeshPredictibly("fast-csg-remesh-predictibly", "Same as fast-csg-remesh but ensuring it remeshes faces starting from a predictable vertex. Slower but good for tests.");
+const Feature Feature::ExperimentalFlattenTree("flatten", "Push transforms down and flatten the rendering tree to enhance lazy-union (more unions bubble up), manifold (less intermediate transforms to avoid Manifold single precision transforms) and manifold-batch (higher arity of operations).");
 const Feature Feature::ExperimentalRoof("roof", "Enable <code>roof</code>");
 const Feature Feature::ExperimentalInputDriverDBus("input-driver-dbus", "Enable DBus input drivers (requires restart)");
 const Feature Feature::ExperimentalLazyUnion("lazy-union", "Enable lazy unions.");

--- a/src/Feature.h
+++ b/src/Feature.h
@@ -21,6 +21,7 @@ public:
   static const Feature ExperimentalFastCsgExactCorefinementCallback;
   static const Feature ExperimentalFastCsgRemesh;
   static const Feature ExperimentalFastCsgRemeshPredictibly;
+  static const Feature ExperimentalFlattenTree;
   static const Feature ExperimentalRoof;
   static const Feature ExperimentalInputDriverDBus;
   static const Feature ExperimentalLazyUnion;

--- a/src/core/ModuleInstantiation.h
+++ b/src/core/ModuleInstantiation.h
@@ -45,3 +45,5 @@ public:
 private:
   std::unique_ptr<LocalScope> else_scope;
 };
+
+std::shared_ptr<AbstractNode> lazyUnionNode(const ModuleInstantiation *inst);

--- a/src/core/TreeFlattener.cc
+++ b/src/core/TreeFlattener.cc
@@ -386,6 +386,12 @@ void flattenTree(Tree& tree) {
 //     printTreeDebug(*tree.root());
 // #endif
 
+  // TODO: detect when caching would work against top-level lazy-union!
+  // for (i=[0:N-1]) translate([i,0,0])
+  //   for(j=[0:N-1]) translate([0,j,0])
+  //     sphere(d=(overlap ? 1.1 : 0.9), $fn=50);
+
+
   TreeFlattener flattener(tree, repeatedNodeIds);
   tree.setRoot(flattener.flatten(tree.root()));
 

--- a/src/core/TreeFlattener.cc
+++ b/src/core/TreeFlattener.cc
@@ -1,0 +1,333 @@
+#include "TreeFlattener.h"
+
+#include "ColorNode.h"
+#include "CsgOpNode.h"
+#include "node.h"
+#include "NodeVisitor.h"
+#include "TransformNode.h"
+#include "Tree.h"
+
+#include <unordered_set>
+#include <unordered_map>
+#include <stack>
+
+using NodesGroupedByContent = std::unordered_map<std::string, std::unordered_set<const AbstractNode*>>;
+
+/** Best effort cloning of known tree types. */
+shared_ptr<AbstractNode> cloneWithoutChildren(const shared_ptr<const AbstractNode>& node) {
+  if (dynamic_pointer_cast<const ListNode>(node)) return make_shared<ListNode>(node->modinst);
+  else if (dynamic_pointer_cast<const ListNode>(node)) return make_shared<ListNode>(node->modinst);
+  else if (auto groupNode = dynamic_pointer_cast<const GroupNode>(node)) return make_shared<GroupNode>(node->modinst, groupNode->verbose_name());
+  else if (auto csgOpNode = dynamic_pointer_cast<const CsgOpNode>(node)) return make_shared<CsgOpNode>(node->modinst, csgOpNode->type);
+  // else if (auto transformNode = dynamic_pointer_cast<const TransformNode>(node)) return make_shared<TransformNode>(node->modinst, transformNode->matrix);
+  // else if (auto colodNode = dynamic_pointer_cast<const ColorNode>(node)) return make_shared<ColorNode>(node->modinst, colorNode->color);
+  else return nullptr;
+}
+
+/** Detect flags on nodes that should not be inlined.
+ * Not testing for isRoot, as we'll be called on the actual tree root
+ * to only render what's below it.
+ */
+bool hasFlagsPreventingInlining(const shared_ptr<const AbstractNode>& node) {
+  return node && node->modinst &&
+      (node->modinst->isBackground() || node->modinst->isHighlight());
+}
+
+bool isAssociativeFlattenable(OpenSCADOperator op) {
+  return
+    // op == OpenSCADOperator::HULL ||
+    op == OpenSCADOperator::UNION ||
+    op == OpenSCADOperator::INTERSECTION ||
+}
+
+
+/** Groups all the nodes in the by their textual representation.
+ * Adds to out, so can be called on multiple trees to, say, detect identical
+ * nodes across different animation frames.
+ */
+class RepeatedNodesDetector : public NodeVisitor
+{
+public:
+  RepeatedNodesDetector(const Tree& tree, NodesGroupedByContent& out) : tree(tree), out(out) {}
+
+  Response visit(State& state, const AbstractNode& node) override {
+    if (state.isPrefix()) {
+      auto key = this->tree.getIdString(node);
+      out[key].insert(&node);
+    }
+    return Response::ContinueTraversal;
+  }
+
+private:
+  const Tree& tree;
+  NodesGroupedByContent& out;
+};
+
+/** Get the set of nodes which content occurred more than once.
+ * These are nodes for which caching would be important during rendering.
+ */
+std::unordered_set<const AbstractNode*> getRepeatedNodes(const NodesGroupedByContent &group) {
+  std::unordered_set<const AbstractNode*> nodes;
+  for (auto &pair : group) {
+    if (pair.second.size() > 1) {
+      for (auto node : pair.second) {
+        nodes.insert(node);
+      }
+    }
+  }
+  return std::move(nodes);
+}
+
+/** Transforms trees by pushing transform nodes down through many operations.
+ *
+ * Avoids pushing through repeated nodes, which would defeat caching, or through nodes w/ special marks.
+ */
+class TransformsPusher
+{
+  using Children = std::vector<shared_ptr<const AbstractNode>>;
+  struct State {
+    std::optional<Transform3d> transform;
+    std::optional<Color4f> color;
+  };
+  std::unordered_set<const AbstractNode*>& repeatedNodes;
+  bool traverseHulls;
+
+public:
+  TransformsPusher(std::unordered_set<const AbstractNode*>& repeatedNodes)
+    : repeatedNodes(repeatedNodes), traverseHulls(false) {}
+
+  void setTraverseHulls(bool value) {
+    traverseHulls = value;
+  }
+
+  shared_ptr<const AbstractNode> transform(const shared_ptr<const AbstractNode>& node, const State &state = State {}) {
+    if (!node) return node;
+
+    if (auto transformNode = dynamic_pointer_cast<const TransformNode>(node)) {
+      if (node->children.size() > 1 ||
+          node->children.size() == 1 && canPushThrough(node->children[0])) {
+        
+        State newState = state;
+        if (auto transform = state.transform) {
+          newState.transform = *transform * transformNode->matrix;
+        } else {
+          newState.transform = transformNode->matrix;
+        }
+
+        Children children = node->children;
+        for (auto &child : children) {
+          child = transform(child, newState);
+        }
+        assert(children != node->children);
+        auto newUnion = lazyUnionNode(node->modinst);
+        newUnion->children = children;
+        return newUnion;
+      }
+    }
+
+    if ((state.transform || state.color) && !canPushThrough(node)) {
+      return wrapWithState(transformChildren(node, State {}), state);
+    } else {
+      return transformChildren(node, state);
+    }
+  }
+
+private:
+
+  shared_ptr<const AbstractNode> transformChildren(const shared_ptr<const AbstractNode>& node, const State &state) {
+    Children children = node->children;
+    for (auto &child : children) {
+      child = transform(child, state);
+    }
+    if (children != node->children) {
+      auto clone = cloneWithoutChildren(node);
+      assert(clone);
+      if (!clone) {
+        return wrapWithState(node, state);
+      }
+      clone->children = children;
+      return clone;
+    }
+    return node;
+  }
+
+  bool canPushThrough(const shared_ptr<const AbstractNode>& node) const {
+    if (hasFlagsPreventingInlining(node)) {
+      return false;
+    }
+    if (auto csgOpNode = dynamic_pointer_cast<const CsgOpNode>(node)) {
+      switch (csgOpNode->type) {
+        case OpenSCADOperator::UNION:
+        case OpenSCADOperator::INTERSECTION:
+        case OpenSCADOperator::DIFFERENCE:
+          return true;
+        case OpenSCADOperator::HULL:
+          return traverseHulls;
+        default:
+          return false;
+      }
+    }
+    return
+        dynamic_pointer_cast<const ListNode>(node) ||
+        dynamic_pointer_cast<const GroupNode>(node);
+  }
+  
+  shared_ptr<const AbstractNode> wrapWithState(const shared_ptr<const AbstractNode>& node, const State &state) const {
+    auto res = node;
+    if (auto transform = state.transform) {
+      auto transformNode = make_shared<TransformNode>(node->modinst, "??");
+      transformNode->children.push_back(res);
+      transformNode->matrix = *transform;
+      res = transformNode;
+    }
+    if (auto color = state.color) {
+      auto colorNode = make_shared<ColorNode>(node->modinst);
+      colorNode->children.push_back(res);
+      colorNode->color = *color;
+      res = colorNode;
+    }
+    return res;
+  }
+};
+
+/**
+ * Flattens nodes w/ associative operations, treating ListNode & GroupNode as unions.
+ */
+class TreeFlattener
+{
+  std::unordered_set<const AbstractNode*>& repeatedNodes;
+
+public:
+  TreeFlattener(std::unordered_set<const AbstractNode*>& repeatedNodes)
+    : repeatedNodes(repeatedNodes) {}
+  
+  shared_ptr<const AbstractNode> flatten(const shared_ptr<const AbstractNode>& node) {
+    if (!node) return node;
+
+    using Children = std::vector<shared_ptr<const AbstractNode>>;
+
+    if (canInline(node)) {
+      auto makeOp = [&](OpenSCADOperator op, const Children& children) -> shared_ptr<const AbstractNode> {
+        if (children.size() == 1) {
+          return children[0];
+        }
+        if (children == node->children) {
+          return node;
+        } 
+
+        shared_ptr<AbstractNode> ret;
+        if (op == OpenSCADOperator::UNION) {
+          ret = lazyUnionNode(node->modinst);
+        } else {
+          ret = make_shared<CsgOpNode>(node->modinst, op);
+        }
+        ret->children = children;
+        return ret;
+      };
+
+      if (dynamic_pointer_cast<const ListNode>(node) || 
+          dynamic_pointer_cast<const GroupNode>(node)) {
+        Children children;
+        flattenChildren(node, children, OpenSCADOperator::UNION);
+        return makeOp(OpenSCADOperator::UNION, children);
+      } else if (auto csgOpNode = dynamic_pointer_cast<const CsgOpNode>(node)) {
+        if (isAssociativeFlattenable(csgOpNode->type)) {
+          Children
+          // return makeOp(csgOpNode->type || children);
+          children;
+          flattenChildren(csgOpNode, children, csgOpNode->type);
+        }
+      } else {
+        Children children = node->children;
+        for (auto &child : children) {
+          child = flatten(child);
+        }
+        if (children != node->children) {
+          auto clone = cloneWithoutChildren(node);
+          if (clone) {
+            clone->children = children;
+            return clone;
+          }
+        }
+      }
+    }
+    return node;
+  }
+
+private:
+
+  void flattenChildren(const shared_ptr<const AbstractNode>& node, std::vector<shared_ptr<const AbstractNode>> &out, const std::optional<OpenSCADOperator> allowedOp) {
+    if (!node) {
+      return;
+    }
+    for (auto child : node->children) {
+      if (canInline(child)) {
+        if (dynamic_pointer_cast<const ListNode>(child) || dynamic_pointer_cast<const GroupNode>(child)) {
+          flattenChildren(child, out, allowedOp);
+          continue;
+        }
+        if (auto csgNode = dynamic_pointer_cast<const CsgOpNode>(child)) {
+          if (allowedOp && csgNode->type == *allowedOp && isAssociativeFlattenable(*allowedOp)) {
+            flattenChildren(csgNode, out, allowedOp);
+          }
+        // }
+           ||         continue;
+      }
+      out.push_back(flatten(child));
+    }
+  }
+
+  bool canInline(const shared_ptr<const AbstractNode>& node) const {
+    if (!node || hasFlagsPreventingInlining(node)) {
+      return false;
+    }
+    if (repeatedNodes.find(node.get()) != repeatedNodes.end()) {
+      return false;
+    }
+    return true;
+  }
+};
+
+void printTreeDebug(const AbstractNode& node, const std::string& indent = "") {
+  auto hasChildren = node.getChildren().size() > 0;
+  LOG(message_group::None,Location::NONE,"", "%1$s",
+      (indent + node.toString() + (hasChildren ? " {" : ";")).c_str());
+  for (const auto child : node.getChildren()) {
+    if (child) printTreeDebug(*child, indent + "  ");
+  }
+  if (hasChildren) LOG(message_group::None,Location::NONE,"", "%1$s", (indent + "}").c_str());
+}
+
+void flattenTree(Tree& tree, bool traverseHulls) {
+  NodesGroupedByContent nodesByContent;
+  {
+    RepeatedNodesDetector detector(tree, nodesByContent);
+    detector.traverse(*tree.root());
+  }
+
+  std::unordered_set<const AbstractNode*> repeatedNodes = getRepeatedNodes(nodesByContent);
+
+#ifdef DEBUG
+    LOG(message_group::None,Location::NONE,"","[flatten] BEFORE:");
+    printTreeDebug(*tree.root());
+#endif
+
+  TransformsPusher pusher(repeatedNodes);
+  pusher.setTraverseHulls(traverseHulls);
+  auto pushedRoot = pusher.transform(tree.root());
+
+#ifdef DEBUG
+    LOG(message_group::None,Location::NONE,"","[flatten] AFTER PUSH DOWN:");
+    printTreeDebug(*pushedRoot);
+#endif
+
+  TreeFlattener flattener(repeatedNodes);
+  auto flattenedRoot = flattener.flatten(pushedRoot);
+
+#ifdef DEBUG
+    LOG(message_group::None,Location::NONE,"","[flatten] AFTER FLATTEN:");
+    printTreeDebug(*flattenedRoot);
+#endif
+
+  tree.setRoot(flattenedRoot);
+}

--- a/src/core/TreeFlattener.cc
+++ b/src/core/TreeFlattener.cc
@@ -291,6 +291,16 @@ public:
           if (children != node->children) {
             return makeOp(csgOpNode->type, children);
           }
+        } else if (csgOpNode->type == OpenSCADOperator::DIFFERENCE && node->children.size() > 1) {
+          // difference() { A(); union() { B(); C(); } } -> difference() { A(); B(); C(); }
+          auto firstChild = node->children[0];
+          auto otherChildren = node->children;
+          otherChildren.erase(otherChildren.begin());
+          Children children = {firstChild};
+          flattenChildren(otherChildren, children, OpenSCADOperator::UNION);
+          if (children != node->children) {
+            return makeOp(OpenSCADOperator::DIFFERENCE, children);
+          }
         }
       } else {
         Children children = node->children;

--- a/src/core/TreeFlattener.h
+++ b/src/core/TreeFlattener.h
@@ -1,0 +1,14 @@
+#pragma once
+
+class Tree;
+
+/**
+ * Flattens associative ops (unions, intersections, but not hull)
+ * and pushes colors and transforms down.
+ *
+ * This creates flatter trees, with higher arity in commutative operations
+ * and more lazy unions at the top.
+ * 
+ * Skips special nodes and subtrees which are repeated to avoid defeating caching.
+*/
+void flattenTree(Tree& tree);

--- a/src/core/control.cc
+++ b/src/core/control.cc
@@ -35,7 +35,7 @@
 #include "printutils.h"
 #include <cstdint>
 
-static std::shared_ptr<AbstractNode> lazyUnionNode(const ModuleInstantiation *inst)
+std::shared_ptr<AbstractNode> lazyUnionNode(const ModuleInstantiation *inst)
 {
   if (Feature::ExperimentalLazyUnion.is_enabled()) {
     return std::make_shared<ListNode>(inst);

--- a/src/core/node.cc
+++ b/src/core/node.cc
@@ -93,7 +93,7 @@ std::string AbstractIntersectionNode::name() const
   return "intersection";
 }
 
-void AbstractNode::progress_prepare()
+void AbstractNode::progress_prepare() const
 {
   std::for_each(this->children.begin(), this->children.end(), std::mem_fn(&AbstractNode::progress_prepare));
   this->progress_mark = ++progress_report_count;
@@ -116,9 +116,9 @@ std::ostream& operator<<(std::ostream& stream, const AbstractNode& node)
    If a second root modifier was found, nextLocation (if non-zero) will be set to point to
    the location of that second modifier.
  */
-std::shared_ptr<AbstractNode> find_root_tag(const std::shared_ptr<AbstractNode>& node, const Location **nextLocation)
+std::shared_ptr<const AbstractNode> find_root_tag(const std::shared_ptr<const AbstractNode>& node, const Location **nextLocation)
 {
-  std::shared_ptr<AbstractNode> rootTag;
+  std::shared_ptr<const AbstractNode> rootTag;
 
   std::function<void (const std::shared_ptr<const AbstractNode>&)> recursive_find_tag = [&](const std::shared_ptr<const AbstractNode>& node) {
       for (const auto& child : node->children) {

--- a/src/core/node.h
+++ b/src/core/node.h
@@ -13,7 +13,7 @@ extern int progress_report_count;
 extern void (*progress_report_f)(const std::shared_ptr<const AbstractNode>&, void *, int);
 extern void *progress_report_vp;
 
-void progress_report_prep(const std::shared_ptr<AbstractNode>& root, void (*f)(const std::shared_ptr<const AbstractNode>& node, void *vp, int mark), void *vp);
+void progress_report_prep(const std::shared_ptr<const AbstractNode>& root, void (*f)(const std::shared_ptr<const AbstractNode>& node, void *vp, int mark), void *vp);
 void progress_report_fin();
 
 /*!
@@ -46,7 +46,7 @@ public:
      are inserted into the cache*/
   virtual class Geometry *evaluate_geometry(class PolySetEvaluator *) const { return nullptr; }
 
-  const std::vector<std::shared_ptr<AbstractNode>>& getChildren() const {
+  const std::vector<std::shared_ptr<const AbstractNode>>& getChildren() const {
     return this->children;
   }
   size_t index() const { return this->idx; }
@@ -54,13 +54,15 @@ public:
   static void resetIndexCounter() { idx_counter = 1; }
 
   // FIXME: Make protected
-  std::vector<std::shared_ptr<AbstractNode>> children;
+  std::vector<std::shared_ptr<const AbstractNode>> children;
   const ModuleInstantiation *modinst;
 
   // progress_mark is a running number used for progress indication
   // FIXME: Make all progress handling external, put it in the traverser class?
-  int progress_mark{0};
-  void progress_prepare();
+  // Mutable only so progress_prepare can set it sneakily. This allows us to
+  // store shared_ptr<const AbstractNode> in many places.
+  mutable int progress_mark{0};
+  void progress_prepare() const;
   void progress_report() const;
 
   int idx; // Node index (unique per tree)
@@ -138,4 +140,4 @@ public:
 };
 
 std::ostream& operator<<(std::ostream& stream, const AbstractNode& node);
-std::shared_ptr<AbstractNode> find_root_tag(const std::shared_ptr<AbstractNode>& node, const Location **nextLocation = nullptr);
+std::shared_ptr<const AbstractNode> find_root_tag(const std::shared_ptr<const AbstractNode>& node, const Location **nextLocation = nullptr);

--- a/src/core/progress.cc
+++ b/src/core/progress.cc
@@ -6,7 +6,7 @@ int progress_mark_;
 void (*progress_report_f)(const std::shared_ptr<const AbstractNode> &, void *, int);
 void *progress_report_userdata;
 
-void progress_report_prep(const std::shared_ptr<AbstractNode> &root, void (*f)(const std::shared_ptr<const AbstractNode> &node, void *userdata, int mark), void *userdata)
+void progress_report_prep(const std::shared_ptr<const AbstractNode> &root, void (*f)(const std::shared_ptr<const AbstractNode> &node, void *userdata, int mark), void *userdata)
 {
   progress_report_count = 0;
   progress_report_f = f;

--- a/src/core/progress.h
+++ b/src/core/progress.h
@@ -10,7 +10,7 @@ extern int progress_report_count;
 extern void (*progress_report_f)(const std::shared_ptr<const AbstractNode> &, void *, int);
 extern void *progress_report_userdata;
 
-void progress_report_prep(const std::shared_ptr<AbstractNode> &root, void (*f)(const std::shared_ptr<const AbstractNode> &node, void *userdata, int mark), void *userdata);
+void progress_report_prep(const std::shared_ptr<const AbstractNode> &root, void (*f)(const std::shared_ptr<const AbstractNode> &node, void *userdata, int mark), void *userdata);
 void progress_report_fin();
 void progress_update(const std::shared_ptr<const AbstractNode> &node, int mark);
 // CGALUtils::applyUnion3D may process nodes out of order, so allow for an increment instead of tracking exact node

--- a/src/gui/MainWindow.cc
+++ b/src/gui/MainWindow.cc
@@ -120,6 +120,7 @@
 
 #endif // ENABLE_CGAL
 
+#include "TreeFlattener.h"
 #include "PrintInitDialog.h"
 #include "input/InputDriverEvent.h"
 #include "input/InputDriverManager.h"
@@ -1228,6 +1229,11 @@ void MainWindow::instantiateRoot()
 
     std::shared_ptr<const FileContext> file_context;
     this->absolute_root_node = this->root_file->instantiate(*builtin_context, &file_context);
+    if (Feature::ExperimentalFlattenTree.is_enabled()) {
+      this->tree.setRoot(this->absolute_root_node);
+      flattenTree(this->tree);
+      this->absolute_root_node = tree.root();
+    }
     if (file_context) {
       this->qglview->cam.updateView(file_context, false);
       viewportControlWidget->cameraChanged();

--- a/src/gui/MainWindow.h
+++ b/src/gui/MainWindow.h
@@ -53,8 +53,8 @@ public:
 
   SourceFile *root_file; // Result of parsing
   SourceFile *parsed_file; // Last parse for include list
-  std::shared_ptr<AbstractNode> absolute_root_node; // Result of tree evaluation
-  std::shared_ptr<AbstractNode> root_node; // Root if the root modifier (!) is used
+  std::shared_ptr<const AbstractNode> absolute_root_node; // Result of tree evaluation
+  std::shared_ptr<const AbstractNode> root_node; // Root if the root modifier (!) is used
   Tree tree;
   EditorInterface *activeEditor;
   TabManager *tabManager;

--- a/src/openscad.cc
+++ b/src/openscad.cc
@@ -59,6 +59,7 @@
 
 #include "CSGNode.h"
 #include "CSGTreeEvaluator.h"
+#include "TreeFlattener.h"
 
 #include "Camera.h"
 #include <chrono>
@@ -492,6 +493,11 @@ int do_export(const CommandLine& cmd, const RenderVariables& render_variables, F
     LOG(message_group::Warning, *nextLocation, builtin_context->documentRoot(), "More than one Root Modifier (!)");
   }
   Tree tree(root_node, fparent.string());
+
+  if (Feature::ExperimentalFlattenTree.is_enabled()) {
+    flattenTree(tree);
+    root_node = tree.root();
+  }
 
   if (curFormat == FileFormat::CSG) {
     // https://github.com/openscad/openscad/issues/128

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -346,6 +346,10 @@ function(add_cmdline_test TESTCMD_BASENAME)
       set(EXPERIMENTAL_OPTION ${EXPERIMENTAL_OPTION} "--enable=roof" "--enable=lazy-union" "--enable=textmetrics" "--enable=import-function")
     endif()
 
+    if (EXPERIMENTAL AND NOT (${TESTCMD_BASENAME} STREQUAL dumptest))
+      set(EXPERIMENTAL_OPTION ${EXPERIMENTAL_OPTION} "--enable=flatten")
+    endif()
+
     # Enable fast-csg for all tests but those that have different expectations or fail for other reasons.
     if (NOT SCADFILE IN_LIST SCADFILES_WITH_DIFFERENT_FAST_CSG_EXPECTATIONS
         AND NOT SCADFILE IN_LIST SCADFILES_FAILING_WITH_FAST_CSG


### PR DESCRIPTION
This is a rehash of https://github.com/openscad/openscad/pull/3637, hopefully more likely to be productionized.

Goals:
*   Get as many lazy top-level unions as possible
*   Push down transforms to reduce the # of transforms being done, mitigate precision concerns (esp. w/ the Manifold rendering backend introduced in https://github.com/openscad/openscad/pull/4533) + allow more unions to bubble up.

Note that I've improved Manifold's tree flattening in https://github.com/elalish/manifold/pull/368. We could potentially ask Manifold for a lazy top-level union instead of its full rendering (it keeps a lazy CSG AST under the hood), which could be a better approach than this PR (it might still need to deal with the issue of transforms precision). Still, I wanted to get this draft PR out there as it works even w/o Manifold.

