### PR TITLE
Update msys2-install-dependencies.sh

### DIFF
--- a/scripts/msys2-install-dependencies.sh
+++ b/scripts/msys2-install-dependencies.sh
@@ -15,7 +15,7 @@ date "+### %Y-%m-%d %T msys2-install-dependencies started"
 pacman --query --explicit
 
 date "+### %Y-%m-%d %T install pactoys (for pacboy)"
-pacman --noconfirm --sync --needed pactoys
+pacman --noconfirm --sync --needed pactoys libxml2
 # pacboy is a pacman wrapper for MSYS2 which handles the package prefixes automatically
 #            name:p means MINGW_PACKAGE_PREFIX-only
 #            name:  disables any translation for name


### PR DESCRIPTION
libxml2 is needed for pacboy to work.
without libxml2 , pacboy invokes pacman with unknown option "-a"