### PR TITLE
meson required for MacOS M2 build

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,7 +141,7 @@ To pull the various submodules (incl. the [MCAD library](https://github.com/open
 Prerequisites:
 
 * Xcode
-* automake, libtool, cmake, pkg-config, wget (we recommend installing these using Homebrew)
+* automake, libtool, cmake, pkg-config, wget, meson (we recommend installing these using Homebrew)
 
 Install Dependencies:
 


### PR DESCRIPTION
Might be needed on non-ARM Macs, but my M2 wouldn't build without meson installed.