### PR TITLE
Green refactoring: Move duplicated FBO handling out of platform-specific context code

### DIFF
--- a/src/glview/NULLGL.cc
+++ b/src/glview/NULLGL.cc
@@ -19,3 +19,9 @@ std::string glew_dump() { return std::string("GL Renderer: NULLGL Glew\n"); }
 std::string glew_extensions_dump() { return std::string("NULLGL Glew Extensions"); }
 bool report_glerror(const char *function) { return false; }
 
+#include "fbo.h"
+
+fbo_t *fbo_new() { return nullptr; }
+void fbo_unbind(fbo_t *fbo) {}
+void fbo_delete(fbo_t *fbo) {}
+bool fbo_init(fbo_t *fbo, size_t width, size_t height) { return false; }

--- a/src/glview/OffscreenContextAll.hpp
+++ b/src/glview/OffscreenContextAll.hpp
@@ -5,11 +5,6 @@
 #include <ostream>
 #include "imageutils.h"
 
-void bind_offscreen_context(OffscreenContext *ctx)
-{
-  if (ctx) fbo_bind(ctx->fbo);
-}
-
 /*
    Capture framebuffer from OpenGL and write it to the given filename as PNG.
  */
@@ -60,11 +55,6 @@ OffscreenContext *create_offscreen_context_common(OffscreenContext *ctx)
   GLenum err = glewInit(); // must come after Context creation and before FBO c$
   if (GLEW_OK != err) {
     std::cerr << "Unable to init GLEW: " << glewGetErrorString(err) << "\n";
-    return nullptr;
-  }
-
-  ctx->fbo = fbo_new();
-  if (!fbo_init(ctx->fbo, ctx->width, ctx->height)) {
     return nullptr;
   }
 

--- a/src/glview/OffscreenContextCGL.mm
+++ b/src/glview/OffscreenContextCGL.mm
@@ -1,6 +1,7 @@
 #include "OffscreenContext.h"
 #include "imageutils.h"
-#include "fbo.h"
+#include "system-gl.h"
+
 #include <iostream>
 #include <sstream>
 
@@ -14,7 +15,6 @@ struct OffscreenContext
   NSAutoreleasePool *pool;
   int width;
   int height;
-  fbo_t *fbo;
 };
 
 #include "OffscreenContextAll.hpp"
