### PR TITLE
Gsoc 2023: Rename vertices_size to num_vertices where appropriate

### DIFF
--- a/src/glview/VertexStateManager.cc
+++ b/src/glview/VertexStateManager.cc
@@ -1,33 +1,33 @@
 #include "VertexStateManager.h"
 
-void VertexStateManager::initializeSize(size_t vertices_size) {
+void VertexStateManager::initializeSize(size_t num_vertices) {
   std::vector<GLuint> placeholder;
   size_t placeholder_index = 0;
-  initializeSizeHelper(vertices_size, false, placeholder, placeholder_index);
+  initializeSizeHelper(num_vertices, false, placeholder, placeholder_index);
 }
 
-void VertexStateManager::initializeSize(size_t vertices_size, std::vector<GLuint> & vbos, size_t & vbo_index) {
-  initializeSizeHelper(vertices_size, true, vbos, vbo_index);
+void VertexStateManager::initializeSize(size_t num_vertices, std::vector<GLuint> & vbos, size_t & vbo_index) {
+  initializeSizeHelper(num_vertices, true, vbos, vbo_index);
 }
 
-void VertexStateManager::initializeSizeHelper(size_t vertices_size, bool multiple_vbo, std::vector<GLuint> & vbos, size_t & vbo_index) {
+void VertexStateManager::initializeSizeHelper(size_t num_vertices, bool multiple_vbo, std::vector<GLuint> & vbos, size_t & vbo_index) {
   if (Feature::ExperimentalVxORenderersDirect.is_enabled() || Feature::ExperimentalVxORenderersPrealloc.is_enabled()) {
-    size_t elements_size = 0;
+    size_t vertices_size = 0, elements_size = 0;
     if (Feature::ExperimentalVxORenderersIndexing.is_enabled()) {
       if (multiple_vbo) {
         vertex_array.elementsVBO() = vbos[vbo_index++];
       }
-      if (vertices_size <= 0xff) {
+      if (num_vertices <= 0xff) {
           vertex_array.addElementsData(std::make_shared<AttributeData<GLubyte, 1, GL_UNSIGNED_BYTE>>());
-      } else if (vertices_size <= 0xffff) {
+      } else if (num_vertices <= 0xffff) {
           vertex_array.addElementsData(std::make_shared<AttributeData<GLushort, 1, GL_UNSIGNED_SHORT>>());
       } else {
           vertex_array.addElementsData(std::make_shared<AttributeData<GLuint, 1, GL_UNSIGNED_INT>>());
       }
-      elements_size = vertices_size * vertex_array.elements().stride();
+      elements_size = num_vertices * vertex_array.elements().stride();
       vertex_array.elementsSize(elements_size);
     }
-    vertices_size *= vertex_array.stride();
+    vertices_size = num_vertices * vertex_array.stride();
     vertex_array.verticesSize(vertices_size);
 
     GL_TRACE("glBindBuffer(GL_ARRAY_BUFFER, %d)", vertex_array.verticesVBO());

--- a/src/glview/VertexStateManager.cc
+++ b/src/glview/VertexStateManager.cc
@@ -43,13 +43,13 @@ void VertexStateManager::initializeSizeHelper(size_t num_vertices, bool multiple
     vertex_array.addElementsData(std::make_shared<AttributeData<GLuint, 1, GL_UNSIGNED_INT>>());
   }
 }
-void VertexStateManager::addColor(const Color4f& last_color) {
+void VertexStateManager::addColor(const Color4f& color) {
   renderer.add_shader_pointers(vertex_array);
   Renderer::shaderinfo_t shader_info = renderer.getShader();
   std::shared_ptr<VertexState> color_state = std::make_shared<VBOShaderVertexState>(0, 0, vertex_array.verticesVBO(), vertex_array.elementsVBO());
-  color_state->glBegin().emplace_back([shader_info, last_color]() {
-    GL_CHECKD(glUniform4f(shader_info.data.csg_rendering.color_area, last_color[0], last_color[1], last_color[2], last_color[3]));
-    GL_CHECKD(glUniform4f(shader_info.data.csg_rendering.color_edge, (last_color[0] + 1) / 2, (last_color[1] + 1) / 2, (last_color[2] + 1) / 2, 1.0));
+  color_state->glBegin().emplace_back([shader_info, color]() {
+    GL_CHECKD(glUniform4f(shader_info.data.csg_rendering.color_area, color[0], color[1], color[2], color[3]));
+    GL_CHECKD(glUniform4f(shader_info.data.csg_rendering.color_edge, (color[0] + 1) / 2, (color[1] + 1) / 2, (color[2] + 1) / 2, 1.0));
   });
   vertex_array.states().emplace_back(std::move(color_state));
 }

--- a/src/glview/VertexStateManager.cc
+++ b/src/glview/VertexStateManager.cc
@@ -30,14 +30,10 @@ void VertexStateManager::initializeSizeHelper(size_t num_vertices, bool multiple
     vertices_size = num_vertices * vertex_array.stride();
     vertex_array.verticesSize(vertices_size);
 
-    GL_TRACE("glBindBuffer(GL_ARRAY_BUFFER, %d)", vertex_array.verticesVBO());
     GL_CHECKD(glBindBuffer(GL_ARRAY_BUFFER, vertex_array.verticesVBO()));
-    GL_TRACE("glBufferData(GL_ARRAY_BUFFER, %d, %p, GL_STATIC_DRAW)", vertices_size % (void *)nullptr);
     GL_CHECKD(glBufferData(GL_ARRAY_BUFFER, vertices_size, nullptr, GL_STATIC_DRAW));
     if (Feature::ExperimentalVxORenderersIndexing.is_enabled()) {
-      GL_TRACE("glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, %d)", vertex_array.elementsVBO());
       GL_CHECKD(glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, vertex_array.elementsVBO()));
-      GL_TRACE("glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, %d, %p, GL_STATIC_DRAW)", elements_size % (void *)nullptr);
       GL_CHECKD(glBufferData(GL_ELEMENT_ARRAY_BUFFER, elements_size, nullptr, GL_STATIC_DRAW));
     }
   } else if (Feature::ExperimentalVxORenderersIndexing.is_enabled()) {
@@ -52,9 +48,7 @@ void VertexStateManager::addColor(const Color4f& last_color) {
   Renderer::shaderinfo_t shader_info = renderer.getShader();
   std::shared_ptr<VertexState> color_state = std::make_shared<VBOShaderVertexState>(0, 0, vertex_array.verticesVBO(), vertex_array.elementsVBO());
   color_state->glBegin().emplace_back([shader_info, last_color]() {
-    GL_TRACE("glUniform4f(%d, %f, %f, %f, %f)", shader_info.data.csg_rendering.color_area % last_color[0] % last_color[1] % last_color[2] % last_color[3]);
     GL_CHECKD(glUniform4f(shader_info.data.csg_rendering.color_area, last_color[0], last_color[1], last_color[2], last_color[3]));
-    GL_TRACE("glUniform4f(%d, %f, %f, %f, 1.0)", shader_info.data.csg_rendering.color_edge % ((last_color[0] + 1) / 2) % ((last_color[1] + 1) / 2) % ((last_color[2] + 1) / 2));
     GL_CHECKD(glUniform4f(shader_info.data.csg_rendering.color_edge, (last_color[0] + 1) / 2, (last_color[1] + 1) / 2, (last_color[2] + 1) / 2, 1.0));
   });
   vertex_array.states().emplace_back(std::move(color_state));

--- a/src/glview/VertexStateManager.h
+++ b/src/glview/VertexStateManager.h
@@ -9,11 +9,11 @@
 class VertexStateManager {
 public:
   VertexStateManager(VBORenderer& r, VertexArray& v_a) : vertex_array(v_a), renderer(r) {}
-  void initializeSize(size_t vertices_size);
-  void initializeSize(size_t vertices_size, std::vector<GLuint> & vbos, size_t & vbo_index);
+  void initializeSize(size_t num_vertices);
+  void initializeSize(size_t num_vertices, std::vector<GLuint> & vbos, size_t & vbo_index);
   void addColor(const Color4f& last_color);
 private:
   VBORenderer& renderer;
   VertexArray& vertex_array;
-  void initializeSizeHelper(size_t vertices_size, bool multiple_vbo, std::vector<GLuint> & vbos, size_t & vbo_index);
+  void initializeSizeHelper(size_t num_vertices, bool multiple_vbo, std::vector<GLuint> & vbos, size_t & vbo_index);
 };

--- a/src/glview/VertexStateManager.h
+++ b/src/glview/VertexStateManager.h
@@ -11,7 +11,7 @@ public:
   VertexStateManager(VBORenderer& r, VertexArray& v_a) : vertex_array(v_a), renderer(r) {}
   void initializeSize(size_t num_vertices);
   void initializeSize(size_t num_vertices, std::vector<GLuint> & vbos, size_t & vbo_index);
-  void addColor(const Color4f& last_color);
+  void addColor(const Color4f& color);
 private:
   VBORenderer& renderer;
   VertexArray& vertex_array;

--- a/src/glview/cgal/CGALRenderer.cc
+++ b/src/glview/cgal/CGALRenderer.cc
@@ -147,15 +147,15 @@ void CGALRenderer::createPolySets()
   vertex_array.addSurfaceData();
 
 
-  size_t vertices_size = 0;
+  size_t num_vertices = 0;
   if (this->polysets.size()) {
     for (const auto& polyset : this->polysets) {
-      vertices_size += getSurfaceBufferSize(*polyset);
-      vertices_size += getEdgeBufferSize(*polyset);
+      num_vertices += getSurfaceBufferSize(*polyset);
+      num_vertices += getEdgeBufferSize(*polyset);
     }
   }
 
-  vsm.initializeSize(vertices_size);
+  vsm.initializeSize(num_vertices);
 
   for (const auto& polyset : this->polysets) {
     Color4f color;

--- a/src/glview/preview/OpenCSGRenderer.cc
+++ b/src/glview/preview/OpenCSGRenderer.cc
@@ -171,19 +171,19 @@ void OpenCSGRenderer::createCSGProducts(const CSGProducts& products, const Rende
     vertex_array.writeSurface();
     add_shader_data(vertex_array);
 
-    size_t vertices_size = 0;
+    size_t num_vertices = 0;
     for (const auto& csgobj : product.intersections) {
       if (csgobj.leaf->geom) {
-        vertices_size += getSurfaceBufferSize(csgobj, highlight_mode, background_mode, OpenSCADOperator::INTERSECTION);
+        num_vertices += getSurfaceBufferSize(csgobj, highlight_mode, background_mode, OpenSCADOperator::INTERSECTION);
       }
     }
     for (const auto& csgobj : product.subtractions) {
       if (csgobj.leaf->geom) {
-        vertices_size += getSurfaceBufferSize(csgobj, highlight_mode, background_mode, OpenSCADOperator::DIFFERENCE);
+        num_vertices += getSurfaceBufferSize(csgobj, highlight_mode, background_mode, OpenSCADOperator::DIFFERENCE);
       }
     }
 
-    vsm.initializeSize(vertices_size, all_vbos_, vbo_index);
+    vsm.initializeSize(num_vertices, all_vbos_, vbo_index);
 
     for (const auto& csgobj : product.intersections) {
       if (csgobj.leaf->geom) {

--- a/src/glview/preview/ThrownTogetherRenderer.cc
+++ b/src/glview/preview/ThrownTogetherRenderer.cc
@@ -62,12 +62,12 @@ void ThrownTogetherRenderer::prepare(bool /*showfaces*/, bool /*showedges*/, con
     VertexStateManager vsm(*this, vertex_array);
 
     
-    size_t vertices_size = 0;
-    if (this->root_products) vertices_size += (getSurfaceBufferSize(this->root_products, false, false, true) * 2);
-    if (this->background_products) vertices_size += getSurfaceBufferSize(this->background_products, false, true, true);
-    if (this->highlight_products) vertices_size += getSurfaceBufferSize(this->highlight_products, true, false, true);
+    size_t num_vertices = 0;
+    if (this->root_products) num_vertices += (getSurfaceBufferSize(this->root_products, false, false, true) * 2);
+    if (this->background_products) num_vertices += getSurfaceBufferSize(this->background_products, false, true, true);
+    if (this->highlight_products) num_vertices += getSurfaceBufferSize(this->highlight_products, true, false, true);
 
-    vsm.initializeSize(vertices_size);
+    vsm.initializeSize(num_vertices);
 
     if (this->root_products) createCSGProducts(*this->root_products, vertex_array, false, false);
     if (this->background_products) createCSGProducts(*this->background_products, vertex_array, false, true);


### PR DESCRIPTION
This PR also removes a couple of `GL_TRACE` statements. All these fixes address some feedback that @kintel previously left on #4675 that I decided to make into a separate PR.