### PR TITLE
Bump glib to 2.76.3 for macOS

### DIFF
--- a/patches/glib-iconv-macos.patch
+++ b/patches/glib-iconv-macos.patch
@@ -1,0 +1,39 @@
+--- glib-2.76.3/meson.build	2023-05-23 06:55:59.000000000 -0400
++++ glib-2.76.3-openscad/meson.build	2023-06-15 22:05:45.000000000 -0400
+@@ -854,6 +854,7 @@
+   endif
+ endif
+ 
++osx_ldflags = []
+ glib_have_os_x_9_or_later = false
+ glib_have_carbon = false
+ glib_have_cocoa = false
+@@ -886,6 +887,7 @@
+ 
+   if glib_have_cocoa
+     glib_conf.set('HAVE_COCOA', true)
++    osx_ldflags += ['-Wl,-framework,Foundation', '-Wl,-framework,AppKit']
+   endif
+ endif
+ 
+@@ -2103,11 +2105,16 @@
+   if cc.has_function('ngettext', dependencies : libintl)
+     libintl_deps += [libintl]
+   else
+-    libintl_pthread = cc.find_library('pthread', required : false)
+-    if libintl_pthread.found() and cc.has_function('ngettext', dependencies : [libintl, libintl_pthread])
+-      libintl_deps += [libintl, libintl_pthread]
++    libintl_iconv = cc.find_library('iconv', required : false)
++    if cc.has_function('ngettext', args : osx_ldflags, dependencies : [libintl, libintl_iconv])
++      libintl_deps += [libintl, libintl_iconv]
+     else
+-      libintl = disabler()
++      libintl_pthread = cc.find_library('pthread', required : false)
++      if libintl_pthread.found() and cc.has_function('ngettext', dependencies : [libintl, libintl_pthread])
++        libintl_deps += [libintl, libintl_pthread]
++      else
++        libintl = disabler()
++      endif
+     endif
+   endif
+ endif

--- a/patches/glib-pcre-macos.patch
+++ b/patches/glib-pcre-macos.patch
@@ -1,0 +1,11 @@
+--- glib-2.76.3/meson.build	2023-05-23 06:55:59.000000000 -0400
++++ glib-2.76.3-openscad/meson.build	2023-06-16 00:04:05.000000000 -0400
+@@ -2038,7 +2040,7 @@
+ endif
+ 
+ pcre2_req = '>=10.32'
+-pcre2 = dependency('libpcre2-8', version: pcre2_req, required: false, allow_fallback: false)
++pcre2 = dependency('libpcre2-8', version: pcre2_req, required: false, default_options: ['default_library=static'])
+ if not pcre2.found()
+   if cc.get_id() == 'msvc' or cc.get_id() == 'clang-cl'
+   # MSVC: Search for the PCRE2 library by the configuration, which corresponds

--- a/scripts/macosx-build-dependencies.sh
+++ b/scripts/macosx-build-dependencies.sh
@@ -52,6 +52,7 @@ PACKAGES=(
     "fontconfig 2.14.1"
     "hidapi 0.12.0"
     "lib3mf 1.8.1"
+    # FIXME: Re-evaluate patches if bumping glib past 2.76.3
     "glib2 2.76.3"
     "pixman 0.42.2"
     "cairo 1.16.0"
@@ -745,6 +746,7 @@ build_glib2()
   fi
   tar xJf "glib-$version.tar.xz"
   cd "glib-$version"
+  # FIXME: Once bumping past glib-2.76.3, we may not need these patches
   patch -p1 < $OPENSCADDIR/patches/glib-iconv-macos.patch
   patch -p1 < $OPENSCADDIR/patches/glib-pcre-macos.patch
 

--- a/scripts/macosx-build-dependencies.sh
+++ b/scripts/macosx-build-dependencies.sh
@@ -52,7 +52,7 @@ PACKAGES=(
     "fontconfig 2.14.1"
     "hidapi 0.12.0"
     "lib3mf 1.8.1"
-    "glib2 2.71.0"
+    "glib2 2.76.3"
     "pixman 0.42.2"
     "cairo 1.16.0"
     "cgal 5.5"
@@ -745,11 +745,13 @@ build_glib2()
   fi
   tar xJf "glib-$version.tar.xz"
   cd "glib-$version"
+  patch -p1 < $OPENSCADDIR/patches/glib-iconv-macos.patch
+  patch -p1 < $OPENSCADDIR/patches/glib-pcre-macos.patch
 
   # Build each arch separately
   for arch in ${ARCHS[*]}; do
     sed -e "s,@MAC_OSX_VERSION_MIN@,$MAC_OSX_VERSION_MIN,g" -e "s,@DEPLOYDIR@,$DEPLOYDIR,g" $OPENSCADDIR/scripts/macos-$arch.txt.in > macos-$arch.txt
-    meson setup --prefix $DEPLOYDIR --cross-file macos-$arch.txt --force-fallback-for libpcre,libpcre2-8 -Dgtk_doc=false -Dman=false -Ddtrace=false -Dtests=false build-$arch
+    meson setup --prefix $DEPLOYDIR --cross-file macos-$arch.txt --force-fallback-for libpcre2-8 -Dgtk_doc=false -Dman=false -Ddtrace=false -Dtests=false build-$arch
     meson compile -C build-$arch
     DESTDIR=install/ meson install -C build-$arch
   done


### PR DESCRIPTION
Bump to latest (2.76.3) version of glib.
Includes a patch to make the latest glib build correctly for our build variant. See https://gitlab.gnome.org/GNOME/glib/-/issues/3025 for related discussion.