@@ -86,9 +86,6 @@ OffscreenContext *create_offscreen_context(int w, int h)
 
 bool teardown_offscreen_context(OffscreenContext *ctx)
 {
-  fbo_unbind(ctx->fbo);
-  fbo_delete(ctx->fbo);
-
   /*
    * Cleanup
    */

--- a/src/glview/OffscreenContextEGL.cc
+++ b/src/glview/OffscreenContextEGL.cc
@@ -27,7 +27,6 @@
 #include "printutils.h"
 #include "imageutils.h"
 #include "system-gl.h"
-#include "fbo.h"
 
 #include <GL/gl.h>
 #include <EGL/egl.h>
@@ -42,7 +41,7 @@
 
 struct OffscreenContext {
 
-  OffscreenContext(int width, int height) : context(nullptr), display(nullptr), width(width), height(height), fbo(nullptr)
+  OffscreenContext(int width, int height) : context(nullptr), display(nullptr), width(width), height(height)
   {
   }
 
@@ -50,7 +49,6 @@ struct OffscreenContext {
   EGLDisplay display;
   int width;
   int height;
-  fbo_t *fbo;
 };
 
 #include "OffscreenContextAll.hpp"
@@ -206,8 +204,6 @@ OffscreenContext *create_offscreen_context(int w, int h)
 bool teardown_offscreen_context(OffscreenContext *ctx)
 {
   if (ctx) {
-    fbo_unbind(ctx->fbo);
-    fbo_delete(ctx->fbo);
     eglTerminate(ctx->display);
     return true;
   }

--- a/src/glview/OffscreenContextGLX.cc
+++ b/src/glview/OffscreenContextGLX.cc
@@ -38,6 +38,7 @@
 #include "OffscreenContext.h"
 #include "printutils.h"
 
+#include "system-gl.h"
 #include <GL/gl.h>
 #include <GL/glx.h>
 

--- a/src/glview/OffscreenContextGLX.cc
+++ b/src/glview/OffscreenContextGLX.cc
@@ -37,7 +37,6 @@
 
 #include "OffscreenContext.h"
 #include "printutils.h"
-#include "fbo.h"
 
 #include <GL/gl.h>
 #include <GL/glx.h>
@@ -56,7 +55,6 @@ struct OffscreenContext
   Window xwindow{0};
   int width;
   int height;
-  fbo_t *fbo{nullptr};
 };
 
 #include "OffscreenContextAll.hpp"
@@ -227,8 +225,6 @@ OffscreenContext *create_offscreen_context(int w, int h)
 bool teardown_offscreen_context(OffscreenContext *ctx)
 {
   if (ctx) {
-    fbo_unbind(ctx->fbo);
-    fbo_delete(ctx->fbo);
     XDestroyWindow(ctx->xdisplay, ctx->xwindow);
     glXDestroyContext(ctx->xdisplay, ctx->openGLContext);
     XCloseDisplay(ctx->xdisplay);

--- a/src/glview/OffscreenContextWGL.cc
+++ b/src/glview/OffscreenContextWGL.cc
@@ -17,7 +17,6 @@
 
 #include "OffscreenContext.h"
 #include "printutils.h"
-#include "fbo.h"
 
 #include <GL/gl.h> // must be included after glew.h
 
@@ -32,7 +31,6 @@ struct OffscreenContext
   HGLRC openGLContext;
   int width;
   int height;
-  fbo_t *fbo;
 };
 
 #include "OffscreenContextAll.hpp"
@@ -44,7 +42,6 @@ void offscreen_context_init(OffscreenContext& ctx, int width, int height)
   ctx.openGLContext = (HGLRC)nullptr;
   ctx.width = width;
   ctx.height = height;
-  ctx.fbo = nullptr;
 }
 
 std::string get_os_info()
@@ -214,9 +211,6 @@ OffscreenContext *create_offscreen_context(int w, int h)
 bool teardown_offscreen_context(OffscreenContext *ctx)
 {
   if (ctx) {
-    fbo_unbind(ctx->fbo);
-    fbo_delete(ctx->fbo);
-
     wglMakeCurrent(nullptr, nullptr);
     wglDeleteContext(ctx->openGLContext);
     ReleaseDC(ctx->window, ctx->dev_context);

--- a/src/glview/OffscreenContextWGL.cc
+++ b/src/glview/OffscreenContextWGL.cc
@@ -17,6 +17,7 @@
 
 #include "OffscreenContext.h"
 #include "printutils.h"
+#include "system-gl.h"
 
 #include <GL/gl.h> // must be included after glew.h
 

--- a/src/glview/OffscreenView.cc
+++ b/src/glview/OffscreenView.cc
@@ -11,12 +11,18 @@ OffscreenView::OffscreenView(int width, int height)
 {
   this->ctx = create_offscreen_context(width, height);
   if (this->ctx == nullptr) throw -1;
+
+  this->fbo = fbo_new();
+  if (!fbo_init(this->fbo, width, height)) throw -1;
+
   GLView::initializeGL();
   GLView::resizeGL(width, height);
 }
 
 OffscreenView::~OffscreenView()
 {
+  fbo_unbind(this->fbo);
+  fbo_delete(this->fbo);
   teardown_offscreen_context(this->ctx);
 }
 

--- a/src/glview/OffscreenView.h
+++ b/src/glview/OffscreenView.h
@@ -7,6 +7,8 @@
 #include <iostream>
 #include "GLView.h"
 
+#include "fbo.h"
+
 class OffscreenView : public GLView
 {
 public:
@@ -14,6 +16,7 @@ public:
   ~OffscreenView() override;
   bool save(std::ostream& output) const;
   OffscreenContext *ctx;
+  fbo_t *fbo;
 
   // overrides
   bool save(const char *filename) const override;


### PR DESCRIPTION
Done in anticipation of cleaning up the offscreen context code.