### PR TITLE
Avoid excessive reallocations in PolySet

### DIFF
--- a/src/core/SurfaceNode.cc
+++ b/src/core/SurfaceNode.cc
@@ -234,22 +234,22 @@ const Geometry *SurfaceNode::createGeometry() const
 
       double vx = (v1 + v2 + v3 + v4) / 4;
 
-      p->append_poly();
+      p->append_poly(3);
       p->append_vertex(ox + j - 1, oy + i - 1, v1);
       p->append_vertex(ox + j, oy + i - 1, v2);
       p->append_vertex(ox + j - 0.5, oy + i - 0.5, vx);
 
-      p->append_poly();
+      p->append_poly(3);
       p->append_vertex(ox + j, oy + i - 1, v2);
       p->append_vertex(ox + j, oy + i, v4);
       p->append_vertex(ox + j - 0.5, oy + i - 0.5, vx);
 
-      p->append_poly();
+      p->append_poly(3);
       p->append_vertex(ox + j, oy + i, v4);
       p->append_vertex(ox + j - 1, oy + i, v3);
       p->append_vertex(ox + j - 0.5, oy + i - 0.5, vx);
 
-      p->append_poly();
+      p->append_poly(3);
       p->append_vertex(ox + j - 1, oy + i, v3);
       p->append_vertex(ox + j - 1, oy + i - 1, v1);
       p->append_vertex(ox + j - 0.5, oy + i - 0.5, vx);
@@ -262,13 +262,13 @@ const Geometry *SurfaceNode::createGeometry() const
     double v3 = data[ (columns - 1) + (i - 1) * columns ];
     double v4 = data[ (columns - 1) + (i) * columns ];
 
-    p->append_poly();
+    p->append_poly(4);
     p->append_vertex(ox + 0, oy + i - 1, min_val);
     p->append_vertex(ox + 0, oy + i - 1, v1);
     p->append_vertex(ox + 0, oy + i, v2);
     p->append_vertex(ox + 0, oy + i, min_val);
 
-    p->append_poly();
+    p->append_poly(4);
     p->insert_vertex(ox + columns - 1, oy + i - 1, min_val);
     p->insert_vertex(ox + columns - 1, oy + i - 1, v3);
     p->insert_vertex(ox + columns - 1, oy + i, v4);
@@ -282,13 +282,13 @@ const Geometry *SurfaceNode::createGeometry() const
     double v3 = data[ (i - 1) + (lines - 1) * columns ];
     double v4 = data[ (i) + (lines - 1) * columns ];
 
-    p->append_poly();
+    p->append_poly(4);
     p->insert_vertex(ox + i - 1, oy + 0, min_val);
     p->insert_vertex(ox + i - 1, oy + 0, v1);
     p->insert_vertex(ox + i, oy + 0, v2);
     p->insert_vertex(ox + i, oy + 0, min_val);
 
-    p->append_poly();
+    p->append_poly(4);
     p->append_vertex(ox + i - 1, oy + lines - 1, min_val);
     p->append_vertex(ox + i - 1, oy + lines - 1, v3);
     p->append_vertex(ox + i, oy + lines - 1, v4);
@@ -297,8 +297,7 @@ const Geometry *SurfaceNode::createGeometry() const
 
   // the bottom of the shape (one less than the real minimum value), making it a solid volume
   if (columns > 1 && lines > 1) {
-    p->append_poly();
-    p->polygons.back().reserve(2 * (columns - 1) + 2 * (lines - 1) ); // inelegant, could vertex count be argument to append_poly?  or separate call poly_reserve(x)?
+    p->append_poly(2 * (columns - 1) + 2 * (lines - 1) );
     for (int i = 0; i < columns - 1; ++i)
       p->insert_vertex(ox + i, oy + 0, min_val);
     for (int i = 0; i < lines - 1; ++i)

--- a/src/core/primitives.cc
+++ b/src/core/primitives.cc
@@ -130,6 +130,8 @@ const Geometry *CubeNode::createGeometry() const
     z2 = this->z;
   }
 
+  p->reserve(6);
+
   p->append_poly(4); // top
   p->append_vertex(x1, y1, z2);
   p->append_vertex(x2, y1, z2);
@@ -237,6 +239,8 @@ const Geometry *SphereNode::createGeometry() const
     generate_circle(ring[i].points.data(), radius, fragments);
   }
 
+  p->reserve(rings * fragments + 2);
+
   p->append_poly(fragments);
   for (int i = 0; i < fragments; ++i)
     p->append_vertex(ring[0].points[i].x, ring[0].points[i].y, ring[0].z);
@@ -335,6 +339,8 @@ const Geometry *CylinderNode::createGeometry() const
   generate_circle(circle1.data(), r1, fragments);
   generate_circle(circle2.data(), r2, fragments);
 
