### PR TITLE
Added simplified LOG() overloads for a common logging cases

### DIFF
--- a/src/Cache.h
+++ b/src/Cache.h
@@ -181,7 +181,7 @@ void Cache<Key, T>::trim(size_t m)
     Node *u = n;
     n = n->p;
 #ifdef DEBUG
-    LOG(message_group::None, Location::NONE, "", "Trimming cache: %1$s (%2$d bytes)", u->keyPtr->substr(0, 40), u->c);
+    LOG("Trimming cache: %1$s (%2$d bytes)", u->keyPtr->substr(0, 40), u->c);
 #endif
     unlink(*u);
   }

--- a/src/Feature.cc
+++ b/src/Feature.cc
@@ -90,7 +90,7 @@ void Feature::enable_feature(const std::string& feature_name, bool status)
   if (it != feature_map.end()) {
     it->second->enable(status);
   } else {
-    LOG(message_group::Warning, Location::NONE, "", "Ignoring request to enable unknown feature '%1$s'.", feature_name);
+    LOG(message_group::Warning, "Ignoring request to enable unknown feature '%1$s'.", feature_name);
   }
 }
 

--- a/src/FontCache.cc
+++ b/src/FontCache.cc
@@ -209,7 +209,7 @@ void FontCache::registerProgressHandler(InitHandlerFunc *handler, void *userdata
 void FontCache::register_font_file(const std::string& path)
 {
   if (!FcConfigAppFontAddFile(this->config, reinterpret_cast<const FcChar8 *>(path.c_str()))) {
-    LOG(message_group::None, Location::NONE, "", "Can't register font '%1$s'", path);
+    LOG("Can't register font '%1$s'", path);
   }
 }
 
@@ -219,7 +219,7 @@ void FontCache::add_font_dir(const std::string& path)
     return;
   }
   if (!FcConfigAppFontAddDir(this->config, reinterpret_cast<const FcChar8 *>(path.c_str()))) {
-    LOG(message_group::None, Location::NONE, "", "Can't register font directory '%1$s'", path);
+    LOG("Can't register font directory '%1$s'", path);
   }
 }
 

--- a/src/FontCache.cc
+++ b/src/FontCache.cc
@@ -126,7 +126,7 @@ FontCache::FontCache()
   // Just load the configs. We'll build the fonts once all configs are loaded
   this->config = FcInitLoadConfig();
   if (!this->config) {
-    LOG(message_group::Font_Warning, Location::NONE, "", "Can't initialize fontconfig library, text() objects will not be rendered");
+    LOG(message_group::Font_Warning, "Can't initialize fontconfig library, text() objects will not be rendered");
     return;
   }
 
@@ -171,7 +171,7 @@ FontCache::FontCache()
 
   const FT_Error error = FT_Init_FreeType(&this->library);
   if (error) {
-    LOG(message_group::Font_Warning, Location::NONE, "", "Can't initialize freetype library, text() objects will not be rendered");
+    LOG(message_group::Font_Warning, "Can't initialize freetype library, text() objects will not be rendered");
     return;
   }
 
@@ -376,7 +376,7 @@ FT_Face FontCache::find_face_fontconfig(const std::string& font) const
     if (!charmap_set) charmap_set = try_charmap(face, TT_PLATFORM_MACINTOSH, TT_MAC_ID_ROMAN);
     if (!charmap_set) charmap_set = try_charmap(face, TT_PLATFORM_ISO, TT_ISO_ID_8859_1);
     if (!charmap_set) charmap_set = try_charmap(face, TT_PLATFORM_ISO, TT_ISO_ID_7BIT_ASCII);
-    if (!charmap_set) LOG(message_group::Font_Warning, Location::NONE, "", "Could not select a char map for font %1$s/%2$s'", face->family_name, face->style_name);
+    if (!charmap_set) LOG(message_group::Font_Warning, "Could not select a char map for font %1$s/%2$s'", face->family_name, face->style_name);
   }
 
   return error ? nullptr : face;

--- a/src/RenderStatistic.cc
+++ b/src/RenderStatistic.cc
@@ -259,7 +259,7 @@ void LogVisitor::visit(const CGAL_Nef_polyhedron& nef)
     LOG("   Facets:     %1$6d", nef.p3->number_of_facets());
     LOG("   Volumes:    %1$6d", nef.p3->number_of_volumes());
     if (!simple) {
-      LOG(message_group::UI_Warning, Location::NONE, "", "Object may not be a valid 2-manifold and may need repair!");
+      LOG(message_group::UI_Warning, "Object may not be a valid 2-manifold and may need repair!");
     }
     printBoundingBox3(nef.getBoundingBox());
   }
@@ -272,7 +272,7 @@ void LogVisitor::visit(const CGALHybridPolyhedron& poly)
   LOG("   Vertices:   %1$6d", poly.numVertices());
   LOG("   Facets:     %1$6d", poly.numFacets());
   if (!simple) {
-    LOG(message_group::UI_Warning, Location::NONE, "", "Object may not be a valid 2-manifold and may need repair!");
+    LOG(message_group::UI_Warning, "Object may not be a valid 2-manifold and may need repair!");
   }
   printBoundingBox3(poly.getBoundingBox());
 }

