### PR TITLE
Enable Manifold in WASM builds

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -131,7 +131,6 @@ jobs:
                   -DWASM=ON \
                   -DSNAPSHOT=ON \
                   -DEXPERIMENTAL=ON \
-                  -DENABLE_MANIFOLD=OFF \
                   -DENABLE_CAIRO=OFF \
                   -DUSE_MIMALLOC=OFF \
                   -DBoost_USE_STATIC_RUNTIME=ON \

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -131,6 +131,7 @@ jobs:
                   -DWASM=ON \
                   -DSNAPSHOT=ON \
                   -DEXPERIMENTAL=ON \
+                  -DENABLE_TBB=OFF \
                   -DENABLE_CAIRO=OFF \
                   -DUSE_MIMALLOC=OFF \
                   -DBoost_USE_STATIC_RUNTIME=ON \

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -753,7 +753,7 @@ endif()
 
 if(ENABLE_MANIFOLD)
 
-  if(NOT DEFINED MANIFOLD_PAR)
+  if(NOT DEFINED MANIFOLD_PAR AND ENABLE_TBB)
     set(MANIFOLD_PAR TBB CACHE STRING "Parallel backend, either \"TBB\" or \"OpenMP\" or \"NONE\"" FORCE)
   endif()
 


### PR DESCRIPTION
[This example now runs great](https://ochafik.com/openscad/#%7B%22source%22%3A%7B%22name%22%3A%22input.stl%22%2C%22content%22%3A%22%2F%2F%20Copyright%202021%20Google%20LLC.%5Cn%2F%2F%20SPDX-License-Identifier%3A%20Apache-2.0%5Cn%2F%2F%5Cn%2F%2F%20Author%3A%20Olivier%20Chafik%20(http%3A%2F%2Fochafik.com)%5Cn%2F%2F%5Cn%2F%2F%20This%20is%20my%20little%20print-in-place%20chain%2Fscalemail%20project%20where%20I%20wanted%20to%20be%5Cn%2F%2F%20able%20to%20draw%20on%20each%20scale%20separately%2C%20or%20across%20all%20of%20them%20(3D%20printing%20of%5Cn%2F%2F%20large%20etchings%20may%20work%20best%20with%20support%20material%2C%20but%20for%20small%20text%20it's%5Cn%2F%2F%20fine).%5Cn%2F%2F%5Cn%2F%2F%20This%20is%20my%20little%20chain%2Fscalemail%20project%20where%20I%20wanted%20to%20be%20able%20to%20draw%20on%20each%5Cn%2F%2F%20scale%20separately.%20OpenSCAD%20was%20taking%20too%20much%20time%20to%20render%20this%2C%20so%20I%20began%5Cn%2F%2F%20a%20rendering%20optimization%20crusade%20(toyed%20with%20multithreading%2C%20lazier%20unions%2C%20faster%5Cn%2F%2F%20union%20algorithms)%2C%20current%20result%20(Feb%2014th%202021)%20being%20this%20model%20renders%20in%5Cn%2F%2F%2068sec%20instead%20of%206minutes%20(5x%20faster)%20for%20use_sweep%20%3D%20false%2C%5Cn%2F%2F%20and%201.5sec%20instead%20of%2039sec%20(27x%20faster)%20for%20use_sweep%20%3D%20true.%5Cn%2F%2F%5Cn%2F%2F%20To%20reproduce%20this%20speedup%20before%20those%20changes%20are%20upstreamed%20(if%20they%20are)%3A%5Cn%2F%2F%5Cn%2F%2F%20openscad%20--enable%3Dfast-union%20--enable%3Dlazy-union%20--enable%3Dlazy-module%20--enable%3Dflatten-children%20--enable%3Dpush-transforms-down-unions%20scalemail.scad%20-o%20scalemail.stl%5Cn%2F%2F%5Cn%5Cn%2F%2F%20Precision%20and%20thickness%20of%20curves%5Cn%24fn%3D20%3B%5Cnstep%20%3D%200.01%3B%2F%2F%24preview%20%3F%200.01%20%3A%200.001%3B%5Cnthickness%20%3D%200.6%3B%5Cn%5Cnuse_sweep%20%3D%20false%3B%5Cn%5Cn%2F%2F%20Just%20leave%20this%20empty%20to%20get%20each%20tile%20numbered%20individually.%5Cnglobal_text%20%3D%20%5C%22%5C%5Cu2665%5C%22%3B%5Cn%5Cn%2F%2F%20Width%20%26%20height%20of%20the%20grid.%20Model%20will%20have%20N*N%20tiles.%5CnN%20%3D%202%3B%5Cn%5Cn%2F%2F%20Parameters%20of%20the%20torus%20knot%5Cnn%3D4%3B%5Cnm%3D1%3B%5Cnheight%20%3D%201.5%3B%5Cnr1%20%3D%202%3B%5Cnr2%20%3D%203%3B%5Cn%5Cnplate_fill%20%3D%201.2%3B%5Cnepsilon%20%3D%200.01%3B%5Cnstride%20%3D%20r1%20%2B%20r2%3B%5CnzScale%20%3D%20height%20%2F%202%3B%5Cnplate_thickness%20%3D%20thickness%20*%201.5%3B%5Cnextra_pillar_height%20%3D%20thickness%3B%5CnavgRadius%20%3D%20(r1%20%2B%20r2)%20%2F%202%3B%5Cninner_pillar_end_ratio%20%3D%200.7%3B%5Cntext_etching_depth%20%3D%20plate_thickness%20%2F%202%3B%5Cnindividual_text_size%20%3D%202%3B%5Cnglobal_text_size_factor%20%3D%200.8%3B%5Cnglobal_text_size%20%3D%20N%20*%20stride%20*%20global_text_size_factor%3B%5Cnplate_z%20%3D%20-zScale%20-%20thickness%20%2F%202%20-%20plate_thickness%20-%20extra_pillar_height%3B%5Cn%5Cnfunction%20f(t)%20%3D%20%5B%5Cn%20%20cos(m%20*%20t)%20*%20(avgRadius%20%2B%20(r2%20-%20r1)%20%2F%202%20*%20cos(n%20*%20t))%2C%5Cn%20%20sin(m%20*%20t)%20*%20(avgRadius%20%2B%20(r2%20-%20r1)%20%2F%202%20*%20cos(n%20*%20t))%2C%5Cn%20%20zScale%20*%20sin(n%20*%20t)%5Cn%5D%3B%5Cn%5Cn%5Cnuse%20%3Csweep.scad%3E%5Cnuse%20%3Cscad-utils%2Fshapes.scad%3E%5Cnmodule%20draw_curve_sweep(p%2C%20thickness)%5Cn%20%20sweep(circle(thickness%20%2F%202)%2C%20construct_transform_path(p)%2C%20true)%3B%5Cn%5Cnmodule%20draw_curve(p%2C%20thickness)%5Cn%20%20if%20(use_sweep)%5Cn%20%20%20%20draw_curve_sweep(p%2C%20thickness)%3B%5Cn%20%20else%5Cn%20%20%20%20for%20(i%3D%5B0%3Alen(p)-2%5D)%5Cn%20%20%20%20%20%20%20%20hull()%20%7B%5Cn%20%20%20%20%20%20%20%20%20%20%20%20translate(p%5Bi%5D)%20sphere(d%3Dthickness)%3B%5Cn%20%20%20%20%20%20%20%20%20%20%20%20translate(p%5Bi%2B1%5D)%20sphere(d%3Dthickness)%3B%5Cn%20%20%20%20%20%20%20%20%7D%5Cn%5Cnmodule%20torus_knot()%20draw_curve(%5Bfor%20(t%3D%5B0%3Astep%3A1%5D)%20f(t%20*%20360)%5D%2C%20thickness)%3B%5Cn%5Cnmodule%20etching_text(size%2C%20text)%5Cn%20%20translate(%5B0%2C%200%2C%20plate_z%20-%20epsilon%5D)%5Cn%20%20%20%20linear_extrude(height%20%3D%20text_etching_depth)%5Cn%20%20%20%20%20%20mirror(%5B-1%2C%200%2C%200%5D)%5Cn%20%20%20%20%20%20%20%20text(text%20%3D%20text%2C%20size%20%3D%20size%2C%20valign%20%3D%20%5C%22center%5C%22%2C%20halign%3D%5C%22center%5C%22)%3B%5Cn%5Cnmodule%20scalemail()%5Cn%20%20for%20(i%3D%5B0%3AN-1%5D)%20translate(%5Bi%20*%20stride%2C0%2C0%5D)%5Cn%20%20%20%20for(j%3D%5B0%3AN-1%5D)%20translate(%5B0%2Cj%20*%20stride%2C0%5D)%5Cn%20%20%20%20%20%20unit(global_text%20%3D%3D%20%5C%22%5C%22%20%3F%20str((N%20-%20j%20-%201)%20*%20N%20%2B%20(N%20-%20i%20-%201))%20%3A%20undef)%3B%5Cn%5Cnif%20(global_text%20%3D%3D%20%5C%22%5C%22)%5Cn%20%20scalemail()%3B%5Cnelse%5Cn%20%20difference()%20%7B%5Cn%20%20%20%20scalemail()%3B%5Cn%20%20%20%20translate(%5Bstride%20*%20N%20%2F%202%20-%20stride%20%2F%202%2C%20stride%20*%20N%20%2F%202%20-%20stride%20%2F%202%2C%200%5D)%5Cn%20%20%20%20%20%20etching_text(global_text_size%2C%20global_text)%3B%5Cn%20%20%7D%5Cn%5Cnmodule%20unit(text)%20%7B%5Cn%20%20torus_knot()%3B%5Cn%5Cn%20%20%2F%2F%20Draw%20the%20pillars%20from%20mid-height%20positions.%5Cn%20%20mid_param_offset%20%3D%20360%20%2F%20n%20%2F%202%3B%5Cn%20%20mid_angles%20%3D%20%5Bfor%20(i%3D%5B0%3An-1%5D)%20i%20*%20360%2Fn%20%2B%20mid_param_offset%5D%3B%5Cn%20%20mid_heights%20%3D%20%5Bfor%20(a%3Dmid_angles)%20f(a)%5D%3B%5Cn%20%20for%20(i%3D%5B0%3An-1%5D)%20%7B%5Cn%20%20%20%20pillar_end%20%3D%20mid_heights%5Bi%5D%3B%5Cn%20%20%20%20angle%20%3D%20mid_angles%5Bi%5D%3B%5Cn%20%20%20%20hull()%20%7B%5Cn%20%20%20%20%20%20translate(pillar_end)%5Cn%20%20%20%20%20%20%20%20sphere(d%3Dthickness)%3B%5Cn%20%20%20%20%20%20translate(%5Bpillar_end%5B0%5D%2C%20pillar_end%5B1%5D%2C%20-zScale%20-%20thickness%20%2F%202%20-%20extra_pillar_height%5D)%5Cn%20%20%20%20%20%20%20%20cylinder(thickness%20%2F%202%20%2B%20extra_pillar_height%2C%20d%3Dthickness)%3B%5Cn%5Cn%20%20%20%20%20%20translate(%5Binner_pillar_end_ratio%20*%20pillar_end%5B0%5D%2C%20inner_pillar_end_ratio%20*%20pillar_end%5B1%5D%2C%20-zScale%20-%20thickness%20%2F%202%20-%20extra_pillar_height%20-%20plate_thickness%5D)%5Cn%20%20%20%20%20%20%20%20cylinder(plate_thickness%2C%20d%3Dthickness)%3B%5Cn%5Cn%20%20%20%20%20%20rotate(%5B0%2C%200%2C%20(i%20%2B%200.5)%20*%20360%20%2F%20n%5D)%5Cn%20%20%20%20%20%20%20%20translate(%5Bplate_fill%20*%20(avgRadius%20-%20thickness%20%2F%202)%2C%200%2C%20-zScale%20-%20thickness%20%2F%202%20-%20plate_thickness%5D)%5Cn%20%20%20%20%20%20%20%20%20%20cylinder(h%3Dplate_thickness%2C%20d%3Dthickness)%3B%5Cn%20%20%20%20%7D%5Cn%20%20%7D%5Cn%5Cn%20%20difference()%20%7B%5Cn%20%20%20%20hull()%5Cn%20%20%20%20%20%20for%20(i%3D%5B0%3An-1%5D)%5Cn%20%20%20%20%20%20%20%20rotate(%5B0%2C%200%2C%20(i%20%2B%200.5)%20*%20360%20%2F%20n%5D)%5Cn%20%20%20%20%20%20%20%20%20%20translate(%5Bplate_fill%20*%20(avgRadius%20-%20thickness%20%2F%202)%2C%200%2C%20plate_z%5D)%5Cn%20%20%20%20%20%20%20%20%20%20%20%20cylinder(h%3Dplate_thickness%2C%20d%3Dthickness)%3B%5Cn%5Cn%20%20%20%20if%20(!is_undef(text))%20etching_text(individual_text_size%2C%20text)%3B%5Cn%20%20%7D%5Cn%7D%22%7D%2C%22autorender%22%3Atrue%2C%22autoparse%22%3Atrue%2C%22autorotate%22%3Afalse%2C%22features%22%3A%5B%22fast-csg%22%2C%22fast-csg-trust-corefinement%22%2C%22fast-csg-exact-callbacks%22%2C%22fast-csg-remesh%22%2C%22manifold%22%2C%22lazy-union%22%5D%2C%22viewerFocused%22%3Afalse%2C%22showExp%22%3Afalse%2C%22camera%22%3Anull%7D) in the browser!

<img width="1284" alt="image" src="https://user-images.githubusercontent.com/273860/226729403-853189d6-0148-4a9e-927d-18f2b16782a9.png">
