### PR TITLE
Fix: Bump required version of glib2

### DIFF
--- a/scripts/macosx-build-dependencies.sh
+++ b/scripts/macosx-build-dependencies.sh
@@ -52,7 +52,7 @@ PACKAGES=(
     "fontconfig 2.14.1"
     "hidapi 0.12.0"
     "lib3mf 1.8.1"
-    "glib2 2.71.0"
+    "glib2 2.75.0"
     "pixman 0.42.2"
     "cairo 1.16.0"
     "cgal 5.5"


### PR DESCRIPTION
glib2 2.75 is required to be build on MacOS with latest clang (14.0.3). More info https://gitlab.gnome.org/GNOME/glib/-/issues/2759