--- a/src/RenderStatistic.cc
+++ b/src/RenderStatistic.cc
@@ -205,43 +205,43 @@ void RenderStatistic::printAll(const shared_ptr<const Geometry>& geom, const Cam
 
 void LogVisitor::visit(const GeometryList& geomlist)
 {
-  LOG(message_group::None, Location::NONE, "", "Top level object is a list of objects:");
-  LOG(message_group::None, Location::NONE, "", "   Objects:    %1$d",
+  LOG("Top level object is a list of objects:");
+  LOG("   Objects:    %1$d",
       geomlist.getChildren().size());
 }
 
 void LogVisitor::visit(const Polygon2d& poly)
 {
-  LOG(message_group::None, Location::NONE, "", "Top level object is a 2D object:");
-  LOG(message_group::None, Location::NONE, "", "   Contours:   %1$6d", poly.outlines().size());
+  LOG("Top level object is a 2D object:");
+  LOG("   Contours:   %1$6d", poly.outlines().size());
   if (is_enabled(RenderStatistic::BOUNDING_BOX)) {
     const auto& bb = poly.getBoundingBox();
-    LOG(message_group::None, Location::NONE, "", "Bounding box:");
-    LOG(message_group::None, Location::NONE, "", "   Min:  %1$.2f, %2$.2f", bb.min().x(), bb.min().y());
-    LOG(message_group::None, Location::NONE, "", "   Max:  %1$.2f, %2$.2f", bb.max().x(), bb.max().y());
-    LOG(message_group::None, Location::NONE, "", "   Size: %1$.2f, %2$.2f", bb.max().x() - bb.min().x(), bb.max().y() - bb.min().y());
+    LOG("Bounding box:");
+    LOG("   Min:  %1$.2f, %2$.2f", bb.min().x(), bb.min().y());
+    LOG("   Max:  %1$.2f, %2$.2f", bb.max().x(), bb.max().y());
+    LOG("   Size: %1$.2f, %2$.2f", bb.max().x() - bb.min().x(), bb.max().y() - bb.min().y());
   }
   if (is_enabled(RenderStatistic::AREA)) {
-    LOG(message_group::None, Location::NONE, "", "Measurements:");
-    LOG(message_group::None, Location::NONE, "", "   Area: %1$.2f", poly.area());
+    LOG("Measurements:");
+    LOG("   Area: %1$.2f", poly.area());
   }
 }
 
 void LogVisitor::printBoundingBox3(const BoundingBox& bb)
 {
   if (is_enabled(RenderStatistic::BOUNDING_BOX)) {
-    LOG(message_group::None, Location::NONE, "", "Bounding box:");
-    LOG(message_group::None, Location::NONE, "", "   Min:  %1$.2f, %2$.2f, %3$.2f", bb.min().x(), bb.min().y(), bb.min().z());
-    LOG(message_group::None, Location::NONE, "", "   Max:  %1$.2f, %2$.2f, %3$.2f", bb.max().x(), bb.max().y(), bb.max().z());
-    LOG(message_group::None, Location::NONE, "", "   Size: %1$.2f, %2$.2f, %3$.2f", bb.max().x() - bb.min().x(), bb.max().y() - bb.min().y(), bb.max().z() - bb.min().z());
+    LOG("Bounding box:");
+    LOG("   Min:  %1$.2f, %2$.2f, %3$.2f", bb.min().x(), bb.min().y(), bb.min().z());
+    LOG("   Max:  %1$.2f, %2$.2f, %3$.2f", bb.max().x(), bb.max().y(), bb.max().z());
+    LOG("   Size: %1$.2f, %2$.2f, %3$.2f", bb.max().x() - bb.min().x(), bb.max().y() - bb.min().y(), bb.max().z() - bb.min().z());
   }
 }
 
 void LogVisitor::visit(const PolySet& ps)
 {
   assert(ps.getDimension() == 3);
-  LOG(message_group::None, Location::NONE, "", "Top level object is a 3D object:");
-  LOG(message_group::None, Location::NONE, "", "   Facets:     %1$6d", ps.numFacets());
+  LOG("Top level object is a 3D object:");
+  LOG("   Facets:     %1$6d", ps.numFacets());
   printBoundingBox3(ps.getBoundingBox());
 }
 
@@ -250,14 +250,14 @@ void LogVisitor::visit(const CGAL_Nef_polyhedron& nef)
 {
   if (nef.getDimension() == 3) {
     bool simple = nef.p3->is_simple();
-    LOG(message_group::None, Location::NONE, "", "Top level object is a 3D object:");
-    LOG(message_group::None, Location::NONE, "", "   Simple:     %1$s", (simple ? "yes" : "no"));
-    LOG(message_group::None, Location::NONE, "", "   Vertices:   %1$6d", nef.p3->number_of_vertices());
-    LOG(message_group::None, Location::NONE, "", "   Halfedges:  %1$6d", nef.p3->number_of_halfedges());
-    LOG(message_group::None, Location::NONE, "", "   Edges:      %1$6d", nef.p3->number_of_edges());
-    LOG(message_group::None, Location::NONE, "", "   Halffacets: %1$6d", nef.p3->number_of_halffacets());
-    LOG(message_group::None, Location::NONE, "", "   Facets:     %1$6d", nef.p3->number_of_facets());
-    LOG(message_group::None, Location::NONE, "", "   Volumes:    %1$6d", nef.p3->number_of_volumes());
+    LOG("Top level object is a 3D object:");
+    LOG("   Simple:     %1$s", (simple ? "yes" : "no"));
+    LOG("   Vertices:   %1$6d", nef.p3->number_of_vertices());
+    LOG("   Halfedges:  %1$6d", nef.p3->number_of_halfedges());
+    LOG("   Edges:      %1$6d", nef.p3->number_of_edges());
+    LOG("   Halffacets: %1$6d", nef.p3->number_of_halffacets());
+    LOG("   Facets:     %1$6d", nef.p3->number_of_facets());
+    LOG("   Volumes:    %1$6d", nef.p3->number_of_volumes());
     if (!simple) {
       LOG(message_group::UI_Warning, Location::NONE, "", "Object may not be a valid 2-manifold and may need repair!");
     }
@@ -267,10 +267,10 @@ void LogVisitor::visit(const CGAL_Nef_polyhedron& nef)
 void LogVisitor::visit(const CGALHybridPolyhedron& poly)
 {
   bool simple = poly.isManifold();
-  LOG(message_group::None, Location::NONE, "", "   Top level object is a 3D object (fast-csg):");
-  LOG(message_group::None, Location::NONE, "", "   Simple:     %1$s", (simple ? "yes" : "no"));
-  LOG(message_group::None, Location::NONE, "", "   Vertices:   %1$6d", poly.numVertices());
-  LOG(message_group::None, Location::NONE, "", "   Facets:     %1$6d", poly.numFacets());
+  LOG("   Top level object is a 3D object (fast-csg):");
+  LOG("   Simple:     %1$s", (simple ? "yes" : "no"));
+  LOG("   Vertices:   %1$6d", poly.numVertices());
+  LOG("   Facets:     %1$6d", poly.numFacets());
   if (!simple) {
     LOG(message_group::UI_Warning, Location::NONE, "", "Object may not be a valid 2-manifold and may need repair!");
   }
@@ -281,16 +281,16 @@ void LogVisitor::visit(const CGALHybridPolyhedron& poly)
 #ifdef ENABLE_MANIFOLD
 void LogVisitor::visit(const ManifoldGeometry& mani_geom)
 {
-  LOG(message_group::None, Location::NONE, "", "   Top level object is a 3D object (manifold):");
+  LOG("   Top level object is a 3D object (manifold):");
   auto &mani = mani_geom.getManifold();
   auto bbox = mani.BoundingBox();
   
-  LOG(message_group::None, Location::NONE, "", "   Status:     %1$s", ManifoldUtils::statusToString(mani.Status()));
-  LOG(message_group::None, Location::NONE, "", "   Genus:      %1$d", mani.Genus());
-  LOG(message_group::None, Location::NONE, "", "   Vertices:   %1$6d", mani.NumVert());
-  LOG(message_group::None, Location::NONE, "", "   Facets:     %1$6d", mani.NumTri());
-  LOG(message_group::None, Location::NONE, "", "   BBox.min:   %1$f, %2$f, %3$f", bbox.min.x, bbox.min.y, bbox.min.z);
-  LOG(message_group::None, Location::NONE, "", "   BBox.max:   %1$f, %2$f, %3$f", bbox.max.x, bbox.max.y, bbox.max.z);
+  LOG("   Status:     %1$s", ManifoldUtils::statusToString(mani.Status()));
+  LOG("   Genus:      %1$d", mani.Genus());
+  LOG("   Vertices:   %1$6d", mani.NumVert());
+  LOG("   Facets:     %1$6d", mani.NumTri());
+  LOG("   BBox.min:   %1$f, %2$f, %3$f", bbox.min.x, bbox.min.y, bbox.min.z);
+  LOG("   BBox.max:   %1$f, %2$f, %3$f", bbox.max.x, bbox.max.y, bbox.max.z);
   
   assert(false && "not implemented");
 }
@@ -299,11 +299,11 @@ void LogVisitor::visit(const ManifoldGeometry& mani_geom)
 void LogVisitor::printCamera(const Camera& camera)
 {
   if (is_enabled(RenderStatistic::CAMERA)) {
-    LOG(message_group::None, Location::NONE, "", "Camera:");
-    LOG(message_group::None, Location::NONE, "", "   Translation: %1$.2f, %2$.2f, %3$.2f", camera.getVpt().x(), camera.getVpt().y(), camera.getVpt().z());
-    LOG(message_group::None, Location::NONE, "", "   Rotation:    %1$.2f, %2$.2f, %3$.2f", camera.getVpr().x(), camera.getVpr().y(), camera.getVpr().z());
-    LOG(message_group::None, Location::NONE, "", "   Distance:    %1$.2f", camera.zoomValue());
-    LOG(message_group::None, Location::NONE, "", "   FOV:         %1$.2f", camera.fovValue());
+    LOG("Camera:");
+    LOG("   Translation: %1$.2f, %2$.2f, %3$.2f", camera.getVpt().x(), camera.getVpt().y(), camera.getVpt().z());
+    LOG("   Rotation:    %1$.2f, %2$.2f, %3$.2f", camera.getVpr().x(), camera.getVpr().y(), camera.getVpr().z());
+    LOG("   Distance:    %1$.2f", camera.zoomValue());
+    LOG("   FOV:         %1$.2f", camera.fovValue());
   }
 }
 
@@ -319,7 +319,7 @@ void LogVisitor::printCacheStatistic()
 void LogVisitor::printRenderingTime(const std::chrono::milliseconds ms)
 {
   // always enabled
-  LOG(message_group::None, Location::NONE, "", "Total rendering time: %1$d:%2$02d:%3$02d.%4$03d",
+  LOG("Total rendering time: %1$d:%2$02d:%3$02d.%4$03d",
       (ms.count() / 1000 / 60 / 60),
       (ms.count() / 1000 / 60 % 60),
       (ms.count() / 1000 % 60),

--- a/src/core/CSGTreeEvaluator.cc
+++ b/src/core/CSGTreeEvaluator.cc
@@ -220,7 +220,7 @@ Response CSGTreeEvaluator::visit(State& state, const TransformNode& node)
 {
   if (state.isPrefix()) {
     if (matrix_contains_infinity(node.matrix) || matrix_contains_nan(node.matrix)) {
-      LOG(message_group::Warning, Location::NONE, "", "Transformation matrix contains Not-a-Number and/or Infinity - removing object.");
+      LOG(message_group::Warning, "Transformation matrix contains Not-a-Number and/or Infinity - removing object.");
       return Response::PruneTraversal;
     }
     state.setMatrix(state.matrix() * node.matrix);

--- a/src/core/ColorNode.cc
+++ b/src/core/ColorNode.cc
@@ -260,7 +260,7 @@ static std::shared_ptr<AbstractNode> builtin_color(const ModuleInstantiation *in
         node->color = *hexColor;
       } else {
         LOG(message_group::Warning, inst->location(), parameters.documentRoot(), "Unable to parse color \"%1$s\"", colorname);
-        LOG(message_group::None, Location::NONE, "", "Please see https://en.wikipedia.org/wiki/Web_colors");
+        LOG("Please see https://en.wikipedia.org/wiki/Web_colors");
       }
     }
   }

--- a/src/core/Expression.cc
+++ b/src/core/Expression.cc
@@ -667,7 +667,7 @@ Echo::Echo(AssignmentList args, Expression *expr, const Location& loc)
 const Expression *Echo::evaluateStep(const std::shared_ptr<const Context>& context) const
 {
   Arguments arguments{this->arguments, context};
-  LOG(message_group::Echo, Location::NONE, "", "%1$s", STR(arguments));
+  LOG(message_group::Echo, "%1$s", STR(arguments));
   return expr.get();
 }
 

--- a/src/core/ImportNode.cc
+++ b/src/core/ImportNode.cc
@@ -139,7 +139,7 @@ static std::shared_ptr<AbstractNode> do_import(const ModuleInstantiation *inst, 
     double val = dpi.toDouble();
     if (val < 0.001) {
       std::string filePath = boostfs_uncomplete(inst->location().filePath(), parameters.documentRoot()).generic_string();
-      LOG(message_group::Warning, Location::NONE, "",
+      LOG(message_group::Warning,
           "Invalid dpi value giving, using default of %1$f dpi. Value must be positive and >= 0.001, file %2$s, import() at line %3$d",
           origin.toEchoStringNoThrow(), filePath, filePath, inst->location().firstLine()
           );

--- a/src/core/ImportNode.cc
+++ b/src/core/ImportNode.cc
@@ -75,7 +75,7 @@ static std::shared_ptr<AbstractNode> do_import(const ModuleInstantiation *inst, 
   } else {
     const auto& filename_val = parameters["filename"];
     if (!filename_val.isUndefined()) {
-      LOG(message_group::Deprecated, Location::NONE, "", "filename= is deprecated. Please use file=");
+      LOG(message_group::Deprecated, "filename= is deprecated. Please use file=");
     }
     filename = lookup_file(filename_val.isUndefined() ? "" : filename_val.toString(), inst->location().filePath().parent_path().string(), parameters.documentRoot());
   }
@@ -107,7 +107,7 @@ static std::shared_ptr<AbstractNode> do_import(const ModuleInstantiation *inst, 
   } else {
     const auto& layername = parameters["layername"];
     if (layername.isDefined()) {
-      LOG(message_group::Deprecated, Location::NONE, "", "layername= is deprecated. Please use layer=");
+      LOG(message_group::Deprecated, "layername= is deprecated. Please use layer=");
       node->layer = layername.toString();
     }
   }
@@ -213,7 +213,7 @@ const Geometry *ImportNode::createGeometry() const
   }
 #endif
   default:
-    LOG(message_group::Error, Location::NONE, "", "Unsupported file format while trying to import file '%1$s', import() at line %2$d", this->filename, loc.firstLine());
+    LOG(message_group::Error, "Unsupported file format while trying to import file '%1$s', import() at line %2$d", this->filename, loc.firstLine());
     g = new PolySet(3);
   }
 

--- a/src/core/LinearExtrudeNode.cc
+++ b/src/core/LinearExtrudeNode.cc
@@ -82,7 +82,7 @@ static std::shared_ptr<AbstractNode> builtin_linear_extrude(const ModuleInstanti
   node->fa = parameters["$fa"].toDouble();
 
   if (!parameters["file"].isUndefined() && parameters["file"].type() == Value::Type::STRING) {
-    LOG(message_group::Deprecated, Location::NONE, "", "Support for reading files in linear_extrude will be removed in future releases. Use a child import() instead.");
+    LOG(message_group::Deprecated, "Support for reading files in linear_extrude will be removed in future releases. Use a child import() instead.");
     auto filename = lookup_file(parameters["file"].toString(), inst->location().filePath().parent_path().string(), parameters.documentRoot());
     node->filename = filename;
     handle_dep(filename);

--- a/src/core/RotateExtrudeNode.cc
+++ b/src/core/RotateExtrudeNode.cc
@@ -55,7 +55,7 @@ static std::shared_ptr<AbstractNode> builtin_rotate_extrude(const ModuleInstanti
   node->fa = parameters["$fa"].toDouble();
 
   if (!parameters["file"].isUndefined()) {
-    LOG(message_group::Deprecated, Location::NONE, "", "Support for reading files in rotate_extrude will be removed in future releases. Use a child import() instead.");
+    LOG(message_group::Deprecated, "Support for reading files in rotate_extrude will be removed in future releases. Use a child import() instead.");
     auto filename = lookup_file(parameters["file"].toString(), inst->location().filePath().parent_path().string(), parameters.documentRoot());
     node->filename = filename;
     handle_dep(filename);

--- a/src/core/SourceFile.cc
+++ b/src/core/SourceFile.cc
@@ -176,7 +176,7 @@ std::shared_ptr<AbstractNode> SourceFile::instantiate(const std::shared_ptr<cons
   } catch (HardWarningException& e) {
     throw;
   } catch (EvaluationException& e) {
-    // LOG(message_group::NONE,Location::NONE,"",e.what()); //please output the message before throwing the exception
+    // LOG(message_group::NONE,,e.what()); //please output the message before throwing the exception
     *resulting_file_context = nullptr;
   }
   return node;

--- a/src/core/SourceFile.cc
+++ b/src/core/SourceFile.cc
@@ -176,7 +176,7 @@ std::shared_ptr<AbstractNode> SourceFile::instantiate(const std::shared_ptr<cons
   } catch (HardWarningException& e) {
     throw;
   } catch (EvaluationException& e) {
-    // LOG(message_group::None,Location::NONE,"",e.what()); //please output the message before throwing the exception
+    // LOG(message_group::NONE,Location::NONE,"",e.what()); //please output the message before throwing the exception
     *resulting_file_context = nullptr;
   }
   return node;

--- a/src/core/SourceFile.cc
+++ b/src/core/SourceFile.cc
@@ -63,7 +63,7 @@ void SourceFile::registerUse(const std::string& path, const Location& loc)
     if (fs::is_regular_file(path)) {
       FontCache::instance()->register_font_file(path);
     } else {
-      LOG(message_group::Error, Location::NONE, "", "Can't read font with path '%1$s'", path);
+      LOG(message_group::Error, "Can't read font with path '%1$s'", path);
     }
   } else {
     auto pos = std::find(usedlibs.begin(), usedlibs.end(), path);

--- a/src/core/SourceFileCache.cc
+++ b/src/core/SourceFileCache.cc
@@ -75,7 +75,7 @@ std::time_t SourceFileCache::evaluate(const std::string& mainFile, const std::st
 
 #ifdef DEBUG
   // Causes too much debug output
-  //if (!shouldCompile) LOG(message_group::None,Location::NONE,"","Using cached library: %1$s (%2$p)",filename,file);
+  //if (!shouldCompile) LOG(message_group::NONE,Location::NONE,"","Using cached library: %1$s (%2$p)",filename,file);
 #endif
 
   // If cache lookup failed (non-existing or old timestamp), compile file

--- a/src/core/SourceFileCache.cc
+++ b/src/core/SourceFileCache.cc
@@ -75,7 +75,7 @@ std::time_t SourceFileCache::evaluate(const std::string& mainFile, const std::st
 
 #ifdef DEBUG
   // Causes too much debug output
-  //if (!shouldCompile) LOG(message_group::NONE,Location::NONE,"","Using cached library: %1$s (%2$p)",filename,file);
+  //if (!shouldCompile) LOG(message_group::NONE,,"Using cached library: %1$s (%2$p)",filename,file);
 #endif
 
   // If cache lookup failed (non-existing or old timestamp), compile file

--- a/src/core/SourceFileCache.cc
+++ b/src/core/SourceFileCache.cc
@@ -92,7 +92,7 @@ std::time_t SourceFileCache::evaluate(const std::string& mainFile, const std::st
     {
       std::ifstream ifs(filename.c_str());
       if (!ifs.is_open()) {
-        LOG(message_group::Warning, Location::NONE, "", "Can't open library file '%1$s'\n", filename);
+        LOG(message_group::Warning, "Can't open library file '%1$s'\n", filename);
         return 0;
       }
       text = STR(ifs.rdbuf(), "\n\x03\n", commandline_commands);

--- a/src/core/SurfaceNode.cc
+++ b/src/core/SurfaceNode.cc
@@ -163,12 +163,12 @@ img_data_t SurfaceNode::read_png_or_dat(std::string filename) const
   try{
     ret_val = lodepng::load_file(png, filename);
   } catch (std::bad_alloc& ba) {
-    LOG(message_group::Warning, Location::NONE, "", "bad_alloc caught for '%1$s'.", ba.what());
+    LOG(message_group::Warning, "bad_alloc caught for '%1$s'.", ba.what());
     return data;
   }
 
   if (ret_val == 78) {
-    LOG(message_group::Warning, Location::NONE, "", "The file '%1$s' couldn't be opened.", filename);
+    LOG(message_group::Warning, "The file '%1$s' couldn't be opened.", filename);
     return data;
   }
 
@@ -181,7 +181,7 @@ img_data_t SurfaceNode::read_png_or_dat(std::string filename) const
   std::vector<uint8_t> img;
   auto error = lodepng::decode(img, width, height, png);
   if (error) {
-    LOG(message_group::Warning, Location::NONE, "", "Can't read PNG image '%1$s'", filename);
+    LOG(message_group::Warning, "Can't read PNG image '%1$s'", filename);
     data.clear();
     return data;
   }
@@ -197,7 +197,7 @@ img_data_t SurfaceNode::read_dat(std::string filename) const
   std::ifstream stream(filename.c_str());
 
   if (!stream.good()) {
-    LOG(message_group::Warning, Location::NONE, "", "Can't open DAT file '%1$s'.", filename);
+    LOG(message_group::Warning, "Can't open DAT file '%1$s'.", filename);
     return data;
   }
 
@@ -231,7 +231,7 @@ img_data_t SurfaceNode::read_dat(std::string filename) const
       }
     } catch (const boost::bad_lexical_cast& blc) {
       if (!stream.eof()) {
-        LOG(message_group::Warning, Location::NONE, "", "Illegal value in '%1$s': %2$s", filename, blc.what());
+        LOG(message_group::Warning, "Illegal value in '%1$s': %2$s", filename, blc.what());
       }
       return data;
     }

--- a/src/core/Value.cc
+++ b/src/core/Value.cc
@@ -415,7 +415,7 @@ public:
     try {
       (tostream_visitor(stream))(v);
     } catch (EvaluationException& e) {
-      LOG(message_group::Error, Location::NONE, "", e.what());
+      LOG(message_group::Error, e.what());
       throw;
     }
     return stream.str();
@@ -503,7 +503,7 @@ public:
   {
     const uint32_t steps = v->numValues();
     if (steps >= RangeType::MAX_RANGE_STEPS) {
-      LOG(message_group::Warning, Location::NONE, "", "Bad range parameter in for statement: too many elements (%1$lu).", steps);
+      LOG(message_group::Warning, "Bad range parameter in for statement: too many elements (%1$lu).", steps);
       return "";
     }
 
@@ -959,15 +959,15 @@ Value multvecmat(const VectorType& vectorvec, const VectorType& matrixvec)
     for (size_t j = 0; j < vectorvec.size(); ++j) {
       if (matrixvec[j].type() != Value::Type::VECTOR ||
           matrixvec[j].toVector().size() != firstRowSize) {
-        LOG(message_group::Warning, Location::NONE, "", "Matrix must be rectangular. Problem at row %1$lu", j);
+        LOG(message_group::Warning, "Matrix must be rectangular. Problem at row %1$lu", j);
         return Value::undef(STR("Matrix must be rectangular. Problem at row ", j));
       }
       if (vectorvec[j].type() != Value::Type::NUMBER) {
-        LOG(message_group::Warning, Location::NONE, "", "Vector must contain only numbers. Problem at index %1$lu", j);
+        LOG(message_group::Warning, "Vector must contain only numbers. Problem at index %1$lu", j);
         return Value::undef(STR("Vector must contain only numbers. Problem at index ", j));
       }
       if (matrixvec[j].toVector()[i].type() != Value::Type::NUMBER) {
-        LOG(message_group::Warning, Location::NONE, "", "Matrix must contain only numbers. Problem at row %1$lu, col %2$lu", j, i);
+        LOG(message_group::Warning, "Matrix must contain only numbers. Problem at row %1$lu, col %2$lu", j, i);
         return Value::undef(STR("Matrix must contain only numbers. Problem at row ", j, ", col ", i));
       }
       r_e += vectorvec[j].toDouble() * matrixvec[j].toVector()[i].toDouble();

--- a/src/core/builtin_functions.cc
+++ b/src/core/builtin_functions.cc
@@ -137,14 +137,14 @@ Value builtin_rands(Arguments arguments, const Location& loc)
   if (std::isinf(min) || std::isnan(min)) {
     LOG(message_group::Warning, loc, arguments.documentRoot(), "rands() range min cannot be infinite");
     min = -std::numeric_limits<double>::max() / 2;
-    LOG(message_group::Warning, Location::NONE, "", "resetting to %1f", min);
+    LOG(message_group::Warning, "resetting to %1f", min);
   }
 
   double max = arguments[1]->toDouble();
   if (std::isinf(max)  || std::isnan(max)) {
     LOG(message_group::Warning, loc, arguments.documentRoot(), "rands() range max cannot be infinite");
     max = std::numeric_limits<double>::max() / 2;
-    LOG(message_group::Warning, Location::NONE, "", "resetting to %1f", max);
+    LOG(message_group::Warning, "resetting to %1f", max);
   }
   if (max < min) {
     double tmp = min; min = max; max = tmp;
@@ -153,7 +153,7 @@ Value builtin_rands(Arguments arguments, const Location& loc)
   double numresultsd = std::abs(arguments[2]->toDouble() );
   if (std::isinf(numresultsd) || std::isnan(numresultsd)) {
     LOG(message_group::Warning, loc, arguments.documentRoot(), "rands() cannot create an infinite number of results");
-    LOG(message_group::Warning, Location::NONE, "", "resetting number of results to 1");
+    LOG(message_group::Warning, "resetting number of results to 1");
     numresultsd = 1;
   }
   auto numresults = boost_numeric_cast<size_t, double>(numresultsd);

--- a/src/core/control.cc
+++ b/src/core/control.cc
@@ -64,7 +64,7 @@ static boost::optional<size_t> validChildIndex(const Value& value, const Childre
 
 static std::shared_ptr<AbstractNode> builtin_child(const ModuleInstantiation *inst, const std::shared_ptr<const Context>& context)
 {
-  LOG(message_group::Deprecated, Location::NONE, "", "child() will be removed in future releases. Use children() instead.");
+  LOG(message_group::Deprecated, "child() will be removed in future releases. Use children() instead.");
 
   if (!inst->scope.moduleInstantiations.empty()) {
     LOG(message_group::Warning, inst->location(), context->documentRoot(),
@@ -152,7 +152,7 @@ static std::shared_ptr<AbstractNode> builtin_children(const ModuleInstantiation 
 
 static std::shared_ptr<AbstractNode> builtin_echo(const ModuleInstantiation *inst, Arguments arguments, const Children& children)
 {
-  LOG(message_group::Echo, Location::NONE, "", "%1$s", STR(arguments));
+  LOG(message_group::Echo, "%1$s", STR(arguments));
 
   auto node = children.instantiate(lazyUnionNode(inst));
   // echo without child geometries should not count as valid CSGNode

--- a/src/core/customizer/ParameterSet.cc
+++ b/src/core/customizer/ParameterSet.cc
@@ -13,7 +13,7 @@ bool ParameterSets::readFile(const std::string& filename)
   try {
     boost::property_tree::read_json(filename, root);
   } catch (const boost::property_tree::json_parser_error& e) {
-    LOG(message_group::Error, Location::NONE, "", "Cannot open Parameter Set '%1$s': %2$s", filename, e.what());
+    LOG(message_group::Error, "Cannot open Parameter Set '%1$s': %2$s", filename, e.what());
     return false;
   }
 
@@ -51,6 +51,6 @@ void ParameterSets::writeFile(const std::string& filename) const
   try {
     boost::property_tree::write_json(filename, root);
   } catch (const boost::property_tree::json_parser_error& e) {
-    LOG(message_group::Error, Location::NONE, "", "Cannot write Parameter Set '%1$s': %2$s", filename, e.what());
+    LOG(message_group::Error, "Cannot write Parameter Set '%1$s': %2$s", filename, e.what());
   }
 }

--- a/src/core/parser.y
+++ b/src/core/parser.y
@@ -764,7 +764,7 @@ bool parse(SourceFile *&file, const std::string& text, const std::string &filena
     mainFilePath = fs::absolute(fs::path(mainFile));
   } catch (...) {
     // yyerror tries to print the file path, which throws again, and we can't do that
-	LOG(message_group::Error, Location::NONE, "", "Parser error: file access denied");
+	LOG(message_group::Error, "Parser error: file access denied");
     return false;
   }
 

--- a/src/core/parsersettings.cc
+++ b/src/core/parsersettings.cc
@@ -38,19 +38,19 @@ fs::path search_libs(const fs::path& localpath)
 static bool check_valid(const fs::path& p, const std::vector<std::string> *openfilenames)
 {
   if (p.empty()) {
-    // LOG(message_group::Warning,Location::NONE,"","File path is blank: %1$s",p);
+    // LOG(message_group::Warning,,"File path is blank: %1$s",p);
     return false;
   }
   if (!p.has_parent_path()) {
-    // LOG(message_group::Warning,Location::NONE,"","No parent path: %1$s",p);
+    // LOG(message_group::Warning,,"No parent path: %1$s",p);
     return false;
   }
   if (!fs::exists(p)) {
-    // LOG(message_group::Warning,Location::NONE,"","File not found: %1$s",p);
+    // LOG(message_group::Warning,,"File not found: %1$s",p);
     return false;
   }
   if (fs::is_directory(p)) {
-    // LOG(message_group::Warning,Location::NONE,"","%1$s invalid - points to a directory",p);
+    // LOG(message_group::Warning,,"%1$s invalid - points to a directory",p);
     return false;
   }
   const std::string& fullname = p.generic_string();
@@ -58,7 +58,7 @@ static bool check_valid(const fs::path& p, const std::vector<std::string> *openf
   if (openfilenames) {
     for (const auto& s : *openfilenames) {
       if (s == fullname) {
-        // LOG(message_group::Warning,Location::NONE,"","circular include file %1$s",fullname);
+        // LOG(message_group::Warning,,"circular include file %1$s",fullname);
         return false;
       }
     }

--- a/src/geometry/ClipperUtils.cc
+++ b/src/geometry/ClipperUtils.cc
@@ -62,7 +62,7 @@ ClipperLib::PolyTree sanitize(const ClipperLib::Paths& paths)
     // Most likely caught a RangeTest exception from clipper
     // Note that Clipper up to v6.2.1 incorrectly throws
     // an exception of type char* rather than a clipperException()
-    LOG(message_group::Warning, Location::NONE, "", "Range check failed for polygon. skipping");
+    LOG(message_group::Warning, "Range check failed for polygon. skipping");
   }
   clipper.Execute(ClipperLib::ctUnion, result, ClipperLib::pftEvenOdd);
   return result;

--- a/src/geometry/Geometry.cc
+++ b/src/geometry/Geometry.cc
@@ -40,7 +40,7 @@ unsigned int GeometryList::getDimension() const
   for (const auto& item : this->children) {
     if (!dim) dim = item.second->getDimension();
     else if (dim != item.second->getDimension()) {
-      LOG(message_group::Warning, Location::NONE, "", "Mixing 2D and 3D objects is not supported.");
+      LOG(message_group::Warning, "Mixing 2D and 3D objects is not supported.");
       break;
     }
   }

--- a/src/geometry/GeometryCache.cc
+++ b/src/geometry/GeometryCache.cc
@@ -55,8 +55,8 @@ void GeometryCache::setMaxSizeMB(size_t limit)
 
 void GeometryCache::print()
 {
-  LOG(message_group::None, Location::NONE, "", "Geometries in cache: %1$d", this->cache.size());
-  LOG(message_group::None, Location::NONE, "", "Geometry cache size in bytes: %1$d", this->cache.totalCost());
+  LOG("Geometries in cache: %1$d", this->cache.size());
+  LOG("Geometry cache size in bytes: %1$d", this->cache.totalCost());
 }
 
 GeometryCache::cache_entry::cache_entry(const shared_ptr<const Geometry>& geom)

--- a/src/geometry/GeometryEvaluator.cc
+++ b/src/geometry/GeometryEvaluator.cc
@@ -223,7 +223,7 @@ Polygon2d *GeometryEvaluator::applyHull2D(const AbstractNode& node)
       }
       geometry->addOutline(outline);
     } catch (const CGAL::Failure_exception& e) {
-      LOG(message_group::Warning, Location::NONE, "", "GeometryEvaluator::applyHull2D() during CGAL::convex_hull_2(): %1$s", e.what());
+      LOG(message_group::Warning, "GeometryEvaluator::applyHull2D() during CGAL::convex_hull_2(): %1$s", e.what());
     }
   }
   return geometry;
@@ -323,7 +323,7 @@ void GeometryEvaluator::smartCacheInsert(const AbstractNode& node,
   } else {
     if (!GeometryCache::instance()->contains(key)) {
       if (!GeometryCache::instance()->insert(key, geom)) {
-        LOG(message_group::Warning, Location::NONE, "", "GeometryEvaluator: Node didn't fit into cache.");
+        LOG(message_group::Warning, "GeometryEvaluator: Node didn't fit into cache.");
       }
     }
   }
@@ -415,7 +415,7 @@ Polygon2d *GeometryEvaluator::applyToChildren2D(const AbstractNode& node, OpenSC
     clipType = ClipperLib::ctDifference;
     break;
   default:
-    LOG(message_group::Error, Location::NONE, "", "Unknown boolean operation %1$d", int(op));
+    LOG(message_group::Error, "Unknown boolean operation %1$d", int(op));
     return nullptr;
     break;
   }
@@ -1267,7 +1267,7 @@ static Geometry *rotatePolygon(const RotateExtrudeNode& node, const Polygon2d& p
       max_x = fmax(max_x, v[0]);
 
       if ((max_x - min_x) > max_x && (max_x - min_x) > fabs(min_x)) {
-        LOG(message_group::Error, Location::NONE, "", "all points for rotate_extrude() must have the same X coordinate sign (range is %1$.2f -> %2$.2f)", min_x, max_x);
+        LOG(message_group::Error, "all points for rotate_extrude() must have the same X coordinate sign (range is %1$.2f -> %2$.2f)", min_x, max_x);
         delete ps;
         return nullptr;
       }

--- a/src/geometry/IndexedMesh.cc
+++ b/src/geometry/IndexedMesh.cc
@@ -63,7 +63,7 @@ void IndexedMesh::append_geometry(const shared_ptr<const Geometry>& geom)
     PolySet ps(3);
     bool err = CGALUtils::createPolySetFromNefPolyhedron3(*(N->p3), ps);
     if (err) {
-      LOG(message_group::Error, Location::NONE, "", "Nef->PolySet failed");
+      LOG(message_group::Error, "Nef->PolySet failed");
     } else {
       mesh.append_geometry(ps);
     }

--- a/src/geometry/PolySetUtils.cc
+++ b/src/geometry/PolySetUtils.cc
@@ -117,7 +117,7 @@ void tessellate_faces(const PolySet& inps, PolySet& outps)
   }
 
   if (degeneratePolygons > 0) {
-    LOG(message_group::Warning, Location::NONE, "", "PolySet has degenerate polygons");
+    LOG(message_group::Warning, "PolySet has degenerate polygons");
   }
 }
 

--- a/src/geometry/Polygon2d.cc
+++ b/src/geometry/Polygon2d.cc
@@ -65,7 +65,7 @@ bool Polygon2d::isEmpty() const
 void Polygon2d::transform(const Transform2d& mat)
 {
   if (mat.matrix().determinant() == 0) {
-    LOG(message_group::Warning, Location::NONE, "", "Scaling a 2D object with 0 - removing object");
+    LOG(message_group::Warning, "Scaling a 2D object with 0 - removing object");
     this->theoutlines.clear();
     return;
   }

--- a/src/geometry/cgal/CGALCache.cc
+++ b/src/geometry/cgal/CGALCache.cc
@@ -13,7 +13,7 @@ shared_ptr<const Geometry> CGALCache::get(const std::string& id) const
 {
   const auto& N = this->cache[id]->N;
 #ifdef DEBUG
-  LOG(message_group::None, Location::NONE, "", "CGAL Cache hit: %1$s (%2$d bytes)", id.substr(0, 40), N ? N->memsize() : 0);
+  LOG("CGAL Cache hit: %1$s (%2$d bytes)", id.substr(0, 40), N ? N->memsize() : 0);
 #endif
   return N;
 }
@@ -29,8 +29,8 @@ bool CGALCache::insert(const std::string& id, const shared_ptr<const Geometry>& 
   assert(acceptsGeometry(N));
   auto inserted = this->cache.insert(id, new cache_entry(N), N ? N->memsize() : 0);
 #ifdef DEBUG
-  if (inserted) LOG(message_group::None, Location::NONE, "", "CGAL Cache insert: %1$s (%2$d bytes)", id.substr(0, 40), (N ? N->memsize() : 0));
-  else LOG(message_group::None, Location::NONE, "", "CGAL Cache insert failed: %1$s (%2$d bytes)", id.substr(0, 40), (N ? N->memsize() : 0));
+  if (inserted) LOG("CGAL Cache insert: %1$s (%2$d bytes)", id.substr(0, 40), (N ? N->memsize() : 0));
+  else LOG("CGAL Cache insert failed: %1$s (%2$d bytes)", id.substr(0, 40), (N ? N->memsize() : 0));
 #endif
   return inserted;
 }
@@ -62,8 +62,8 @@ void CGALCache::clear()
 
 void CGALCache::print()
 {
-  LOG(message_group::None, Location::NONE, "", "CGAL Polyhedrons in cache: %1$d", this->cache.size());
-  LOG(message_group::None, Location::NONE, "", "CGAL cache size in bytes: %1$d", this->cache.totalCost());
+  LOG("CGAL Polyhedrons in cache: %1$d", this->cache.size());
+  LOG("CGAL cache size in bytes: %1$d", this->cache.totalCost());
 }
 
 CGALCache::cache_entry::cache_entry(const shared_ptr<const Geometry>& N)

--- a/src/geometry/cgal/CGALHybridPolyhedron.cc
+++ b/src/geometry/cgal/CGALHybridPolyhedron.cc
@@ -194,8 +194,7 @@ bool CGALHybridPolyhedron::canCorefineWith(const CGALHybridPolyhedron& other) co
     reasonWontCorefine = "non manifoldness detected";
   }
   if (reasonWontCorefine) {
-    LOG(message_group::NONE, Location::NONE, "",
-        "[fast-csg] Performing safer but slower nef operation instead of corefinement because %1$s. "
+    LOG("[fast-csg] Performing safer but slower nef operation instead of corefinement because %1$s. "
         "(can override with fast-csg-trust-corefinement)",
         reasonWontCorefine);
   }
@@ -321,8 +320,7 @@ void CGALHybridPolyhedron::nefPolyBinOp(
   auto& rhs = *other.convertToNef();
 
   if (Feature::ExperimentalFastCsgDebug.is_enabled()) {
-    LOG(message_group::NONE, Location::NONE, "",
-        "[fast-csg] %1$s: %2$s vs. %3$s",
+    LOG("[fast-csg] %1$s: %2$s vs. %3$s",
         opName.c_str(), describeForDebug(lhs), describeForDebug(rhs));
   }
 
@@ -330,8 +328,7 @@ void CGALHybridPolyhedron::nefPolyBinOp(
 
   if (Feature::ExperimentalFastCsgDebug.is_enabled()) {
     if (!lhs.is_simple()) {
-      LOG(message_group::Warning, Location::NONE, "",
-          "[fast-csg] %1$s output is a %2$s", opName.c_str(), describeForDebug(lhs));
+      LOG("[fast-csg] %1$s output is a %2$s", opName.c_str(), describeForDebug(lhs));
     }
   }
 }
@@ -356,8 +353,7 @@ bool CGALHybridPolyhedron::meshBinOp(
     auto& rhs = *other.convertToMesh();
 
     if (debug) {
-      LOG(message_group::NONE, Location::NONE, "",
-          "[fast-csg] %1$s #%2$lu: %3$s vs. %4$s",
+      LOG("[fast-csg] %1$s #%2$lu: %3$s vs. %4$s",
           opName.c_str(), opNumber, describeForDebug(lhs), describeForDebug(rhs));
 
       std::ostringstream lhsOut, rhsOut;
@@ -383,14 +379,14 @@ bool CGALHybridPolyhedron::meshBinOp(
     }
     if (debug) {
       if (!CGAL::is_valid_polygon_mesh(lhs) || !CGAL::is_closed(lhs)) {
-        LOG(message_group::Warning, Location::NONE, "",
+        LOG(message_group::Warning,
             "[fast-csg] %1$s #%2$lu output is %3$s", opName.c_str(), opNumber, describeForDebug(lhs));
       }
     }
     // union && difference assert triggered by testdata/scad/bugs/rotate-diff-nonmanifold-crash.scad and testdata/scad/bugs/issue204.scad
   } catch (const CGAL::Failure_exception& e) {
     success = false;
-    LOG(message_group::Warning, Location::NONE, "",
+    LOG(message_group::Warning,
         "[fast-csg] Corefinement %1$s #%2$lu failed with an error: %3$s\n", opName.c_str(), opNumber, e.what());
   }
 
@@ -402,7 +398,7 @@ bool CGALHybridPolyhedron::meshBinOp(
     other.data = previousOtherData;
 
     if (debug) {
-      LOG(message_group::Warning, Location::NONE, "",
+      LOG(message_group::Warning,
           "Dumps of operands were written to %1$s and %2$s", lhsDebugDumpFile.c_str(), rhsDebugDumpFile.c_str());
     }
   }

--- a/src/geometry/cgal/CGALHybridPolyhedron.cc
+++ b/src/geometry/cgal/CGALHybridPolyhedron.cc
@@ -194,7 +194,7 @@ bool CGALHybridPolyhedron::canCorefineWith(const CGALHybridPolyhedron& other) co
     reasonWontCorefine = "non manifoldness detected";
   }
   if (reasonWontCorefine) {
-    LOG(message_group::None, Location::NONE, "",
+    LOG(message_group::NONE, Location::NONE, "",
         "[fast-csg] Performing safer but slower nef operation instead of corefinement because %1$s. "
         "(can override with fast-csg-trust-corefinement)",
         reasonWontCorefine);
@@ -321,7 +321,7 @@ void CGALHybridPolyhedron::nefPolyBinOp(
   auto& rhs = *other.convertToNef();
 
   if (Feature::ExperimentalFastCsgDebug.is_enabled()) {
-    LOG(message_group::None, Location::NONE, "",
+    LOG(message_group::NONE, Location::NONE, "",
         "[fast-csg] %1$s: %2$s vs. %3$s",
         opName.c_str(), describeForDebug(lhs), describeForDebug(rhs));
   }
@@ -356,7 +356,7 @@ bool CGALHybridPolyhedron::meshBinOp(
     auto& rhs = *other.convertToMesh();
 
     if (debug) {
-      LOG(message_group::None, Location::NONE, "",
+      LOG(message_group::NONE, Location::NONE, "",
           "[fast-csg] %1$s #%2$lu: %3$s vs. %4$s",
           opName.c_str(), opNumber, describeForDebug(lhs), describeForDebug(rhs));
 

--- a/src/geometry/cgal/CGALHybridPolyhedron.cc
+++ b/src/geometry/cgal/CGALHybridPolyhedron.cc
@@ -214,7 +214,7 @@ void CGALHybridPolyhedron::transform(const Transform3d& mat)
 {
   auto det = mat.matrix().determinant();
   if (det == 0) {
-    LOG(message_group::Warning, Location::NONE, "", "Scaling a 3D object with 0 - removing object");
+    LOG(message_group::Warning, "Scaling a 3D object with 0 - removing object");
     clear();
   } else {
     auto t = CGALUtils::createAffineTransformFromMatrix<CGAL_HybridKernel3>(mat);
@@ -378,7 +378,7 @@ bool CGALHybridPolyhedron::meshBinOp(
         remove(rhsDebugDumpFile.c_str());
       }
     } else {
-      LOG(message_group::Warning, Location::NONE, "", "[fast-csg] Corefinement %1$s #%2$lu failed",
+      LOG(message_group::Warning, "[fast-csg] Corefinement %1$s #%2$lu failed",
           opName.c_str(), opNumber);
     }
     if (debug) {

--- a/src/geometry/cgal/CGAL_Nef_polyhedron.cc
+++ b/src/geometry/cgal/CGAL_Nef_polyhedron.cc
@@ -101,7 +101,7 @@ void CGAL_Nef_polyhedron::transform(const Transform3d& matrix)
 {
   if (!this->isEmpty()) {
     if (matrix.matrix().determinant() == 0) {
-      LOG(message_group::Warning, Location::NONE, "", "Scaling a 3D object with 0 - removing object");
+      LOG(message_group::Warning, "Scaling a 3D object with 0 - removing object");
       this->reset();
     } else {
       auto N = new CGAL_Nef_polyhedron3(*this->p3);

--- a/src/geometry/cgal/Polygon2d-CGAL.cc
+++ b/src/geometry/cgal/Polygon2d-CGAL.cc
@@ -131,7 +131,7 @@ PolySet *Polygon2d::tessellate() const
     }
 
   } catch (const CGAL::Precondition_exception& e) {
-    LOG(message_group::None, Location::NONE, "", "CGAL error in Polygon2d::tesselate(): %1$s", e.what());
+    LOG("CGAL error in Polygon2d::tesselate(): %1$s", e.what());
     return nullptr;
   }
 

--- a/src/geometry/cgal/cgalutils-applyops-hybrid-minkowski.cc
+++ b/src/geometry/cgal/cgalutils-applyops-hybrid-minkowski.cc
@@ -231,7 +231,7 @@ shared_ptr<const Geometry> applyMinkowskiHybrid(const Geometry::Geometries& chil
     t_tot.reset();
     return operands[0];
   } catch (const std::exception& e) {
-    LOG(message_group::Warning, Location::NONE, "",
+    LOG(message_group::Warning,
         "[fast-csg] Minkowski failed with error, falling back to Nef operation: %1$s\n", e.what());
 
     auto N = shared_ptr<const Geometry>(applyOperator3D(children, OpenSCADOperator::MINKOWSKI));

--- a/src/geometry/cgal/cgalutils-applyops-hybrid.cc
+++ b/src/geometry/cgal/cgalutils-applyops-hybrid.cc
@@ -74,7 +74,7 @@ shared_ptr<CGALHybridPolyhedron> applyUnion3DHybrid(
       return nullptr;
     }
   } catch (const CGAL::Failure_exception& e) {
-    LOG(message_group::Error, Location::NONE, "", "CGAL error in CGALUtils::applyUnion3DHybrid: %1$s", e.what());
+    LOG(message_group::Error, "CGAL error in CGALUtils::applyUnion3DHybrid: %1$s", e.what());
   }
   return nullptr;
 }
@@ -124,7 +124,7 @@ shared_ptr<CGALHybridPolyhedron> applyOperator3DHybrid(const Geometry::Geometrie
         N->minkowski(*chN);
         break;
       default:
-        LOG(message_group::Error, Location::NONE, "", "Unsupported CGAL operator: %1$d", static_cast<int>(op));
+        LOG(message_group::Error, "Unsupported CGAL operator: %1$d", static_cast<int>(op));
       }
       if (item.first) item.first->progress_report();
     }
@@ -132,7 +132,7 @@ shared_ptr<CGALHybridPolyhedron> applyOperator3DHybrid(const Geometry::Geometrie
   // union && difference assert triggered by testdata/scad/bugs/rotate-diff-nonmanifold-crash.scad and testdata/scad/bugs/issue204.scad
   catch (const CGAL::Failure_exception& e) {
     std::string opstr = op == OpenSCADOperator::INTERSECTION ? "intersection" : op == OpenSCADOperator::DIFFERENCE ? "difference" : op == OpenSCADOperator::UNION ? "union" : "UNKNOWN";
-    LOG(message_group::Error, Location::NONE, "", "CGAL error in CGALUtils::applyOperator3DHybrid %1$s: %2$s", opstr, e.what());
+    LOG(message_group::Error, "CGAL error in CGALUtils::applyOperator3DHybrid %1$s: %2$s", opstr, e.what());
 
   }
   return N;

--- a/src/geometry/cgal/cgalutils-applyops.cc
+++ b/src/geometry/cgal/cgalutils-applyops.cc
@@ -89,7 +89,7 @@ shared_ptr<const Geometry> applyOperator3D(const Geometry::Geometries& children,
         N->minkowski(*chN);
         break;
       default:
-        LOG(message_group::Error, Location::NONE, "", "Unsupported CGAL operator: %1$d", static_cast<int>(op));
+        LOG(message_group::Error, "Unsupported CGAL operator: %1$d", static_cast<int>(op));
       }
       if (item.first) item.first->progress_report();
     }
@@ -97,12 +97,12 @@ shared_ptr<const Geometry> applyOperator3D(const Geometry::Geometries& children,
   // union && difference assert triggered by tests/data/scad/bugs/rotate-diff-nonmanifold-crash.scad and tests/data/scad/bugs/issue204.scad
   catch (const CGAL::Failure_exception& e) {
     std::string opstr = op == OpenSCADOperator::INTERSECTION ? "intersection" : op == OpenSCADOperator::DIFFERENCE ? "difference" : op == OpenSCADOperator::UNION ? "union" : "UNKNOWN";
-    LOG(message_group::Error, Location::NONE, "", "CGAL error in CGALUtils::applyBinaryOperator %1$s: %2$s", opstr, e.what());
+    LOG(message_group::Error, "CGAL error in CGALUtils::applyBinaryOperator %1$s: %2$s", opstr, e.what());
   }
   // boost any_cast throws exceptions inside CGAL code, ending here https://github.com/openscad/openscad/issues/3756
   catch (const std::exception& e) {
     std::string opstr = op == OpenSCADOperator::INTERSECTION ? "intersection" : op == OpenSCADOperator::DIFFERENCE ? "difference" : op == OpenSCADOperator::UNION ? "union" : "UNKNOWN";
-    LOG(message_group::Error, Location::NONE, "", "exception in CGALUtils::applyBinaryOperator %1$s: %2$s", opstr, e.what());
+    LOG(message_group::Error, "exception in CGALUtils::applyBinaryOperator %1$s: %2$s", opstr, e.what());
   }
   return shared_ptr<Geometry>(N);
 }
@@ -155,7 +155,7 @@ shared_ptr<const Geometry> applyUnion3D(
       return nullptr;
     }
   } catch (const CGAL::Failure_exception& e) {
-    LOG(message_group::Error, Location::NONE, "", "CGAL error in CGALUtils::applyUnion3D: %1$s", e.what());
+    LOG(message_group::Error, "CGAL error in CGALUtils::applyUnion3D: %1$s", e.what());
   }
   return nullptr;
 }
@@ -230,7 +230,7 @@ bool applyHull(const Geometry::Geometries& children, PolySet& result)
       PRINTDB("After hull valid: %d", r.is_valid());
       success = !createPolySetFromPolyhedron(r, result);
     } catch (const CGAL::Failure_exception& e) {
-      LOG(message_group::Error, Location::NONE, "", "CGAL error in applyHull(): %1$s", e.what());
+      LOG(message_group::Error, "CGAL error in applyHull(): %1$s", e.what());
     }
   }
   return success;

--- a/src/geometry/cgal/cgalutils-coplanar-faces-remesher.h
+++ b/src/geometry/cgal/cgalutils-coplanar-faces-remesher.h
@@ -184,7 +184,7 @@ public:
           }
 
           if (!walkAroundPatch(borderEdge, isFaceOnPatch, patch.borderPath)) {
-            LOG(message_group::Error, Location::NONE, "",
+            LOG(message_group::Error,
                 "[fast-csg-remesh] Failed to collect path around patch faces, invalid mesh!");
             return false;
           }
@@ -210,8 +210,7 @@ public:
           }
           if (hasHoles) {
             if (verbose) {
-              LOG(message_group::NONE, Location::NONE, "",
-                  "[fast-csg-remesh] Skipping remeshing of patch with %1$lu faces as it seems to have holes.", patch.borderPathEdges.size());
+              LOG("[fast-csg-remesh] Skipping remeshing of patch with %1$lu faces as it seems to have holes.", patch.borderPathEdges.size());
             }
             return false;
           }
@@ -282,8 +281,7 @@ public:
 
       auto facesAfter = tm.number_of_faces();
       if (verbose && facesBefore != facesAfter) {
-        LOG(message_group::NONE, Location::NONE, "",
-            "[fast-csg-remesh] Remeshed from %1$lu to %2$lu faces (%3$lu % improvement)", facesBefore, facesAfter,
+        LOG("[fast-csg-remesh] Remeshed from %1$lu to %2$lu faces (%3$lu % improvement)", facesBefore, facesAfter,
             (facesBefore - facesAfter) * 100 / facesBefore);
       }
     } catch (const CGAL::Assertion_exception& e) {

--- a/src/geometry/cgal/cgalutils-coplanar-faces-remesher.h
+++ b/src/geometry/cgal/cgalutils-coplanar-faces-remesher.h
@@ -287,7 +287,7 @@ public:
             (facesBefore - facesAfter) * 100 / facesBefore);
       }
     } catch (const CGAL::Assertion_exception& e) {
-      LOG(message_group::Error, Location::NONE, "", "CGAL error in remeshSplitFaces: %1$s", e.what());
+      LOG(message_group::Error, "CGAL error in remeshSplitFaces: %1$s", e.what());
     }
   }
 

--- a/src/geometry/cgal/cgalutils-coplanar-faces-remesher.h
+++ b/src/geometry/cgal/cgalutils-coplanar-faces-remesher.h
@@ -210,7 +210,7 @@ public:
           }
           if (hasHoles) {
             if (verbose) {
-              LOG(message_group::None, Location::NONE, "",
+              LOG(message_group::NONE, Location::NONE, "",
                   "[fast-csg-remesh] Skipping remeshing of patch with %1$lu faces as it seems to have holes.", patch.borderPathEdges.size());
             }
             return false;
@@ -282,7 +282,7 @@ public:
 
       auto facesAfter = tm.number_of_faces();
       if (verbose && facesBefore != facesAfter) {
-        LOG(message_group::None, Location::NONE, "",
+        LOG(message_group::NONE, Location::NONE, "",
             "[fast-csg-remesh] Remeshed from %1$lu to %2$lu faces (%3$lu % improvement)", facesBefore, facesAfter,
             (facesBefore - facesAfter) * 100 / facesBefore);
       }

--- a/src/geometry/cgal/cgalutils-hybrid.cc
+++ b/src/geometry/cgal/cgalutils-hybrid.cc
@@ -78,7 +78,7 @@ std::shared_ptr<CGALHybridPolyhedron> createHybridPolyhedronFromPolySet(const Po
       // PMP::orient_to_bound_a_volume seems just fine.
       orientToBoundAVolume(*mesh);
     } else {
-      LOG(message_group::Warning, Location::NONE, "", "Warning: mesh is not closed!");
+      LOG(message_group::Warning, "Warning: mesh is not closed!");
     }
   }
 
@@ -111,7 +111,7 @@ std::shared_ptr<CGALHybridPolyhedron> createMutableHybridPolyhedronFromGeometry(
     return createHybridPolyhedronFromPolySet(*mani->toPolySet());
 #endif
   } else {
-    LOG(message_group::Warning, Location::NONE, "", "Unsupported geometry format.");
+    LOG(message_group::Warning, "Unsupported geometry format.");
     return nullptr;
   }
 }

--- a/src/geometry/cgal/cgalutils-mesh-edits.h
+++ b/src/geometry/cgal/cgalutils-mesh-edits.h
@@ -124,7 +124,7 @@ public:
           }
           return true;
         } else {
-          LOG(message_group::Warning, Location::NONE, "", "Failed to add face with %1$lu vertices!", polygon.size());
+          LOG(message_group::Warning, "Failed to add face with %1$lu vertices!", polygon.size());
           return false;
         }
       };
@@ -140,7 +140,7 @@ public:
           polygon.push_back(getDestinationVertex(v));
         }
         if (polygon.size() < 3) {
-          LOG(message_group::Warning, Location::NONE, "", "Attempted to remove too many vertices around this copied face, remesh aborted!");
+          LOG(message_group::Warning, "Attempted to remove too many vertices around this copied face, remesh aborted!");
           return false;
         }
 
@@ -169,7 +169,7 @@ public:
         polygon.push_back(getDestinationVertex(v));
       }
       if (polygon.size() < 3) {
-        LOG(message_group::Warning, Location::NONE, "", "Attempted to remove too many vertices around this added face, remesh aborted!");
+        LOG(message_group::Warning, "Attempted to remove too many vertices around this added face, remesh aborted!");
         return false;
       }
       if (!addFace(polygon)) {
@@ -178,11 +178,11 @@ public:
     }
 
     if (wasValid && !CGAL::is_valid_polygon_mesh(copy)) {
-      LOG(message_group::Warning, Location::NONE, "", "Remeshing output isn't valid");
+      LOG(message_group::Warning, "Remeshing output isn't valid");
       return false;
     }
     if (wasClosed && !CGAL::is_closed(copy)) {
-      LOG(message_group::Warning, Location::NONE, "", "Remeshing output isn't closed");
+      LOG(message_group::Warning, "Remeshing output isn't closed");
       return false;
     }
 

--- a/src/geometry/cgal/cgalutils-polyhedron.cc
+++ b/src/geometry/cgal/cgalutils-polyhedron.cc
@@ -266,7 +266,7 @@ bool createPolyhedronFromPolySet(const PolySet& ps, Polyhedron& p)
     CGAL_Build_PolySet<Polyhedron> builder(ps);
     p.delegate(builder);
   } catch (const CGAL::Assertion_exception& e) {
-    LOG(message_group::Error, Location::NONE, "", "CGAL error in CGALUtils::createPolyhedronFromPolySet: %1$s", e.what());
+    LOG(message_group::Error, "CGAL error in CGALUtils::createPolyhedronFromPolySet: %1$s", e.what());
     err = true;
   }
   return err;

--- a/src/geometry/cgal/cgalutils-project.cc
+++ b/src/geometry/cgal/cgalutils-project.cc
@@ -200,13 +200,13 @@ for (int i = 0; i < 8; ++i) pts.push_back(bigcuboid.vertex(i));
         CGAL_Nef_polyhedron3 nef_bigbox(bigbox);
         newN.p3.reset(new CGAL_Nef_polyhedron3(nef_bigbox.intersection(*N.p3)));
       } catch (const CGAL::Failure_exception& e) {
-        LOG(message_group::Error, Location::NONE, "", " CGAL error in CGALUtils::project during bigbox intersection: %1$s", e.what());
+        LOG(message_group::Error, " CGAL error in CGALUtils::project during bigbox intersection: %1$s", e.what());
 
       }
     }
 
     if (!newN.p3 || newN.p3->is_empty()) {
-      LOG(message_group::Warning, Location::NONE, "", "Projection() failed.");
+      LOG(message_group::Warning, "Projection() failed.");
       return poly;
     }
 
@@ -228,7 +228,7 @@ for (int i = 0; i < 8; ++i) pts.push_back(bigcuboid.vertex(i));
       }
       poly = convertToPolygon2d(*zremover.output_nefpoly2d);
     } catch (const CGAL::Failure_exception& e) {
-      LOG(message_group::Error, Location::NONE, "", "CGAL error in CGALUtils::project while flattening: %1$s", e.what());
+      LOG(message_group::Error, "CGAL error in CGALUtils::project while flattening: %1$s", e.what());
     }
     PRINTD("</svg>");
 
@@ -238,7 +238,7 @@ for (int i = 0; i < 8; ++i) pts.push_back(bigcuboid.vertex(i));
     PolySet ps(3);
     bool err = CGALUtils::createPolySetFromNefPolyhedron3(*N.p3, ps);
     if (err) {
-      LOG(message_group::Error, Location::NONE, "", "Nef->PolySet failed");
+      LOG(message_group::Error, "Nef->PolySet failed");
       return poly;
     }
     poly = PolySetUtils::project(ps);

--- a/src/geometry/cgal/cgalutils.cc
+++ b/src/geometry/cgal/cgalutils.cc
@@ -85,7 +85,7 @@ CGAL_Nef_polyhedron *createNefPolyhedronFromPolySet(const PolySet& ps)
          std::string(e.what()).find("has_on") != std::string::npos) ||
         std::string(e.what()).find("ss_plane.has_on(sv_prev->point())") != std::string::npos ||
         std::string(e.what()).find("ss_circle.has_on(sp)") != std::string::npos) {
-      LOG(message_group::None, Location::NONE, "", "PolySet has nonplanar faces. Attempting alternate construction");
+      LOG("PolySet has nonplanar faces. Attempting alternate construction");
       plane_error = true;
     } else {
       LOG(message_group::Error, Location::NONE, "", "CGAL error in CGAL_Nef_polyhedron3(): %1$s", e.what());

--- a/src/geometry/cgal/cgalutils.cc
+++ b/src/geometry/cgal/cgalutils.cc
@@ -72,9 +72,9 @@ CGAL_Nef_polyhedron *createNefPolyhedronFromPolySet(const PolySet& ps)
     auto err = CGALUtils::createPolyhedronFromPolySet(psq, P);
     if (!err) {
       if (!P.is_closed()) {
-        LOG(message_group::Error, Location::NONE, "", "The given mesh is not closed! Unable to convert to CGAL_Nef_Polyhedron.");
+        LOG(message_group::Error, "The given mesh is not closed! Unable to convert to CGAL_Nef_Polyhedron.");
       } else if (!P.is_valid(false, 0)) {
-        LOG(message_group::Error, Location::NONE, "", "The given mesh is invalid! Unable to convert to CGAL_Nef_Polyhedron.");
+        LOG(message_group::Error, "The given mesh is invalid! Unable to convert to CGAL_Nef_Polyhedron.");
       } else {
         N = new CGAL_Nef_polyhedron3(P);
       }
@@ -88,7 +88,7 @@ CGAL_Nef_polyhedron *createNefPolyhedronFromPolySet(const PolySet& ps)
       LOG("PolySet has nonplanar faces. Attempting alternate construction");
       plane_error = true;
     } else {
-      LOG(message_group::Error, Location::NONE, "", "CGAL error in CGAL_Nef_polyhedron3(): %1$s", e.what());
+      LOG(message_group::Error, "CGAL error in CGAL_Nef_polyhedron3(): %1$s", e.what());
     }
   }
   if (plane_error) try {
@@ -100,7 +100,7 @@ CGAL_Nef_polyhedron *createNefPolyhedronFromPolySet(const PolySet& ps)
       }
       if (!err) N = new CGAL_Nef_polyhedron3(P);
     } catch (const CGAL::Assertion_exception& e) {
-      LOG(message_group::Error, Location::NONE, "", "Alternate construction failed. CGAL error in CGAL_Nef_polyhedron3(): %1$s", e.what());
+      LOG(message_group::Error, "Alternate construction failed. CGAL error in CGAL_Nef_polyhedron3(): %1$s", e.what());
     }
   return new CGAL_Nef_polyhedron(N);
 }
@@ -316,7 +316,7 @@ bool createPolySetFromNefPolyhedron3(const CGAL::Nef_polyhedron_3<K>& N, PolySet
   // 2. Validate mesh (manifoldness)
   auto unconnected = GeometryUtils::findUnconnectedEdges(polygons);
   if (unconnected > 0) {
-    LOG(message_group::Error, Location::NONE, "", "Non-manifold mesh encountered: %1$d unconnected edges", unconnected);
+    LOG(message_group::Error, "Non-manifold mesh encountered: %1$d unconnected edges", unconnected);
   }
   // 3. Triangulate each face
   const auto& verts = allVertices.getArray();
@@ -380,7 +380,7 @@ bool createPolySetFromNefPolyhedron3(const CGAL::Nef_polyhedron_3<K>& N, PolySet
   // 4. Validate mesh (manifoldness)
   auto unconnected2 = GeometryUtils::findUnconnectedEdges(allTriangles);
   if (unconnected2 > 0) {
-    LOG(message_group::Error, Location::NONE, "", "Non-manifold mesh created: %1$d unconnected edges", unconnected2);
+    LOG(message_group::Error, "Non-manifold mesh created: %1$d unconnected edges", unconnected2);
   }
 
   for (const auto& t : allTriangles) {
@@ -454,7 +454,7 @@ Transform3d computeResizeTransform(
   for (unsigned int i = 0; i < dimension; ++i) {
     if (newsize[i]) {
       if (bbox_size[i] == NT(0)) {
-        LOG(message_group::Warning, Location::NONE, "", "Resize in direction normal to flat object is not implemented");
+        LOG(message_group::Warning, "Resize in direction normal to flat object is not implemented");
         return Transform3d::Identity();
       } else {
         scale[i] = NT(newsize[i]) / bbox_size[i];
@@ -498,7 +498,7 @@ shared_ptr<const PolySet> getGeometryAsPolySet(const shared_ptr<const Geometry>&
     if (!N->isEmpty()) {
       bool err = CGALUtils::createPolySetFromNefPolyhedron3(*N->p3, *ps);
       if (err) {
-        LOG(message_group::Error, Location::NONE, "", "Nef->PolySet failed.");
+        LOG(message_group::Error, "Nef->PolySet failed.");
       }
     }
     return ps;

--- a/src/geometry/manifold/ManifoldGeometry.cc
+++ b/src/geometry/manifold/ManifoldGeometry.cc
@@ -128,7 +128,7 @@ shared_ptr<Polyhedron> ManifoldGeometry::toPolyhedron() const
     CGALPolyhedronBuilderFromManifold<Polyhedron> builder(mesh);
     p->delegate(builder);
   } catch (const CGAL::Assertion_exception& e) {
-    LOG(message_group::Error, Location::NONE, "", "CGAL error in CGALUtils::createPolyhedronFromPolySet: %1$s", e.what());
+    LOG(message_group::Error, "CGAL error in CGALUtils::createPolyhedronFromPolySet: %1$s", e.what());
   }
   return p;
 }

--- a/src/geometry/manifold/manifold-applyops-minkowski.cc
+++ b/src/geometry/manifold/manifold-applyops-minkowski.cc
@@ -210,12 +210,12 @@ shared_ptr<const Geometry> applyMinkowskiManifold(const Geometry::Geometries& ch
     t_tot.reset();
     return operands[0];
   } catch (const std::exception& e) {
-    LOG(message_group::Warning, Location::NONE, "",
+    LOG(message_group::Warning,
         "[manifold] Minkowski failed with error, falling back to Nef operation: %1$s\n", e.what());
 
     return ManifoldUtils::applyOperator3DManifold(children, OpenSCADOperator::MINKOWSKI);
   } catch (...) {
-    LOG(message_group::Warning, Location::NONE, "",
+    LOG(message_group::Warning,
         "[manifold] Minkowski hard-crashed, falling back to Nef operation.");
 
     return ManifoldUtils::applyOperator3DManifold(children, OpenSCADOperator::MINKOWSKI);

--- a/src/geometry/manifold/manifold-applyops.cc
+++ b/src/geometry/manifold/manifold-applyops.cc
@@ -65,7 +65,7 @@ shared_ptr<const ManifoldGeometry> applyOperator3DManifold(const Geometry::Geome
       N->minkowski(*chN);
       break;
     default:
-      LOG(message_group::Error, Location::NONE, "", "Unsupported CGAL operator: %1$d", static_cast<int>(op));
+      LOG(message_group::Error, "Unsupported CGAL operator: %1$d", static_cast<int>(op));
     }
     if (item.first) item.first->progress_report();
   }

--- a/src/geometry/manifold/manifoldutils.cc
+++ b/src/geometry/manifold/manifoldutils.cc
@@ -97,7 +97,7 @@ std::shared_ptr<ManifoldGeometry> createMutableManifoldFromSurfaceMesh(const Tri
 
   auto mani = std::make_shared<manifold::Manifold>(std::move(mesh));
   if (mani->Status() != Error::NoError) {
-    LOG(message_group::Error, Location::NONE, "",
+    LOG(message_group::Error,
         "[manifold] Surface_mesh -> Manifold conversion failed: %1$s", 
         ManifoldUtils::statusToString(mani->Status()));
   }

--- a/src/geometry/manifold/manifoldutils.cc
+++ b/src/geometry/manifold/manifoldutils.cc
@@ -138,7 +138,7 @@ std::shared_ptr<ManifoldGeometry> createMutableManifoldFromPolySet(const PolySet
     if (CGALUtils::isClosed(m)) {
       CGALUtils::orientToBoundAVolume(m);
     } else {
-      LOG(message_group::Error, Location::NONE, "", "[manifold] Input mesh is not closed!");
+      LOG(message_group::Error, "[manifold] Input mesh is not closed!");
     }
   }
 

--- a/src/geometry/polyset-utils-old.cc
+++ b/src/geometry/polyset-utils-old.cc
@@ -238,6 +238,6 @@ void tessellate_faces(const PolySet& inps, PolySet& outps) {
       outps.append_vertex(t[2].x(), t[2].y(), t[2].z());
     }
   }
-  if (degeneratePolygons > 0) LOG(message_group::Warning, Location::NONE, "", "PolySet has degenerate polygons");
+  if (degeneratePolygons > 0) LOG(message_group::Warning, "PolySet has degenerate polygons");
 }
 } // namespace PolySetUtils

--- a/src/geometry/polyset-utils-old.cc
+++ b/src/geometry/polyset-utils-old.cc
@@ -199,7 +199,7 @@ bool triangulate_polygon(const PolySet::Polygon& pgon, std::vector<PolySet::Poly
   } catch (const CGAL::Failure_exception& e) {
     // Using failure exception to catch precondition errors for malformed polygons
     // in e.g. CGAL::orientation_2().
-    LOG(message_group::None, Location::NONE, "", "CGAL error in triangulate_polygon(): %1$s", e.what());
+    LOG("CGAL error in triangulate_polygon(): %1$s", e.what());
     err = true;
   }
   return err;

--- a/src/glview/Camera.cc
+++ b/src/glview/Camera.cc
@@ -103,7 +103,7 @@ void Camera::updateView(const std::shared_ptr<const FileContext>& context, bool 
       setVpr(x, y, z);
       noauto = true;
     } else {
-      LOG(message_group::Warning, Location::NONE, "", "Unable to convert $vpr=%1$s to a vec3 or vec2 of numbers", vpr->toEchoString());
+      LOG(message_group::Warning, "Unable to convert $vpr=%1$s to a vec3 or vec2 of numbers", vpr->toEchoString());
     }
   }
 
@@ -113,7 +113,7 @@ void Camera::updateView(const std::shared_ptr<const FileContext>& context, bool 
       setVpt(x, y, z);
       noauto = true;
     } else {
-      LOG(message_group::Warning, Location::NONE, "", "Unable to convert $vpt=%1$s to a vec3 or vec2 of numbers", vpt->toEchoString());
+      LOG(message_group::Warning, "Unable to convert $vpt=%1$s to a vec3 or vec2 of numbers", vpt->toEchoString());
     }
   }
 
@@ -123,7 +123,7 @@ void Camera::updateView(const std::shared_ptr<const FileContext>& context, bool 
       setVpd(vpd->toDouble());
       noauto = true;
     } else {
-      LOG(message_group::Warning, Location::NONE, "", "Unable to convert $vpd=%1$s to a number", vpd->toEchoString());
+      LOG(message_group::Warning, "Unable to convert $vpd=%1$s to a number", vpd->toEchoString());
     }
   }
 
@@ -133,12 +133,12 @@ void Camera::updateView(const std::shared_ptr<const FileContext>& context, bool 
       setVpf(vpf->toDouble());
       noauto = true;
     } else {
-      LOG(message_group::Warning, Location::NONE, "", "Unable to convert $vpf=%1$s to a number", vpf->toEchoString());
+      LOG(message_group::Warning, "Unable to convert $vpf=%1$s to a number", vpf->toEchoString());
     }
   }
 
   if (enableWarning && (viewall || autocenter) && noauto) {
-    LOG(message_group::UI_Warning, Location::NONE, "", "Viewall and autocenter disabled in favor of $vp*");
+    LOG(message_group::UI_Warning, "Viewall and autocenter disabled in favor of $vp*");
     viewall = false;
     autocenter = false;
   }

--- a/src/glview/ColorMap.cc
+++ b/src/glview/ColorMap.cc
@@ -76,7 +76,7 @@ RenderColorScheme::RenderColorScheme(const fs::path& path) : _path(path)
       addColor(RenderColor::BACKGROUND_STOP_COLOR, "background");
     }
   } catch (const std::exception& e) {
-    LOG(message_group::None, Location::NONE, "", "Error reading color scheme file: '%1$s': %2$s", path.generic_string().c_str(), e.what());
+    LOG("Error reading color scheme file: '%1$s': %2$s", path.generic_string().c_str(), e.what());
     _error = e.what();
     _name = "";
     _index = 0;

--- a/src/glview/CsgInfo.h
+++ b/src/glview/CsgInfo.h
@@ -37,7 +37,7 @@ public:
         LOG("Normalized CSG tree has %1$d elements", int(this->root_products->size()));
       } else {
         this->root_products.reset();
-        LOG(message_group::Warning, Location::NONE, "", "CSG normalization resulted in an empty tree");
+        LOG(message_group::Warning, "CSG normalization resulted in an empty tree");
       }
     }
 

--- a/src/glview/CsgInfo.h
+++ b/src/glview/CsgInfo.h
@@ -27,14 +27,14 @@ public:
     std::vector<shared_ptr<CSGNode>> highlightNodes = evaluator.getHighlightNodes();
     std::vector<shared_ptr<CSGNode>> backgroundNodes = evaluator.getBackgroundNodes();
 
-    LOG(message_group::None, Location::NONE, "", "Compiling design (CSG Products normalization)...");
+    LOG("Compiling design (CSG Products normalization)...");
     CSGTreeNormalizer normalizer(RenderSettings::inst()->openCSGTermLimit);
     if (csgRoot) {
       shared_ptr<CSGNode> normalizedRoot = normalizer.normalize(csgRoot);
       if (normalizedRoot) {
         this->root_products.reset(new CSGProducts());
         this->root_products->import(normalizedRoot);
-        LOG(message_group::None, Location::NONE, "", "Normalized CSG tree has %1$d elements", int(this->root_products->size()));
+        LOG("Normalized CSG tree has %1$d elements", int(this->root_products->size()));
       } else {
         this->root_products.reset();
         LOG(message_group::Warning, Location::NONE, "", "CSG normalization resulted in an empty tree");
@@ -42,7 +42,7 @@ public:
     }
 
     if (highlightNodes.size() > 0) {
-      LOG(message_group::None, Location::NONE, "", "Compiling highlights (%1$i CSG Trees)...", highlightNodes.size());
+      LOG("Compiling highlights (%1$i CSG Trees)...", highlightNodes.size());
       this->highlights_products.reset(new CSGProducts());
       for (auto& highlightNode : highlightNodes) {
         highlightNode = normalizer.normalize(highlightNode);
@@ -51,7 +51,7 @@ public:
     }
 
     if (backgroundNodes.size() > 0) {
-      LOG(message_group::None, Location::NONE, "", "Compiling background (%1$i CSG Trees)...", backgroundNodes.size());
+      LOG("Compiling background (%1$i CSG Trees)...", backgroundNodes.size());
       this->background_products.reset(new CSGProducts());
       for (auto& backgroundNode : backgroundNodes) {
         backgroundNode = normalizer.normalize(backgroundNode);

--- a/src/glview/GLView.cc
+++ b/src/glview/GLView.cc
@@ -67,7 +67,7 @@ void GLView::setColorScheme(const std::string& cs)
   if (colorscheme) {
     setColorScheme(*colorscheme);
   } else {
-    LOG(message_group::UI_Warning, Location::NONE, "", "GLView: unknown colorscheme %1$s", cs);
+    LOG(message_group::UI_Warning, "GLView: unknown colorscheme %1$s", cs);
   }
 }
 

--- a/src/glview/OffscreenView.cc
+++ b/src/glview/OffscreenView.cc
@@ -23,7 +23,7 @@ OffscreenView::~OffscreenView()
 #ifdef ENABLE_OPENCSG
 void OffscreenView::display_opencsg_warning()
 {
-  LOG(message_group::None, Location::NONE, "", "OpenSCAD recommended OpenGL version is 2.0.");
+  LOG("OpenSCAD recommended OpenGL version is 2.0.");
 }
 #endif
 

--- a/src/glview/Renderer.cc
+++ b/src/glview/Renderer.cc
@@ -137,7 +137,7 @@ std::string Renderer::loadShaderSource(const std::string& name) {
   if (f.is_open()) {
     buffer << f.rdbuf();
   } else {
-    LOG(message_group::UI_Error, Location::NONE, "", "Cannot open shader source file: '%1$s'", shaderPath);
+    LOG(message_group::UI_Error, "Cannot open shader source file: '%1$s'", shaderPath);
   }
   return buffer.str();
 }

--- a/src/glview/preview/CSGTreeNormalizer.cc
+++ b/src/glview/preview/CSGTreeNormalizer.cc
@@ -88,7 +88,7 @@ entrypoint:
     }
     this->nodecount++;
     if (nodecount > this->limit) {
-      LOG(message_group::Warning, Location::NONE, "", "Normalized tree is growing past %1$d elements. Aborting normalization.\n", this->limit);
+      LOG(message_group::Warning, "Normalized tree is growing past %1$d elements. Aborting normalization.\n", this->limit);
       this->aborted = true;
       return {};
     }

--- a/src/gui/CGALWorker.cc
+++ b/src/gui/CGALWorker.cc
@@ -39,9 +39,9 @@ void CGALWorker::work()
   } catch (const HardWarningException& e) {
     LOG("Rendering cancelled on first warning.");
   } catch (const std::exception& e) {
-    LOG(message_group::Error, Location::NONE, "", "Rendering cancelled by exception %1$s", e.what());
+    LOG(message_group::Error, "Rendering cancelled by exception %1$s", e.what());
   } catch (...) {
-    LOG(message_group::Error, Location::NONE, "", "Rendering cancelled by unknown exception.");
+    LOG(message_group::Error, "Rendering cancelled by unknown exception.");
   }
 
   emit done(root_geom);

--- a/src/gui/CGALWorker.cc
+++ b/src/gui/CGALWorker.cc
@@ -35,9 +35,9 @@ void CGALWorker::work()
     GeometryEvaluator evaluator(*this->tree);
     root_geom = evaluator.evaluateGeometry(*this->tree->root(), true);
   } catch (const ProgressCancelException& e) {
-    LOG(message_group::None, Location::NONE, "", "Rendering cancelled.");
+    LOG("Rendering cancelled.");
   } catch (const HardWarningException& e) {
-    LOG(message_group::None, Location::NONE, "", "Rendering cancelled on first warning.");
+    LOG("Rendering cancelled on first warning.");
   } catch (const std::exception& e) {
     LOG(message_group::Error, Location::NONE, "", "Rendering cancelled by exception %1$s", e.what());
   } catch (...) {

--- a/src/gui/Console.cc
+++ b/src/gui/Console.cc
@@ -136,7 +136,7 @@ void Console::actionSaveAs_triggered()
     QTextStream stream(&file);
     stream << text;
     stream.flush();
-    LOG(message_group::None, Location::NONE, "", "Console content saved to '%1$s'.", fileName.toStdString());
+    LOG("Console content saved to '%1$s'.", fileName.toStdString());
   }
 }
 

--- a/src/gui/Console.cc
+++ b/src/gui/Console.cc
@@ -100,7 +100,7 @@ void Console::update()
   this->setMaximumBlockCount(0);
   for (const auto& line : this->msgBuffer) {
     QTextCharFormat charFormat;
-    if (line.group != message_group::None && line.group != message_group::Echo) charFormat.setForeground(QBrush(QColor("#000000")));
+    if (line.group != message_group::NONE && line.group != message_group::Echo) charFormat.setForeground(QBrush(QColor("#000000")));
     charFormat.setBackground(QBrush(QColor(getGroupColor(line.group).c_str())));
     if (!line.link.isEmpty()) {
       charFormat.setAnchor(true);

--- a/src/gui/ExportPdfDialog.cc
+++ b/src/gui/ExportPdfDialog.cc
@@ -155,7 +155,7 @@ ExportPdfDialog::ExportPdfDialog()
 		break;
 	default:   // provide a sane default.  Shouldn't execute, but needed at least to compile.
 		rbS_A4->setChecked(TRUE);
-		//  LOG(message_group::Export_Warning, Location::NONE, "", "Export Paper Size Unknon( %1$8c )", paper);
+		//  LOG(message_group::Export_Warning, "Export Paper Size Unknon( %1$8c )", paper);
   	}	
   }
 
@@ -171,7 +171,7 @@ ExportPdfDialog::ExportPdfDialog()
 		rbOAuto->setChecked(TRUE);
 		break;
 	default:   // provide a sane default.  Shouldn't execute, but needed at least to compile.
-		//  LOG(message_group::Export_Warning, Location::NONE, "", "Export Paper Size Unknon( %1$8c )", paper);
+		//  LOG(message_group::Export_Warning, "Export Paper Size Unknon( %1$8c )", paper);
 		rbOAuto->setChecked(TRUE);
 		break;
   	}	

--- a/src/gui/MainWindow.cc
+++ b/src/gui/MainWindow.cc
@@ -173,7 +173,7 @@ QAction *findAction(const QList<QAction *>& actions, const std::string& name)
 }
 
 void fileExportedMessage(const char *format, const QString& filename) {
-  LOG(message_group::None, Location::NONE, "", "%1$s export finished: %2$s", format, filename.toUtf8().constData());
+  LOG("%1$s export finished: %2$s", format, filename.toUtf8().constData());
 }
 
 QAction *getExport3DAction(const MainWindow *mainWindow) {
@@ -1087,7 +1087,7 @@ void MainWindow::compile(bool reload, bool forcedone)
       auto mtime = this->root_file->handleDependencies();
       if (mtime > this->deps_mtime) {
         this->deps_mtime = mtime;
-        LOG(message_group::None, Location::NONE, "", "Used file cache size: %1$d files", SourceFileCache::instance()->size());
+        LOG("Used file cache size: %1$d files", SourceFileCache::instance()->size());
         didcompile = true;
       }
     }
@@ -1223,7 +1223,7 @@ void MainWindow::instantiateRoot()
 
   if (this->root_file) {
     // Evaluate CSG tree
-    LOG(message_group::None, Location::NONE, "", "Compiling design (CSG Tree generation)...");
+    LOG("Compiling design (CSG Tree generation)...");
     this->processEvents();
 
     AbstractNode::resetIndexCounter();
@@ -1260,7 +1260,7 @@ void MainWindow::instantiateRoot()
     } else {
       LOG(message_group::Error, Location::NONE, "", "Compilation failed!");
     }
-    LOG(message_group::None, Location::NONE, "", " ");
+    LOG(" ");
     this->processEvents();
   }
 }
@@ -1274,7 +1274,7 @@ void MainWindow::compileCSG()
   OpenSCAD::hardwarnings = Preferences::inst()->getValue("advanced/enableHardwarnings").toBool();
   try{
     assert(this->root_node);
-    LOG(message_group::None, Location::NONE, "", "Compiling design (CSG Products generation)...");
+    LOG("Compiling design (CSG Products generation)...");
     this->processEvents();
 
     // Main CSG evaluation
@@ -1300,14 +1300,14 @@ void MainWindow::compileCSG()
       renderStatistic.printCacheStatistic();
       this->processEvents();
     } catch (const ProgressCancelException&) {
-      LOG(message_group::None, Location::NONE, "", "CSG generation cancelled.");
+      LOG("CSG generation cancelled.");
     } catch (const HardWarningException&) {
-      LOG(message_group::None, Location::NONE, "", "CSG generation cancelled due to hardwarning being enabled.");
+      LOG("CSG generation cancelled due to hardwarning being enabled.");
     }
     progress_report_fin();
     updateStatusBar(nullptr);
 
-    LOG(message_group::None, Location::NONE, "", "Compiling design (CSG Products normalization)...");
+    LOG("Compiling design (CSG Products normalization)...");
     this->processEvents();
 
     size_t normalizelimit = 2ul * Preferences::inst()->getValue("advanced/openCSGLimit").toUInt();
@@ -1327,7 +1327,7 @@ void MainWindow::compileCSG()
 
     const std::vector<shared_ptr<CSGNode>>& highlight_terms = csgrenderer.getHighlightNodes();
     if (highlight_terms.size() > 0) {
-      LOG(message_group::None, Location::NONE, "", "Compiling highlights (%1$d CSG Trees)...", highlight_terms.size());
+      LOG("Compiling highlights (%1$d CSG Trees)...", highlight_terms.size());
       this->processEvents();
 
       this->highlights_products.reset(new CSGProducts());
@@ -1343,7 +1343,7 @@ void MainWindow::compileCSG()
 
     const auto& background_terms = csgrenderer.getBackgroundNodes();
     if (background_terms.size() > 0) {
-      LOG(message_group::None, Location::NONE, "", "Compiling background (%1$d CSG Trees)...", background_terms.size());
+      LOG("Compiling background (%1$d CSG Trees)...", background_terms.size());
       this->processEvents();
 
       this->background_products.reset(new CSGProducts());
@@ -1365,7 +1365,7 @@ void MainWindow::compileCSG()
     }
 #ifdef ENABLE_OPENCSG
     else {
-      LOG(message_group::None, Location::NONE, "", "Normalized tree has %1$d elements!",
+      LOG("Normalized tree has %1$d elements!",
           (this->root_products ? this->root_products->size() : 0));
       this->opencsgRenderer = new OpenCSGRenderer(this->root_products,
                                                   this->highlights_products,
@@ -1375,7 +1375,7 @@ void MainWindow::compileCSG()
     this->thrownTogetherRenderer = new ThrownTogetherRenderer(this->root_products,
                                                               this->highlights_products,
                                                               this->background_products);
-    LOG(message_group::None, Location::NONE, "", "Compile and preview finished.");
+    LOG("Compile and preview finished.");
     renderStatistic.printRenderingTime();
     this->processEvents();
   } catch (const HardWarningException&) {
@@ -1480,7 +1480,7 @@ void MainWindow::writeBackup(QFile *file)
   writer << activeEditor->toPlainText();
   this->activeEditor->parameterWidget->saveBackupFile(file->fileName());
 
-  LOG(message_group::None, Location::NONE, "", "Saved backup file: %1$s", file->fileName().toUtf8().constData());
+  LOG("Saved backup file: %1$s", file->fileName().toUtf8().constData());
 }
 
 void MainWindow::saveBackup()
@@ -1536,7 +1536,7 @@ void MainWindow::actionShowLibraryFolder()
     }
   }
   auto url = QString::fromStdString(path);
-  LOG(message_group::None, Location::NONE, "", "Opening file browser for %1$s", url.toStdString());
+  LOG("Opening file browser for %1$s", url.toStdString());
   QDesktopServices::openUrl(QUrl::fromLocalFile(url));
 }
 
@@ -1890,8 +1890,8 @@ void MainWindow::prepareCompile(const char *afterCompileSlot, bool procevents, b
 {
   autoReloadTimer->stop();
   setCurrentOutput();
-  LOG(message_group::None, Location::NONE, "", " ");
-  LOG(message_group::None, Location::NONE, "", "Parsing design (AST generation)...");
+  LOG(" ");
+  LOG("Parsing design (AST generation)...");
   this->processEvents();
   this->afterCompileSlot = afterCompileSlot;
   this->procevents = procevents;
@@ -1967,11 +1967,11 @@ void MainWindow::action3DPrint()
 
   switch (selectedService) {
   case print_service_t::PRINT_SERVICE:
-    LOG(message_group::None, Location::NONE, "", "Sending design to print service %1$s...", printService->getDisplayName().toStdString());
+    LOG("Sending design to print service %1$s...", printService->getDisplayName().toStdString());
     sendToPrintService();
     break;
   case print_service_t::OCTOPRINT:
-    LOG(message_group::None, Location::NONE, "", "Sending design to OctoPrint...");
+    LOG("Sending design to OctoPrint...");
     sendToOctoPrint();
     break;
   default:
@@ -2027,7 +2027,7 @@ void MainWindow::sendToOctoPrint()
 
   QTemporaryFile exportFile{QDir::temp().filePath("OpenSCAD.XXXXXX." + fileFormat.toLower())};
   if (!exportFile.open()) {
-    LOG(message_group::None, Location::NONE, "", "Could not open temporary file.");
+    LOG("Could not open temporary file.");
     return;
   }
   const QString exportFileName = exportFile.fileName();
@@ -2176,7 +2176,7 @@ void MainWindow::actionRenderDone(const shared_ptr<const Geometry>& root_geom)
       options.emplace_back(RenderStatistic::BOUNDING_BOX);
     }
     renderStatistic.printAll(root_geom, qglview->cam, options);
-    LOG(message_group::None, Location::NONE, "", "Rendering finished.");
+    LOG("Rendering finished.");
 
     this->root_geom = root_geom;
     this->cgalRenderer = new CGALRenderer(root_geom);
@@ -2342,8 +2342,8 @@ void MainWindow::updateStatusBar(ProgressWidget *progressWidget)
 }
 
 void MainWindow::exceptionCleanup(){
-  LOG(message_group::None, Location::NONE, "", "Execution aborted");
-  LOG(message_group::None, Location::NONE, "", " ");
+  LOG("Execution aborted");
+  LOG(" ");
   GuiLocker::unlock();
   if (designActionAutoReload->isChecked()) autoReloadTimer->start();
 }
@@ -2355,7 +2355,7 @@ void MainWindow::UnknownExceptionCleanup(std::string msg){
   } else {
     LOG(message_group::Error, Location::NONE, "", "Compilation aborted by exception: %1$s", msg);
   }
-  LOG(message_group::None, Location::NONE, "", " ");
+  LOG(" ");
   GuiLocker::unlock();
   if (designActionAutoReload->isChecked()) autoReloadTimer->start();
 }
@@ -2429,13 +2429,13 @@ void MainWindow::actionCheckValidity()
   setCurrentOutput();
 
   if (!this->root_geom) {
-    LOG(message_group::None, Location::NONE, "", "Nothing to validate! Try building first (press F6).");
+    LOG("Nothing to validate! Try building first (press F6).");
     clearCurrentOutput();
     return;
   }
 
   if (this->root_geom->getDimension() != 3) {
-    LOG(message_group::None, Location::NONE, "", "Current top level object is not a 3D object.");
+    LOG("Current top level object is not a 3D object.");
     clearCurrentOutput();
     return;
   }
@@ -2450,7 +2450,7 @@ void MainWindow::actionCheckValidity()
   } else if (auto N = CGALUtils::getNefPolyhedronFromGeometry(this->root_geom)) {
     valid = N->p3 ? const_cast<CGAL_Nef_polyhedron3&>(*N->p3).is_valid() : false;
   }
-  LOG(message_group::None, Location::NONE, "", "Valid:      %1$6s", (valid ? "yes" : "no"));
+  LOG("Valid:      %1$6s", (valid ? "yes" : "no"));
   clearCurrentOutput();
 #endif /* ENABLE_CGAL */
 }
@@ -2659,7 +2659,7 @@ void MainWindow::actionExportCSG()
 
   std::ofstream fstream(csg_filename.toLocal8Bit());
   if (!fstream.is_open()) {
-    LOG(message_group::None, Location::NONE, "", "Can't open file \"%1$s\" for export", csg_filename.toLocal8Bit().constData());
+    LOG("Can't open file \"%1$s\" for export", csg_filename.toLocal8Bit().constData());
   } else {
     fstream << this->tree.getString(*this->root_node, "\t") << "\n";
     fstream.close();
@@ -2685,7 +2685,7 @@ void MainWindow::actionExportImage()
       fileExportedMessage("PNG", img_filename);
       clearCurrentOutput();
     } else {
-      LOG(message_group::None, Location::NONE, "", "Can't open file \"%1$s\" for export image", img_filename.toLocal8Bit().constData());
+      LOG("Can't open file \"%1$s\" for export image", img_filename.toLocal8Bit().constData());
     }
   }
 }
@@ -2718,7 +2718,7 @@ void MainWindow::actionFlushCaches()
   SourceFileCache::instance()->clear();
 
   setCurrentOutput();
-  LOG(message_group::None, Location::NONE, "", "Caches Flushed");
+  LOG("Caches Flushed");
 }
 
 void MainWindow::viewModeActionsUncheck()

--- a/src/gui/MainWindow.cc
+++ b/src/gui/MainWindow.cc
@@ -2148,8 +2148,7 @@ void MainWindow::cgalRender()
   this->cgalRenderer = nullptr;
   this->root_geom.reset();
 
-  LOG(message_group::NONE, Location::NONE, "",
-      "Rendering Polygon Mesh using %1$s...",
+  LOG("Rendering Polygon Mesh using %1$s...",
       Feature::ExperimentalManifold.is_enabled() ? "Manifold" : "CGAL");
 
   this->progresswidget = new ProgressWidget(this);

--- a/src/gui/MainWindow.cc
+++ b/src/gui/MainWindow.cc
@@ -1246,7 +1246,7 @@ void MainWindow::instantiateRoot()
         this->root_node = this->absolute_root_node;
       }
       if (nextLocation) {
-        LOG(message_group::None, *nextLocation, builtin_context->documentRoot(), "More than one Root Modifier (!)");
+        LOG(message_group::NONE, *nextLocation, builtin_context->documentRoot(), "More than one Root Modifier (!)");
       }
 
       // FIXME: Consider giving away ownership of root_node to the Tree, or use reference counted pointers
@@ -2148,7 +2148,7 @@ void MainWindow::cgalRender()
   this->cgalRenderer = nullptr;
   this->root_geom.reset();
 
-  LOG(message_group::None, Location::NONE, "",
+  LOG(message_group::NONE, Location::NONE, "",
       "Rendering Polygon Mesh using %1$s...",
       Feature::ExperimentalManifold.is_enabled() ? "Manifold" : "CGAL");
 

--- a/src/gui/MainWindow.cc
+++ b/src/gui/MainWindow.cc
@@ -1256,9 +1256,9 @@ void MainWindow::instantiateRoot()
 
   if (!this->root_node) {
     if (parser_error_pos < 0) {
-      LOG(message_group::Error, Location::NONE, "", "Compilation failed! (no top level object found)");
+      LOG(message_group::Error, "Compilation failed! (no top level object found)");
     } else {
-      LOG(message_group::Error, Location::NONE, "", "Compilation failed!");
+      LOG(message_group::Error, "Compilation failed!");
     }
     LOG(" ");
     this->processEvents();
@@ -1320,7 +1320,7 @@ void MainWindow::compileCSG()
         this->root_products->import(this->normalizedRoot);
       } else {
         this->root_products.reset();
-        LOG(message_group::Warning, Location::NONE, "", "CSG normalization resulted in an empty tree");
+        LOG(message_group::Warning, "CSG normalization resulted in an empty tree");
         this->processEvents();
       }
     }
@@ -1360,8 +1360,8 @@ void MainWindow::compileCSG()
     if (this->root_products &&
         (this->root_products->size() >
          Preferences::inst()->getValue("advanced/openCSGLimit").toUInt())) {
-      LOG(message_group::UI_Warning, Location::NONE, "", "Normalized tree has %1$d elements!", this->root_products->size());
-      LOG(message_group::UI_Warning, Location::NONE, "", "OpenCSG rendering has been disabled.");
+      LOG(message_group::UI_Warning, "Normalized tree has %1$d elements!", this->root_products->size());
+      LOG(message_group::UI_Warning, "OpenCSG rendering has been disabled.");
     }
 #ifdef ENABLE_OPENCSG
     else {
@@ -1487,7 +1487,7 @@ void MainWindow::saveBackup()
 {
   auto path = PlatformUtils::backupPath();
   if ((!fs::exists(path)) && (!PlatformUtils::createBackupPath())) {
-    LOG(message_group::UI_Warning, Location::NONE, "", "Cannot create backup path: %1$s", path);
+    LOG(message_group::UI_Warning, "Cannot create backup path: %1$s", path);
     return;
   }
 
@@ -1505,7 +1505,7 @@ void MainWindow::saveBackup()
   }
 
   if ((!this->tempFile->isOpen()) && (!this->tempFile->open())) {
-    LOG(message_group::UI_Warning, Location::NONE, "", "Failed to create backup file");
+    LOG(message_group::UI_Warning, "Failed to create backup file");
     return;
   }
   return writeBackup(this->tempFile);
@@ -1530,9 +1530,9 @@ void MainWindow::actionShowLibraryFolder()
 {
   auto path = PlatformUtils::userLibraryPath();
   if (!fs::exists(path)) {
-    LOG(message_group::UI_Warning, Location::NONE, "", "Library path %1$s doesn't exist. Creating", path);
+    LOG(message_group::UI_Warning, "Library path %1$s doesn't exist. Creating", path);
     if (!PlatformUtils::createUserLibraryPath()) {
-      LOG(message_group::UI_Error, Location::NONE, "", "Cannot create library path: %1$s", path);
+      LOG(message_group::UI_Error, "Cannot create library path: %1$s", path);
     }
   }
   auto url = QString::fromStdString(path);
@@ -2005,7 +2005,7 @@ void MainWindow::sendToOctoPrint()
   OctoPrint octoPrint;
 
   if (octoPrint.url().trimmed().isEmpty()) {
-    LOG(message_group::Error, Location::NONE, "", "OctoPrint connection not configured. Please check preferences.");
+    LOG(message_group::Error, "OctoPrint connection not configured. Please check preferences.");
     return;
   }
 
@@ -2060,7 +2060,7 @@ void MainWindow::sendToOctoPrint()
     const QString profile = QString::fromStdString(Settings::Settings::octoPrintSlicerProfile.value());
     octoPrint.slice(fileUrl, slicer, profile, action != "slice", action == "print");
   } catch (const NetworkException& e) {
-    LOG(message_group::Error, Location::NONE, "", "%1$s", e.getErrorMessage());
+    LOG(message_group::Error, "%1$s", e.getErrorMessage());
   }
 
   updateStatusBar(nullptr);
@@ -2077,7 +2077,7 @@ void MainWindow::sendToPrintService()
 
   QTemporaryFile exportFile;
   if (!exportFile.open()) {
-    LOG(message_group::Error, Location::NONE, "", "Could not open temporary file.");
+    LOG(message_group::Error, "Could not open temporary file.");
     return;
   }
   const QString exportFilename = exportFile.fileName();
@@ -2095,7 +2095,7 @@ void MainWindow::sendToPrintService()
 
   QFile file(exportFilename);
   if (!file.open(QIODevice::ReadOnly)) {
-    LOG(message_group::Error, Location::NONE, "", "Unable to open exported STL file.");
+    LOG(message_group::Error, "Unable to open exported STL file.");
     return;
   }
   const QString fileContentBase64 = file.readAll().toBase64();
@@ -2103,7 +2103,7 @@ void MainWindow::sendToPrintService()
   if (fileContentBase64.length() > PrintService::inst()->getFileSizeLimit()) {
     const auto msg = QString{_("Exported design exceeds the service upload limit of (%1 MB).")}.arg(PrintService::inst()->getFileSizeLimitMB());
     QMessageBox::warning(this, _("Upload Error"), msg, QMessageBox::Ok);
-    LOG(message_group::Error, Location::NONE, "", "%1$s", msg.toStdString());
+    LOG(message_group::Error, "%1$s", msg.toStdString());
     return;
   }
 
@@ -2118,7 +2118,7 @@ void MainWindow::sendToPrintService()
     });
     QDesktopServices::openUrl(QUrl{partUrl});
   } catch (const NetworkException& e) {
-    LOG(message_group::Error, Location::NONE, "", "%1$s", e.getErrorMessage());
+    LOG(message_group::Error, "%1$s", e.getErrorMessage());
   }
 
   updateStatusBar(nullptr);
@@ -2184,7 +2184,7 @@ void MainWindow::actionRenderDone(const shared_ptr<const Geometry>& root_geom)
     if (viewActionWireframe->isChecked()) viewModeWireframe();
     else viewModeSurface();
   } else {
-    LOG(message_group::UI_Warning, Location::NONE, "", "No top level geometry to render");
+    LOG(message_group::UI_Warning, "No top level geometry to render");
   }
 
   updateStatusBar(nullptr);
@@ -2351,9 +2351,9 @@ void MainWindow::exceptionCleanup(){
 void MainWindow::UnknownExceptionCleanup(std::string msg){
   setCurrentOutput(); // we need to show this error
   if (msg.size() == 0) {
-    LOG(message_group::Error, Location::NONE, "", "Compilation aborted by unknown exception");
+    LOG(message_group::Error, "Compilation aborted by unknown exception");
   } else {
-    LOG(message_group::Error, Location::NONE, "", "Compilation aborted by exception: %1$s", msg);
+    LOG(message_group::Error, "Compilation aborted by exception: %1$s", msg);
   }
   LOG(" ");
   GuiLocker::unlock();
@@ -2460,7 +2460,7 @@ void MainWindow::actionCheckValidity()
 bool MainWindow::canExport(unsigned int dim)
 {
   if (!this->root_geom) {
-    LOG(message_group::Error, Location::NONE, "", "Nothing to export! Try rendering first (press F6)");
+    LOG(message_group::Error, "Nothing to export! Try rendering first (press F6)");
     clearCurrentOutput();
     return false;
   }
@@ -2488,20 +2488,20 @@ bool MainWindow::canExport(unsigned int dim)
   }
 
   if (this->root_geom->getDimension() != dim) {
-    LOG(message_group::UI_Error, Location::NONE, "", "Current top level object is not a %1$dD object.", dim);
+    LOG(message_group::UI_Error, "Current top level object is not a %1$dD object.", dim);
     clearCurrentOutput();
     return false;
   }
 
   if (this->root_geom->isEmpty()) {
-    LOG(message_group::UI_Error, Location::NONE, "", "Current top level object is empty.");
+    LOG(message_group::UI_Error, "Current top level object is empty.");
     clearCurrentOutput();
     return false;
   }
 
   auto N = dynamic_cast<const CGAL_Nef_polyhedron *>(this->root_geom.get());
   if (N && !N->p3->is_simple()) {
-    LOG(message_group::UI_Warning, Location::NONE, "", "Object may not be a valid 2-manifold and may need repair! See https://en.wikibooks.org/wiki/OpenSCAD_User_Manual/STL_Import_and_Export");
+    LOG(message_group::UI_Warning, "Object may not be a valid 2-manifold and may need repair! See https://en.wikibooks.org/wiki/OpenSCAD_User_Manual/STL_Import_and_Export");
   }
 
   return true;
@@ -2644,7 +2644,7 @@ void MainWindow::actionExportCSG()
   setCurrentOutput();
 
   if (!this->root_node) {
-    LOG(message_group::Error, Location::NONE, "", "Nothing to export. Please try compiling first.");
+    LOG(message_group::Error, "Nothing to export. Please try compiling first.");
     clearCurrentOutput();
     return;
   }

--- a/src/gui/OctoPrint.cc
+++ b/src/gui/OctoPrint.cc
@@ -133,7 +133,7 @@ const QString OctoPrint::upload(const QString& exportFileName, const QString& fi
     const auto doc = QJsonDocument::fromJson(reply->readAll());
     PRINTDB("Response: %s", QString{doc.toJson()}.toStdString());
     auto location = reply->header(QNetworkRequest::LocationHeader).toString();
-    LOG(message_group::None, Location::NONE, "", "Uploaded successfully to %1$s", location.toStdString());
+    LOG("Uploaded successfully to %1$s", location.toStdString());
     return location;
   }
     );
@@ -160,7 +160,7 @@ void OctoPrint::slice(const QString& fileUrl, const QString& slicer, const QStri
     [](QNetworkReply *reply) {
     const auto doc = QJsonDocument::fromJson(reply->readAll());
     PRINTDB("Response: %s", QString{doc.toJson()}.toStdString());
-    LOG(message_group::None, Location::NONE, "", "Slice command successfully executed.");
+    LOG("Slice command successfully executed.");
   }
     );
 }

--- a/src/gui/PrintService.cc
+++ b/src/gui/PrintService.cc
@@ -38,7 +38,7 @@ PrintService::PrintService()
     LOG(message_group::Error, Location::NONE, "", "%1$s", e.getErrorMessage());
   }
   if (enabled) {
-    LOG(message_group::None, Location::NONE, "", "External print service available: %1$s (upload limit = %2$d MB)", displayName.toStdString(), fileSizeLimitMB);
+    LOG("External print service available: %1$s (upload limit = %2$d MB)", displayName.toStdString(), fileSizeLimitMB);
   }
 }
 
@@ -137,7 +137,7 @@ const QString PrintService::upload(const QString& fileName, const QString& conte
         const QString msg = "Could not get data.cartUrl field from response.";
         throw NetworkException(QNetworkReply::ProtocolFailure, msg);
       }
-      LOG(message_group::None, Location::NONE, "", "Upload finished, opening URL %1$s.", cartUrl.toStdString());
+      LOG("Upload finished, opening URL %1$s.", cartUrl.toStdString());
       return cartUrl;
     }
   );

