### PR TITLE
Add new, more capable, GLX offscreen support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -604,9 +604,11 @@ elseif(UNIX)
       target_compile_definitions(OpenSCAD PRIVATE ENABLE_GLX)
       set(OFFSCREEN_METHOD "Unix GLX on X11")
       message(STATUS "Offscreen OpenGL Context - using Unix GLX on X11")
-      set(PLATFORM_SOURCES ${PLATFORM_SOURCES} src/glview/offscreen-old/OffscreenContextGLX.cc)
+      set(PLATFORM_SOURCES ${PLATFORM_SOURCES}
+          src/glview/offscreen-old/OffscreenContextGLX.cc
+          src/glview/OffscreenContextGLX.cc)
       find_package(X11 REQUIRED)
-      target_link_libraries(OpenSCAD PRIVATE X11::X11)
+      target_link_libraries(OpenSCAD PRIVATE X11::X11 ${CMAKE_DL_LIBS})
     endif()
   endif()
 elseif(WIN32)

--- a/src/glview/OffscreenContextFactory.cc
+++ b/src/glview/OffscreenContextFactory.cc
@@ -14,6 +14,7 @@
 #endif
 #ifdef ENABLE_GLX
 #include "offscreen-old/OffscreenContextGLX.h"
+#include "OffscreenContextGLX.h"
 #endif
 #ifdef NULLGL
 #include "OffscreenContextNULL.h"