+  p->reserve(fragments * 2 + 2);
+  
   for (int i = 0; i < fragments; ++i) {
     int j = (i + 1) % fragments;
     if (r1 == r2) {

--- a/src/core/primitives.cc
+++ b/src/core/primitives.cc
@@ -130,37 +130,37 @@ const Geometry *CubeNode::createGeometry() const
     z2 = this->z;
   }
 
-  p->append_poly(); // top
+  p->append_poly(4); // top
   p->append_vertex(x1, y1, z2);
   p->append_vertex(x2, y1, z2);
   p->append_vertex(x2, y2, z2);
   p->append_vertex(x1, y2, z2);
 
-  p->append_poly(); // bottom
+  p->append_poly(4); // bottom
   p->append_vertex(x1, y2, z1);
   p->append_vertex(x2, y2, z1);
   p->append_vertex(x2, y1, z1);
   p->append_vertex(x1, y1, z1);
 
-  p->append_poly(); // side1
+  p->append_poly(4); // side1
   p->append_vertex(x1, y1, z1);
   p->append_vertex(x2, y1, z1);
   p->append_vertex(x2, y1, z2);
   p->append_vertex(x1, y1, z2);
 
-  p->append_poly(); // side2
+  p->append_poly(4); // side2
   p->append_vertex(x2, y1, z1);
   p->append_vertex(x2, y2, z1);
   p->append_vertex(x2, y2, z2);
   p->append_vertex(x2, y1, z2);
 
-  p->append_poly(); // side3
+  p->append_poly(4); // side3
   p->append_vertex(x2, y2, z1);
   p->append_vertex(x1, y2, z1);
   p->append_vertex(x1, y2, z2);
   p->append_vertex(x2, y2, z2);
 
-  p->append_poly(); // side4
+  p->append_poly(4); // side4
   p->append_vertex(x1, y2, z1);
   p->append_vertex(x1, y1, z1);
   p->append_vertex(x1, y1, z2);
@@ -237,7 +237,7 @@ const Geometry *SphereNode::createGeometry() const
     generate_circle(ring[i].points.data(), radius, fragments);
   }
 
-  p->append_poly();
+  p->append_poly(fragments);
   for (int i = 0; i < fragments; ++i)
     p->append_vertex(ring[0].points[i].x, ring[0].points[i].y, ring[0].z);
 
@@ -250,7 +250,7 @@ const Geometry *SphereNode::createGeometry() const
       if (r2i >= fragments) goto sphere_next_r1;
       if ((double)r1i / fragments < (double)r2i / fragments) {
 sphere_next_r1:
-        p->append_poly();
+        p->append_poly(3);
         int r1j = (r1i + 1) % fragments;
         p->insert_vertex(r1->points[r1i].x, r1->points[r1i].y, r1->z);
         p->insert_vertex(r1->points[r1j].x, r1->points[r1j].y, r1->z);
@@ -258,7 +258,7 @@ sphere_next_r1:
         r1i++;
       } else {
 sphere_next_r2:
-        p->append_poly();
+        p->append_poly(3);
         int r2j = (r2i + 1) % fragments;
         p->append_vertex(r2->points[r2i].x, r2->points[r2i].y, r2->z);
         p->append_vertex(r2->points[r2j].x, r2->points[r2j].y, r2->z);
@@ -268,7 +268,7 @@ sphere_next_r2:
     }
   }
 