--- a/src/gui/PrintService.cc
+++ b/src/gui/PrintService.cc
@@ -35,7 +35,7 @@ PrintService::PrintService()
   try {
     init();
   } catch (const NetworkException& e) {
-    LOG(message_group::Error, Location::NONE, "", "%1$s", e.getErrorMessage());
+    LOG(message_group::Error, "%1$s", e.getErrorMessage());
   }
   if (enabled) {
     LOG("External print service available: %1$s (upload limit = %2$d MB)", displayName.toStdString(), fileSizeLimitMB);

--- a/src/gui/ScintillaEditor.cc
+++ b/src/gui/ScintillaEditor.cc
@@ -91,7 +91,7 @@ EditorColorScheme::EditorColorScheme(const fs::path& path) : path(path)
     _name = QString::fromStdString(pt.get<std::string>("name"));
     _index = pt.get<int>("index");
   } catch (const std::exception& e) {
-    LOG(message_group::None, Location::NONE, "", "Error reading color scheme file '%1$s': %2$s", path.generic_string(), e.what());
+    LOG("Error reading color scheme file '%1$s': %2$s", path.generic_string(), e.what());
     _name = "";
     _index = 0;
   }
@@ -265,7 +265,7 @@ void ScintillaEditor::addTemplate(const fs::path& path)
 
         templateMap.insert(key, ScadTemplate(content, cursor_offset));
       } catch (const std::exception& e) {
-        LOG(message_group::None, Location::NONE, "", "Error reading template file '%1$s': %2$s", path.generic_string(), e.what());
+        LOG("Error reading template file '%1$s': %2$s", path.generic_string(), e.what());
       }
     }
   }

