### PR TITLE
VBO: Make vertex-object-renderers-direct and -prealloc enabled by default

### DIFF
--- a/src/Feature.cc
+++ b/src/Feature.cc
@@ -36,8 +36,6 @@ const Feature Feature::ExperimentalInputDriverDBus("input-driver-dbus", "Enable 
 const Feature Feature::ExperimentalLazyUnion("lazy-union", "Enable lazy unions.");
 const Feature Feature::ExperimentalVxORenderers("vertex-object-renderers", "Enable vertex object renderers");
 const Feature Feature::ExperimentalVxORenderersIndexing("vertex-object-renderers-indexing", "Enable indexing in vertex object renderers");
-const Feature Feature::ExperimentalVxORenderersDirect("vertex-object-renderers-direct", "Enable direct buffer writes in vertex object renderers");
-const Feature Feature::ExperimentalVxORenderersPrealloc("vertex-object-renderers-prealloc", "Enable preallocating buffers in vertex object renderers");
 const Feature Feature::ExperimentalTextMetricsFunctions("textmetrics", "Enable the <code>textmetrics()</code> and <code>fontmetrics()</code> functions.");
 const Feature Feature::ExperimentalImportFunction("import-function", "Enable import function returning data instead of geometry.");
 const Feature Feature::ExperimentalPredictibleOutput("predictible-output", "Attempt to produce predictible, diffable outputs (e.g. sorting the STL, or remeshing in a determined order)");

--- a/src/Feature.h
+++ b/src/Feature.h
@@ -23,8 +23,6 @@ public:
   static const Feature ExperimentalLazyUnion;
   static const Feature ExperimentalVxORenderers;
   static const Feature ExperimentalVxORenderersIndexing;
-  static const Feature ExperimentalVxORenderersDirect;
-  static const Feature ExperimentalVxORenderersPrealloc;
   static const Feature ExperimentalTextMetricsFunctions;
   static const Feature ExperimentalImportFunction;
   static const Feature ExperimentalPredictibleOutput;

--- a/src/glview/VertexArray.h
+++ b/src/glview/VertexArray.h
@@ -340,9 +340,7 @@ public:
   inline size_t verticesSize() const { return vertices_size_; }
   inline void setVerticesSize(size_t vertices_size) {
     vertices_size_ = vertices_size;
-    if (Feature::ExperimentalVxORenderersPrealloc.is_enabled()) {
-      interleaved_buffer_.resize(vertices_size_);
-    }
+    interleaved_buffer_.resize(vertices_size_);
   }
   inline size_t verticesOffset() const { return vertices_offset_; }
   inline void setVerticesOffset(size_t offset) { vertices_offset_ = offset; }

--- a/src/glview/cgal/CGALRenderer.cc
+++ b/src/glview/cgal/CGALRenderer.cc
@@ -217,14 +217,12 @@ void CGALRenderer::createPolySets()
   }
 
   if (this->polysets.size()) {
-    if (Feature::ExperimentalVxORenderersDirect.is_enabled() || Feature::ExperimentalVxORenderersPrealloc.is_enabled()) {
-      if (Feature::ExperimentalVxORenderersIndexing.is_enabled()) {
-        GL_TRACE0("glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, 0)");
-        GL_CHECKD(glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, 0));
-      }
-      GL_TRACE0("glBindBuffer(GL_ARRAY_BUFFER, 0)");
-      GL_CHECKD(glBindBuffer(GL_ARRAY_BUFFER, 0));
+    if (Feature::ExperimentalVxORenderersIndexing.is_enabled()) {
+      GL_TRACE0("glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, 0)");
+      GL_CHECKD(glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, 0));
     }
+    GL_TRACE0("glBindBuffer(GL_ARRAY_BUFFER, 0)");
+    GL_CHECKD(glBindBuffer(GL_ARRAY_BUFFER, 0));
 
     vertex_array.createInterleavedVBOs();
   }

--- a/src/glview/cgal/CGAL_OGL_VBO_helper.h
+++ b/src/glview/cgal/CGAL_OGL_VBO_helper.h
@@ -285,14 +285,12 @@ public:
     points_edges_states.emplace_back(std::move(vs));
     points_edges_array.addAttributePointers(last_size);
 
-    if (Feature::ExperimentalVxORenderersDirect.is_enabled() || Feature::ExperimentalVxORenderersPrealloc.is_enabled()) {
-      if (Feature::ExperimentalVxORenderersIndexing.is_enabled()) {
-        GL_TRACE0("glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, 0)");
-        GL_CHECKD(glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, 0));
-      }
-      GL_TRACE0("glBindBuffer(GL_ARRAY_BUFFER, 0)");
-      GL_CHECKD(glBindBuffer(GL_ARRAY_BUFFER, 0));
+    if (Feature::ExperimentalVxORenderersIndexing.is_enabled()) {
+      GL_TRACE0("glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, 0)");
+      GL_CHECKD(glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, 0));
     }
