### PR TITLE
Use gettext functionality from glib instead of directly from gettext

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -238,9 +238,6 @@ if (MSVC)
   find_package(double-conversion CONFIG REQUIRED)
   target_link_libraries(OpenSCAD PRIVATE double-conversion::double-conversion)
 
-  find_library(GETTEXT_LIBRARY libintl)
-  target_link_libraries(OpenSCAD PRIVATE ${GETTEXT_LIBRARY})
-
   # call before setting local CMAKE_MODULE_PATH so we use VCPKG version of FindGLEW
   find_graphics()
 

--- a/README.md
+++ b/README.md
@@ -141,7 +141,7 @@ To pull the various submodules (incl. the [MCAD library](https://github.com/open
 Prerequisites:
 
 * Xcode
-* automake, libtool, cmake, pkg-config, wget (we recommend installing these using Homebrew)
+* automake, libtool, cmake, pkg-config, wget, itstool, gettext (we recommend installing these using Homebrew)
 
 Install Dependencies:
 

--- a/scripts/common-build-dependencies.sh
+++ b/scripts/common-build-dependencies.sh
@@ -99,29 +99,6 @@ build_libffi()
   make install
 }
 
-build_gettext()
-{
-  version="$1"
-
-  if [ -f "$DEPLOYDIR"/lib/libgettextpo.a ]; then
-    echo "gettext already installed. not building"
-    return
-  fi
-
-  echo "Building gettext $version..."
-  cd "$BASEDIR"/src
-  rm -rf "gettext-$version"
-  if [ ! -f "gettext-$version.tar.gz" ]; then
-    curl --insecure -LO "http://ftpmirror.gnu.org/gettext/gettext-$version.tar.gz"
-  fi
-  tar xzf "gettext-$version.tar.gz"
-  cd "gettext-$version"
-
-  ./configure --prefix="$DEPLOYDIR" --disable-java --disable-native-java
-  make -j$NUMCPU
-  make install
-}
-
 build_glib2()
 {
   version="$1"

--- a/scripts/macosx-build-dependencies.sh
+++ b/scripts/macosx-build-dependencies.sh
@@ -726,14 +726,19 @@ build_glib2()
 
   # If we're building for multiple archs, create fat binaries
   if (( ${#ARCHS[@]} > 1 )); then
-    LIBS=()
+    GLIBLIBS=()
+    INTLLIBS=()
     for arch in ${ARCHS[*]}; do
-      LIBS+=(build-$arch/install/$DEPLOYDIR/lib/libglib-2.0.dylib)
+      GLIBLIBS+=(build-$arch/install/$DEPLOYDIR/lib/libglib-2.0.dylib)
+      INTLLIBS+=(build-$arch/install/$DEPLOYDIR/lib/libintl.dylib)
     done
-    lipo -create ${LIBS[@]} -output $DEPLOYDIR/lib/libglib-2.0.dylib
+    lipo -create ${GLIBLIBS[@]} -output $DEPLOYDIR/lib/libglib-2.0.dylib
+    lipo -create ${INTLLIBS[@]} -output $DEPLOYDIR/lib/libintl.dylib
   fi
 
   install_name_tool -id @rpath/libglib-2.0.dylib $DEPLOYDIR/lib/libglib-2.0.dylib
+  install_name_tool -id @rpath/libintl.dylib $DEPLOYDIR/lib/libintl.dylib
+  install_name_tool -change $DEPLOYDIR/lib/libintl.8.dylib @rpath/libintl.dylib $DEPLOYDIR/lib/libglib-2.0.dylib
   echo $version > $DEPLOYDIR/share/macosx-build-dependencies/glib2.version
 }
 

--- a/scripts/macosx-build-dependencies.sh
+++ b/scripts/macosx-build-dependencies.sh
@@ -41,7 +41,7 @@ PACKAGES=(
     "gmp 6.2.1"
     "mpfr 4.2.0"
     "glew 2.2.0"
-    "gettext 0.21.1"
+    "gettext REMOVE"
     "libffi REMOVE"
     "freetype 2.12.1"
     "ragel REMOVE"
@@ -692,43 +692,10 @@ remove_libffi()
   find $DEPLOYDIR -type f -name "ffi*" -o -name "libffi*" -exec rm -f {} \;
 }
 
-build_gettext()
+remove_gettext()
 {
-  version="$1"
-
-  echo "Building gettext $version..."
-  cd "$BASEDIR"/src
-  rm -rf "gettext-$version"
-  if [ ! -f "gettext-$version.tar.gz" ]; then
-    curl --insecure -LO "http://ftpmirror.gnu.org/gettext/gettext-$version.tar.gz"
-  fi
-  tar xzf "gettext-$version.tar.gz"
-  cd "gettext-$version"
-
-  # Build each arch separately
-  for i in ${!ARCHS[@]}; do
-    arch=${ARCHS[$i]}
-    mkdir build-$arch
-    cd build-$arch
-    ../configure --prefix=$DEPLOYDIR CFLAGS="-arch $arch -mmacos-version-min=$MAC_OSX_VERSION_MIN" CXXFLAGS="-arch $arch -mmacos-version-min=$MAC_OSX_VERSION_MIN" LDFLAGS="-arch $arch -mmacos-version-min=$MAC_OSX_VERSION_MIN -Wl,-rpath,$DEPLOYDIR/lib" --disable-shared --with-included-glib --with-included-gettext --with-included-libunistring --disable-java --disable-csharp --host=${GNU_ARCHS[$i]}-apple-darwin17.0.0
-    make -j"$NUMCPU"
-    make -j"$NUMCPU" install DESTDIR=$PWD/install/
-    cd ..
-  done
-
-  # Install the first arch
-  cp -R build-${ARCHS[0]}/install/$DEPLOYDIR/* $DEPLOYDIR
-
-  # If we're building for multiple archs, create fat binaries
-  if (( ${#ARCHS[@]} > 1 )); then
-    LIBS=()
-    for arch in ${ARCHS[*]}; do
-      LIBS+=(build-$arch/install/$DEPLOYDIR/lib/libintl.a)
-    done
-    lipo -create ${LIBS[@]} -output $DEPLOYDIR/lib/libintl.a
-  fi
-
-  echo $version > $DEPLOYDIR/share/macosx-build-dependencies/gettext.version
+  echo "Removing gettext..."
+  find $DEPLOYDIR -type f -name "libintl.*" -o -name "libintl.h" -exec rm -f {} \;
 }
 
 build_glib2()

--- a/scripts/macosx-build-homebrew.sh
+++ b/scripts/macosx-build-homebrew.sh
@@ -70,7 +70,7 @@ for formula in libzip opencsg; do
   time brew link $formula
 done
 
-for formula in gettext qt5 qscintilla2; do
+for formula in qt5 qscintilla2; do
   log "Linking formula $formula"
   time brew link --force $formula
 done

--- a/scripts/uni-build-dependencies.sh
+++ b/scripts/uni-build-dependencies.sh
@@ -34,11 +34,10 @@
 #   ./scripts/uni-build-dependencies.sh qt5
 #   . ./scripts/setenv-unibuild.sh #(Rerun to re-detect qt5)
 #
-# If your system lacks glu, gettext, or glib2, you can build them as well:
+# If your system lacks glu, or glib2, you can build them as well:
 #
 #   ./scripts/uni-build-dependencies.sh glu
 #   ./scripts/uni-build-dependencies.sh glib2
-#   ./scripts/uni-build-dependencies.sh gettext
 #
 # If you want to try Clang compiler (experimental, only works on linux):
 #
@@ -615,30 +614,6 @@ build_eigen()
 
 # glib2 and dependencies
 
-#build_gettext()
-#{
-#  version=$1
-#  ls -l $DEPLOYDIR/include/gettext-po.h
-#  if [ -e $DEPLOYDIR/include/gettext-po.h ]; then
-#    echo "gettext already installed. not building"
-#    return
-#  fi
-#
-#  echo "Building gettext $version..."
-#
-#  cd "$BASEDIR"/src
-#  rm -rf "gettext-$version"
-#  if [ ! -f "glib-$version.tar.gz" ]; then
-#    curl --insecure -LO "http://ftpmirror.gnu.org/gettext/gettext-$version.tar.gz"
-#  fi
-#  tar xzf "gettext-$version.tar.gz"
-#  cd "gettext-$version"
-#
-#  ./configure --prefix="$DEPLOYDIR"
-#  make -j$NUMCPU
-#  make install
-#}
-
 build_pkgconfig()
 {
   if [ "`command -v pkg-config`" ]; then
@@ -802,11 +777,6 @@ if [ $1 ]; then
     build_glu 9.0.0
     exit $?
   fi
-  if [ $1 = "gettext" ]; then
-    # such a huge build, put here by itself
-    build_gettext 0.18.3.1
-    exit $?
-  fi
   if [ $1 = "harfbuzz" ]; then
     # debian 7 lacks only harfbuzz
     build_harfbuzz 6.0.0 --with-glib=yes
@@ -816,7 +786,6 @@ if [ $1 ]; then
     # such a huge build, put here by itself
     build_pkgconfig 0.28
     build_libffi 3.0.13
-    #build_gettext 0.18.3.1
     build_glib2 2.75.0
     exit $?
   fi
@@ -840,7 +809,6 @@ build_boost 1.81.0
 build_cgal 5.5.1
 build_glew 1.9.0
 build_opencsg 1.4.2
-build_gettext 0.18.3.1
 build_glib2 2.75.0
 
 # the following are only needed for text()

--- a/scripts/uni-get-dependencies.sh
+++ b/scripts/uni-get-dependencies.sh
@@ -10,7 +10,7 @@ get_fedora_deps_yum()
   fontconfig-devel freetype-devel \
   boost-devel mpfr-devel gmp-devel glew-devel CGAL-devel gcc gcc-c++ pkgconfig \
   opencsg-devel git libXmu-devel curl imagemagick ImageMagick glib2-devel make \
-  xorg-x11-server-Xvfb gettext qscintilla-qt5-devel \
+  xorg-x11-server-Xvfb qscintilla-qt5-devel \
   mesa-dri-drivers double-conversion-devel tbb-devel
 }
 
@@ -20,7 +20,7 @@ get_fedora_deps_dnf()
   fontconfig-devel freetype-devel \
   boost-devel mpfr-devel gmp-devel glew-devel CGAL-devel gcc gcc-c++ pkgconfig \
   opencsg-devel git libXmu-devel curl ImageMagick glib2-devel make \
-  xorg-x11-server-Xvfb gettext qscintilla-qt5-devel \
+  xorg-x11-server-Xvfb qscintilla-qt5-devel \
   mesa-dri-drivers libzip-devel ccache qt5-qtmultimedia-devel qt5-qtsvg-devel \
   double-conversion-devel tbb-devel
  dnf -y install libxml2-devel
@@ -38,7 +38,7 @@ get_altlinux_deps()
  for i in boost-devel boost-filesystem-devel gcc4.5 gcc4.5-c++ boost-program_options-devel \
   boost-thread-devel boost-system-devel boost-regex-devel eigen3 \
   libmpfr libgmp libgmp_cxx-devel qt5-devel libcgal-devel git-core tbb-devel \
-  libglew-devel flex bison curl imagemagick gettext glib2-devel; do apt-get install $i; done
+  libglew-devel flex bison curl imagemagick glib2-devel; do apt-get install $i; done
 }
 
 get_freebsd_deps()
@@ -46,7 +46,7 @@ get_freebsd_deps()
  pkg_add -r bison boost-libs cmake git bash eigen3 flex gmake gmp mpfr \
   xorg libGLU libXmu libXi xorg-vfbserver glew \
   qt5-core qt5-gui qt5-buildtools qt5-opengl qt5-qmake \
-  opencsg cgal curl imagemagick glib2-devel gettext libdouble-conversion-3.0.0 \
+  opencsg cgal curl imagemagick glib2-devel libdouble-conversion-3.0.0 \
   devel/onetbb
 }
 
@@ -54,14 +54,14 @@ get_netbsd_deps()
 {
  pkgin install bison boost cmake git bash eigen3 flex gmake gmp mpfr \
   qt5 glew cgal opencsg python27 curl \
-  ImageMagick glib2 gettext threadingbuildingblocks
+  ImageMagick glib2 threadingbuildingblocks
 }
 
 get_opensuse_deps()
 {
  zypper install mpfr-devel gmp-devel boost-devel \
   glew-devel cmake git bison flex cgal-devel curl \
-  glib2-devel gettext freetype-devel harfbuzz-devel  \
+  glib2-devel freetype-devel harfbuzz-devel  \
   qscintilla-qt5-devel libqt5-qtbase-devel libQt5OpenGL-devel \
   xvfb-run libzip-devel libqt5-qtmultimedia-devel libqt5-qtsvg-devel \
   double-conversion-devel libboost_filesystem-devel libboost_regex-devel \
@@ -93,7 +93,7 @@ get_mageia_deps()
  urpmi ctags
  urpmi task-c-devel task-c++-devel libqt5-devel libgmp-devel \
   libmpfr-devel libboost-devel eigen3-devel libglew-devel bison flex \
-  cmake imagemagick glib2-devel python curl git x11-server-xvfb gettext \
+  cmake imagemagick glib2-devel python curl git x11-server-xvfb \
   double-conversion-devel tbb
 }
 
@@ -105,7 +105,7 @@ get_debian_deps()
   libmpfr-dev libboost-dev libglew-dev libcairo2-dev \
   libeigen3-dev libcgal-dev libopencsg-dev libgmp3-dev libgmp-dev \
   imagemagick libfreetype6-dev libdouble-conversion-dev \
-  gtk-doc-tools libglib2.0-dev gettext xvfb pkg-config ragel libtbb-dev
+  gtk-doc-tools libglib2.0-dev xvfb pkg-config ragel libtbb-dev
  apt-get -y install libxi-dev libfontconfig-dev libzip-dev
 }
 

--- a/src/gui/ScintillaEditor.cc
+++ b/src/gui/ScintillaEditor.cc
@@ -14,6 +14,7 @@
 #include "PlatformUtils.h"
 #include "Settings.h"
 #include "ScadLexer.h"
+#include "printutils.h"
 
 #include <QWheelEvent>
 #include <QPoint>

--- a/src/gui/ScintillaEditor.h
+++ b/src/gui/ScintillaEditor.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <functional>
+#include <boost/filesystem.hpp>
 #include <boost/property_tree/ptree.hpp>
 #include <boost/property_tree/json_parser.hpp>
 
@@ -26,14 +27,14 @@ class ScadLexer2;
 class EditorColorScheme
 {
 private:
-  const fs::path path;
+  const boost::filesystem::path path;
 
   boost::property_tree::ptree pt;
   QString _name;
   int _index;
 
 public:
-  EditorColorScheme(const fs::path& path);
+  EditorColorScheme(const boost::filesystem::path& path);
   virtual ~EditorColorScheme() = default;
 
   const QString& name() const;
@@ -81,7 +82,7 @@ private:
                          const std::string& defaultValue);
   QColor readColor(const boost::property_tree::ptree& pt, const std::string& name,
                    const QColor& defaultColor);
-  void enumerateColorSchemesInPath(colorscheme_set_t& result_set, const fs::path& path);
+  void enumerateColorSchemesInPath(colorscheme_set_t& result_set, const boost::filesystem::path& path);
   colorscheme_set_t enumerateColorSchemes();
 
   bool eventFilter(QObject *obj, QEvent *event) override;
@@ -99,7 +100,7 @@ private:
   void setLexer(ScadLexer *lexer);
 #endif
   void replaceSelectedText(QString&);
-  void addTemplate(const fs::path& path);
+  void addTemplate(const boost::filesystem::path& path);
   void updateSymbolMarginVisibility();
   void findMarker(int, int, const std::function<int(int)>&);
 

--- a/src/gui/parameter/ParameterWidget.cc
+++ b/src/gui/parameter/ParameterWidget.cc
@@ -27,6 +27,9 @@
 
 #include "ParameterWidget.h"
 
+#include <set>
+#include <string>
+
 #include "GroupWidget.h"
 #include "ParameterSpinBox.h"
 #include "ParameterComboBox.h"

--- a/src/gui/qtgettext.h
+++ b/src/gui/qtgettext.h
@@ -11,12 +11,13 @@
 #endif
 
 #include <QString>
-#include "printutils.h"
+#include <glib/gi18n.h>
+#include <libintl.h>
 
 inline QString q_(const char *msgid, const char *msgctxt)
 {
   return QString::fromUtf8(msgctxt ?
-                           _(msgid, msgctxt):
-                           _(msgid)
+                           g_dpgettext(nullptr, (std::string(msgctxt) + "\004" + msgid).c_str(), strlen(msgctxt) + 1):
+                           gettext(msgid)
                            );
 }

--- a/src/utils/printutils.h
+++ b/src/utils/printutils.h
@@ -8,7 +8,7 @@
 #include <utility>
 #include <sstream>
 
-#include <libintl.h>
+#include <glib/gi18n.h>
 // Undefine some defines from libintl.h to presolve
 // some collisions in boost headers later
 #if defined snprintf
@@ -21,27 +21,6 @@
 #include <clocale>
 #include "AST.h"
 #include <set>
-
-// It seems standard practice to use underscore for gettext, even though it is reserved.
-// Not wanting to risk breaking translations by changing every usage of this,
-// I've opted to just disable the check in this case. - Hans L
-// NOLINTBEGIN(bugprone-reserved-identifier)
-inline char *_(const char *msgid) { return gettext(msgid); }
-inline const char *_(const char *msgid, const char *msgctxt) {
-  /* The separator between msgctxt and msgid in a .mo file.  */
-  const char *GETTEXT_CONTEXT_GLUE = "\004";
-
-  std::string str = msgctxt;
-  str += GETTEXT_CONTEXT_GLUE;
-  str += msgid;
-  auto translation = dcgettext(nullptr, str.c_str(), LC_MESSAGES);
-  if (translation == str) {
-    return gettext(msgid);
-  } else {
-    return translation;
-  }
-}
-// NOLINTEND(bugprone-reserved-identifier)
 
 enum class message_group {
   NONE, Error, Warning, UI_Warning, Font_Warning, Export_Warning, Export_Error, UI_Error, Parser_Error, Trace, Deprecated, Echo


### PR DESCRIPTION
This eliminates gettext as a direct run-time dependency, which greatly simplifies dependency management on macOS, and is potentially a small reduction in complexity on other platforms.

Note: We still need the gettext tools whenever we want to re-compile translation files, but that's done occasionally and we can install the gettext tools separately.
