### PR TITLE
Use python3 instead of python

### DIFF
--- a/scripts/git-archive-all.py
+++ b/scripts/git-archive-all.py
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#! /usr/bin/env python3
 # coding=utf-8
 
 from __future__ import print_function

--- a/scripts/makereleasejson.py
+++ b/scripts/makereleasejson.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 # Used by github-release.sh
 

--- a/scripts/translation-update.sh
+++ b/scripts/translation-update.sh
@@ -118,7 +118,7 @@ GETTEXT_PATH=""
 
 SCRIPTDIR="`dirname \"$0\"`"
 TOPDIR="`dirname \"$SCRIPTDIR\"`"
-CURDIR="`python -c "import os; print(os.path.relpath(os.path.realpath('$BASEDIR'), '$TOPDIR'))"`"
+CURDIR="`python3 -c "import os; print(os.path.relpath(os.path.realpath('$BASEDIR'), '$TOPDIR'))"`"
 
 cd "$TOPDIR" || exit 1
 


### PR DESCRIPTION
macOS recently removed python, which linked to python2. Use python3 everywhere from now on, which should work on all other platforms too.