@@ -32,7 +33,7 @@ const char *defaultProvider() {
   return "egl-old";
 #endif
 #ifdef ENABLE_GLX
-  return "glx-old";
+  return "glx";
 #endif
 #ifdef _WIN32
   return "wgl-old";
@@ -76,6 +77,9 @@ std::shared_ptr<OpenGLContext> create(const std::string& provider, const Offscre
 #ifdef ENABLE_GLX
   if (provider == "glx-old") {
    return offscreen_old::CreateOffscreenContextGLX(attrib.width, attrib.height, attrib.majorGLVersion, attrib.minorGLVersion, 
+                                    attrib.gles, attrib.compatibilityProfile);
+  } else if (provider == "glx") {
+   return CreateOffscreenContextGLX(attrib.width, attrib.height, attrib.majorGLVersion, attrib.minorGLVersion, 
                                     attrib.gles, attrib.compatibilityProfile);
   }
 #endif

--- a/src/glview/OffscreenContextGLX.cc
+++ b/src/glview/OffscreenContextGLX.cc
@@ -1,0 +1,189 @@
+#include "OffscreenContextGLX.h"
+
+#define GLAD_GLX_IMPLEMENTATION
+#include <glad/glx.h>
+
+#include <iostream>
+#include <sstream>
+
+#include "scope_guard.hpp"
+#include "printutils.h"
+
+namespace {
+
+int xlibLastError = 0;
+int xlibErrorHandler(Display *dpy, XErrorEvent *event) {
+  xlibLastError = event->error_code;
+  return 0;
+}
+
+}  // namespace
+
+class OffscreenContextGLX : public OffscreenContext {
+public:
+  GLXContext glxContext = nullptr;
+  Display *display = nullptr;
+  Window xWindow = 0;
+  OffscreenContextGLX(int width, int height) : OffscreenContext(width, height) {}
+  ~OffscreenContextGLX() {
+    if (this->display) {
+      if (this->glxContext) glXDestroyContext(this->display, this->glxContext);
+      if (this->xWindow) XDestroyWindow(this->display, this->xWindow);
+      XCloseDisplay(this->display);
+    }
+  }
+
+  // FIXME: What info are we really interested in here?
+  std::string getInfo() const override {
+    std::ostringstream result;
+
+    int major, minor;
+    glXQueryVersion(this->display, &major, &minor);
+
+    result << "GL context creator: GLX (new)\n"
+	         << "GLX version: " << major << "." << minor << "\n"
+	         << "PNG generator: lodepng\n";
+
+    return result.str();
+  }
+
+  bool makeCurrent() const override {
+    return glXMakeContextCurrent(this->display, this->xWindow, this->xWindow, this->glxContext);
+  }
+
+  // Create an OpenGL context, and a dummy X11 window to draw into, without showing (mapping) it.
+  // This purposely does not use glxCreateWindow, to avoid crashes,
+  // "failed to create drawable" errors, and Mesa "WARNING: Application calling
+  // GLX 1.3 function when GLX 1.3 is not supported! This is an application bug!"
+
+  //  This function will alter ctx.openGLContext and ctx.xwindow if successful
+  bool createGLXContext(size_t majorGLVersion, size_t minorGLVersion, bool compatibilityProfile) {
+    const int attributes[] = {
+      GLX_DRAWABLE_TYPE, GLX_WINDOW_BIT | GLX_PIXMAP_BIT | GLX_PBUFFER_BIT, //support all 3, for OpenCSG
+      GLX_RENDER_TYPE, GLX_RGBA_BIT,
+      GLX_RED_SIZE, 8,
+      GLX_GREEN_SIZE, 8,
+      GLX_BLUE_SIZE, 8,
+      GLX_ALPHA_SIZE, 8,
+      GLX_DEPTH_SIZE, 24, // depth-stencil for OpenCSG
+      GLX_STENCIL_SIZE, 8,
+      GLX_DOUBLEBUFFER, true, // FIXME: Do we need this?
+      None
+    };
+
+    int numConfigs = 0;
+    GLXFBConfig *fbconfigs = nullptr;
+    XVisualInfo *visinfo = nullptr;
+    auto guard = sg::make_scope_guard([fbconfigs, visinfo]() {
+      if (fbconfigs) XFree(fbconfigs);
+      if (visinfo)XFree(visinfo);
+    });
+      fbconfigs = glXChooseFBConfig(this->display, DefaultScreen(this->display), attributes, &numConfigs);
+    if (fbconfigs == nullptr) {
+      std::cerr << "glXChooseFBConfig() failed" << std::endl;
+      return false;
+    }
+    visinfo = glXGetVisualFromFBConfig(this->display, fbconfigs[0]);
+    if (visinfo == nullptr) {
+      std::cerr << "glXGetVisualFromFBConfig failed" << std::endl;
+      return false;
+    }
+
+    // We can't depend on XCreateWindow() returning 0 on failure, so we use a custom Xlib error handler
+    XErrorHandler originalErrorHandler = XSetErrorHandler(xlibErrorHandler);
+    auto errorGuard = sg::make_scope_guard([originalErrorHandler]() {
+      XSetErrorHandler(originalErrorHandler);
+    });
+
+    const auto root = DefaultRootWindow(this->display);
+    XSetWindowAttributes windowAttributes = {
+      .event_mask = StructureNotifyMask | ExposureMask | KeyPressMask,
+      .colormap = XCreateColormap(this->display, root, visinfo->visual, AllocNone), 
+    };
+    unsigned long mask = CWBackPixel | CWBorderPixel | CWColormap | CWEventMask;
+
+    this->xWindow = 
+      XCreateWindow(this->display, root, 0, 0, this->width(), this->height(), 0, 
+                    visinfo->depth, InputOutput, visinfo->visual, mask, &windowAttributes);
+    XSync(this->display, false);
+    if (xlibLastError != Success) {
+      char description[1024];
+      XGetErrorText(this->display, xlibLastError, description, 1023);
+      std::cerr << "XCreateWindow() failed: " << description << std::endl;
+      return false;
+    }
+
+
+    GLint context_attributes[] = {
+      GLX_CONTEXT_MAJOR_VERSION_ARB, static_cast<GLint>(majorGLVersion),
+      GLX_CONTEXT_MINOR_VERSION_ARB, static_cast<GLint>(minorGLVersion),
+      GLX_CONTEXT_PROFILE_MASK_ARB, compatibilityProfile ? GLX_CONTEXT_COMPATIBILITY_PROFILE_BIT_ARB : GLX_CONTEXT_CORE_PROFILE_BIT_ARB,
+      None
+    };
+
+    if (glXCreateContextAttribsARB) {
+      this->glxContext = glXCreateContextAttribsARB(this->display, fbconfigs[0], nullptr, 1, context_attributes);
+      if (!this->glxContext) {
+        std::cerr << "Unable to create GLX context using glXCreateContextAttribsARB()" << std::endl;
+      }
+    }
+    if (!this->glxContext) {
+      this->glxContext = glXCreateNewContext(this->display, fbconfigs[0], GLX_RGBA_TYPE, nullptr, 1);
+      if (!this->glxContext) {
+        std::cerr << "Unable to create GLX context using glXCreateNewContext()" << std::endl;
+        return false;
+      }
+    }
+    return true;
+  }
+};
+
+
+/*
+   create a dummy X window without showing it. (without 'mapping' it)
+   and save information to the ctx.
+
+   This purposely does not use glxCreateWindow, to avoid crashes,
+   "failed to create drawable" errors, and Mesa "WARNING: Application calling
+   GLX 1.3 function when GLX 1.3 is not supported! This is an application bug!"
+
+   This function will alter ctx.openGLContext and ctx.xwindow if successful
+ */
+std::shared_ptr<OffscreenContext> CreateOffscreenContextGLX(size_t width, size_t height,
+							    size_t majorGLVersion, size_t minorGLVersion, bool gles, bool compatibilityProfile)
+{
+  auto ctx = std::make_shared<OffscreenContextGLX>(width, height);
+
+  ctx->display = XOpenDisplay(nullptr);
+  if (ctx->display == nullptr) {
+    std::cerr << "Unable to open a connection to the X server." << std::endl;
+    auto dpyenv = getenv("DISPLAY");
+    std::cerr << "DISPLAY=" << (dpyenv?dpyenv:"") << std::endl;
+    return nullptr;
+  }
+
+  int glxVersion = gladLoaderLoadGLX(ctx->display, DefaultScreen(ctx->display));
+  if (!glxVersion) {
+      std::cerr << "GLAD: Unable to load GLX" << std::endl;
+      return nullptr;
+  }
+  int glxMajor = GLAD_VERSION_MAJOR(glxVersion);
+  int glxMinor = GLAD_VERSION_MINOR(glxVersion);
+  PRINTDB("GLAD: Loaded GLX %d.%d", glxMajor % glxMinor);
+
+  // We require GLX >= 1.3.
+  // However, glxQueryVersion sometimes returns an earlier version than is actually available, so 
+  // we also accept GLX < 1.3 as long as glXGetVisualFromFBConfig() exists.
+  // FIXME: Figure out if this is still relevant with GLAD, as we may want to check functions anyway?
+  if (glxMajor == 1 && glxMinor <= 2 && glXGetVisualFromFBConfig == nullptr) {
+    std::cerr << "Error: GLX version 1.3 functions missing. "
+              << "Your GLX version: " << glxMajor << "." << glxMinor << std::endl;
+    return nullptr;
+  }
+  
+  if (!ctx->createGLXContext(majorGLVersion, minorGLVersion, compatibilityProfile)) {
+    return nullptr;
+  }
+
+	return ctx;
+}

--- a/src/glview/OffscreenContextGLX.h
+++ b/src/glview/OffscreenContextGLX.h
@@ -1,0 +1,9 @@
+#pragma once
+
+#include <memory>
+
+#include "OffscreenContext.h"
+
+std::shared_ptr<OffscreenContext> CreateOffscreenContextGLX(
+    size_t width, size_t height, size_t majorGLVersion,
+    size_t minorGLVersion, bool gles, bool compatibilityProfile);

--- a/src/io/export_png.cc
+++ b/src/io/export_png.cc
@@ -60,7 +60,7 @@ std::unique_ptr<OffscreenView> prepare_preview(Tree& tree, const ViewOptions& op
   try {
     glview = std::make_unique<OffscreenView>(camera.pixel_width, camera.pixel_height);
   } catch (const OffscreenViewException &ex) {
-    fprintf(stderr, "Can't create OffscreenView: %s.\n", ex.what());
+    LOG("Can't create OffscreenView: %1$s.", ex.what());
     return nullptr;
   }
 

--- a/src/utils/scope_guard.hpp
+++ b/src/utils/scope_guard.hpp
@@ -1,0 +1,212 @@
+/*
+ * https://github.com/ricab/scope_guard
+ * Author: ricab
+ *
+ * This is free and unencumbered software released into the public domain.
+ *
+ * Anyone is free to copy, modify, publish, use, compile, sell, or
+ * distribute this software, either in source code form or as a compiled
+ * binary, for any purpose, commercial or non-commercial, and by any
+ * means.
+ *
+ * In jurisdictions that recognize copyright laws, the author or authors
+ * of this software dedicate any and all copyright interest in the
+ * software to the public domain. We make this dedication for the benefit
+ * of the public at large and to the detriment of our heirs and
+ * successors. We intend this dedication to be an overt act of
+ * relinquishment in perpetuity of all present and future rights to this
+ * software under copyright law.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+ * OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+ * ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * For more information, please refer to <http://unlicense.org>
+ */
+#ifndef SCOPE_GUARD_HPP_
+#define SCOPE_GUARD_HPP_
+
+#include <type_traits>
+#include <utility>
+
+#if __cplusplus >= 201703L
+#define SG_NODISCARD [[nodiscard]]
+#ifdef SG_REQUIRE_NOEXCEPT_IN_CPP17
+#define SG_REQUIRE_NOEXCEPT
+#endif
+#else
+#define SG_NODISCARD
+#endif
+
+namespace sg
+{
+  namespace detail
+  {
+    /* --- Some custom type traits --- */
+
+    // Type trait determining whether a type is callable with no arguments
+    template<typename T, typename = void>
+    struct is_noarg_callable_t
+      : public std::false_type
+    {}; // in general, false
+
+    template<typename T>
+    struct is_noarg_callable_t<T, decltype(std::declval<T&&>()())>
+      : public std::true_type
+    {}; // only true when call expression valid
+
+    // Type trait determining whether a no-argument callable returns void
+    template<typename T>
+    struct returns_void_t
+      : public std::is_same<void, decltype(std::declval<T&&>()())>
+    {};
+
+    /* Type trait determining whether a no-arg callable is nothrow invocable if
+    required. This is where SG_REQUIRE_NOEXCEPT logic is encapsulated. */
+    template<typename T>
+    struct is_nothrow_invocable_if_required_t
+      : public
+#ifdef SG_REQUIRE_NOEXCEPT
+          std::is_nothrow_invocable<T> /* Note: _r variants not enough to
+                                          confirm void return: any return can be
+                                          discarded so all returns are
+                                          compatible with void */
+#else
+          std::true_type
+#endif
+    {};
+
+    // logic AND of two or more type traits
+    template<typename A, typename B, typename... C>
+    struct and_t : public and_t<A, and_t<B, C...>>
+    {}; // for more than two arguments
+
+    template<typename A, typename B>
+    struct and_t<A, B> : public std::conditional<A::value, B, A>::type
+    {}; // for two arguments
+
+    // Type trait determining whether a type is a proper scope_guard callback.
+    template<typename T>
+    struct is_proper_sg_callback_t
+      : public and_t<is_noarg_callable_t<T>,
+                     returns_void_t<T>,
+                     is_nothrow_invocable_if_required_t<T>,
+                     std::is_nothrow_destructible<T>>
+    {};
+
+
+    /* --- The actual scope_guard template --- */
+
+    template<typename Callback,
+             typename = typename std::enable_if<
+               is_proper_sg_callback_t<Callback>::value>::type>
+    class scope_guard;
+
+
+    /* --- Now the friend maker --- */
+
+    template<typename Callback>
+    detail::scope_guard<Callback> make_scope_guard(Callback&& callback)
+    noexcept(std::is_nothrow_constructible<Callback, Callback&&>::value); /*
+    we need this in the inner namespace due to MSVC bugs preventing
+    sg::detail::scope_guard from befriending a sg::make_scope_guard
+    template instance in the parent namespace (see https://is.gd/xFfFhE). */
+
+
+    /* --- The template specialization that actually defines the class --- */
+
+    template<typename Callback>
+    class SG_NODISCARD scope_guard<Callback> final
+    {
+    public:
+      typedef Callback callback_type;
+
+      scope_guard(scope_guard&& other)
+      noexcept(std::is_nothrow_constructible<Callback, Callback&&>::value);
+
+      ~scope_guard() noexcept; // highlight noexcept dtor
+
+      void dismiss() noexcept;
+
+    public:
+      scope_guard() = delete;
+      scope_guard(const scope_guard&) = delete;
+      scope_guard& operator=(const scope_guard&) = delete;
+      scope_guard& operator=(scope_guard&&) = delete;
+
+    private:
+      explicit scope_guard(Callback&& callback)
+      noexcept(std::is_nothrow_constructible<Callback, Callback&&>::value); /*
+                                                      meant for friends only */
+
+      friend scope_guard<Callback> make_scope_guard<Callback>(Callback&&)
+      noexcept(std::is_nothrow_constructible<Callback, Callback&&>::value); /*
+      only make_scope_guard can create scope_guards from scratch (i.e. non-move)
+      */
+
+    private:
+      Callback m_callback;
+      bool m_active;
+
+    };
+
+  } // namespace detail
+
+
+  /* --- Now the single public maker function --- */
+
+  using detail::make_scope_guard; // see comment on declaration above
+
+} // namespace sg
+
+////////////////////////////////////////////////////////////////////////////////
+template<typename Callback>
+sg::detail::scope_guard<Callback>::scope_guard(Callback&& callback)
+noexcept(std::is_nothrow_constructible<Callback, Callback&&>::value)
+  : m_callback(std::forward<Callback>(callback)) /* use () instead of {} because
+    of DR 1467 (https://is.gd/WHmWuo), which still impacts older compilers
+    (e.g. GCC 4.x and clang <=3.6, see https://godbolt.org/g/TE9tPJ and
+    https://is.gd/Tsmh8G) */
+  , m_active{true}
+{}
+
+////////////////////////////////////////////////////////////////////////////////
+template<typename Callback>
+sg::detail::scope_guard<Callback>::scope_guard::~scope_guard() noexcept  /*
+need the extra injected-class-name here to make different compilers happy */
+{
+  if(m_active)
+    m_callback();
+}
+
+////////////////////////////////////////////////////////////////////////////////
+template<typename Callback>
+sg::detail::scope_guard<Callback>::scope_guard(scope_guard&& other)
+noexcept(std::is_nothrow_constructible<Callback, Callback&&>::value)
+  : m_callback(std::forward<Callback>(other.m_callback)) // idem
+  , m_active{std::move(other.m_active)}
+{
+  other.m_active = false;
+}
+
+////////////////////////////////////////////////////////////////////////////////
+template<typename Callback>
+inline void sg::detail::scope_guard<Callback>::dismiss() noexcept
+{
+  m_active = false;
+}
+
+////////////////////////////////////////////////////////////////////////////////
+template<typename Callback>
+inline auto sg::detail::make_scope_guard(Callback&& callback)
+noexcept(std::is_nothrow_constructible<Callback, Callback&&>::value)
+-> detail::scope_guard<Callback>
+{
+  return detail::scope_guard<Callback>{std::forward<Callback>(callback)};
+}
+
+#endif /* SCOPE_GUARD_HPP_ */


### PR DESCRIPTION
This is the GLX portion of https://github.com/openscad/openscad/pull/4582 - splitting up that PR as testing on all platforms is time consuming.

 * [x] Implementation
 * [x] Error handling
 * Automated tests
   * [x] GLEW + new
   * [x] GLEW + old
   * [x] GLAD+ new
   * [x] GLAD + old
 * export test
   * [x] GLEW + new
   * [x] GLEW + old
   * [x] GLAD+ new
   * [x] GLAD + old
