### PR TITLE
Update installer.nsi Include EstimatedSize and DisplayIcon (Issue #4694)

### DIFF
--- a/scripts/installer.nsi
+++ b/scripts/installer.nsi
@@ -29,6 +29,8 @@ WriteRegStr HKLM "Software\Microsoft\Windows\CurrentVersion\Uninstall\OpenSCAD" 
 WriteRegStr HKLM "Software\Microsoft\Windows\CurrentVersion\Uninstall\OpenSCAD" "URLUpdateInfo" "https://openscad.org/downloads.html"
 WriteRegStr HKLM "Software\Microsoft\Windows\CurrentVersion\Uninstall\OpenSCAD" "HelpLink" "https://forum.openscad.org/"
 WriteRegStr HKLM "Software\Microsoft\Windows\CurrentVersion\Uninstall\OpenSCAD" "UninstallString" "$INSTDIR\Uninstall.exe"
+WriteRegStr HKLM "Software\Microsoft\Windows\CurrentVersion\Uninstall\OpenSCAD" "DisplayIcon" "$INSTDIR\openscad.exe"
+WriteRegStr HKLM "Software\Microsoft\Windows\CurrentVersion\Uninstall\OpenSCAD" "EstimatedSize" "68750"
 WriteRegStr HKCR ".scad" "PerceivedType" "text"
 SectionEnd
 Section "Uninstall"


### PR DESCRIPTION
In response to issue #4694, I've made a couple of changes to the install script for windows. It adds registry keys for the estimated install size for the Add and Remove Programs settings page as well as the correct icon for the OpenSCAD entry in the Application list.