--- a/src/gui/TabManager.cc
+++ b/src/gui/TabManager.cc
@@ -543,13 +543,13 @@ bool TabManager::refreshDocument()
   if (!editor->filepath.isEmpty()) {
     QFile file(editor->filepath);
     if (!file.open(QIODevice::ReadOnly | QIODevice::Text)) {
-      LOG(message_group::None, Location::NONE, "", "Failed to open file %1$s: %2$s",
+      LOG("Failed to open file %1$s: %2$s",
           editor->filepath.toLocal8Bit().constData(), file.errorString().toLocal8Bit().constData());
     } else {
       QTextStream reader(&file);
       reader.setCodec("UTF-8");
       auto text = reader.readAll();
-      LOG(message_group::None, Location::NONE, "", "Loaded design '%1$s'.", editor->filepath.toLocal8Bit().constData());
+      LOG("Loaded design '%1$s'.", editor->filepath.toLocal8Bit().constData());
       if (editor->toPlainText() != text) {
         editor->setPlainText(text);
         setContentRenderState(); // since last render
@@ -625,7 +625,7 @@ bool TabManager::shouldClose()
 void TabManager::saveError(const QIODevice& file, const std::string& msg, const QString& filepath)
 {
   const char *fileName = filepath.toLocal8Bit().constData();
-  LOG(message_group::None, Location::NONE, "", "%1$s %2$s (%3$s)", msg.c_str(), fileName, file.errorString().toLocal8Bit().constData());
+  LOG("%1$s %2$s (%3$s)", msg.c_str(), fileName, file.errorString().toLocal8Bit().constData());
 
   const std::string dialogFormatStr = msg + "\n\"%1\"\n(%2)";
   const QString dialogFormat(dialogFormatStr.c_str());
@@ -675,7 +675,7 @@ bool TabManager::save(EditorInterface *edt, const QString& path)
     file.cancelWriting();
   }
   if (saveOk) {
-    LOG(message_group::None, Location::NONE, "", "Saved design '%1$s'.", path.toLocal8Bit().constData());
+    LOG("Saved design '%1$s'.", path.toLocal8Bit().constData());
     edt->parameterWidget->saveFile(path);
     edt->setContentModified(false);
     edt->parameterWidget->setModified(false);

--- a/src/gui/UIUtils.cc
+++ b/src/gui/UIUtils.cc
@@ -113,7 +113,7 @@ static ptree *examplesTree()
       examples_tree = new ptree;
       read_json(path, *examples_tree);
     } catch (const std::exception& e) {
-      LOG(message_group::None, Location::NONE, "", "Error reading examples.json: %1$s", e.what());
+      LOG("Error reading examples.json: %1$s", e.what());
       delete examples_tree;
       examples_tree = nullptr;
     }

--- a/src/io/DxfData.cc
+++ b/src/io/DxfData.cc
@@ -81,7 +81,7 @@ DxfData::DxfData(double fn, double fs, double fa,
 {
   std::ifstream stream(filename.c_str());
   if (!stream.good()) {
-    LOG(message_group::Warning, Location::NONE, "", "Can't open DXF file '%1$s'.", filename);
+    LOG(message_group::Warning, "Can't open DXF file '%1$s'.", filename);
     return;
   }
 
@@ -145,7 +145,7 @@ DxfData::DxfData(double fn, double fs, double fa,
       id = boost::lexical_cast<int>(id_str);
     } catch (const boost::bad_lexical_cast& blc) {
       if (!stream.eof()) {
-        LOG(message_group::Warning, Location::NONE, "", "Illegal ID '%1$s' in `%2$s'", id_str, filename);
+        LOG(message_group::Warning, "Illegal ID '%1$s' in `%2$s'", id_str, filename);
       }
       break;
     }
@@ -370,9 +370,9 @@ DxfData::DxfData(double fn, double fs, double fa,
         break;
       }
     } catch (boost::bad_lexical_cast& blc) {
-      LOG(message_group::Warning, Location::NONE, "", "Illegal value '%1$s'in `%2$s'", data, filename);
+      LOG(message_group::Warning, "Illegal value '%1$s'in `%2$s'", data, filename);
     } catch (const std::out_of_range& oor) {
-      LOG(message_group::Warning, Location::NONE, "", "Not enough input values for %1$s. in '%2$s'", data, filename);
+      LOG(message_group::Warning, "Not enough input values for %1$s. in '%2$s'", data, filename);
     }
   }
 

--- a/src/io/DxfData.cc
+++ b/src/io/DxfData.cc
@@ -378,10 +378,10 @@ DxfData::DxfData(double fn, double fs, double fa,
 
   for (const auto& i : unsupported_entities_list) {
     if (layername.empty()) {
-      LOG(message_group::Warning, Location::NONE, "",
+      LOG(message_group::Warning,
           "Unsupported DXF Entity '%1$s' (%2$x) in %3$s.", i.first, i.second, QuotedString(boostfs_uncomplete(filename, fs::current_path()).generic_string()));
     } else {
-      LOG(message_group::Warning, Location::NONE, "",
+      LOG(message_group::Warning,
           "Unsupported DXF Entity '%1$s' (%2$x) in layer '%3$s' of %4$s", i.first, i.second, layername, boostfs_uncomplete(filename, fs::current_path()).generic_string());
     }
   }
@@ -404,7 +404,7 @@ DxfData::DxfData(double fn, double fs, double fa,
         auto lv = grid.data(this->points[lines[idx].idx[j]][0], this->points[lines[idx].idx[j]][1]);
         for (int k : lv) {
           if (k < 0 || static_cast<unsigned int>(k) >= lines.size()) {
-            LOG(message_group::Warning, Location::NONE, "",
+            LOG(message_group::Warning,
                 "Bad DXF line index in %1$s.", QuotedString(boostfs_uncomplete(filename, fs::current_path()).generic_string()));
             continue;
           }
@@ -433,7 +433,7 @@ create_open_path:
       auto lv = grid.data(ref_point[0], ref_point[1]);
       for (int k : lv) {
         if (k < 0 || static_cast<unsigned int>(k) >= lines.size()) {
-          LOG(message_group::Warning, Location::NONE, "",
+          LOG(message_group::Warning,
               "Bad DXF line index in %1$s.", QuotedString(boostfs_uncomplete(filename, fs::current_path()).generic_string()));
           continue;
         }
@@ -474,7 +474,7 @@ found_next_line_in_open_path:;
       auto lv = grid.data(ref_point[0], ref_point[1]);
       for (int k : lv) {
         if (k < 0 || static_cast<unsigned int>(k) >= lines.size()) {
-          LOG(message_group::Warning, Location::NONE, "",
+          LOG(message_group::Warning,
               "Bad DXF line index in %1$s.", QuotedString(boostfs_uncomplete(filename, fs::current_path()).generic_string()));
           continue;
         }

--- a/src/io/export.cc
+++ b/src/io/export.cc
@@ -109,7 +109,7 @@ bool exportFileByNameStream(const shared_ptr<const Geometry>& root_geom, const E
   }
   std::ofstream fstream(exportInfo.name2open, mode);
   if (!fstream.is_open()) {
-    LOG(message_group::None, Location::NONE, "", _("Can't open file \"%1$s\" for export"), exportInfo.name2display);
+    LOG(_("Can't open file \"%1$s\" for export"), exportInfo.name2display);
     return false;
   } else {
     bool onerror = false;

--- a/src/io/export.cc
+++ b/src/io/export.cc
@@ -125,7 +125,7 @@ bool exportFileByNameStream(const shared_ptr<const Geometry>& root_geom, const E
       onerror = true;
     }
     if (onerror) {
-      LOG(message_group::Error, Location::NONE, "", _("\"%1$s\" write error. (Disk full?)"), exportInfo.name2display);
+      LOG(message_group::Error, _("\"%1$s\" write error. (Disk full?)"), exportInfo.name2display);
     }
     return !onerror;
   }

--- a/src/io/export_3mf.cc
+++ b/src/io/export_3mf.cc
@@ -62,7 +62,7 @@ using namespace NMR;
 
 static void export_3mf_error(std::string msg, PLib3MFModel *& model)
 {
-  LOG(message_group::Export_Error, Location::NONE, "", std::move(msg));
+  LOG(message_group::Export_Error, std::move(msg));
   if (model) {
     lib3mf_release(model);
     model = nullptr;
@@ -118,12 +118,12 @@ static bool append_polyset(const PolySet& ps, PLib3MFModelMeshObject *& model)
 static bool append_nef(const CGAL_Nef_polyhedron& root_N, PLib3MFModelMeshObject *& model)
 {
   if (!root_N.p3) {
-    LOG(message_group::Export_Error, Location::NONE, "", "Export failed, empty geometry.");
+    LOG(message_group::Export_Error, "Export failed, empty geometry.");
     return false;
   }
 
   if (!root_N.p3->is_simple()) {
-    LOG(message_group::Export_Warning, Location::NONE, "", "Exported object may not be a valid 2-manifold and may need repair");
+    LOG(message_group::Export_Warning, "Exported object may not be a valid 2-manifold and may need repair");
   }
 
   PolySet ps{3};
@@ -172,19 +172,19 @@ void export_3mf(const shared_ptr<const Geometry>& geom, std::ostream& output)
   DWORD interfaceVersionMajor, interfaceVersionMinor, interfaceVersionMicro;
   HRESULT result = lib3mf_getinterfaceversion(&interfaceVersionMajor, &interfaceVersionMinor, &interfaceVersionMicro);
   if (result != LIB3MF_OK) {
-    LOG(message_group::Export_Error, Location::NONE, "", "Error reading 3MF library version");
+    LOG(message_group::Export_Error, "Error reading 3MF library version");
     return;
   }
 
   if ((interfaceVersionMajor != NMR_APIVERSION_INTERFACE_MAJOR)) {
-    LOG(message_group::Export_Error, Location::NONE, "", "Invalid 3MF library major version %1$d.%2$d.%3$d, expected %4$d.%5$d.%6$d", interfaceVersionMajor, interfaceVersionMinor, interfaceVersionMicro, NMR_APIVERSION_INTERFACE_MAJOR, NMR_APIVERSION_INTERFACE_MINOR, NMR_APIVERSION_INTERFACE_MICRO);
+    LOG(message_group::Export_Error, "Invalid 3MF library major version %1$d.%2$d.%3$d, expected %4$d.%5$d.%6$d", interfaceVersionMajor, interfaceVersionMinor, interfaceVersionMicro, NMR_APIVERSION_INTERFACE_MAJOR, NMR_APIVERSION_INTERFACE_MINOR, NMR_APIVERSION_INTERFACE_MICRO);
     return;
   }
 
   PLib3MFModel *model;
   result = lib3mf_createmodel(&model);
   if (result != LIB3MF_OK) {
-    LOG(message_group::Export_Error, Location::NONE, "", "Can't create 3MF model.");
+    LOG(message_group::Export_Error, "Can't create 3MF model.");
     return;
   }
 
@@ -204,7 +204,7 @@ void export_3mf(const shared_ptr<const Geometry>& geom, std::ostream& output)
   lib3mf_release(writer);
   lib3mf_release(model);
   if (result != LIB3MF_OK) {
-    LOG(message_group::Export_Error, Location::NONE, "", "Error writing 3MF model.");
+    LOG(message_group::Export_Error, "Error writing 3MF model.");
   }
 
 
@@ -226,7 +226,7 @@ void export_3mf(const shared_ptr<const Geometry>& geom, std::ostream& output)
 
 static void export_3mf_error(std::string msg)
 {
-  LOG(message_group::Export_Error, Location::NONE, "", std::move(msg));
+  LOG(message_group::Export_Error, std::move(msg));
 }
 
 /*
@@ -289,12 +289,12 @@ static bool append_polyset(const PolySet& ps, Lib3MF::PWrapper& wrapper, Lib3MF:
 static bool append_nef(const CGAL_Nef_polyhedron& root_N, Lib3MF::PWrapper& wrapper, Lib3MF::PModel& model)
 {
   if (!root_N.p3) {
-    LOG(message_group::Export_Error, Location::NONE, "", "Export failed, empty geometry.");
+    LOG(message_group::Export_Error, "Export failed, empty geometry.");
     return false;
   }
 
   if (!root_N.p3->is_simple()) {
-    LOG(message_group::Export_Warning, Location::NONE, "", "Exported object may not be a valid 2-manifold and may need repair");
+    LOG(message_group::Export_Warning, "Exported object may not be a valid 2-manifold and may need repair");
   }
 
   PolySet ps{3};
@@ -348,18 +348,18 @@ void export_3mf(const shared_ptr<const Geometry>& geom, std::ostream& output)
     wrapper = Lib3MF::CWrapper::loadLibrary();
     wrapper->GetLibraryVersion(interfaceVersionMajor, interfaceVersionMinor, interfaceVersionMicro);
     if (interfaceVersionMajor != LIB3MF_VERSION_MAJOR) {
-      LOG(message_group::Error, Location::NONE, "", "Invalid 3MF library major version %1$d.%2$d.%3$d, expected %4$d.%5$d.%6$d",
+      LOG(message_group::Error, "Invalid 3MF library major version %1$d.%2$d.%3$d, expected %4$d.%5$d.%6$d",
           interfaceVersionMajor, interfaceVersionMinor, interfaceVersionMicro,
           LIB3MF_VERSION_MAJOR, LIB3MF_VERSION_MINOR, LIB3MF_VERSION_MICRO);
       return;
     }
   } catch (Lib3MF::ELib3MFException& e) {
-    LOG(message_group::Export_Error, Location::NONE, "", e.what());
+    LOG(message_group::Export_Error, e.what());
     return;
   }
 
   if ((interfaceVersionMajor != LIB3MF_VERSION_MAJOR)) {
-    LOG(message_group::Export_Error, Location::NONE, "", "Invalid 3MF library major version %1$d.%2$d.%3$d, expected %4$d.%5$d.%6$d", interfaceVersionMajor, interfaceVersionMinor, interfaceVersionMicro, LIB3MF_VERSION_MAJOR, LIB3MF_VERSION_MINOR, LIB3MF_VERSION_MICRO);
+    LOG(message_group::Export_Error, "Invalid 3MF library major version %1$d.%2$d.%3$d, expected %4$d.%5$d.%6$d", interfaceVersionMajor, interfaceVersionMinor, interfaceVersionMicro, LIB3MF_VERSION_MAJOR, LIB3MF_VERSION_MINOR, LIB3MF_VERSION_MICRO);
     return;
   }
 
@@ -367,11 +367,11 @@ void export_3mf(const shared_ptr<const Geometry>& geom, std::ostream& output)
   try {
     model = wrapper->CreateModel();
     if (!model) {
-      LOG(message_group::Export_Error, Location::NONE, "", "Can't create 3MF model.");
+      LOG(message_group::Export_Error, "Can't create 3MF model.");
       return;
     }
   } catch (Lib3MF::ELib3MFException& e) {
-    LOG(message_group::Export_Error, Location::NONE, "", e.what());
+    LOG(message_group::Export_Error, e.what());
     return;
   }
 
@@ -394,7 +394,7 @@ void export_3mf(const shared_ptr<const Geometry>& geom, std::ostream& output)
   try {
     writer->WriteToCallback((Lib3MF::WriteCallback)lib3mf_write_callback, (Lib3MF::SeekCallback)lib3mf_seek_callback, &output);
   } catch (Lib3MF::ELib3MFException& e) {
-    LOG(message_group::Export_Error, Location::NONE, "", e.what());
+    LOG(message_group::Export_Error, e.what());
   }
   output.flush();
 }

--- a/src/io/export_3mf.cc
+++ b/src/io/export_3mf.cc
@@ -407,7 +407,7 @@ void export_3mf(const shared_ptr<const Geometry>& geom, std::ostream& output)
 
 void export_3mf(const shared_ptr<const Geometry>&, std::ostream&)
 {
-  LOG(message_group::None, Location::NONE, "", "Export to 3MF format was not enabled when building the application.");
+  LOG("Export to 3MF format was not enabled when building the application.");
 }
 
 #endif // ENABLE_LIB3MF

--- a/src/io/export_amf.cc
+++ b/src/io/export_amf.cc
@@ -75,7 +75,7 @@ static size_t add_vertex(std::vector<vertex_str>& vertices, const Point& p) {
 static void append_amf(const CGAL_Nef_polyhedron& root_N, std::ostream& output)
 {
   if (!root_N.p3->is_simple()) {
-    LOG(message_group::Export_Warning, Location::NONE, "", "Export failed, the object isn't a valid 2-manifold.");
+    LOG(message_group::Export_Warning, "Export failed, the object isn't a valid 2-manifold.");
     return;
   }
   try {
@@ -131,7 +131,7 @@ static void append_amf(const CGAL_Nef_polyhedron& root_N, std::ostream& output)
     output << "  </mesh>\r\n"
            << " </object>\r\n";
   } catch (CGAL::Assertion_exception& e) {
-    LOG(message_group::Export_Error, Location::NONE, "", "CGAL error in CGAL_Nef_polyhedron3::convert_to_polyhedron(): %1$s", e.what());
+    LOG(message_group::Export_Error, "CGAL error in CGAL_Nef_polyhedron3::convert_to_polyhedron(): %1$s", e.what());
   }
 }
 

--- a/src/io/export_nef.cc
+++ b/src/io/export_nef.cc
@@ -39,7 +39,7 @@ void export_nefdbg(const shared_ptr<const Geometry>& geom, std::ostream& output)
   if (auto N = CGALUtils::getNefPolyhedronFromGeometry(geom)) {
     output << N->dump();
   } else {
-    LOG(message_group::None, Location::NONE, "", "Not a CGALNefPoly. Add some CSG ops?");
+    LOG("Not a CGALNefPoly. Add some CSG ops?");
   }
 }
 
@@ -48,7 +48,7 @@ void export_nef3(const shared_ptr<const Geometry>& geom, std::ostream& output)
   if (auto N = CGALUtils::getNefPolyhedronFromGeometry(geom)) {
     output << const_cast<CGAL_Nef_polyhedron3&>(*N->p3); // CGAL why?
   } else {
-    LOG(message_group::None, Location::NONE, "", "Not a CGALNefPoly. Add some CSG ops?");
+    LOG("Not a CGALNefPoly. Add some CSG ops?");
   }
 }
 #endif // ifdef ENABLE_CGAL

--- a/src/io/export_pdf.cc
+++ b/src/io/export_pdf.cc
@@ -154,12 +154,12 @@ void draw_geom(const Polygon2d& poly, cairo_t *cr ){
     const Eigen::Vector2d& p0 = o.vertices[0];
     // Move to the first vertice.  Note Y is inverted in Cairo.
     cairo_move_to(cr, mm_to_points(p0.x()), mm_to_points(-p0.y()));
-    // LOG(message_group::Export_Warning, Location::NONE, "", "DRAW VERTICE %1$8.4f %2$8.4f", mm_to_points(p0.x()),mm_to_points(p0.y()));
+    // LOG(message_group::Export_Warning, "DRAW VERTICE %1$8.4f %2$8.4f", mm_to_points(p0.x()),mm_to_points(p0.y()));
     // iterate across the remaining vertices, drawing a line to each.
     for (unsigned int idx = 1; idx < o.vertices.size(); idx++) {
       const Eigen::Vector2d& p = o.vertices[idx];
       cairo_line_to(cr, mm_to_points(p.x()), mm_to_points(-p.y()));
-      // LOG(message_group::Export_Warning, Location::NONE, "", "DRAW VERTICE %1$8.4f %2$8.4f", mm_to_points(p.x()),mm_to_points(p.y()));
+      // LOG(message_group::Export_Warning, "DRAW VERTICE %1$8.4f %2$8.4f", mm_to_points(p.x()),mm_to_points(p.y()));
     }
     // Draw a line from the last vertice to the first vertice.
     cairo_line_to(cr, mm_to_points(p0.x()), mm_to_points(-p0.y()));
@@ -217,8 +217,8 @@ if (exportInfo.options==nullptr) {
   int centerX = mm_to_points(minx)+spanX/2;
   int centerY = mm_to_points(miny)+spanY/2;
   // Temporary Log
-//  LOG(message_group::Export_Warning, Location::NONE, "", "min( %1$6d , %2$6d ), max( %3$6d , %4$6d )", minx, miny, maxx, maxy);
-//  LOG(message_group::Export_Warning, Location::NONE, "", "span( %1$6d , %2$6d ), center ( %3$6d , %4$6d )", spanX, spanY,  centerX, centerY);
+//  LOG(message_group::Export_Warning, "min( %1$6d , %2$6d ), max( %3$6d , %4$6d )", minx, miny, maxx, maxy);
+//  LOG(message_group::Export_Warning, "span( %1$6d , %2$6d ), center ( %3$6d , %4$6d )", spanX, spanY,  centerX, centerY);
   
   // Set orientation and paper size
   if ((exportPdfOptions->Orientation==paperOrientations::AUTO && spanX>spanY)||(exportPdfOptions->Orientation==paperOrientations::LANDSCAPE)) {
@@ -232,9 +232,9 @@ if (exportInfo.options==nullptr) {
   // Does it fit? (in points)	
   bool inpaper = (spanX<=pdfX-MARGIN)&&(spanY<=pdfY-MARGIN);
   if (!inpaper) {
-    LOG(message_group::Export_Warning, Location::NONE, "", "Geometry is too large to fit into selected size.");
+    LOG(message_group::Export_Warning, "Geometry is too large to fit into selected size.");
   }
-  //      LOG(message_group::Export_Warning, Location::NONE, "", "pdfX, pdfY %1$6d %2$6d ", pdfX, pdfY);
+  //      LOG(message_group::Export_Warning, "pdfX, pdfY %1$6d %2$6d ", pdfX, pdfY);
         
   //  Center on page.  Still in points.
   // Note Cairo inverts the Y axis, with zero at the top, positive going down.
@@ -247,8 +247,8 @@ if (exportInfo.options==nullptr) {
   double Mty=-(centerY-pdfY/2+MARGIN);  // INVERTED Top margin, Y axis
   double Mby=-(centerY+pdfY/2-MARGIN);  // INVERTED Bottom margin, Y axis
     // Temporary Log
-    // LOG(message_group::Export_Warning, Location::NONE, "", "tcX, tcY %1$6d , %2$6d", tcX, tcY);
-    // LOG(message_group::Export_Warning, Location::NONE, "", "Mlx, Mry %1$6d %2$6d Mtx, Mty %3$6d %4$6d", Mlx, Mrx, Mty, Mby);
+    // LOG(message_group::Export_Warning, "tcX, tcY %1$6d , %2$6d", tcX, tcY);
+    // LOG(message_group::Export_Warning, "Mlx, Mry %1$6d %2$6d Mtx, Mty %3$6d %4$6d", Mlx, Mrx, Mty, Mby);
   
   // Initialize Cairo Surface and PDF
   cairo_surface_t *surface = cairo_pdf_surface_create_for_stream(export_pdf_write, &output, pdfX, pdfY);
@@ -301,7 +301,7 @@ const std::string get_cairo_version() {
 
 void export_pdf(const shared_ptr<const Geometry>&, std::ostream&, const ExportInfo&) {
 
-  LOG(message_group::Error, Location::NONE, "", "Export to PDF format was not enabled when building the application.");
+  LOG(message_group::Error, "Export to PDF format was not enabled when building the application.");
 
 }
 

--- a/src/io/export_stl.cc
+++ b/src/io/export_stl.cc
@@ -167,14 +167,14 @@ uint64_t append_stl(const CGAL_Nef_polyhedron& root_N, std::ostream& output,
 {
   uint64_t triangle_count = 0;
   if (!root_N.p3->is_simple()) {
-    LOG(message_group::Export_Warning, Location::NONE, "", "Exported object may not be a valid 2-manifold and may need repair");
+    LOG(message_group::Export_Warning, "Exported object may not be a valid 2-manifold and may need repair");
   }
 
   PolySet ps(3);
   if (!CGALUtils::createPolySetFromNefPolyhedron3(*(root_N.p3), ps)) {
     triangle_count += append_stl(ps, output, binary);
   } else {
-    LOG(message_group::Export_Error, Location::NONE, "", "Nef->PolySet failed");
+    LOG(message_group::Export_Error, "Nef->PolySet failed");
   }
 
   return triangle_count;
@@ -189,14 +189,14 @@ uint64_t append_stl(const CGALHybridPolyhedron& hybrid, std::ostream& output,
 {
   uint64_t triangle_count = 0;
   if (!hybrid.isManifold()) {
-    LOG(message_group::Export_Warning, Location::NONE, "", "Exported object may not be a valid 2-manifold and may need repair");
+    LOG(message_group::Export_Warning, "Exported object may not be a valid 2-manifold and may need repair");
   }
 
   auto ps = hybrid.toPolySet();
   if (ps) {
     triangle_count += append_stl(*ps, output, binary);
   } else {
-    LOG(message_group::Export_Error, Location::NONE, "", "Nef->PolySet failed");
+    LOG(message_group::Export_Error, "Nef->PolySet failed");
   }
 
   return triangle_count;
@@ -212,14 +212,14 @@ uint64_t append_stl(const ManifoldGeometry& mani, std::ostream& output,
 {
   uint64_t triangle_count = 0;
   if (!mani.isManifold()) {
-    LOG(message_group::Export_Warning, Location::NONE, "", "Exported object may not be a valid 2-manifold and may need repair");
+    LOG(message_group::Export_Warning, "Exported object may not be a valid 2-manifold and may need repair");
   }
 
   auto ps = mani.toPolySet();
   if (ps) {
     triangle_count += append_stl(*ps, output, binary);
   } else {
-    LOG(message_group::Export_Error, Location::NONE, "", "Manifold->PolySet failed");
+    LOG(message_group::Export_Error, "Manifold->PolySet failed");
   }
 
   return triangle_count;
@@ -279,7 +279,7 @@ void export_stl(const shared_ptr<const Geometry>& geom, std::ostream& output,
     output.put((triangle_count >> 16) & 0xff);
     output.put((triangle_count >> 24) & 0xff);
     if (triangle_count > 4294967295) {
-      LOG(message_group::Export_Error, Location::NONE, "", "Triangle count exceeded 4294967295, so the stl file is not valid");
+      LOG(message_group::Export_Error, "Triangle count exceeded 4294967295, so the stl file is not valid");
     }
   } else {
     output << "endsolid OpenSCAD_Model\n";

--- a/src/io/fileutils.cc
+++ b/src/io/fileutils.cc
@@ -21,7 +21,7 @@ std::string lookup_file(const std::string& filename,
 
     if (!fs::exists(absfile) && fs::exists(absfile_fallback)) {
       resultfile = absfile_fallback.string();
-      LOG(message_group::Deprecated, Location::NONE, "", "Imported file (%1$s) found in document root instead of relative to the importing module. This behavior is deprecated", std::string(filename));
+      LOG(message_group::Deprecated, "Imported file (%1$s) found in document root instead of relative to the importing module. This behavior is deprecated", std::string(filename));
     } else {
       resultfile = absfile.string();
     }

--- a/src/io/import_3mf.cc
+++ b/src/io/import_3mf.cc
@@ -79,12 +79,12 @@ Geometry *import_3mf(const std::string& filename, const Location& loc)
   DWORD interfaceVersionMajor, interfaceVersionMinor, interfaceVersionMicro;
   HRESULT result = lib3mf_getinterfaceversion(&interfaceVersionMajor, &interfaceVersionMinor, &interfaceVersionMicro);
   if (result != LIB3MF_OK) {
-    LOG(message_group::Error, Location::NONE, "", "Error reading 3MF library version");
+    LOG(message_group::Error, "Error reading 3MF library version");
     return new PolySet(3);
   }
 
   if ((interfaceVersionMajor != NMR_APIVERSION_INTERFACE_MAJOR)) {
-    LOG(message_group::Error, Location::NONE, "", "Invalid 3MF library major version %1$d.%2$d.%3$d, expected %4$d.%5$d.%6$d",
+    LOG(message_group::Error, "Invalid 3MF library major version %1$d.%2$d.%3$d, expected %4$d.%5$d.%6$d",
         interfaceVersionMajor, interfaceVersionMinor, interfaceVersionMicro,
         NMR_APIVERSION_INTERFACE_MAJOR, NMR_APIVERSION_INTERFACE_MINOR, NMR_APIVERSION_INTERFACE_MICRO);
     return new PolySet(3);
@@ -93,21 +93,21 @@ Geometry *import_3mf(const std::string& filename, const Location& loc)
   PLib3MFModel *model;
   result = lib3mf_createmodel(&model);
   if (result != LIB3MF_OK) {
-    LOG(message_group::Error, Location::NONE, "", "Could not create model: %1$08lx", result);
+    LOG(message_group::Error, "Could not create model: %1$08lx", result);
     return import_3mf_error();
   }
 
   PLib3MFModelReader *reader;
   result = lib3mf_model_queryreader(model, "3mf", &reader);
   if (result != LIB3MF_OK) {
-    LOG(message_group::Error, Location::NONE, "", "Could not create 3MF reader: %1$08lx", result);
+    LOG(message_group::Error, "Could not create 3MF reader: %1$08lx", result);
     return import_3mf_error(model);
   }
 
   result = lib3mf_reader_readfromfileutf8(reader, filename.c_str());
   lib3mf_release(reader);
   if (result != LIB3MF_OK) {
-    LOG(message_group::Warning, Location::NONE, "", "Could not read file '%1$s', import() at line %2$d", filename.c_str(), loc.firstLine());
+    LOG(message_group::Warning, "Could not read file '%1$s', import() at line %2$d", filename.c_str(), loc.firstLine());
     return import_3mf_error(model);
   }
 
@@ -225,7 +225,7 @@ const std::string get_lib3mf_version() {
     wrapper = Lib3MF::CWrapper::loadLibrary();
     wrapper->GetLibraryVersion(interfaceVersionMajor, interfaceVersionMinor, interfaceVersionMicro);
   } catch (Lib3MF::ELib3MFException& e) {
-    LOG(message_group::Export_Error, Location::NONE, "", e.what());
+    LOG(message_group::Export_Error, e.what());
   }
 
   const OpenSCAD::library_version_number header_version{LIB3MF_VERSION_MAJOR, LIB3MF_VERSION_MINOR, LIB3MF_VERSION_MICRO};
@@ -259,13 +259,13 @@ Geometry *import_3mf(const std::string& filename, const Location& loc)
     wrapper = Lib3MF::CWrapper::loadLibrary();
     wrapper->GetLibraryVersion(interfaceVersionMajor, interfaceVersionMinor, interfaceVersionMicro);
     if (interfaceVersionMajor != LIB3MF_VERSION_MAJOR) {
-      LOG(message_group::Error, Location::NONE, "", "Invalid 3MF library major version %1$d.%2$d.%3$d, expected %4$d.%5$d.%6$d",
+      LOG(message_group::Error, "Invalid 3MF library major version %1$d.%2$d.%3$d, expected %4$d.%5$d.%6$d",
           interfaceVersionMajor, interfaceVersionMinor, interfaceVersionMicro,
           LIB3MF_VERSION_MAJOR, LIB3MF_VERSION_MINOR, LIB3MF_VERSION_MICRO);
       return new PolySet(3);
     }
   } catch (Lib3MF::ELib3MFException& e) {
-    LOG(message_group::Export_Error, Location::NONE, "", e.what());
+    LOG(message_group::Export_Error, e.what());
     return new PolySet(3);
   }
 
@@ -273,11 +273,11 @@ Geometry *import_3mf(const std::string& filename, const Location& loc)
   try {
     model = wrapper->CreateModel();
     if (!model) {
-      LOG(message_group::Error, Location::NONE, "", "Could not create model");
+      LOG(message_group::Error, "Could not create model");
       return new PolySet(3);
     }
   } catch (Lib3MF::ELib3MFException& e) {
-    LOG(message_group::Export_Error, Location::NONE, "", e.what());
+    LOG(message_group::Export_Error, e.what());
     return new PolySet(3);
   }
 
@@ -285,11 +285,11 @@ Geometry *import_3mf(const std::string& filename, const Location& loc)
   try {
     reader = model->QueryReader("3mf");
     if (!reader) {
-      LOG(message_group::Error, Location::NONE, "", "Could not create 3MF reader");
+      LOG(message_group::Error, "Could not create 3MF reader");
       return new PolySet(3);
     }
   } catch (Lib3MF::ELib3MFException& e) {
-    LOG(message_group::Export_Error, Location::NONE, "", e.what());
+    LOG(message_group::Export_Error, e.what());
     return new PolySet(3);
   }
 
@@ -300,7 +300,7 @@ Geometry *import_3mf(const std::string& filename, const Location& loc)
     read_error = true;
   }
   if (!reader || read_error) {
-    LOG(message_group::Warning, Location::NONE, "", "Could not read file '%1$s', import() at line %2$d", filename.c_str(), loc.firstLine());
+    LOG(message_group::Warning, "Could not read file '%1$s', import() at line %2$d", filename.c_str(), loc.firstLine());
     return new PolySet(3);
   }
 
@@ -322,7 +322,7 @@ Geometry *import_3mf(const std::string& filename, const Location& loc)
         return import_3mf_error(first_mesh);
       }
     } catch (Lib3MF::ELib3MFException& e) {
-      LOG(message_group::Error, Location::NONE, "", e.what());
+      LOG(message_group::Error, e.what());
       return import_3mf_error(first_mesh);
     }
 
@@ -396,7 +396,7 @@ const std::string get_lib3mf_version() {
 
 Geometry *import_3mf(const std::string&, const Location& loc)
 {
-  LOG(message_group::Warning, Location::NONE, "", "Import from 3MF format was not enabled when building the application, import() at line %1$d", loc.firstLine());
+  LOG(message_group::Warning, "Import from 3MF format was not enabled when building the application, import() at line %1$d", loc.firstLine());
   return new PolySet(3);
 }
 

--- a/src/io/import_amf.cc
+++ b/src/io/import_amf.cc
@@ -222,7 +222,7 @@ int AmfImporter::streamFile(const char *filename)
   xmlTextReaderPtr reader = createXmlReader(filename);
 
   if (reader == nullptr) {
-    LOG(message_group::Warning, Location::NONE, "", "Can't open import file '%1$s', import() at line %2$d", filename, this->loc.firstLine());
+    LOG(message_group::Warning, "Can't open import file '%1$s', import() at line %2$d", filename, this->loc.firstLine());
     return 1;
   }
 
@@ -238,7 +238,7 @@ int AmfImporter::streamFile(const char *filename)
     ret = -1;
   }
   if (ret != 0) {
-    LOG(message_group::Warning, Location::NONE, "", "Failed to parse file '%1$s', import() at line %2$d", filename, this->loc.firstLine());
+    LOG(message_group::Warning, "Failed to parse file '%1$s', import() at line %2$d", filename, this->loc.firstLine());
   }
   return ret;
 }
@@ -272,7 +272,7 @@ PolySet *AmfImporter::read(const std::string& filename)
     if (auto ps = CGALUtils::getGeometryAsPolySet(CGALUtils::applyUnion3D(children.begin(), children.end()))) {
       p = new PolySet(*ps);
     } else {
-      LOG(message_group::Error, Location::NONE, "", "Error importing multi-object AMF file '%1$s', import() at line %2$d", filename, this->loc.firstLine());
+      LOG(message_group::Error, "Error importing multi-object AMF file '%1$s', import() at line %2$d", filename, this->loc.firstLine());
       p = new PolySet(3);
     }
   }
@@ -330,10 +330,10 @@ xmlTextReaderPtr AmfImporterZIP::createXmlReader(const char *filepath)
     const char *filename = last_slash ? last_slash + 1 : filepath;
     zipfile = zip_fopen(archive, filename, ZIP_FL_NODIR);
     if (zipfile == nullptr) {
-      LOG(message_group::Warning, Location::NONE, "", "Can't read file '%1$s' from zipped AMF '%2$s', import() at line %3$d", filename, filepath, this->loc.firstLine());
+      LOG(message_group::Warning, "Can't read file '%1$s' from zipped AMF '%2$s', import() at line %3$d", filename, filepath, this->loc.firstLine());
     }
     if ((zipfile == nullptr) && (zip_get_num_files(archive) == 1)) {
-      LOG(message_group::Warning, Location::NONE, "", "Trying to read single entry '%1$s'", zip_get_name(archive, 0, 0));
+      LOG(message_group::Warning, "Trying to read single entry '%1$s'", zip_get_name(archive, 0, 0));
       zipfile = zip_fopen_index(archive, 0, 0);
     }
     if (zipfile) {

--- a/src/io/import_nef.cc
+++ b/src/io/import_nef.cc
@@ -25,7 +25,7 @@ CGAL_Nef_polyhedron *import_nef3(const std::string& filename, const Location& lo
     N->p3 = nef;
   } catch (const CGAL::Failure_exception& e) {
     LOG(message_group::Warning, Location::NONE, "", "Failure trying to import '%1$s', import() at line %2$d", filename, loc.firstLine());
-    LOG(message_group::None, Location::NONE, "", e.what());
+    LOG(e.what());
     N = new CGAL_Nef_polyhedron;
   }
   return N;

--- a/src/io/import_nef.cc
+++ b/src/io/import_nef.cc
@@ -15,7 +15,7 @@ CGAL_Nef_polyhedron *import_nef3(const std::string& filename, const Location& lo
   // Open file and position at the end
   std::ifstream f(filename.c_str(), std::ios::in | std::ios::binary);
   if (!f.good()) {
-    LOG(message_group::Warning, Location::NONE, "", "Can't open import file '%1$s', import() at line %2$d", filename, loc.firstLine());
+    LOG(message_group::Warning, "Can't open import file '%1$s', import() at line %2$d", filename, loc.firstLine());
     return N;
   }
 
@@ -24,7 +24,7 @@ CGAL_Nef_polyhedron *import_nef3(const std::string& filename, const Location& lo
     f >> *nef;
     N->p3 = nef;
   } catch (const CGAL::Failure_exception& e) {
-    LOG(message_group::Warning, Location::NONE, "", "Failure trying to import '%1$s', import() at line %2$d", filename, loc.firstLine());
+    LOG(message_group::Warning, "Failure trying to import '%1$s', import() at line %2$d", filename, loc.firstLine());
     LOG(e.what());
     N = new CGAL_Nef_polyhedron;
   }

--- a/src/io/import_obj.cc
+++ b/src/io/import_obj.cc
@@ -13,7 +13,7 @@ PolySet *import_obj(const std::string& filename, const Location& loc) {
   
   std::ifstream f(filename.c_str(), std::ios::in | std::ios::binary );
   if (!f.good()) {
-    LOG(message_group::Warning, Location::NONE, "",
+    LOG(message_group::Warning,
         "Can't open import file '%1$s', import() at line %2$d",
         filename, loc.firstLine());
     return p.release();

--- a/src/io/import_obj.cc
+++ b/src/io/import_obj.cc
@@ -67,7 +67,7 @@ PolySet *import_obj(const std::string& filename, const Location& loc) {
         if(ind >= 1 && ind  <= pts.size())
           p->append_vertex(pts[ind-1][0], pts[ind-1][1], pts[ind-1][2]);
         else
-          LOG(message_group::Warning, Location::NONE, "", "Index %1$d out of range in Line %2$d", filename, lineno);
+          LOG(message_group::Warning, "Index %1$d out of range in Line %2$d", filename, lineno);
       }
 
     } else if (boost::regex_search(line, results, ex_vt)) { // ignore texture coords
@@ -78,7 +78,7 @@ PolySet *import_obj(const std::string& filename, const Location& loc) {
     } else if (boost::regex_search(line, results, ex_s)) { // ignore smooting
     } else if (boost::regex_search(line, results, ex_g)) { // ignore group name
     } else {
-      LOG(message_group::Warning, Location::NONE, "", "Unrecognized Line  %1$s in line Line %2$d", line, lineno);
+      LOG(message_group::Warning, "Unrecognized Line  %1$s in line Line %2$d", line, lineno);
     }
   }
   return p.release();

--- a/src/io/import_off.cc
+++ b/src/io/import_off.cc
@@ -13,14 +13,14 @@ PolySet *import_off(const std::string& filename, const Location& loc)
   CGAL_Polyhedron poly;
   std::ifstream file(filename.c_str(), std::ios::in | std::ios::binary);
   if (!file.good()) {
-    LOG(message_group::Warning, Location::NONE, "", "Can't open import file '%1$s', import() at line %2$d", filename, loc.firstLine());
+    LOG(message_group::Warning, "Can't open import file '%1$s', import() at line %2$d", filename, loc.firstLine());
   } else {
     file >> poly;
     file.close();
     CGALUtils::createPolySetFromPolyhedron(poly, *p);
   }
 #else
-  LOG(message_group::Warning, Location::NONE, "", "OFF import requires CGAL, import() at line %2$d", filename, loc.firstLine());
+  LOG(message_group::Warning, "OFF import requires CGAL, import() at line %2$d", filename, loc.firstLine());
 #endif // ifdef ENABLE_CGAL
   return p;
 }

--- a/src/io/import_stl.cc
+++ b/src/io/import_stl.cc
@@ -69,7 +69,7 @@ PolySet *import_stl(const std::string& filename, const Location& loc) {
   // Open file and position at the end
   std::ifstream f(filename.c_str(), std::ios::in | std::ios::binary | std::ios::ate);
   if (!f.good()) {
-    LOG(message_group::Warning, Location::NONE, "",
+    LOG(message_group::Warning,
         "Can't open import file '%1$s', import() at line %2$d",
         filename, loc.firstLine());
     return p.release();

--- a/src/io/import_svg.cc
+++ b/src/io/import_svg.cc
@@ -209,7 +209,7 @@ Polygon2d *import_svg(double fn, double fs, double fa,
     libsvg_free(shapes);
     return ClipperUtils::apply(polygons, ClipperLib::ctUnion);
   } catch (const std::exception& e) {
-    LOG(message_group::Error, Location::NONE, "", "%1$s, import() at line %2$d", e.what(), loc.firstLine());
+    LOG(message_group::Error, "%1$s, import() at line %2$d", e.what(), loc.firstLine());
     return new Polygon2d();
   }
 }

--- a/src/openscad.cc
+++ b/src/openscad.cc
@@ -836,7 +836,7 @@ int gui(vector<string>& inputFiles, const fs::path& original_path, int argc, cha
 bool QtUseGUI() { return false; }
 int gui(const vector<string>& inputFiles, const fs::path& original_path, int argc, char **argv)
 {
-  LOG(message_group::Error, Location::NONE, "", "Compiled without QT, but trying to run GUI\n");
+  LOG(message_group::Error, "Compiled without QT, but trying to run GUI\n");
   return 1;
 }
 #endif // OPENSCAD_QTGUI
@@ -1064,11 +1064,11 @@ int main(int argc, char **argv)
     output_files = vm["o"].as<vector<string>>();
   }
   if (vm.count("s")) {
-    LOG(message_group::Deprecated, Location::NONE, "", "The -s option is deprecated. Use -o instead.\n");
+    LOG(message_group::Deprecated, "The -s option is deprecated. Use -o instead.\n");
     output_files.push_back(vm["s"].as<string>());
   }
   if (vm.count("x")) {
-    LOG(message_group::Deprecated, Location::NONE, "", "The -x option is deprecated. Use -o instead.\n");
+    LOG(message_group::Deprecated, "The -x option is deprecated. Use -o instead.\n");
     output_files.push_back(vm["x"].as<string>());
   }
   if (vm.count("d")) {

--- a/src/openscad.cc
+++ b/src/openscad.cc
@@ -128,7 +128,7 @@ private:
 static void help(const char *arg0, const po::options_description& desc, bool failure = false)
 {
   const fs::path progpath(arg0);
-  LOG(message_group::None, Location::NONE, "", "Usage: %1$s [options] file.scad\n%2$s", progpath.filename().string(), desc);
+  LOG("Usage: %1$s [options] file.scad\n%2$s", progpath.filename().string(), desc);
   exit(failure ? 1 : 0);
 }
 
@@ -136,7 +136,7 @@ static void help(const char *arg0, const po::options_description& desc, bool fai
 #define TOSTRING(x) STRINGIFY(x)
 static void version()
 {
-  LOG(message_group::None, Location::NONE, "", "OpenSCAD version %1$s", TOSTRING(OPENSCAD_VERSION));
+  LOG("OpenSCAD version %1$s", TOSTRING(OPENSCAD_VERSION));
   exit(0);
 }
 
@@ -148,7 +148,7 @@ static int info()
     OffscreenView glview(512, 512);
     std::cout << glview.getRendererInfo() << "\n";
   } catch (int error) {
-    LOG(message_group::None, Location::NONE, "", "Can't create OpenGL OffscreenView. Code: %1$i. Exiting.\n", error);
+    LOG("Can't create OpenGL OffscreenView. Code: %1$i. Exiting.\n", error);
     return 1;
   }
 
@@ -169,7 +169,7 @@ static bool with_output(const bool is_stdout, const std::string& filename, F f, 
   }
   std::ofstream fstream(filename, mode);
   if (!fstream.is_open()) {
-    LOG(message_group::None, Location::NONE, "", "Can't open file \"%1$s\" for export", filename);
+    LOG("Can't open file \"%1$s\" for export", filename);
     return false;
   } else {
     f(fstream);
@@ -192,7 +192,7 @@ void localization_init() {
     bind_textdomain_codeset("openscad", "UTF-8");
     textdomain("openscad");
   } else {
-    LOG(message_group::None, Location::NONE, "", "Could not initialize localization.");
+    LOG("Could not initialize localization.");
   }
 }
 
@@ -211,10 +211,10 @@ Camera get_camera(const po::variables_map& vm)
         }
         camera.setup(cam_parameters);
       } catch (bad_lexical_cast&) {
-        LOG(message_group::None, Location::NONE, "", "Camera setup requires numbers as parameters");
+        LOG("Camera setup requires numbers as parameters");
       }
     } else {
-      LOG(message_group::None, Location::NONE, "", "Camera setup requires either 7 numbers for Gimbal Camera or 6 numbers for Vector Camera");
+      LOG("Camera setup requires either 7 numbers for Gimbal Camera or 6 numbers for Vector Camera");
       exit(1);
     }
   } else {
@@ -237,7 +237,7 @@ Camera get_camera(const po::variables_map& vm)
     } else if (proj == "p" || proj == "perspective") {
       camera.projection = Camera::ProjectionType::PERSPECTIVE;
     } else {
-      LOG(message_group::None, Location::NONE, "", "projection needs to be 'o' or 'p' for ortho or perspective\n");
+      LOG("projection needs to be 'o' or 'p' for ortho or perspective\n");
       exit(1);
     }
   }
@@ -248,14 +248,14 @@ Camera get_camera(const po::variables_map& vm)
     vector<string> strs;
     boost::split(strs, vm["imgsize"].as<string>(), is_any_of(","));
     if (strs.size() != 2) {
-      LOG(message_group::None, Location::NONE, "", "Need 2 numbers for imgsize");
+      LOG("Need 2 numbers for imgsize");
       exit(1);
     } else {
       try {
         w = lexical_cast<int>(strs[0]);
         h = lexical_cast<int>(strs[1]);
       } catch (bad_lexical_cast&) {
-        LOG(message_group::None, Location::NONE, "", "Need 2 numbers for imgsize");
+        LOG("Need 2 numbers for imgsize");
       }
     }
   }
@@ -273,11 +273,11 @@ static bool checkAndExport(const shared_ptr<const Geometry>& root_geom, unsigned
                            FileFormat format, const bool is_stdout, const std::string& filename)
 {
   if (root_geom->getDimension() != nd) {
-    LOG(message_group::None, Location::NONE, "", "Current top level object is not a %1$dD object.", nd);
+    LOG("Current top level object is not a %1$dD object.", nd);
     return false;
   }
   if (root_geom->isEmpty()) {
-    LOG(message_group::None, Location::NONE, "", "Current top level object is empty.");
+    LOG("Current top level object is empty.");
     return false;
   }
 
@@ -303,11 +303,11 @@ void set_render_color_scheme(const std::string& color_scheme, const bool exit_if
   }
 
   if (exit_if_not_found) {
-    LOG(message_group::None, Location::NONE, "", (boost::algorithm::join(ColorMap::inst()->colorSchemeNames(), "\n")));
+    LOG((boost::algorithm::join(ColorMap::inst()->colorSchemeNames(), "\n")));
 
     exit(1);
   } else {
-    LOG(message_group::None, Location::NONE, "", "Unknown color scheme '%1$s', using default '%2$s'.", arg_colorscheme, ColorMap::inst()->defaultColorSchemeName());
+    LOG("Unknown color scheme '%1$s', using default '%2$s'.", arg_colorscheme, ColorMap::inst()->defaultColorSchemeName());
   }
 }
 
@@ -353,7 +353,7 @@ int cmdline(const CommandLine& cmd)
     if (format_iter != exportFileFormatOptions.exportFileFormats.end()) {
       export_format = format_iter->second;
     } else {
-      LOG(message_group::None, Location::NONE, "", "Either add a valid suffix or specify one using the --export-format option.");
+      LOG("Either add a valid suffix or specify one using the --export-format option.");
       return 1;
     }
   }
@@ -365,7 +365,7 @@ int cmdline(const CommandLine& cmd)
     output_dir = fs::current_path();
   }
   if (!fs::is_directory(output_dir)) {
-    LOG(message_group::None, Location::NONE, "", "\n'%1$s' is not a directory for output file %2$s - Skipping\n", output_dir.generic_string(), cmd.output_file);
+    LOG("\n'%1$s' is not a directory for output file %2$s - Skipping\n", output_dir.generic_string(), cmd.output_file);
     return 1;
   }
 
@@ -382,7 +382,7 @@ int cmdline(const CommandLine& cmd)
   } else {
     std::ifstream ifs(cmd.filename);
     if (!ifs.is_open()) {
-      LOG(message_group::None, Location::NONE, "", "Can't open input file '%1$s'!\n", cmd.filename);
+      LOG("Can't open input file '%1$s'!\n", cmd.filename);
       return 1;
     }
     handle_dep(cmd.filename);
@@ -397,7 +397,7 @@ int cmdline(const CommandLine& cmd)
     root_file = nullptr;
   }
   if (!root_file) {
-    LOG(message_group::None, Location::NONE, "", "Can't parse file '%1$s'!\n", cmd.filename);
+    LOG("Can't parse file '%1$s'!\n", cmd.filename);
     return 1;
   }
 
@@ -439,7 +439,7 @@ int cmdline(const CommandLine& cmd)
       frame_file.replace_extension(extension);
       string frame_str = frame_file.generic_string();
 
-      LOG(message_group::None, Location::NONE, "", "Exporting %1$s...", cmd.filename);
+      LOG("Exporting %1$s...", cmd.filename);
 
       CommandLine frame_cmd = cmd;
       frame_cmd.output_file = frame_str;
@@ -553,7 +553,7 @@ int do_export(const CommandLine& cmd, const RenderVariables& render_variables, F
           } else {
             root_geom = CGALUtils::getNefPolyhedronFromGeometry(root_geom);
           }
-          LOG(message_group::None, Location::NONE, "", "Converted to Nef polyhedron");
+          LOG("Converted to Nef polyhedron");
         }
       } else {
         root_geom.reset(new CGAL_Nef_polyhedron());
@@ -596,7 +596,7 @@ int do_export(const CommandLine& cmd, const RenderVariables& render_variables, F
 
     renderStatistic.printAll(root_geom, camera, cmd.summaryOptions, cmd.summaryFile);
 #else
-    LOG(message_group::None, Location::NONE, "", "OpenSCAD has been compiled without CGAL support!\n");
+    LOG("OpenSCAD has been compiled without CGAL support!\n");
     return 1;
 #endif // ifdef ENABLE_CGAL
 
@@ -996,14 +996,14 @@ int main(int argc, char **argv)
   try {
     po::store(po::command_line_parser(argc, argv).options(all_options).positional(p).extra_parser(customSyntax).run(), vm);
   } catch (const std::exception& e) { // Catches e.g. unknown options
-    LOG(message_group::None, Location::NONE, "", "%1$s\n", e.what());
+    LOG("%1$s\n", e.what());
     help(argv[0], desc, true);
   }
 
   OpenSCAD::debug = "";
   if (vm.count("debug")) {
     OpenSCAD::debug = vm["debug"].as<string>();
-    LOG(message_group::None, Location::NONE, "", "Debug on. --debug=%1$s", OpenSCAD::debug);
+    LOG("Debug on. --debug=%1$s", OpenSCAD::debug);
   }
   if (vm.count("quiet")) {
     OpenSCAD::quiet = true;
@@ -1027,7 +1027,7 @@ int main(int argc, char **argv)
       try {
         (*(flag.second) = flagConvert(opt));
       } catch (const std::runtime_error& e) {
-        LOG(message_group::None, Location::NONE, "", "Could not parse '--%1$s %2$s' as flag", name, opt);
+        LOG("Could not parse '--%1$s %2$s' as flag", name, opt);
       }
     }
   }
@@ -1051,7 +1051,7 @@ int main(int argc, char **argv)
       try {
         viewOptions[option] = true;
       } catch (const std::out_of_range& e) {
-        LOG(message_group::None, Location::NONE, "", "Unknown --view option '%1$s' ignored. Use -h to list available options.", option);
+        LOG("Unknown --view option '%1$s' ignored. Use -h to list available options.", option);
       }
     }
   }
@@ -1128,7 +1128,7 @@ int main(int argc, char **argv)
     if (format_iter != exportFileFormatOptions.exportFileFormats.end()) {
       export_format.emplace(format_iter->second);
     } else {
-      LOG(message_group::None, Location::NONE, "", "Unknown --export-format option '%1$s'.  Use -h to list available options.", format);
+      LOG("Unknown --export-format option '%1$s'.  Use -h to list available options.", format);
       return 1;
     }
   }
@@ -1143,7 +1143,7 @@ int main(int argc, char **argv)
   if (animate_frames) {
     for (const auto& filename : output_files) {
       if (filename == "-") {
-        LOG(message_group::None, Location::NONE, "", "Option --animate is not supported when exporting to stdout.");
+        LOG("Option --animate is not supported when exporting to stdout.");
         return 1;
       }
     }
@@ -1198,17 +1198,17 @@ int main(int argc, char **argv)
       const vector<std::string>& geom_out(output_files);
       int result = write_deps(deps_out, geom_out);
       if (!result) {
-        LOG(message_group::None, Location::NONE, "", "Error writing deps");
+        LOG("Error writing deps");
         return 1;
       }
     }
   } else if (QtUseGUI()) {
     if (vm.count("export-format")) {
-      LOG(message_group::None, Location::NONE, "", "Ignoring --export-format option");
+      LOG("Ignoring --export-format option");
     }
     rc = gui(inputFiles, original_path, argc, argv);
   } else {
-    LOG(message_group::None, Location::NONE, "", "Requested GUI mode but can't open display!\n");
+    LOG("Requested GUI mode but can't open display!\n");
     return 1;
   }
 

--- a/src/platform/PlatformUtils-win.cc
+++ b/src/platform/PlatformUtils-win.cc
@@ -38,7 +38,7 @@ std::string winapi_wstr_to_utf8(std::wstring wstr)
   int numbytes = WideCharToMultiByte(CodePage, dwFlags, lpWideCharStr,
                                      cchWideChar, lpMultiByteStr, cbMultiByte, lpDefaultChar, lpUsedDefaultChar);
 
-  // LOG(message_group::None,Location::NONE,"","utf16 to utf8 conversion: numbytes %1$i",numbytes);
+  // LOG(message_group::NONE,Location::NONE,"","utf16 to utf8 conversion: numbytes %1$i",numbytes);
 
   std::string utf8_str(numbytes, 0);
   lpMultiByteStr = &utf8_str[0];

--- a/src/platform/PlatformUtils-win.cc
+++ b/src/platform/PlatformUtils-win.cc
@@ -38,7 +38,7 @@ std::string winapi_wstr_to_utf8(std::wstring wstr)
   int numbytes = WideCharToMultiByte(CodePage, dwFlags, lpWideCharStr,
                                      cchWideChar, lpMultiByteStr, cbMultiByte, lpDefaultChar, lpUsedDefaultChar);
 
-  // LOG(message_group::NONE,Location::NONE,"","utf16 to utf8 conversion: numbytes %1$i",numbytes);
+  // LOG(message_group::NONE,,"utf16 to utf8 conversion: numbytes %1$i",numbytes);
 
   std::string utf8_str(numbytes, 0);
   lpMultiByteStr = &utf8_str[0];

--- a/src/platform/PlatformUtils-win.cc
+++ b/src/platform/PlatformUtils-win.cc
@@ -49,8 +49,8 @@ std::string winapi_wstr_to_utf8(std::wstring wstr)
 
   if (result != numbytes) {
     DWORD errcode = GetLastError();
-    LOG(message_group::Error, Location::NONE, "", "Error converting w_char str to utf8 string");
-    LOG(message_group::Error, Location::NONE, "", "error code %1$i", errcode);
+    LOG(message_group::Error, "Error converting w_char str to utf8 string");
+    LOG(message_group::Error, "error code %1$i", errcode);
   }
 
   return utf8_str;
@@ -93,7 +93,7 @@ std::string PlatformUtils::documentsPath()
 {
   const std::string retval = getFolderPath(CSIDL_PERSONAL);
   if (retval.empty()) {
-    LOG(message_group::Error, Location::NONE, "", "Could not find My Documents location");
+    LOG(message_group::Error, "Could not find My Documents location");
   }
   return retval;
 }
@@ -102,7 +102,7 @@ std::string PlatformUtils::userConfigPath()
 {
   const std::string retval = getFolderPath(CSIDL_LOCAL_APPDATA);
   if (retval.empty()) {
-    LOG(message_group::Error, Location::NONE, "", "Could not find Local AppData location");
+    LOG(message_group::Error, "Could not find Local AppData location");
   }
   return retval + std::string("/") + PlatformUtils::OPENSCAD_FOLDER_NAME;
 }

--- a/src/platform/PlatformUtils.cc
+++ b/src/platform/PlatformUtils.cc
@@ -101,10 +101,10 @@ bool PlatformUtils::createUserLibraryPath()
       OK = fs::create_directories(path);
     }
     if (!OK) {
-      LOG(message_group::Error, Location::NONE, "", "Cannot create %1$s", path);
+      LOG(message_group::Error, "Cannot create %1$s", path);
     }
   } catch (const fs::filesystem_error& ex) {
-    LOG(message_group::Error, Location::NONE, "", "%1$s", ex.what());
+    LOG(message_group::Error, "%1$s", ex.what());
   }
   return OK;
 }
@@ -126,7 +126,7 @@ std::string PlatformUtils::userLibraryPath()
     // LOG(message_group::NONE,Location::NONE,"","Appended path %1$s",path);
     // LOG(message_group::NONE,Location::NONE,"","Exists: %1$i",fs::exists(path));
   } catch (const fs::filesystem_error& ex) {
-    LOG(message_group::Error, Location::NONE, "", "%1$s", ex.what());
+    LOG(message_group::Error, "%1$s", ex.what());
   }
   return path.generic_string();
 }
@@ -145,7 +145,7 @@ std::string PlatformUtils::backupPath()
     path /= OPENSCAD_FOLDER_NAME;
     path /= "backups";
   } catch (const fs::filesystem_error& ex) {
-    LOG(message_group::Error, Location::NONE, "", "%1$s", ex.what());
+    LOG(message_group::Error, "%1$s", ex.what());
   }
   return path.generic_string();
 }
@@ -159,10 +159,10 @@ bool PlatformUtils::createBackupPath()
       OK = fs::create_directories(path);
     }
     if (!OK) {
-      LOG(message_group::Error, Location::NONE, "", "Cannot create %1$s", path);
+      LOG(message_group::Error, "Cannot create %1$s", path);
     }
   } catch (const fs::filesystem_error& ex) {
-    LOG(message_group::Error, Location::NONE, "", "%1$s", ex.what());
+    LOG(message_group::Error, "%1$s", ex.what());
   }
   return OK;
 }

--- a/src/platform/PlatformUtils.cc
+++ b/src/platform/PlatformUtils.cc
@@ -118,13 +118,13 @@ std::string PlatformUtils::userLibraryPath()
     path = fs::path(pathstr);
     if (!fs::exists(path)) return "";
     path = fs::canonical(path);
-    // LOG(message_group::NONE,Location::NONE,"","path size %1$i",fs::stringy(path).size());
-    // LOG(message_group::NONE,Location::NONE,"","lib path found: [%1$s]",path);
+    // LOG(message_group::NONE,,"path size %1$i",fs::stringy(path).size());
+    // LOG(message_group::NONE,,"lib path found: [%1$s]",path);
     if (path.empty()) return "";
     path /= OPENSCAD_FOLDER_NAME;
     path /= "libraries";
-    // LOG(message_group::NONE,Location::NONE,"","Appended path %1$s",path);
-    // LOG(message_group::NONE,Location::NONE,"","Exists: %1$i",fs::exists(path));
+    // LOG(message_group::NONE,,"Appended path %1$s",path);
+    // LOG(message_group::NONE,,"Exists: %1$i",fs::exists(path));
   } catch (const fs::filesystem_error& ex) {
     LOG(message_group::Error, "%1$s", ex.what());
   }

--- a/src/platform/PlatformUtils.cc
+++ b/src/platform/PlatformUtils.cc
@@ -118,13 +118,13 @@ std::string PlatformUtils::userLibraryPath()
     path = fs::path(pathstr);
     if (!fs::exists(path)) return "";
     path = fs::canonical(path);
-    // LOG(message_group::None,Location::NONE,"","path size %1$i",fs::stringy(path).size());
-    // LOG(message_group::None,Location::NONE,"","lib path found: [%1$s]",path);
+    // LOG(message_group::NONE,Location::NONE,"","path size %1$i",fs::stringy(path).size());
+    // LOG(message_group::NONE,Location::NONE,"","lib path found: [%1$s]",path);
     if (path.empty()) return "";
     path /= OPENSCAD_FOLDER_NAME;
     path /= "libraries";
-    // LOG(message_group::None,Location::NONE,"","Appended path %1$s",path);
-    // LOG(message_group::None,Location::NONE,"","Exists: %1$i",fs::exists(path));
+    // LOG(message_group::NONE,Location::NONE,"","Appended path %1$s",path);
+    // LOG(message_group::NONE,Location::NONE,"","Exists: %1$i",fs::exists(path));
   } catch (const fs::filesystem_error& ex) {
     LOG(message_group::Error, Location::NONE, "", "%1$s", ex.what());
   }

--- a/src/platform/PlatformUtils.cc
+++ b/src/platform/PlatformUtils.cc
@@ -97,7 +97,7 @@ bool PlatformUtils::createUserLibraryPath()
   bool OK = false;
   try {
     if (!fs::exists(fs::path(path))) {
-      LOG(message_group::None, Location::NONE, "", "Creating library folder %1$s", path);
+      LOG("Creating library folder %1$s", path);
       OK = fs::create_directories(path);
     }
     if (!OK) {

--- a/src/utils/boost-utils.h
+++ b/src/utils/boost-utils.h
@@ -38,9 +38,9 @@ template <class Tout, class Tin> Tout boost_numeric_cast(Tin input)
     result = 0;
   }
   if (status.str() != "ok") {
-    LOG(message_group::Warning, Location::NONE, "", "Problem converting this number: %1$s", std::to_string(input));
-    LOG(message_group::Warning, Location::NONE, "", "%1$s", status.str());
-    LOG(message_group::Warning, Location::NONE, "", "setting result to %1$u", result);
+    LOG(message_group::Warning, "Problem converting this number: %1$s", std::to_string(input));
+    LOG(message_group::Warning, "%1$s", status.str());
+    LOG(message_group::Warning, "setting result to %1$u", result);
   }
   return result;
 }

--- a/src/utils/printutils.cc
+++ b/src/utils/printutils.cc
@@ -134,7 +134,7 @@ void PRINTDEBUG(const std::string& filename, const std::string& msg)
   boost::algorithm::to_lower(lowdebug);
   if (OpenSCAD::debug == "all" ||
       lowdebug.find(lowshortfname) != std::string::npos) {
-    Message msgObj = {shortfname + ": " + msg, Location::NONE, "", message_group::NONE, };
+    Message msgObj{shortfname + ": " + msg, message_group::NONE, Location::NONE, ""};
     PRINT_NOCACHE(msgObj);
   }
 }

--- a/src/utils/printutils.cc
+++ b/src/utils/printutils.cc
@@ -87,7 +87,7 @@ void PRINT(const Message& msgObj)
 
   //to error log
   if (outputhandler2 &&
-      !(msgObj.group == message_group::None || msgObj.group == message_group::Echo || msgObj.group == message_group::Trace)) {
+      !(msgObj.group == message_group::NONE || msgObj.group == message_group::Echo || msgObj.group == message_group::Trace)) {
 
     outputhandler2(msgObj, outputhandler_data);
   }
@@ -134,7 +134,7 @@ void PRINTDEBUG(const std::string& filename, const std::string& msg)
   boost::algorithm::to_lower(lowdebug);
   if (OpenSCAD::debug == "all" ||
       lowdebug.find(lowshortfname) != std::string::npos) {
-    Message msgObj = {shortfname + ": " + msg, Location::NONE, "", message_group::None, };
+    Message msgObj = {shortfname + ": " + msg, Location::NONE, "", message_group::NONE, };
     PRINT_NOCACHE(msgObj);
   }
 }
@@ -173,7 +173,7 @@ void resetSuppressedMessages()
 std::string getGroupName(const enum message_group& group)
 {
   switch (group) {
-  case message_group::None:
+  case message_group::NONE:
   case message_group::Warning:
   case message_group::UI_Warning:
     return "WARNING";
@@ -222,5 +222,5 @@ std::string getGroupColor(const enum message_group& group)
 
 bool getGroupTextPlain(const enum message_group& group)
 {
-  return group == message_group::None || group == message_group::Echo;
+  return group == message_group::NONE || group == message_group::Echo;
 }

--- a/src/utils/printutils.h
+++ b/src/utils/printutils.h
@@ -63,7 +63,7 @@ struct Message {
   {
   }
 
-  Message(std::string msg, Location loc, std::string docPath, message_group group)
+  Message(std::string msg, Location loc = Location::NONE, std::string docPath = "", message_group group = message_group::None)
     : msg(std::move(msg)), loc(std::move(loc)), docPath(std::move(docPath)), group(group)
   {
   }
@@ -202,7 +202,7 @@ private:
 
 public:
   template <typename ... Args>
-  MessageClass(std::string&& fmt, Args&&... args) : fmt(std::forward<std::string>(fmt)), args(std::forward<Args>(args)...)
+  MessageClass(std::string&& fmt, Args&&... args) : fmt(fmt), args(std::forward<Args>(args)...)
   {
   }
 
@@ -214,10 +214,10 @@ public:
 
 extern std::set<std::string> printedDeprecations;
 
-template <typename F, typename ... Args>
-void LOG(const message_group& msg_grp, Location loc, std::string docPath, F&& f, Args&&... args)
+template <typename ... Args>
+void LOG(const message_group& msg_grp, Location loc, std::string docPath, std::string&& f, Args&&... args)
 {
-  const auto msg = MessageClass<Args...>(std::forward<F>(f), std::forward<Args>(args)...);
+  const auto msg = MessageClass<Args...>(std::move(f), std::forward<Args>(args)...);
   auto formatted = msg.format();
 
   //check for deprecations
@@ -227,4 +227,11 @@ void LOG(const message_group& msg_grp, Location loc, std::string docPath, F&& f,
   Message msgObj{std::move(formatted), std::move(loc), std::move(docPath), msg_grp};
 
   PRINT(msgObj);
+}
+
+template <typename ... Args>
+void LOG(std::string&& f, Args&&... args)
+{
+  const auto msg = MessageClass<Args...>(std::move(f), std::forward<Args>(args)...);
+  PRINT(Message{msg.format()});
 }

--- a/src/utils/printutils.h
+++ b/src/utils/printutils.h
@@ -44,7 +44,7 @@ inline const char *_(const char *msgid, const char *msgctxt) {
 // NOLINTEND(bugprone-reserved-identifier)
 
 enum class message_group {
-  Error, Warning, UI_Warning, Font_Warning, Export_Warning, Export_Error, UI_Error, Parser_Error, Trace, Deprecated, None, Echo
+  NONE, Error, Warning, UI_Warning, Font_Warning, Export_Warning, Export_Error, UI_Error, Parser_Error, Trace, Deprecated, Echo
 };
 
 
@@ -59,17 +59,17 @@ struct Message {
   enum message_group group;
 
   Message()
-    : msg(""), loc(Location::NONE), docPath(""), group(message_group::None)
+    : msg(""), loc(Location::NONE), docPath(""), group(message_group::NONE)
   {
   }
 
-  Message(std::string msg, Location loc = Location::NONE, std::string docPath = "", message_group group = message_group::None)
+  Message(std::string msg, Location loc = Location::NONE, std::string docPath = "", message_group group = message_group::NONE)
     : msg(std::move(msg)), loc(std::move(loc)), docPath(std::move(docPath)), group(group)
   {
   }
 
   [[nodiscard]] std::string str() const {
-    const auto g = group == message_group::None ? "" : getGroupName(group) + ": ";
+    const auto g = group == message_group::NONE ? "" : getGroupName(group) + ": ";
     const auto l = loc.isNone() ? "" : " " + loc.toRelativeString(docPath);
     return g + msg + l;
   }

--- a/src/utils/printutils.h
+++ b/src/utils/printutils.h
@@ -231,11 +231,11 @@ void LOG(const message_group& msgGroup, Location loc, std::string docPath, std::
 template <typename ... Args>
 void LOG(const message_group& msgGroup, std::string&& f, Args&&... args)
 {
-	LOG(msgGroup, Location::NONE, "", std::move(f), std::forward<Args>(args)...);
+  LOG(msgGroup, Location::NONE, "", std::move(f), std::forward<Args>(args)...);
 }
 
 template <typename ... Args>
 void LOG(std::string&& f, Args&&... args)
 {
-	LOG(message_group::NONE, Location::NONE, "", std::move(f), std::forward<Args>(args)...);
+  LOG(message_group::NONE, Location::NONE, "", std::move(f), std::forward<Args>(args)...);
 }


### PR DESCRIPTION
After finding myself prepending `LOG(message_group::None, Location::NONE, "", ` to a bunch of log statements, I figured it might make sense to make overloads for the common use-cases where we don't specify location or document:

`LOG(message_group::None, Location::NONE, "", ...)` becomes `LOG(...)`
`LOG(message_group::Warning, Location::NONE, "", ...)` becomes `LOG(message_group::Warning, ...)` (and similar for other message_group values)