### PR TITLE
GitHub CI: Cancel jobs if a new push happens while jobs are running

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -1,5 +1,5 @@
 name: linux
-run-name: Testing concurrency...
+run-name: Testing concurrency 2...
 
 on:
   push:

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -1,4 +1,5 @@
 name: linux
+run-name: Testing concurrency...
 
 on:
   push:

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -1,5 +1,5 @@
 name: linux
-run-name: Testing concurrency 2...
+run-name: Testing concurrency 3...
 
 on:
   push:

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -1,5 +1,4 @@
 name: linux
-run-name: Testing concurrency 3...
 
 on:
   push:

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -7,6 +7,10 @@ on:
       - master
   pull_request:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+  
 jobs:
   build:
     strategy:


### PR DESCRIPTION
This somehow doesn't work. Any ideas are welcome.
It's not a huge deal, but we're currently wasting a lot of cycles whenever a second push happens while the CI is still running.