### PR TITLE
Support patch version in macosx-build-dependencies + bump xcode

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -162,7 +162,7 @@ jobs:
           destination: wasm
   openscad-macos:
     macos:
-      xcode: 13.2.1
+      xcode: 14.3.1
     environment:
       OPENSCAD_LIBRARIES: /Users/distiller/libraries/install
       PKG_CONFIG_PATH: /Users/distiller/libraries/install/lib/pkgconfig

--- a/scripts/macosx-build-dependencies.sh
+++ b/scripts/macosx-build-dependencies.sh
@@ -38,7 +38,7 @@ PACKAGES=(
     "double_conversion 3.2.1"
     "boost 1.81.0"
     "eigen 3.4.0"
-    "gmp 6.2.1"
+    "gmp 6.2.1 patch"
     "mpfr 4.2.0"
     "glew 2.2.0"
     "gettext 0.21.1"
@@ -103,9 +103,9 @@ package_version()
     return 1
 }
 
-# Usage: check_version_file <package> <version>
+# Usage: check_version_file <package> <version> [<patch>]
 # Checks if $DEPLOYDIR/fileshare/macosx-build-dependencies/$package.version exists
-# and its contents equals $version
+# and its contents equals $version[.$patch]
 # Returns success (0) if it does
 check_version_file()
 {
@@ -114,7 +114,7 @@ check_version_file()
 	if [ -z "$2" ]; then
 	    return 0
 	else
-	    [[ $(cat $versionfile) == $2 ]]
+	    [[ $(cat $versionfile) == $2${3:+.}$3 ]]
 	    return $?
 	fi
     else
@@ -126,7 +126,7 @@ check_version_file()
 # Returns success (0) if the/a version of the package is already installed
 is_installed()
 {
-    if check_version_file $1 $2; then
+    if check_version_file $1 $2 $3; then
 	return 0
     else
 	return 1
@@ -138,6 +138,7 @@ build()
 {
     local package=$1
     local version=$2
+    local patch=$3
 
     if [[ $version == "REMOVE" ]]; then
 	local should_remove=$(( $OPTION_FORCE == 1 ))
@@ -156,15 +157,17 @@ build()
     else
 	local should_install=$(( $OPTION_FORCE == 1 ))
 	if [[ $should_install == 0 ]]; then
-            if ! is_installed $package $version; then
+            if ! is_installed $package $version $patch; then
 		should_install=1
 	    else
-   		echo "$package $version already installed - not building"
+   		echo "$package $version $patch already installed - not building"
 	    fi
 	fi
 	if [[ $should_install == 1 ]]; then
             set -e
-            build_$package $version
+	    echo "Building $package $version $patch..."
+            build_$package $version $patch
+	    echo $version${patch:+.}$patch > $DEPLOYDIR/share/macosx-build-dependencies/$package.version
             set +e
 	fi
     fi
@@ -173,8 +176,6 @@ build()
 build_double_conversion()
 {
   version="$1"
-
-  echo "Building double-conversion $version..."
   cd "$BASEDIR"/src
   rm -rf "double-conversion-$version"
   if [ ! -f "double-conversion-$version.tar.gz" ]; then
@@ -185,14 +186,11 @@ build_double_conversion()
   cmake -DCMAKE_INSTALL_PREFIX=$DEPLOYDIR -DCMAKE_OSX_DEPLOYMENT_TARGET="$MAC_OSX_VERSION_MIN" -DCMAKE_OSX_ARCHITECTURES="$ARCHS_COMBINED" .
   make -j$NUMCPU
   make install
-  echo $version > $DEPLOYDIR/share/macosx-build-dependencies/double_conversion.version
 }
 
 build_qt5()
 {
   version=$1
-
-  echo "Building Qt" $version "..."
   cd $BASEDIR/src
   v=(${version//./ }) # Split into array
   rm -rf qt-everywhere-src-$version
@@ -246,14 +244,11 @@ build_qt5()
 	lipo -create $(find build-*/install -name $libname) -output $plugin
     done
   fi
-
-  echo $version > $DEPLOYDIR/share/macosx-build-dependencies/qt5.version
 }
 
 build_qscintilla()
 {
   version=$1
-  echo "Building QScintilla" $version "..."
   cd $BASEDIR/src
   rm -rf QScintilla_src-$version
   QSCINTILLA_FILENAME="QScintilla_src-$version.tar.gz"
@@ -265,14 +260,11 @@ build_qscintilla()
   qmake qscintilla.pro QMAKE_APPLE_DEVICE_ARCHS="${ARCHS[*]}"
   make -j"$NUMCPU" install
   install_name_tool -id @rpath/libqscintilla2_qt5.dylib $DEPLOYDIR/lib/libqscintilla2_qt5.dylib
-  echo $version > $DEPLOYDIR/share/macosx-build-dependencies/qscintilla.version
 }
 
 build_gmp()
 {
   version=$1
-
-  echo "Building gmp" $version "..."
   cd $BASEDIR/src
   rm -rf gmp-$version
   if [ ! -f gmp-$version.tar.bz2 ]; then
@@ -310,14 +302,11 @@ build_gmp()
   install_name_tool -id @rpath/libgmp.dylib $DEPLOYDIR/lib/libgmp.dylib
   install_name_tool -id @rpath/libgmpxx.dylib $DEPLOYDIR/lib/libgmpxx.dylib
   install_name_tool -change $DEPLOYDIR/lib/libgmp.10.dylib @rpath/libgmp.dylib $DEPLOYDIR/lib/libgmpxx.dylib
-  echo $version > $DEPLOYDIR/share/macosx-build-dependencies/gmp.version
 }
 
 build_mpfr()
 {
   version=$1
-
-  echo "Building mpfr" $version "..."
   cd $BASEDIR/src
   rm -rf mpfr-$version
   if [ ! -f mpfr-$version.tar.bz2 ]; then
@@ -349,15 +338,12 @@ build_mpfr()
   fi
 
   install_name_tool -id @rpath/libmpfr.dylib $DEPLOYDIR/lib/libmpfr.dylib
-  echo $version > $DEPLOYDIR/share/macosx-build-dependencies/mpfr.version
 }
 
 build_boost()
 {
   version=$1
-
   bversion=`echo $version | tr "." "_"`
-  echo "Building boost" $version "..."
   cd $BASEDIR/src
   rm -rf boost_$bversion
   if [ ! -f boost_$bversion.tar.bz2 ]; then
@@ -373,14 +359,11 @@ build_boost()
 
   ./bootstrap.sh --prefix=$DEPLOYDIR --with-libraries=thread,program_options,filesystem,chrono,system,regex,date_time,atomic
   ./b2 -j"$NUMCPU" -d+2 $BOOST_TOOLSET cflags="-mmacosx-version-min=$MAC_OSX_VERSION_MIN ${ARCH_FLAGS[*]}" linkflags="-mmacosx-version-min=$MAC_OSX_VERSION_MIN ${ARCH_FLAGS[*]} -headerpad_max_install_names" install
-  echo $version > $DEPLOYDIR/share/macosx-build-dependencies/boost.version
 }
 
 build_cgal()
 {
   version=$1
-
-  echo "Building CGAL" $version "..."
   cd $BASEDIR/src
   rm -rf CGAL-$version
   if [ ! -f CGAL-$version.tar.xz ]; then
@@ -396,14 +379,11 @@ build_cgal()
     install_name_tool -id @rpath/libCGAL_Core.dylib $DEPLOYDIR/lib/libCGAL_Core.dylib
     install_name_tool -change libCGAL.11.dylib @rpath/libCGAL.dylib $DEPLOYDIR/lib/libCGAL_Core.dylib
   fi
-  echo $version > $DEPLOYDIR/share/macosx-build-dependencies/cgal.version
 }
 
 build_onetbb()
 {
   version=$1
-
-  echo "Building oneTBB" $version "..."
   cd $BASEDIR/src
   rm -rf oneTBB-$version
   if [ ! -f oneTBB-$version.tar.gz ]; then
@@ -416,14 +396,11 @@ build_onetbb()
   make install  
   # install_name_tool -id @rpath/libtbb.dylib $DEPLOYDIR/lib/libtbb.dylib
   # install_name_tool -id @rpath/libtbbmalloc.dylib $DEPLOYDIR/lib/libtbbmalloc.dylib
-  echo $version > $DEPLOYDIR/share/macosx-build-dependencies/onetbb.version
 }
 
 build_glew()
 {
   version=$1
-
-  echo "Building GLEW" $version "..."
   cd $BASEDIR/src
   rm -rf glew-$version
   if [ ! -f glew-$version.tgz ]; then
@@ -437,14 +414,11 @@ build_glew()
     ARCH_FLAGS+=(-arch $arch)
   done
   make GLEW_PREFIX=$DEPLOYDIR GLEW_DEST=$DEPLOYDIR CFLAGS.EXTRA="-no-cpp-precomp -dynamic -fno-common -mmacosx-version-min=$MAC_OSX_VERSION_MIN ${ARCH_FLAGS[*]}" LDFLAGS.EXTRA="-install_name @rpath/libGLEW.dylib -mmacosx-version-min=$MAC_OSX_VERSION_MIN ${ARCH_FLAGS[*]}" POPT="-Os" STRIP= install
-  echo $version > $DEPLOYDIR/share/macosx-build-dependencies/glew.version
 }
 
 build_opencsg()
 {
   version=$1
-
-  echo "Building OpenCSG" $version "..."
   cd $BASEDIR/src
   rm -rf OpenCSG-$version
   if [ ! -f OpenCSG-$version.tar.gz ]; then
@@ -456,14 +430,11 @@ build_opencsg()
   qmake -r INSTALLDIR=$DEPLOYDIR QMAKE_APPLE_DEVICE_ARCHS="${ARCHS[*]}"
   make install
   install_name_tool -id @rpath/libopencsg.dylib $DEPLOYDIR/lib/libopencsg.dylib
-  echo $version > $DEPLOYDIR/share/macosx-build-dependencies/opencsg.version
 }
 
 build_eigen()
 {
   version=$1
-
-  echo "Building eigen" $version "..."
   cd $BASEDIR/src
   rm -rf eigen-$version
 
@@ -479,7 +450,6 @@ build_eigen()
   cd build
   cmake -DCMAKE_INSTALL_PREFIX=$DEPLOYDIR -DEIGEN_TEST_NOQT=TRUE -DCMAKE_OSX_DEPLOYMENT_TARGET="$MAC_OSX_VERSION_MIN" -DCMAKE_OSX_ARCHITECTURES="$ARCHS_COMBINED" ..
   make -j"$NUMCPU" install
-  echo $version > $DEPLOYDIR/share/macosx-build-dependencies/eigen.version
 }
 
 # Usage:
@@ -509,8 +479,6 @@ build_sparkle()
 #  github=${1%%:*}  # Cut at first colon
 #  version=${1#*:}  # cut until first colon
 #
-#  echo "Building Sparkle" $version "..."
-#
 #  # Let Sparkle use the default compiler
 #  unset CC
 #  unset CXX
@@ -528,15 +496,11 @@ build_sparkle()
 #  rm -rf $DEPLOYDIR/lib/Sparkle.framework
 #  cp -Rf build/Release/Sparkle.framework $DEPLOYDIR/lib/ 
 #  Install_name_tool -id $DEPLOYDIR/lib/Sparkle.framework/Versions/A/Sparkle $DEPLOYDIR/lib/Sparkle.framework/Sparkle
-
-  echo $version > $DEPLOYDIR/share/macosx-build-dependencies/sparkle.version
 }
 
 build_freetype()
 {
   version="$1"
-
-  echo "Building freetype $version..."
   cd "$BASEDIR"/src
   rm -rf "freetype-$version"
   if [ ! -f "freetype-$version.tar.gz" ]; then
@@ -571,14 +535,11 @@ build_freetype()
   fi
 
   install_name_tool -id @rpath/libfreetype.dylib $DEPLOYDIR/lib/libfreetype.dylib
-  echo $version > $DEPLOYDIR/share/macosx-build-dependencies/freetype.version
 }
 
 build_libzip()
 {
   version="$1"
-
-  echo "Building libzip $version..."
   cd "$BASEDIR"/src
   rm -rf "libzip-$version"
   if [ ! -f "libzip-$version.tar.gz" ]; then
@@ -592,7 +553,6 @@ build_libzip()
   make -j$NUMCPU
   make install
   install_name_tool -id @rpath/libzip.dylib $DEPLOYDIR/lib/libzip.dylib
-  echo $version > $DEPLOYDIR/share/macosx-build-dependencies/libzip.version
 }
 
 remove_libxml2()
@@ -604,8 +564,6 @@ remove_libxml2()
 build_libuuid()
 {
   version=$1
-
-  echo "Building libuuid $version..."
   cd $BASEDIR/src
   rm -rf uuid-$version
   if [ ! -f uuid-$version.tar.gz ]; then
@@ -643,14 +601,11 @@ build_libuuid()
   fi
 
   install_name_tool -id @rpath/libuuid.dylib $DEPLOYDIR/lib/libuuid.dylib
-  echo $version > $DEPLOYDIR/share/macosx-build-dependencies/libuuid.version
 }
 
 build_fontconfig()
 {
   version=$1
-
-  echo "Building fontconfig $version..."
   cd "$BASEDIR"/src
   rm -rf "fontconfig-$version"
   if [ ! -f "fontconfig-$version.tar.gz" ]; then
@@ -685,7 +640,6 @@ build_fontconfig()
   fi
 
   install_name_tool -id @rpath/libfontconfig.dylib $DEPLOYDIR/lib/libfontconfig.dylib
-  echo $version > $DEPLOYDIR/share/macosx-build-dependencies/fontconfig.version
 }
 
 remove_libffi()
@@ -697,8 +651,6 @@ remove_libffi()
 build_gettext()
 {
   version="$1"
-
-  echo "Building gettext $version..."
   cd "$BASEDIR"/src
   rm -rf "gettext-$version"
   if [ ! -f "gettext-$version.tar.gz" ]; then
@@ -729,16 +681,11 @@ build_gettext()
     done
     lipo -create ${LIBS[@]} -output $DEPLOYDIR/lib/libintl.a
   fi
-
-  echo $version > $DEPLOYDIR/share/macosx-build-dependencies/gettext.version
 }
 
 build_glib2()
 {
   version="$1"
-
-  echo "Building glib2 $version..."
-
   cd "$BASEDIR"/src
   rm -rf "glib-$version"
   maj_min_version="${version%.*}" #Drop micro
@@ -772,7 +719,6 @@ build_glib2()
   fi
 
   install_name_tool -id @rpath/libglib-2.0.dylib $DEPLOYDIR/lib/libglib-2.0.dylib
-  echo $version > $DEPLOYDIR/share/macosx-build-dependencies/glib2.version
 }
 
 remove_ragel()
@@ -784,8 +730,6 @@ remove_ragel()
 build_harfbuzz()
 {
   version=$1
-
-  echo "Building harfbuzz $version..."
   cd "$BASEDIR"/src
   rm -rf "harfbuzz-$version"
   if [ ! -f "harfbuzz-$version.tar.xz" ]; then
@@ -817,14 +761,11 @@ build_harfbuzz()
   fi
 
   install_name_tool -id @rpath/libharfbuzz.dylib $DEPLOYDIR/lib/libharfbuzz.dylib
-  echo $version > $DEPLOYDIR/share/macosx-build-dependencies/harfbuzz.version
 }
 
 build_hidapi()
 {
   version=$1
-
-  echo "Building hidapi $version..."
   cd "$BASEDIR"/src
   rm -rf "hidapi-hidapi-$version"
   if [ ! -f "hidapi-$version.zip" ]; then
@@ -857,14 +798,11 @@ build_hidapi()
   fi
 
   install_name_tool -id @rpath/libhidapi.dylib $DEPLOYDIR/lib/libhidapi.dylib
-  echo $version > $DEPLOYDIR/share/macosx-build-dependencies/hidapi.version
 }
 
 build_lib3mf()
 {
   version=$1
-
-  echo "Building lib3mf" $version "..."
   cd $BASEDIR/src
   rm -rf lib3mf-$version
   if [ ! -f $version.tar.gz ]; then
@@ -875,7 +813,6 @@ build_lib3mf()
   cmake -DLIB3MF_TESTS=false -DCMAKE_PREFIX_PATH=$DEPLOYDIR -DCMAKE_INSTALL_PREFIX=$DEPLOYDIR  -DCMAKE_OSX_DEPLOYMENT_TARGET="$MAC_OSX_VERSION_MIN" -DCMAKE_OSX_ARCHITECTURES="$ARCHS_COMBINED" .
   make -j"$NUMCPU" VERBOSE=1
   make -j"$NUMCPU" install
-  echo $version > $DEPLOYDIR/share/macosx-build-dependencies/lib3mf.version
 }
 
 build_pixman()
@@ -883,8 +820,6 @@ build_pixman()
   version=$1
   PIXMAN_DIR="pixman-${version}"
   PIXMAN_FILENAME="${PIXMAN_DIR}.tar.gz"
-
-  echo "Building pixman" $version "..."
 
   cd $BASEDIR/src
   rm -rf "$PIXMAN_DIR"
@@ -920,7 +855,6 @@ build_pixman()
   fi
 
   install_name_tool -id @rpath/libpixman-1.dylib $DEPLOYDIR/lib/"libpixman-1.dylib"
-  echo $version > $DEPLOYDIR/share/macosx-build-dependencies/pixman.version
 }
 
 build_cairo()
@@ -928,8 +862,6 @@ build_cairo()
   version=$1
   CAIRO_DIR="cairo-${version}"
   CAIRO_FILENAME="${CAIRO_DIR}.tar.xz"
-
-  echo "Building cairo" $version "..."
 
   cd $BASEDIR/src
   rm -rf "$CAIRO_DIR"
@@ -969,7 +901,6 @@ build_cairo()
 
   install_name_tool -id @rpath/libcairo.dylib $DEPLOYDIR/lib/libcairo.dylib
   install_name_tool -change @rpath/libpixman.dylib @rpath/libpixman-1.dylib $DEPLOYDIR/lib/libcairo.dylib
-  echo $version > $DEPLOYDIR/share/macosx-build-dependencies/cairo.version
 }
 
 if [ ! -f $OPENSCADDIR/openscad.appdata.xml.in ]; then


### PR DESCRIPTION
This allows us to add local patches to a package without having to force-rebuild dependencies.

Also bumping CircleCI xcode version as the existing one is deprecated.