### PR TITLE
Added empty manual workflow

### DIFF
--- a/.github/workflows/manual.yml
+++ b/.github/workflows/manual.yml
@@ -1,0 +1,10 @@
+name: manual
+
+on:
+  workflow_dispatch:
+
+jobs:
+  build:
+    steps:
+    - uses: actions/checkout@v3
+


### PR DESCRIPTION
This is here to easily enable custom workflow runs; a `workflow_dispatch` even must be present in the master branch to allow running custom workflows from other branches.