### PR TITLE
Add image difference mask to tests

### DIFF
--- a/tests/image_compare.py
+++ b/tests/image_compare.py
@@ -2,6 +2,7 @@
 
 from PIL import Image
 import numpy as np
+import os
 import sys
 
 
@@ -36,15 +37,28 @@ def Compare3x3(img1, img2):
   a = a[:,0:-2] * a[:,1:-1] * a[:,2:]
   a = s * np.abs(a)**(1/9)
 
-  return a
+  mask_a = np.array(img2)
+  if len(s.shape)==3:
+    gray_s = np.any(s, axis=2)
+  else:
+    mask_a = np.stack((mask_a,)*3, axis=2)
+    gray_s = s
+  for i in range(3):
+    for j in range(3):
+      mask_a[i:mask_a.shape[0]-2+i, j:mask_a.shape[1]-2+j][gray_s] = [255,40,40]
+
+  return a, mask_a
 
 def CompareImageFiles(path1, path2):
   img1 = Image.open(path1)
   img2 = Image.open(path2)
+  split = os.path.splitext(path2)
+  maskpath = f'{split[0]}_mask{split[1]}'
 
   # Obtains the 3x3 pixel block comparisons, flattens both image dimensions
   # and color channels into a 1D array, and sorts in descending order.
-  pixel_diffs = np.sort(Compare3x3(img1, img2).ravel())[::-1]
+  diff_arr, mask = Compare3x3(img1, img2)
+  pixel_diffs = np.sort(diff_arr.ravel())[::-1]
   pixel_cnt = pixel_diffs.shape[0]
 
   diff_cnt = np.sum(pixel_diffs!=0)
@@ -58,6 +72,7 @@ def CompareImageFiles(path1, path2):
     # that are actually differing.
     med_diff = np.median(pixel_diffs[:diff_cnt])
     print(f'{perc_diff:0.8f}% of 3x3 blocks differ with median block diff: {med_diff:0.2f}')
+    Image.fromarray(mask).save(maskpath)
     return False
 
 if __name__ == '__main__':

--- a/tests/image_compare.py
+++ b/tests/image_compare.py
@@ -15,6 +15,10 @@ def Compare3x3(img1, img2):
      012 123 234) for difference between the two images, and returns an array
      of the geometric mean difference for any blocks that have like-signed
      differences of magnitude 3 or greater in all 9 pixels.
+
+     A mask image is generated highlighting in bright red (#FF2828) the
+     pixels of the second image which contributed to the failed equality
+     test.  For "actual.png" the mask is saved to "actual_mask.png".
   '''
   a1 = np.array(img1, dtype=float)
   a2 = np.array(img2, dtype=float)
@@ -73,6 +77,7 @@ def CompareImageFiles(path1, path2):
     med_diff = np.median(pixel_diffs[:diff_cnt])
     print(f'{perc_diff:0.8f}% of 3x3 blocks differ with median block diff: {med_diff:0.2f}')
     Image.fromarray(mask).save(maskpath)
+    print(f'Highlight mask saved to: {maskpath}')
     return False
 
 if __name__ == '__main__':

--- a/tests/test_pretty_print.py
+++ b/tests/test_pretty_print.py
@@ -286,9 +286,9 @@ class Templates(object):
 
     image_template = '''<table>
     <tbody>
-    <tr><td colspan="2">{test_name}</td></tr>
-    <tr><td> Expected image </td><td> Actual image </td></tr>
-    <tr><td> {expected} </td><td> {actual} </td></tr>
+    <tr><td colspan="3">{test_name}</td></tr>
+    <tr><td> Expected image </td><td> Actual image </td><td> Failure mask </td></tr>
+    <tr><td> {expected} </td><td> {actual} </td><td> {mask} </td></tr>
     </tbody>
     </table>
 
@@ -358,6 +358,14 @@ def to_html(project_name, startdate, tests, enddate, sysinfo, sysid, imgcomparer
             actual_img = png_encode64(test.actualfile,
                                   data=test.actualfile_data, alt=alttxt)
 
+            split = os.path.splitext(test.actualfile)
+            test.maskfile = f'{split[0]}_mask{split[1]}'
+            test.maskfile_data = tryread(test.maskfile)
+            if not os.path.exists(test.maskfile):
+                alttxt = 'mask missing for ' + test.fullname
+            mask_img = png_encode64(test.maskfile,
+                                  data=test.maskfile_data, alt=alttxt)
+
             if not os.path.exists(test.expectedfile):
                 alttxt = 'no img generated for ' + test.fullname
             expected_img = png_encode64(test.expectedfile,
@@ -367,7 +375,8 @@ def to_html(project_name, startdate, tests, enddate, sysinfo, sysid, imgcomparer
                           test_name=test.fullname,
                           test_log=test.fulltestlog,
                           actual=actual_img,
-                          expected=expected_img)
+                          expected=expected_img,
+                          mask=mask_img)
         else:
             raise TypeError('Unknown test type %r' % test.type)
 


### PR DESCRIPTION
This adds in support in the testing suite for generating an image with a bright red overlay on the parts of the image that differ between expected and actual.  It also adds an output column to the html report that includes this difference highlighting image.  The highlight image is only generated if there is a test failure result from image comparison, which occurs if and only if there is some part of the image which could be highlighted.
![image](https://github.com/openscad/openscad/assets/1266642/1e08731f-3dba-4ccc-a7bc-9246c34a0c46)

For future clarification, the mask is added onto the actual rather than the expected.  In most cases this doesn't matter much, but this could make a difference in certain cases where the test does not pick up a difference (such as 1 or 2 pixel width stripes).  In that case those additional anomalies in the actual image created by the current test run would be preserved in the difference image unhighlighted.