### PR TITLE
Set resource class for macOS runner.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -161,6 +161,7 @@ jobs:
           path: /tmp/out
           destination: wasm
   openscad-macos:
+    resource_class: macos.x86.medium.gen2
     macos:
       xcode: 14.3.1
     environment:


### PR DESCRIPTION
As notified by CircleCI:

> This is your final reminder to update any projects using the macOS medium resource by October 2nd. After 10/2, any jobs that run on the medium macOS resource will show an “invalid resource class” error.

> Please update the resource class key in your configuration file to macos.x86.medium.gen2 before October 2nd.