### PR TITLE
Remove unnecessary warning when a search string wasn't found in a vector

### DIFF
--- a/src/core/builtin_functions.cc
+++ b/src/core/builtin_functions.cc
@@ -549,10 +549,6 @@ static VectorType search(
         }
       }
     }
-    if (matchCount == 0) {
-      gchar utf8_of_cp[6] = ""; //A buffer for a single unicode character to be copied into
-      if (ptr_ft) g_utf8_strncpy(utf8_of_cp, ptr_ft, 1);
-    }
     if (num_returns_per_match == 0 || num_returns_per_match > 1) {
       returnvec.emplace_back(std::move(resultvec));
     }
@@ -595,11 +591,6 @@ static VectorType search(
           break;
         }
       }
-    }
-    if (matchCount == 0) {
-      gchar utf8_of_cp[6] = ""; //A buffer for a single unicode character to be copied into
-      if (ptr_ft) g_utf8_strncpy(utf8_of_cp, ptr_ft, 1);
-      LOG(message_group::Warning, loc, session->documentRoot(), "search term not found: \"%1$s\"", utf8_of_cp);
     }
     if (num_returns_per_match == 0 || num_returns_per_match > 1) {
       returnvec.emplace_back(std::move(resultvec));

--- a/tests/regression/echotest/search-tests-expected.echo
+++ b/tests/regression/echotest/search-tests-expected.echo
@@ -20,11 +20,7 @@ WARNING: Invalid entry in search vector at index 1, required number of values in
 ECHO: []
 WARNING: Invalid entry in search vector at index 1, required number of values in the entry: 1. Invalid entry: "string" in file search-tests.scad, line 76
 ECHO: []
-WARNING: search term not found: "a" in file search-tests.scad, line 79
 ECHO: [[]]
-WARNING: search term not found: "b" in file search-tests.scad, line 82
-WARNING: search term not found: "c" in file search-tests.scad, line 82
-WARNING: search term not found: "d" in file search-tests.scad, line 82
 ECHO: [[0], [], [], []]
 ECHO: [[], [], [], []]
 WARNING: Invalid entry in search vector at index 1, required number of values in the entry: 1. Invalid entry: undef in file search-tests.scad, line 87


### PR DESCRIPTION
Follow-up to #1312, which removed one of the warning cases, but not this.
