### PR TITLE
add missing include of <cstdint> for uint32_t

### DIFF
--- a/src/glview/OpenGLContext.h
+++ b/src/glview/OpenGLContext.h
@@ -2,6 +2,7 @@
 
 #include <vector>
 #include <string>
+#include <cstdint>
 
 class OpenGLContext {
 protected:


### PR DESCRIPTION
An update in the compiler toolchain to gcc 13 detected this obvious oversight.