-  p->append_poly();
+  p->append_poly(fragments);
   for (int i = 0; i < fragments; ++i) {
     p->insert_vertex(
       ring[rings - 1].points[i].x,
@@ -338,20 +338,20 @@ const Geometry *CylinderNode::createGeometry() const
   for (int i = 0; i < fragments; ++i) {
     int j = (i + 1) % fragments;
     if (r1 == r2) {
-      p->append_poly();
+      p->append_poly(4);
       p->insert_vertex(circle1[i].x, circle1[i].y, z1);
       p->insert_vertex(circle2[i].x, circle2[i].y, z2);
       p->insert_vertex(circle2[j].x, circle2[j].y, z2);
       p->insert_vertex(circle1[j].x, circle1[j].y, z1);
     } else {
       if (r1 > 0) {
-        p->append_poly();
+        p->append_poly(3);
         p->insert_vertex(circle1[i].x, circle1[i].y, z1);
         p->insert_vertex(circle2[i].x, circle2[i].y, z2);
         p->insert_vertex(circle1[j].x, circle1[j].y, z1);
       }
       if (r2 > 0) {
-        p->append_poly();
+        p->append_poly(3);
         p->insert_vertex(circle2[i].x, circle2[i].y, z2);
         p->insert_vertex(circle2[j].x, circle2[j].y, z2);
         p->insert_vertex(circle1[j].x, circle1[j].y, z1);
@@ -360,13 +360,13 @@ const Geometry *CylinderNode::createGeometry() const
   }
 
   if (this->r1 > 0) {
-    p->append_poly();
+    p->append_poly(fragments);
     for (int i = 0; i < fragments; ++i)
       p->insert_vertex(circle1[i].x, circle1[i].y, z1);
   }
 
   if (this->r2 > 0) {
-    p->append_poly();
+    p->append_poly(fragments);
     for (int i = 0; i < fragments; ++i)
       p->append_vertex(circle2[i].x, circle2[i].y, z2);
   }
@@ -472,7 +472,7 @@ const Geometry *PolyhedronNode::createGeometry() const
   auto p = new PolySet(3);
   p->setConvexity(this->convexity);
   for (const auto& face : this->faces) {
-    p->append_poly();
+    p->append_poly(face.size());
     for (const auto& index : face) {
       assert(index < this->points.size());
       const auto& point = points[index];

--- a/src/core/primitives.cc
+++ b/src/core/primitives.cc
@@ -477,6 +477,7 @@ const Geometry *PolyhedronNode::createGeometry() const
 {
   auto p = new PolySet(3);
   p->setConvexity(this->convexity);
+  p->reserve(this->faces.size());
   for (const auto& face : this->faces) {
     p->append_poly(face.size());
     for (const auto& index : face) {
@@ -503,6 +504,7 @@ static std::shared_ptr<AbstractNode> builtin_polyhedron(const ModuleInstantiatio
     LOG(message_group::Error, inst->location(), parameters.documentRoot(), "Unable to convert points = %1$s to a vector of coordinates", parameters["points"].toEchoStringNoThrow());
     return node;
   }
+  node->points.reserve(parameters["points"].toVector().size());
   for (const Value& pointValue : parameters["points"].toVector()) {
     point3d point;
     if (!pointValue.getVec3(point.x, point.y, point.z, 0.0) ||
@@ -528,6 +530,7 @@ static std::shared_ptr<AbstractNode> builtin_polyhedron(const ModuleInstantiatio
     return node;
   }
   size_t faceIndex = 0;
+  node->faces.reserve(faces->toVector().size());
   for (const Value& faceValue : faces->toVector()) {
     if (faceValue.type() != Value::Type::VECTOR) {
       LOG(message_group::Error, inst->location(), parameters.documentRoot(), "Unable to convert faces[%1$d] = %2$s to a vector of numbers", faceIndex, faceValue.toEchoStringNoThrow());

--- a/src/geometry/GeometryEvaluator.cc
+++ b/src/geometry/GeometryEvaluator.cc
@@ -821,19 +821,19 @@ static void add_slice(PolySet *ps, const Polygon2d& poly,
         //Vector2d mid_prev = trans3 * (prev1 +curr1+curr2)/4;
         Vector2d mid = trans_mid * (o.vertices[(i - 1) % o.vertices.size()] + o.vertices[i % o.vertices.size()]) / 2;
         double h_mid = (h1 + h2) / 2;
-        ps->append_poly();
+        ps->append_poly(3);
         ps->insert_vertex(prev1[0], prev1[1], h1);
         ps->insert_vertex(mid[0],   mid[1], h_mid);
         ps->insert_vertex(curr1[0], curr1[1], h1);
-        ps->append_poly();
+        ps->append_poly(3);
         ps->insert_vertex(curr1[0], curr1[1], h1);
         ps->insert_vertex(mid[0],   mid[1], h_mid);
         ps->insert_vertex(curr2[0], curr2[1], h2);
-        ps->append_poly();
+        ps->append_poly(3);
         ps->insert_vertex(curr2[0], curr2[1], h2);
         ps->insert_vertex(mid[0],   mid[1], h_mid);
         ps->insert_vertex(prev2[0], prev2[1], h2);
-        ps->append_poly();
+        ps->append_poly(3);
         ps->insert_vertex(prev2[0], prev2[1], h2);
         ps->insert_vertex(mid[0],   mid[1], h_mid);
         ps->insert_vertex(prev1[0], prev1[1], h1);
@@ -842,23 +842,23 @@ static void add_slice(PolySet *ps, const Polygon2d& poly,
       // Split along shortest diagonal,
       // unless at top for a 0-scaled axis (which can create 0 thickness "ears")
       if (splitfirst xor any_zero) {
-        ps->append_poly();
+        ps->append_poly(3);
         ps->insert_vertex(prev1[0], prev1[1], h1);
         ps->insert_vertex(curr2[0], curr2[1], h2);
         ps->insert_vertex(curr1[0], curr1[1], h1);
         if (!any_zero || (any_non_zero && prev2 != curr2)) {
-          ps->append_poly();
+          ps->append_poly(3);
           ps->insert_vertex(curr2[0], curr2[1], h2);
           ps->insert_vertex(prev1[0], prev1[1], h1);
           ps->insert_vertex(prev2[0], prev2[1], h2);
         }
       } else {
-        ps->append_poly();
+        ps->append_poly(3);
         ps->insert_vertex(prev1[0], prev1[1], h1);
         ps->insert_vertex(prev2[0], prev2[1], h2);
         ps->insert_vertex(curr1[0], curr1[1], h1);
         if (!any_zero || (any_non_zero && prev2 != curr2)) {
-          ps->append_poly();
+          ps->append_poly(3);
           ps->insert_vertex(prev2[0], prev2[1], h2);
           ps->insert_vertex(curr2[0], curr2[1], h2);
           ps->insert_vertex(curr1[0], curr1[1], h1);
@@ -1316,11 +1316,11 @@ static Geometry *rotatePolygon(const RotateExtrudeNode& node, const Polygon2d& p
       fill_ring(rings[(j + 1) % 2], o, a, flip_faces);
 
       for (size_t i = 0; i < o.vertices.size(); ++i) {
-        ps->append_poly();
+        ps->append_poly(3);
         ps->insert_vertex(rings[j % 2][i]);
         ps->insert_vertex(rings[(j + 1) % 2][(i + 1) % o.vertices.size()]);
         ps->insert_vertex(rings[j % 2][(i + 1) % o.vertices.size()]);
-        ps->append_poly();
+        ps->append_poly(3);
         ps->insert_vertex(rings[j % 2][i]);
         ps->insert_vertex(rings[(j + 1) % 2][i]);
         ps->insert_vertex(rings[(j + 1) % 2][(i + 1) % o.vertices.size()]);

--- a/src/geometry/PolySet.cc
+++ b/src/geometry/PolySet.cc
@@ -77,9 +77,6 @@ std::string PolySet::dump() const
 
 void PolySet::append_poly(size_t expected_vertex_count)
 {
-  // Polygon poly;
-  // poly.reserve(expected_vertex_count);
-  // polygons.emplace_back(std::move(poly));
   polygons.emplace_back();
   polygons.back().reserve(expected_vertex_count);
 }

--- a/src/geometry/PolySet.cc
+++ b/src/geometry/PolySet.cc
@@ -75,9 +75,13 @@ std::string PolySet::dump() const
   return out.str();
 }
 
-void PolySet::append_poly()
+void PolySet::append_poly(size_t expected_vertex_count)
 {
-  polygons.push_back(Polygon());
+  // Polygon poly;
+  // poly.reserve(expected_vertex_count);
+  // polygons.emplace_back(std::move(poly));
+  polygons.emplace_back();
+  polygons.back().reserve(expected_vertex_count);
 }
 
 void PolySet::append_poly(const Polygon& poly)

--- a/src/geometry/PolySet.cc
+++ b/src/geometry/PolySet.cc
@@ -77,8 +77,7 @@ std::string PolySet::dump() const
 
 void PolySet::append_poly(size_t expected_vertex_count)
 {
-  polygons.emplace_back();
-  polygons.back().reserve(expected_vertex_count);
+  polygons.emplace_back().reserve(expected_vertex_count);
 }
 
 void PolySet::append_poly(const Polygon& poly)

--- a/src/geometry/PolySet.h
+++ b/src/geometry/PolySet.h
@@ -30,7 +30,7 @@ public:
   void quantizeVertices(std::vector<Vector3d> *pPointsOut = nullptr);
   size_t numFacets() const override { return polygons.size(); }
   void reserve(size_t numFacets) { polygons.reserve(numFacets); }
-  void append_poly();
+  void append_poly(size_t expected_vertex_count);
   void append_poly(const Polygon& poly);
   void append_vertex(double x, double y, double z = 0.0);
   void append_vertex(const Vector3d& v);

--- a/src/geometry/PolySetUtils.cc
+++ b/src/geometry/PolySetUtils.cc
@@ -95,7 +95,7 @@ void tessellate_faces(const PolySet& inps, PolySet& outps)
   for (const auto& faces : polygons) {
     if (faces[0].size() == 3) {
       // trivial case - triangles cannot be concave or have holes
-      outps.append_poly();
+      outps.append_poly(3);
       outps.append_vertex(verts[faces[0][0]]);
       outps.append_vertex(verts[faces[0][1]]);
       outps.append_vertex(verts[faces[0][2]]);
@@ -107,7 +107,7 @@ void tessellate_faces(const PolySet& inps, PolySet& outps)
       auto err = GeometryUtils::tessellatePolygonWithHoles(verts, faces, triangles, nullptr);
       if (!err) {
         for (const auto& t : triangles) {
-          outps.append_poly();
+          outps.append_poly(3);
           outps.append_vertex(verts[t[0]]);
           outps.append_vertex(verts[t[1]]);
           outps.append_vertex(verts[t[2]]);

--- a/src/geometry/cgal/Polygon2d-CGAL.cc
+++ b/src/geometry/cgal/Polygon2d-CGAL.cc
@@ -140,7 +140,7 @@ PolySet *Polygon2d::tessellate() const
   mark_domains(cdt);
   for (auto fit = cdt.finite_faces_begin(); fit != cdt.finite_faces_end(); ++fit) {
     if (fit->info().in_domain()) {
-      polyset->append_poly();
+      polyset->append_poly(3);
       for (int i = 0; i < 3; ++i) {
         polyset->append_vertex(fit->vertex(i)->point()[0],
                                fit->vertex(i)->point()[1],

--- a/src/geometry/cgal/cgalutils-mesh.cc
+++ b/src/geometry/cgal/cgalutils-mesh.cc
@@ -49,7 +49,7 @@ bool createPolySetFromMesh(const TriangleMesh& mesh, PolySet& ps)
   bool err = false;
   ps.reserve(ps.numFacets() + mesh.number_of_faces());
   for (auto& f : mesh.faces()) {
-    ps.append_poly();
+    ps.append_poly(mesh.degree(f));
 
     CGAL::Vertex_around_face_iterator<TriangleMesh> vbegin, vend;
     for (boost::tie(vbegin, vend) = vertices_around_face(mesh.halfedge(f), mesh); vbegin != vend;

--- a/src/geometry/cgal/cgalutils-polyhedron.cc
+++ b/src/geometry/cgal/cgalutils-polyhedron.cc
@@ -287,7 +287,7 @@ bool createPolySetFromPolyhedron(const Polyhedron& p, PolySet& ps)
   for (FCI fi = p.facets_begin(); fi != p.facets_end(); ++fi) {
     HFCC hc = fi->facet_begin();
     HFCC hc_end = hc;
-    ps.append_poly();
+    ps.append_poly(fi->facet_degree());
     do {
       Vertex const& v = *((hc++)->vertex());
       double x = CGAL::to_double(v.point().x());

--- a/src/geometry/cgal/cgalutils-polyhedron.cc
+++ b/src/geometry/cgal/cgalutils-polyhedron.cc
@@ -284,6 +284,8 @@ bool createPolySetFromPolyhedron(const Polyhedron& p, PolySet& ps)
   using FCI = typename Polyhedron::Facet_const_iterator;
   using HFCC = typename Polyhedron::Halfedge_around_facet_const_circulator;
 
+  ps.reserve(p.size_of_facets());
+
   for (FCI fi = p.facets_begin(); fi != p.facets_end(); ++fi) {
     HFCC hc = fi->facet_begin();
     HFCC hc_end = hc;

--- a/src/geometry/cgal/cgalutils.cc
+++ b/src/geometry/cgal/cgalutils.cc
@@ -383,6 +383,7 @@ bool createPolySetFromNefPolyhedron3(const CGAL::Nef_polyhedron_3<K>& N, PolySet
     LOG(message_group::Error, "Non-manifold mesh created: %1$d unconnected edges", unconnected2);
   }
 
+  ps.reserve(allTriangles.size());
   for (const auto& t : allTriangles) {
     ps.append_poly(3);
     ps.append_vertex(verts[t[0]]);

--- a/src/geometry/cgal/cgalutils.cc
+++ b/src/geometry/cgal/cgalutils.cc
@@ -384,7 +384,7 @@ bool createPolySetFromNefPolyhedron3(const CGAL::Nef_polyhedron_3<K>& N, PolySet
   }
 
   for (const auto& t : allTriangles) {
-    ps.append_poly();
+    ps.append_poly(3);
     ps.append_vertex(verts[t[0]]);
     ps.append_vertex(verts[t[1]]);
     ps.append_vertex(verts[t[2]]);

--- a/src/io/export_stl copy.cc
+++ b/src/io/export_stl copy.cc
@@ -1,0 +1,322 @@
+/*
+ *  OpenSCAD (www.openscad.org)
+ *  Copyright (C) 2009-2011 Clifford Wolf <clifford@clifford.at> and
+ *                          Marius Kintel <marius@kintel.net>
+ *
+ *  This program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  As a special exception, you have permission to link this program
+ *  with the CGAL library and distribute executables, as long as you
+ *  follow the requirements of the GNU GPL in regard to all of the
+ *  software in the executable aside from CGAL.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program; if not, write to the Free Software
+ *  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ *
+ */
+
+#include "export.h"
+#include "PolySet.h"
+#include "PolySetUtils.h"
+#include "Reindexer.h"
+#include "double-conversion/double-conversion.h"
+#ifdef ENABLE_MANIFOLD
+#include "ManifoldGeometry.h"
+#endif
+
+#ifdef ENABLE_CGAL
+#include "CGAL_Nef_polyhedron.h"
+#include "CGALHybridPolyhedron.h"
+#include "cgal.h"
+#include "cgalutils.h"
+
+namespace {
+
+#define DC_BUFFER_SIZE (128)
+
+/* Define values for double-conversion library. */
+static constexpr auto dc_flags = double_conversion::DoubleToStringConverter::Flags::UNIQUE_ZERO;
+static constexpr size_t dc_buffer_size = 128;
+// Only finite values in STL outputs!
+static constexpr const char * dc_inf = NULL;
+static constexpr const char * dc_nan = NULL;
+static constexpr char dc_exp = 'e';
+static constexpr int dc_decimal_low_exp = -5;
+static constexpr int dc_decimal_high_exp = 6;
+static constexpr int dc_max_leading_zeros = 5;
+static constexpr int dc_max_trailing_zeros = 0;
+
+std::string toString(const Vector3f& v)
+{
+#if 0
+  char output[DC_BUFFER_SIZE]0
+  snprintf(output, DC_BUFFER_SIZE, "%.9g %.9g %.9g", v[0], v[1], v[2]);
+  return output;
+#else
+  double_conversion::DoubleToStringConverter dc(
+    dc_flags, dc_inf, dc_nan, dc_exp,
+    dc_decimal_low_exp, dc_decimal_high_exp,
+    dc_max_leading_zeros, dc_max_trailing_zeros);
+
+  char buffer[DC_BUFFER_SIZE];
+
+  double_conversion::StringBuilder builder(buffer, DC_BUFFER_SIZE);
+  dc.ToShortestSingle(v[0], &builder);
+  builder.AddCharacter(' ');
+  dc.ToShortestSingle(v[1], &builder);
+  builder.AddCharacter(' ');
+  dc.ToShortestSingle(v[2], &builder);
+  builder.Finalize();
+
+  return buffer;
+#endif
+}
+
+int32_t flipEndianness(int32_t x) {
+  return 
+    ((x << 24) & 0xff000000) | ((x >> 24) & 0xff) |
+    ((x << 8) & 0xff0000) | ((x >> 8) & 0xff00);
+}
+
+template <size_t N>
+void write_floats(std::ostream& output, const std::array<float, N>& data) {
+  static uint16_t test = 0x0001;
+  static bool isLittleEndian = *reinterpret_cast<char *>(&test) == 1;
+
+  if (isLittleEndian) {
+    output.write(reinterpret_cast<char *>(const_cast<float *>(&data[0])), N * sizeof(float));
+  } else {
+    std::array<float, N> copy(data);
+    
+    int32_t *ints = reinterpret_cast<int32_t *>(&copy[0]);
+    for (size_t i = 0; i < N; i++) {
+      ints[i] = flipEndianness(ints[i]);
+    }
+
+    output.write(reinterpret_cast<char *>(&copy[0]), N * sizeof(float));
+  }
+}
+
+uint64_t append_stl(const IndexedTriangleMesh& mesh, std::ostream& output, bool binary)
+{
+  static_assert(sizeof(float) == 4, "Need 32 bit float");
+
+  uint64_t triangle_count = 0;
+  
+  // In ASCII mode only, convert each vertex to string.
+  std::vector<std::string> vertexStrings;
+  if (!binary) {
+    vertexStrings.resize(mesh.vertices.size());
+    std::transform(mesh.vertices.begin(), mesh.vertices.end(), vertexStrings.begin(),
+      [](auto &p) { return toString(p); });
+  }
+
+  // Used for binary mode only
+  std::array<float, 4 * 3> coords;
+
+  for (const auto &t : mesh.triangles) {
+    const auto &p0 = mesh.vertices[t[0]];
+    const auto &p1 = mesh.vertices[t[1]];
+    const auto &p2 = mesh.vertices[t[2]];
+
+    // Tessellation already eliminated these cases.
+    assert(p0 != p1 && p0 != p2 && p1 != p2);
+
+    auto normal = (p1 - p0).cross(p2 - p0);
+    if (!normal.isZero()) {
+      normal.normalize();
+    }
+
+    if (binary) {
+      auto coords_offset = 0;
+      auto addCoords = [&](auto v) {
+        for (auto i : {0, 1, 2})
+          coords[coords_offset++] = v[i];
+      };
+      addCoords(normal);
+      addCoords(p0);
+      addCoords(p1);
+      addCoords(p2);
+      assert(coords_offset == 4 * 3);
+      write_floats(output, coords);
+      char attrib[2] = {0, 0};
+      output.write(attrib, 2);
+    } else {
+      const auto &s0 = vertexStrings[t[0]];
+      const auto &s1 = vertexStrings[t[1]];
+      const auto &s2 = vertexStrings[t[2]];
+
+      // Since the points are different, the precision we use to 
+      // format them to string should guarantee the strings are 
+      // different too.
+      assert(s0 != s1 && s0 != s2 && s1 != s2);
+      
+      output << "  facet normal ";
+      output << toString(normal) << "\n";
+      output << "    outer loop\n";
+      output << "      vertex " << s0 << "\n";
+      output << "      vertex " << s1 << "\n";
+      output << "      vertex " << s2 << "\n";
+      output << "    endloop\n";
+      output << "  endfacet\n";
+    }
+    triangle_count++;
+  }
+
+  return triangle_count;
+}
+
+uint64_t append_stl(const PolySet& ps, std::ostream& output, bool binary)
+{
+  IndexedTriangleMesh triangulated;
+  PolySetUtils::tessellate_faces(ps, triangulated);
+
+  if (Feature::ExperimentalPredictibleOutput.is_enabled()) {
+    IndexedTriangleMesh ordered;
+    Export::ExportMesh exportMesh { triangulated };
+    exportMesh.export_indexed(ordered);
+    return append_stl(ordered, output, binary);
+  } else {
+    return append_stl(triangulated, output, binary);
+  }
+}
+
+/*!
+    Saves the current 3D CGAL Nef polyhedron as STL to the given file.
+    The file must be open.
+ */
+uint64_t append_stl(const CGAL_Nef_polyhedron& root_N, std::ostream& output,
+                    bool binary)
+{
+  uint64_t triangle_count = 0;
+  if (!root_N.p3->is_simple()) {
+    LOG(message_group::Export_Warning, "Exported object may not be a valid 2-manifold and may need repair");
+  }
+
+  PolySet ps(3);
+  if (!CGALUtils::createPolySetFromNefPolyhedron3(*(root_N.p3), ps)) {
+    triangle_count += append_stl(ps, output, binary);
+  } else {
+    LOG(message_group::Export_Error, "Nef->PolySet failed");
+  }
+
+  return triangle_count;
+}
+
+/*!
+   Saves the current 3D CGAL Nef polyhedron as STL to the given file.
+   The file must be open.
+ */
+uint64_t append_stl(const CGALHybridPolyhedron& hybrid, std::ostream& output,
+                    bool binary)
+{
+  uint64_t triangle_count = 0;
+  if (!hybrid.isManifold()) {
+    LOG(message_group::Export_Warning, "Exported object may not be a valid 2-manifold and may need repair");
+  }
+
+  auto ps = hybrid.toPolySet();
+  if (ps) {
+    triangle_count += append_stl(*ps, output, binary);
+  } else {
+    LOG(message_group::Export_Error, "Nef->PolySet failed");
+  }
+
+  return triangle_count;
+}
+
+#ifdef ENABLE_MANIFOLD
+/*!
+   Saves the current 3D Manifold geometry as STL to the given file.
+   The file must be open.
+ */
+uint64_t append_stl(const ManifoldGeometry& mani, std::ostream& output,
+                    bool binary)
+{
+  uint64_t triangle_count = 0;
+  if (!mani.isManifold()) {
+    LOG(message_group::Export_Warning, "Exported object may not be a valid 2-manifold and may need repair");
+  }
+
+  auto ps = mani.toPolySet();
+  if (ps) {
+    triangle_count += append_stl(*ps, output, binary);
+  } else {
+    LOG(message_group::Export_Error, "Manifold->PolySet failed");
+  }
+
+  return triangle_count;
+}
+#endif
+
+
+uint64_t append_stl(const shared_ptr<const Geometry>& geom, std::ostream& output,
+                    bool binary)
+{
+  uint64_t triangle_count = 0;
+  if (const auto geomlist = dynamic_pointer_cast<const GeometryList>(geom)) {
+    for (const Geometry::GeometryItem& item : geomlist->getChildren()) {
+      triangle_count += append_stl(item.second, output, binary);
+    }
+  } else if (const auto N = dynamic_pointer_cast<const CGAL_Nef_polyhedron>(geom)) {
+    triangle_count += append_stl(*N, output, binary);
+  } else if (const auto ps = dynamic_pointer_cast<const PolySet>(geom)) {
+    triangle_count += append_stl(*ps, output, binary);
+  } else if (const auto hybrid = dynamic_pointer_cast<const CGALHybridPolyhedron>(geom)) {
+    triangle_count += append_stl(*hybrid, output, binary);
+#ifdef ENABLE_MANIFOLD
+  } else if (const auto mani = dynamic_pointer_cast<const ManifoldGeometry>(geom)) {
+    triangle_count += append_stl(*mani, output, binary);
+#endif
+  } else if (dynamic_pointer_cast<const Polygon2d>(geom)) { //NOLINT(bugprone-branch-clone)
+    assert(false && "Unsupported file format");
+  } else { //NOLINT(bugprone-branch-clone)
+    assert(false && "Not implemented");
+  }
+
+  return triangle_count;
+}
+
+} // namespace
+
+void export_stl(const shared_ptr<const Geometry>& geom, std::ostream& output,
+                bool binary)
+{
+  if (binary) {
+    char header[80] = "OpenSCAD Model\n";
+    output.write(header, sizeof(header));
+    char tmp_triangle_count[4] = {0, 0, 0, 0}; // We must fill this in below.
+    output.write(tmp_triangle_count, 4);
+  } else {
+    setlocale(LC_NUMERIC, "C"); // Ensure radix is . (not ,) in output
+    output << "solid OpenSCAD_Model\n";
+  }
+
+  uint64_t triangle_count = append_stl(geom, output, binary);
+
+  if (binary) {
+    // Fill in triangle count.
+    output.seekp(80, std::ios_base::beg);
+    output.put(triangle_count & 0xff);
+    output.put((triangle_count >> 8) & 0xff);
+    output.put((triangle_count >> 16) & 0xff);
+    output.put((triangle_count >> 24) & 0xff);
+    if (triangle_count > 4294967295) {
+      LOG(message_group::Export_Error, "Triangle count exceeded 4294967295, so the stl file is not valid");
+    }
+  } else {
+    output << "endsolid OpenSCAD_Model\n";
+    setlocale(LC_NUMERIC, ""); // Set default locale
+  }
+}
+
+#endif // ENABLE_CGAL

--- a/src/io/import_3mf.cc
+++ b/src/io/import_3mf.cc
@@ -167,7 +167,7 @@ Geometry *import_3mf(const std::string& filename, const Location& loc)
         return import_3mf_error(model, object_it, first_mesh, p);
       }
 
-      p->append_poly();
+      p->append_poly(3);
       p->append_vertex(vertex1.m_fPosition[0], vertex1.m_fPosition[1], vertex1.m_fPosition[2]);
       p->append_vertex(vertex2.m_fPosition[0], vertex2.m_fPosition[1], vertex2.m_fPosition[2]);
       p->append_vertex(vertex3.m_fPosition[0], vertex3.m_fPosition[1], vertex3.m_fPosition[2]);
@@ -346,7 +346,7 @@ Geometry *import_3mf(const std::string& filename, const Location& loc)
       vertex2 = object->GetVertex(triangle.m_Indices[1]);
       vertex3 = object->GetVertex(triangle.m_Indices[2]);
 
-      p->append_poly();
+      p->append_poly(3);
       p->append_vertex(vertex1.m_Coordinates[0], vertex1.m_Coordinates[1], vertex1.m_Coordinates[2]);
       p->append_vertex(vertex2.m_Coordinates[0], vertex2.m_Coordinates[1], vertex2.m_Coordinates[2]);
       p->append_vertex(vertex3.m_Coordinates[0], vertex3.m_Coordinates[1], vertex3.m_Coordinates[2]);

--- a/src/io/import_3mf.cc
+++ b/src/io/import_3mf.cc
@@ -150,6 +150,7 @@ Geometry *import_3mf(const std::string& filename, const Location& loc)
     PRINTDB("%s: mesh %d, vertex count: %lu, triangle count: %lu", filename.c_str() % mesh_idx % vertex_count % triangle_count);
 
     auto *p = new PolySet(3);
+    p->reserve(triangle_count);
     for (DWORD idx = 0; idx < triangle_count; ++idx) {
       MODELMESHTRIANGLE triangle;
       if (lib3mf_meshobject_gettriangle(object, idx, &triangle) != LIB3MF_OK) {
@@ -338,6 +339,7 @@ Geometry *import_3mf(const std::string& filename, const Location& loc)
     PRINTDB("%s: mesh %d, vertex count: %lu, triangle count: %lu", filename.c_str() % mesh_idx % vertex_count % triangle_count);
 
     PolySet *p = new PolySet(3);
+    p->reserve(triangle_count);
     for (Lib3MF_uint64 idx = 0; idx < triangle_count; ++idx) {
       Lib3MF::sTriangle triangle = object->GetTriangle(idx);
       Lib3MF::sPosition vertex1, vertex2, vertex3;

--- a/src/io/import_amf.cc
+++ b/src/io/import_amf.cc
@@ -160,7 +160,7 @@ void AmfImporter::end_triangle(AmfImporter *importer, const xmlChar *)
 
   std::vector<Eigen::Vector3d>& v = importer->vertex_list;
 
-  importer->polySet->append_poly();
+  importer->polySet->append_poly(3);
   importer->polySet->append_vertex(v[idx_v1].x(), v[idx_v1].y(), v[idx_v1].z());
   importer->polySet->append_vertex(v[idx_v2].x(), v[idx_v2].y(), v[idx_v2].z());
   importer->polySet->append_vertex(v[idx_v3].x(), v[idx_v3].y(), v[idx_v3].z());

--- a/src/io/import_obj.cc
+++ b/src/io/import_obj.cc
@@ -58,10 +58,10 @@ PolySet *import_obj(const std::string& filename, const Location& loc) {
         return new PolySet(3);
       }
     } else if (boost::regex_search(line, results, ex_f) && results.size() >= 2) {
-      p->append_poly();
       std::string args=results[1];
       std::vector<std::string> words;
       boost::split(words, results[1], boost::is_any_of(" \t"));
+      p->append_poly(words.size());
       for (const std::string& word : words) {
 	int ind=boost::lexical_cast<int>(word);
         if(ind >= 1 && ind  <= pts.size())

--- a/src/io/import_stl.cc
+++ b/src/io/import_stl.cc
@@ -94,6 +94,7 @@ PolySet *import_stl(const std::string& filename, const Location& loc) {
 #endif
     if (file_size == static_cast<std::streamoff>(80ul + 4ul + 50ul * facenum)) {
       binary = true;
+      p->reserve(facenum);
     }
   }
   f.seekg(0);

--- a/src/io/import_stl.cc
+++ b/src/io/import_stl.cc
@@ -144,7 +144,7 @@ PolySet *import_stl(const std::string& filename, const Location& loc) {
               boost::lexical_cast<double>(results[v + 1]);
           }
           if (++i == 3) {
-            p->append_poly();
+            p->append_poly(3);
             p->append_vertex(vdata[0][0], vdata[0][1], vdata[0][2]);
             p->append_vertex(vdata[1][0], vdata[1][1], vdata[1][2]);
             p->append_vertex(vdata[2][0], vdata[2][1], vdata[2][2]);
@@ -169,7 +169,7 @@ PolySet *import_stl(const std::string& filename, const Location& loc) {
           if (f.eof()) break;
           throw;
         }
-        p->append_poly();
+        p->append_poly(3);
         p->append_vertex(facet.data.x1, facet.data.y1, facet.data.z1);
         p->append_vertex(facet.data.x2, facet.data.y2, facet.data.z2);
         p->append_vertex(facet.data.x3, facet.data.y3, facet.data.z3);


### PR DESCRIPTION
PolySet is a vector of polygons (vectors), so we can avoid a myriad of tiny (or big) reallocs by:
*  Reserving the vector of polygons when it's easy (e.g. in binary STL import, primitives...)
*  Requiring a polygon size arg in PolySet::append_poly to reserve the polygon's vector

`sphere(10, $fn=1000);` renders 1.18x faster with this!

And this one that does some actual CSG ops, still 1.13x faster (`--enable=manifold --export-format=binstl`):

```
sphere($fn=1000);
translate([0.5, 0, 0])
  sphere($fn=1000);
```