+    GL_TRACE0("glBindBuffer(GL_ARRAY_BUFFER, 0)");
+    GL_CHECKD(glBindBuffer(GL_ARRAY_BUFFER, 0));
 
     points_edges_array.createInterleavedVBOs();
 

--- a/src/glview/preview/OpenCSGRenderer.cc
+++ b/src/glview/preview/OpenCSGRenderer.cc
@@ -327,14 +327,12 @@ void OpenCSGRenderer::createCSGVBOProducts(const CSGProducts& products, const Re
       }
     }
 
-    if (Feature::ExperimentalVxORenderersDirect.is_enabled() || Feature::ExperimentalVxORenderersPrealloc.is_enabled()) {
-      if (Feature::ExperimentalVxORenderersIndexing.is_enabled()) {
-        GL_TRACE0("glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, 0)");
-        GL_CHECKD(glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, 0));
-      }
-      GL_TRACE0("glBindBuffer(GL_ARRAY_BUFFER, 0)");
-      GL_CHECKD(glBindBuffer(GL_ARRAY_BUFFER, 0));
+    if (Feature::ExperimentalVxORenderersIndexing.is_enabled()) {
+      GL_TRACE0("glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, 0)");
+      GL_CHECKD(glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, 0));
     }
+    GL_TRACE0("glBindBuffer(GL_ARRAY_BUFFER, 0)");
+    GL_CHECKD(glBindBuffer(GL_ARRAY_BUFFER, 0));
 
     vertex_array.createInterleavedVBOs();
     vbo_vertex_products.emplace_back(std::make_unique<OpenCSGVBOProduct>(

--- a/src/glview/preview/ThrownTogetherRenderer.cc
+++ b/src/glview/preview/ThrownTogetherRenderer.cc
@@ -73,14 +73,12 @@ void ThrownTogetherRenderer::prepare(bool /*showfaces*/, bool /*showedges*/, con
     if (this->background_products) createCSGProducts(*this->background_products, vertex_array, false, true);
     if (this->highlight_products) createCSGProducts(*this->highlight_products, vertex_array, true, false);
 
-    if (Feature::ExperimentalVxORenderersDirect.is_enabled() || Feature::ExperimentalVxORenderersPrealloc.is_enabled()) {
-      if (Feature::ExperimentalVxORenderersIndexing.is_enabled()) {
-        GL_TRACE0("glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, 0)");
-        GL_CHECKD(glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, 0));
-      }
-      GL_TRACE0("glBindBuffer(GL_ARRAY_BUFFER, 0)");
-      GL_CHECKD(glBindBuffer(GL_ARRAY_BUFFER, 0));
+    if (Feature::ExperimentalVxORenderersIndexing.is_enabled()) {
+      GL_TRACE0("glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, 0)");
+      GL_CHECKD(glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, 0));
     }
+    GL_TRACE0("glBindBuffer(GL_ARRAY_BUFFER, 0)");
+    GL_CHECKD(glBindBuffer(GL_ARRAY_BUFFER, 0));
 
     vertex_array.createInterleavedVBOs();
   }

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -392,8 +392,6 @@ function(add_cmdline_test TESTCMD_BASENAME)
     # Enable vertex-object-renderers by default for all test if experimental build
     if (EXPERIMENTAL)
       set(EXPERIMENTAL_OPTION ${EXPERIMENTAL_OPTION} "--enable=vertex-object-renderers")
-      set(EXPERIMENTAL_OPTION ${EXPERIMENTAL_OPTION} "--enable=vertex-object-renderers-prealloc")
-      set(EXPERIMENTAL_OPTION ${EXPERIMENTAL_OPTION} "--enable=vertex-object-renderers-direct")
       #set(EXPERIMENTAL_OPTION ${EXPERIMENTAL_OPTION} "--enable=vertex-object-renderers-indexing")
     endif()
 


### PR DESCRIPTION
This enables the `vertex-object-renderers-direct` and `vertex-object-renderers-prealloc` functionality together with `vertex-object-renderers` is enabled, and removes them as options.

The main reason is that `glBufferSubData()` is too slow on macOS, so we'll prefer preallocating buffers, but this has proven to be very slow on Linux too for certain types of models.

Related to https://github.com/openscad/openscad/issues/4782

Fixes #4883, #4504

