### PR TITLE
Rename --render=cgal to --render=force to force-convert to the current backend-specific geometry

### DIFF
--- a/src/geometry/GeometryUtils.cc
+++ b/src/geometry/GeometryUtils.cc
@@ -514,7 +514,7 @@ std::shared_ptr<const Geometry> GeometryUtils::getBackendSpecificGeometry(const 
 #if ENABLE_MANIFOLD
   if (Feature::ExperimentalManifold.is_enabled()) {
     if (const auto ps = std::dynamic_pointer_cast<const PolySet>(geom)) {
-      return ManifoldUtils::createMutableManifoldFromPolySet(*ps);
+      return ManifoldUtils::createManifoldFromPolySet(*ps);
     } else if (auto mani = std::dynamic_pointer_cast<const ManifoldGeometry>(geom)) {
       return geom;
     } else {

--- a/src/geometry/GeometryUtils.cc
+++ b/src/geometry/GeometryUtils.cc
@@ -508,12 +508,12 @@ Transform3d GeometryUtils::getResizeTransform(const BoundingBox &bbox, const Vec
 
 // Return or force creation of backend-specific geometry.
 // Will prefer Manifold if multiple backends are enabled.
-// geom must be a 3D geometry and must be a PolySet or already the correct backend-specific geometry
+// geom must be a 3D PolySet or the correct backend-specific geometry.
 std::shared_ptr<const Geometry> GeometryUtils::getBackendSpecificGeometry(const std::shared_ptr<const Geometry>& geom)
 {
 #if ENABLE_MANIFOLD
   if (Feature::ExperimentalManifold.is_enabled()) {
-    if (auto ps = std::dynamic_pointer_cast<const PolySet>(geom)) {
+    if (const auto ps = std::dynamic_pointer_cast<const PolySet>(geom)) {
       return ManifoldUtils::createMutableManifoldFromPolySet(*ps);
     } else if (auto mani = std::dynamic_pointer_cast<const ManifoldGeometry>(geom)) {
       return geom;

--- a/src/geometry/GeometryUtils.cc
+++ b/src/geometry/GeometryUtils.cc
@@ -2,9 +2,16 @@
 #include "ext/libtess2/Include/tesselator.h"
 #include "printutils.h"
 #include "Reindexer.h"
-#include <unordered_map>
+#include "Feature.h"
+#include "manifoldutils.h"
+#include "PolySet.h"
+#ifdef ENABLE_CGAL
+#include "cgalutils.h"
+#include "CGALHybridPolyhedron.h"
+#endif
 #include <string>
 #include <cmath>
+#include <memory>
 
 #include <boost/functional/hash.hpp>
 
@@ -497,4 +504,42 @@ Transform3d GeometryUtils::getResizeTransform(const BoundingBox &bbox, const Vec
     0, 0, 0, 1;
 
   return t;
+}
+
+// Return or force creation of backend-specific geometry.
+// Will prefer Manifold if multiple backends are enabled.
+// geom must be a 3D geometry and must be a PolySet or already the correct backend-specific geometry
+std::shared_ptr<const Geometry> GeometryUtils::getBackendSpecificGeometry(const std::shared_ptr<const Geometry>& geom)
+{
+#if ENABLE_MANIFOLD
+  if (Feature::ExperimentalManifold.is_enabled()) {
+    if (auto ps = std::dynamic_pointer_cast<const PolySet>(geom)) {
+      return ManifoldUtils::createMutableManifoldFromPolySet(*ps);
+    } else if (auto mani = std::dynamic_pointer_cast<const ManifoldGeometry>(geom)) {
+      return geom;
+    } else {
+      assert(false && "Unexpected geometry");
+    }
+  }
+#endif
+#if ENABLE_CGAL
+  if (Feature::ExperimentalFastCsg.is_enabled()) {
+    if (auto ps = std::dynamic_pointer_cast<const PolySet>(geom)) {
+      return CGALUtils::createHybridPolyhedronFromPolySet(*ps);
+    } else if (auto poly = std::dynamic_pointer_cast<const CGALHybridPolyhedron>(geom)) {
+      return geom;
+    } else {
+      assert(false && "Unexpected geometry");
+    }
+  } else {
+    if (auto ps = std::dynamic_pointer_cast<const PolySet>(geom)) {
+      return CGALUtils::createNefPolyhedronFromPolySet(*ps);
+    } else if (auto poly = std::dynamic_pointer_cast<const CGAL_Nef_polyhedron>(geom)) {
+      return geom;
+    } else {
+      assert(false && "Unexpected geometry");
+    }
+  }
+#endif
+  return nullptr;
 }

--- a/src/geometry/GeometryUtils.h
+++ b/src/geometry/GeometryUtils.h
@@ -1,8 +1,10 @@
 #pragma once
 
 #include "linalg.h"
+#include "Geometry.h"
 #include <vector>
 #include <boost/container/small_vector.hpp>
+#include <memory>
 
 using Polygon = std::vector<Vector3d>;
 using Polygons = std::vector<Polygon>;
@@ -29,6 +31,7 @@ struct IndexedPolyMesh {
 };
 
 namespace GeometryUtils {
+
 bool tessellatePolygon(const Polygon& polygon,
                        Polygons& triangles,
                        const Vector3f *normal = nullptr);
@@ -41,4 +44,6 @@ int findUnconnectedEdges(const std::vector<std::vector<IndexedFace>>& polygons);
 int findUnconnectedEdges(const std::vector<IndexedTriangle>& triangles);
 
 Transform3d getResizeTransform(const BoundingBox &bbox, const Vector3d& newsize, const Eigen::Matrix<bool, 3, 1>& autosize);
+std::shared_ptr<const Geometry> getBackendSpecificGeometry(const std::shared_ptr<const Geometry>& geom);
+
 }

--- a/src/geometry/manifold/ManifoldGeometry.h
+++ b/src/geometry/manifold/ManifoldGeometry.h
@@ -47,6 +47,17 @@ public:
   void operator-=(ManifoldGeometry& other);
   /*! In-place minkowksi operation. */
   void minkowski(ManifoldGeometry& other);
+
+  /*! union. */
+  ManifoldGeometry operator+(const ManifoldGeometry& other) const;
+  /*! intersection. */
+  ManifoldGeometry operator*(const ManifoldGeometry& other) const;
+  /*! difference. */
+  ManifoldGeometry operator-(const ManifoldGeometry& other) const;
+  /*! minkowksi operation. */
+  ManifoldGeometry minkowski(const ManifoldGeometry& other) const;
+
+
   void transform(const Transform3d& mat) override;
   void resize(const Vector3d& newsize, const Eigen::Matrix<bool, 3, 1>& autosize) override;
 
@@ -56,5 +67,5 @@ public:
   const manifold::Manifold& getManifold() const;
 
 private:
-  std::shared_ptr<manifold::Manifold> manifold_;
+  std::shared_ptr<const manifold::Manifold> manifold_;
 };

--- a/src/geometry/manifold/manifold-applyops-minkowski.cc
+++ b/src/geometry/manifold/manifold-applyops-minkowski.cc
@@ -175,7 +175,7 @@ std::shared_ptr<const Geometry> applyMinkowskiManifold(const Geometry::Geometrie
         t.reset();
 
         CGALUtils::triangulateFaces(mesh);
-        return ManifoldUtils::createMutableManifoldFromSurfaceMesh(mesh);
+        return ManifoldUtils::createManifoldFromSurfaceMesh(mesh);
       };
 
       std::vector<std::shared_ptr<const ManifoldGeometry>> result_parts(part_points[0].size() * part_points[1].size());

--- a/src/geometry/manifold/manifold-applyops-minkowski.cc
+++ b/src/geometry/manifold/manifold-applyops-minkowski.cc
@@ -111,9 +111,9 @@ std::shared_ptr<const Geometry> applyMinkowskiManifold(const Geometry::Geometrie
         std::vector<Hull_kernel::Point_3> minkowski_points;
 
         minkowski_points.reserve(points0.size() * points1.size());
-        for (size_t i = 0; i < points0.size(); ++i) {
-          for (size_t j = 0; j < points1.size(); ++j) {
-            minkowski_points.push_back(points0[i] + (points1[j] - CGAL::ORIGIN));
+        for (const auto& p0 : points0) {
+          for (const auto p1 : points1) {
+            minkowski_points.push_back(p0 + (p1 - CGAL::ORIGIN));
           }
         }
 

--- a/src/geometry/manifold/manifoldutils.cc
+++ b/src/geometry/manifold/manifoldutils.cc
@@ -66,7 +66,7 @@ std::shared_ptr<manifold::Manifold> trustedPolySetToManifold(const PolySet& ps) 
 }
 
 template <class TriangleMesh>
-std::shared_ptr<ManifoldGeometry> createMutableManifoldFromSurfaceMesh(const TriangleMesh& tm)
+std::shared_ptr<const ManifoldGeometry> createManifoldFromSurfaceMesh(const TriangleMesh& tm)
 {
   typedef typename TriangleMesh::Vertex_index vertex_descriptor;
 
@@ -102,11 +102,11 @@ std::shared_ptr<ManifoldGeometry> createMutableManifoldFromSurfaceMesh(const Tri
 }
 
 #ifdef ENABLE_CGAL
-template std::shared_ptr<ManifoldGeometry> createMutableManifoldFromSurfaceMesh(const CGAL::Surface_mesh<CGAL::Point_3<CGAL::Epick>> &tm);
-template std::shared_ptr<ManifoldGeometry> createMutableManifoldFromSurfaceMesh(const CGAL_DoubleMesh &tm);
+template std::shared_ptr<const ManifoldGeometry> createManifoldFromSurfaceMesh(const CGAL::Surface_mesh<CGAL::Point_3<CGAL::Epick>> &tm);
+template std::shared_ptr<const ManifoldGeometry> createManifoldFromSurfaceMesh(const CGAL_DoubleMesh &tm);
 #endif
 
-std::shared_ptr<ManifoldGeometry> createMutableManifoldFromPolySet(const PolySet& ps)
+std::shared_ptr<const ManifoldGeometry> createManifoldFromPolySet(const PolySet& ps)
 {
 #ifdef ENABLE_CGAL
   PolySet psq(ps);
@@ -141,22 +141,19 @@ std::shared_ptr<ManifoldGeometry> createMutableManifoldFromPolySet(const PolySet
     }
   }
 
-  return createMutableManifoldFromSurfaceMesh(m);
+  return createManifoldFromSurfaceMesh(m);
 #else
   return std::make_shared<ManifoldGeometry>();
 #endif
 }
 
-std::shared_ptr<ManifoldGeometry> createMutableManifoldFromGeometry(const std::shared_ptr<const Geometry>& geom) {
+std::shared_ptr<const ManifoldGeometry> createManifoldFromGeometry(const std::shared_ptr<const Geometry>& geom) {
   if (auto mani = std::dynamic_pointer_cast<const ManifoldGeometry>(geom)) {
-    return std::make_shared<ManifoldGeometry>(*mani);
+    return mani;
   }
-
-  auto ps = PolySetUtils::getGeometryAsPolySet(geom);
-  if (ps) {
-    return createMutableManifoldFromPolySet(*ps);
+  if (auto ps = PolySetUtils::getGeometryAsPolySet(geom)) {
+    return createManifoldFromPolySet(*ps);
   }
-  
   return nullptr;
 }
 

--- a/src/geometry/manifold/manifoldutils.h
+++ b/src/geometry/manifold/manifoldutils.h
@@ -16,14 +16,14 @@ namespace ManifoldUtils {
 
   const char* statusToString(manifold::Manifold::Error status);
 
-  /*! If the PolySet isn't trusted, use createMutableManifoldFromPolySet which will triangulate and reorient it. */
+  /*! If the PolySet isn't trusted, use createManifoldFromPolySet which will triangulate and reorient it. */
   std::shared_ptr<manifold::Manifold> trustedPolySetToManifold(const PolySet& ps);
 
-  std::shared_ptr<ManifoldGeometry> createMutableManifoldFromPolySet(const PolySet& ps);
-  std::shared_ptr<ManifoldGeometry> createMutableManifoldFromGeometry(const std::shared_ptr<const Geometry>& geom);
+  std::shared_ptr<const ManifoldGeometry> createManifoldFromPolySet(const PolySet& ps);
+  std::shared_ptr<const ManifoldGeometry> createManifoldFromGeometry(const std::shared_ptr<const Geometry>& geom);
 
   template <class TriangleMesh>
-  std::shared_ptr<ManifoldGeometry> createMutableManifoldFromSurfaceMesh(const TriangleMesh& mesh);
+  std::shared_ptr<const ManifoldGeometry> createManifoldFromSurfaceMesh(const TriangleMesh& mesh);
 
   std::shared_ptr<const ManifoldGeometry> applyOperator3DManifold(const Geometry::Geometries& children, OpenSCADOperator op);
 

--- a/src/io/export.h
+++ b/src/io/export.h
@@ -115,7 +115,7 @@ void export_nef3(const std::shared_ptr<const Geometry>& geom, std::ostream& outp
 
 
 enum class Previewer { OPENCSG, THROWNTOGETHER };
-enum class RenderType { GEOMETRY, CGAL, OPENCSG, THROWNTOGETHER };
+enum class RenderType { GEOMETRY, BACKEND_SPECIFIC, OPENCSG, THROWNTOGETHER };
 
 struct ExportFileFormatOptions {
   const std::map<const std::string, FileFormat> exportFileFormats{

--- a/src/openscad.cc
+++ b/src/openscad.cc
@@ -52,6 +52,10 @@
 #include <vector>
 #include <fstream>
 
+#ifdef ENABLE_MANIFOLD
+#include "manifoldutils.h"
+#endif
+
 #ifdef ENABLE_CGAL
 #include "CGAL_Nef_polyhedron.h"
 #include "cgalutils.h"

--- a/src/openscad.cc
+++ b/src/openscad.cc
@@ -338,7 +338,7 @@ struct CommandLine
   const std::string summaryFile;
 };
 
-int do_export(const CommandLine& cmd, const RenderVariables& render_variables, FileFormat curFormat, SourceFile *root_file);
+int do_export(const CommandLine& cmd, const RenderVariables& render_variables, FileFormat export_format, SourceFile *root_file);
 
 int cmdline(const CommandLine& cmd)
 {
@@ -479,7 +479,7 @@ int cmdline(const CommandLine& cmd)
   }
 }
 
-int do_export(const CommandLine& cmd, const RenderVariables& render_variables, FileFormat curFormat, SourceFile *root_file)
+int do_export(const CommandLine& cmd, const RenderVariables& render_variables, FileFormat export_format, SourceFile *root_file)
 {
   auto filename_str = fs::path(cmd.output_file).generic_string();
   auto fpath = fs::absolute(fs::path(cmd.filename));
@@ -529,7 +529,7 @@ int do_export(const CommandLine& cmd, const RenderVariables& render_variables, F
   }
   Tree tree(root_node, fparent.string());
 
-  if (curFormat == FileFormat::CSG) {
+  if (export_format == FileFormat::CSG) {
     // https://github.com/openscad/openscad/issues/128
     // When I use the csg ouptput from the command line the paths in 'import'
     // statements become relative. But unfortunately they become relative to
@@ -540,17 +540,17 @@ int do_export(const CommandLine& cmd, const RenderVariables& render_variables, F
       stream << tree.getString(*root_node, "\t") << "\n";
     });
     fs::current_path(cmd.original_path);
-  } else if (curFormat == FileFormat::AST) {
+  } else if (export_format == FileFormat::AST) {
     fs::current_path(fparent); // Force exported filenames to be relative to document path
     with_output(cmd.is_stdout, filename_str, [root_file](std::ostream& stream) {
       stream << root_file->dump("");
     });
     fs::current_path(cmd.original_path);
-  } else if (curFormat == FileFormat::PARAM) {
+  } else if (export_format == FileFormat::PARAM) {
     with_output(cmd.is_stdout, filename_str, [&root_file, &fpath](std::ostream& stream) {
       export_param(root_file, fpath, stream);
     });
-  } else if (curFormat == FileFormat::TERM) {
+  } else if (export_format == FileFormat::TERM) {
     CSGTreeEvaluator csgRenderer(tree);
     auto root_raw_term = csgRenderer.buildCSGTree(*root_node);
     with_output(cmd.is_stdout, filename_str, [root_raw_term](std::ostream& stream) {
@@ -560,7 +560,7 @@ int do_export(const CommandLine& cmd, const RenderVariables& render_variables, F
         stream << root_raw_term->dump() << "\n";
       }
     });
-  } else if (curFormat == FileFormat::ECHO) {
+  } else if (export_format == FileFormat::ECHO) {
     // echo -> don't need to evaluate any geometry
   } else {
     // start measuring render time
@@ -568,55 +568,54 @@ int do_export(const CommandLine& cmd, const RenderVariables& render_variables, F
     GeometryEvaluator geomevaluator(tree);
     unique_ptr<OffscreenView> glview;
     std::shared_ptr<const Geometry> root_geom;
-    if ((curFormat == FileFormat::ECHO || curFormat == FileFormat::PNG) && (cmd.viewOptions.renderer == RenderType::OPENCSG || cmd.viewOptions.renderer == RenderType::THROWNTOGETHER)) {
+    if ((export_format == FileFormat::ECHO || export_format == FileFormat::PNG) && (cmd.viewOptions.renderer == RenderType::OPENCSG || cmd.viewOptions.renderer == RenderType::THROWNTOGETHER)) {
       // OpenCSG or throwntogether png -> just render a preview
       glview = prepare_preview(tree, cmd.viewOptions, camera);
       if (!glview) return 1;
-    }
-#ifdef ENABLE_CGAL
-    else {
+    } else {
       // Force creation of concrete geometry (mostly for testing)
       // FIXME: Consider adding MANIFOLD as a valid --render argument and ViewOption, to be able to distinguish from CGAL
 
       constexpr bool allownef = true;
       root_geom = geomevaluator.evaluateGeometry(*tree.root(), allownef);
       if (root_geom) {
-        if (cmd.viewOptions.renderer == RenderType::CGAL && root_geom->getDimension() == 3) {
+        if (cmd.viewOptions.renderer == RenderType::BACKEND_SPECIFIC && root_geom->getDimension() == 3) {
           if (auto geomlist = std::dynamic_pointer_cast<const GeometryList>(root_geom)) {
             auto flatlist = geomlist->flatten();
             for (auto& child : flatlist) {
               if (child.second->getDimension() == 3) {
-                child.second = CGALUtils::getNefPolyhedronFromGeometry(child.second);
+                child.second = GeometryUtils::getBackendSpecificGeometry(child.second);
               }
             }
             root_geom = std::make_shared<GeometryList>(flatlist);
           } else {
-            root_geom = CGALUtils::getNefPolyhedronFromGeometry(root_geom);
+            root_geom = GeometryUtils::getBackendSpecificGeometry(root_geom);
           }
-          LOG("Converted to Nef polyhedron");
+          LOG("Converted to backend-specific geometry");
         }
       } else {
-	// FIXME: The default geometry doesn't need to be a Nef polyhedron. Why not make it a PolySet?
-        root_geom = std::make_shared<CGAL_Nef_polyhedron>();
+        root_geom = std::make_shared<PolySet>(3);
+        if (cmd.viewOptions.renderer == RenderType::BACKEND_SPECIFIC) {
+          root_geom = GeometryUtils::getBackendSpecificGeometry(root_geom);
+        }
       }
     }
-#endif
-    if (is3D(curFormat)) {
-      if (!checkAndExport(root_geom, 3, curFormat, cmd.is_stdout, filename_str)) {
+    if (is3D(export_format)) {
+      if (!checkAndExport(root_geom, 3, export_format, cmd.is_stdout, filename_str)) {
         return 1;
       }
     }
 
-    if (is2D(curFormat)) {
-      if (!checkAndExport(root_geom, 2, curFormat, cmd.is_stdout, filename_str)) {
+    if (is2D(export_format)) {
+      if (!checkAndExport(root_geom, 2, export_format, cmd.is_stdout, filename_str)) {
         return 1;
       }
     }
 
-    if (curFormat == FileFormat::PNG) {
+    if (export_format == FileFormat::PNG) {
       bool success = true;
       bool wrote = with_output(cmd.is_stdout, filename_str, [&success, &root_geom, &cmd, &camera, &glview](std::ostream& stream) {
-        if (cmd.viewOptions.renderer == RenderType::CGAL || cmd.viewOptions.renderer == RenderType::GEOMETRY) {
+        if (cmd.viewOptions.renderer == RenderType::BACKEND_SPECIFIC || cmd.viewOptions.renderer == RenderType::GEOMETRY) {
           success = export_png(root_geom, cmd.viewOptions, camera, stream);
         } else {
           success = export_png(*glview, stream);
@@ -1082,8 +1081,12 @@ int main(int argc, char **argv)
   if (vm.count("preview")) {
     if (vm["preview"].as<string>() == "throwntogether") viewOptions.renderer = RenderType::THROWNTOGETHER;
   } else if (vm.count("render")) {
-    if (vm["render"].as<string>() == "cgal") viewOptions.renderer = RenderType::CGAL;
-    else viewOptions.renderer = RenderType::GEOMETRY;
+    // Note: "cgal" is here for backwards compatibility, can probably be removed soon
+    if (vm["render"].as<string>() == "cgal" || vm["render"].as<string>() == "force") {
+      viewOptions.renderer = RenderType::BACKEND_SPECIFIC;
+    } else {
+      viewOptions.renderer = RenderType::GEOMETRY;
+    }
   }
 
   viewOptions.previewer = (viewOptions.renderer == RenderType::THROWNTOGETHER) ? Previewer::THROWNTOGETHER : Previewer::OPENCSG;

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -928,10 +928,10 @@ set_test_config(Examples FILES ${EXAMPLE_2D_FILES} PREFIXES dxfpngtest)
 # o csgpngtest: 1) Export to .csg, 2) import .csg and export to PNG (--render)
 # o monotonepngtest: Same as cgalpngtest but with the "Monotone" color scheme
 # o stlpngtest: Export to STL, Re-import and render to PNG (--render)
-# o stlcgalpngtest: Export to STL, Re-import and render to PNG (--render=cgal)
+# o stlcgalpngtest: Export to STL, Re-import and render to PNG (--render=force)
 # o offpngtest: Export to OFF, Re-import and render to PNG (--render)
-# o offcgalpngtest: Export to STL, Re-import and render to PNG (--render=cgal)
-# o dxfpngtest: Export to DXF, Re-import and render to PNG (--render=cgal)
+# o offcgalpngtest: Export to STL, Re-import and render to PNG (--render=force)
+# o dxfpngtest: Export to DXF, Re-import and render to PNG (--render=force)
 #
 
 add_cmdline_test(astdumptest OPENSCAD SUFFIX ast FILES
@@ -1004,10 +1004,10 @@ add_cmdline_test(lazyunion-dump        EXPERIMENTAL OPENSCAD SUFFIX csg FILES ${
 add_cmdline_test(lazyunion-opencsg     EXPERIMENTAL OPENSCAD SUFFIX png FILES ${LAZYUNION_FILES} ARGS --enable=lazy-union)
 add_cmdline_test(lazyunion-cgalpng     EXPERIMENTAL OPENSCAD SUFFIX png FILES ${LAZYUNION_FILES} ARGS --enable=lazy-union --render)
 add_cmdline_test(lazyunion-monotonepng EXPERIMENTAL OPENSCAD SUFFIX png FILES ${LAZYUNION_3D_FILES} ARGS --colorscheme=Monotone --enable=lazy-union --render )
-add_cmdline_test(lazyunion-stlpngtest  EXPERIMENTAL SCRIPT ${EX_IM_PNGTEST_PY} SUFFIX png FILES ${LAZYUNION_3D_FILES} EXPECTEDDIR lazyunion-monotonepng ARGS ${OPENSCAD_ARG} --format=STL --enable=lazy-union --render=cgal)
-add_cmdline_test(lazyunion-offpngtest  EXPERIMENTAL SCRIPT ${EX_IM_PNGTEST_PY} SUFFIX png FILES ${LAZYUNION_3D_FILES} EXPECTEDDIR lazyunion-monotonepng ARGS ${OPENSCAD_ARG} --format=OFF --enable=lazy-union --render=cgal)
-add_cmdline_test(lazyunion-dxfpngtest  EXPERIMENTAL SCRIPT ${EX_IM_PNGTEST_PY} SUFFIX png FILES ${LAZYUNION_2D_FILES} EXPECTEDDIR lazyunion-cgalpng     ARGS ${OPENSCAD_ARG} --format=DXF --enable=lazy-union --render=cgal)
-add_cmdline_test(lazyunion-svgpngtest  EXPERIMENTAL SCRIPT ${EX_IM_PNGTEST_PY} SUFFIX png FILES ${LAZYUNION_2D_FILES} EXPECTEDDIR lazyunion-cgalpng     ARGS ${OPENSCAD_ARG} --format=SVG --enable=lazy-union --render=cgal)
+add_cmdline_test(lazyunion-stlpngtest  EXPERIMENTAL SCRIPT ${EX_IM_PNGTEST_PY} SUFFIX png FILES ${LAZYUNION_3D_FILES} EXPECTEDDIR lazyunion-monotonepng ARGS ${OPENSCAD_ARG} --format=STL --enable=lazy-union --render=force)
+add_cmdline_test(lazyunion-offpngtest  EXPERIMENTAL SCRIPT ${EX_IM_PNGTEST_PY} SUFFIX png FILES ${LAZYUNION_3D_FILES} EXPECTEDDIR lazyunion-monotonepng ARGS ${OPENSCAD_ARG} --format=OFF --enable=lazy-union --render=force)
+add_cmdline_test(lazyunion-dxfpngtest  EXPERIMENTAL SCRIPT ${EX_IM_PNGTEST_PY} SUFFIX png FILES ${LAZYUNION_2D_FILES} EXPECTEDDIR lazyunion-cgalpng     ARGS ${OPENSCAD_ARG} --format=DXF --enable=lazy-union --render=force)
+add_cmdline_test(lazyunion-svgpngtest  EXPERIMENTAL SCRIPT ${EX_IM_PNGTEST_PY} SUFFIX png FILES ${LAZYUNION_2D_FILES} EXPECTEDDIR lazyunion-cgalpng     ARGS ${OPENSCAD_ARG} --format=SVG --enable=lazy-union --render=force)
 
 add_cmdline_test(manifold-cgalpng      EXPERIMENTAL OPENSCAD SUFFIX png FILES ${SCADFILES_WITH_DIFFERENT_MANIFOLD_EXPECTATIONS} ARGS --enable=manifold --render)
 
@@ -1021,8 +1021,8 @@ add_cmdline_test(offpngtest    SCRIPT ${EX_IM_PNGTEST_PY} SUFFIX png FILES ${EXP
 add_cmdline_test(amfpngtest    SCRIPT ${EX_IM_PNGTEST_PY} SUFFIX png FILES ${EXP_IMP_3D_TEST} EXPECTEDDIR monotonepngtest ARGS ${OPENSCAD_ARG} --format=AMF)
 add_cmdline_test(3mfpngtest    SCRIPT ${EX_IM_PNGTEST_PY} SUFFIX png FILES ${EXP_IMP_3D_TEST} EXPECTEDDIR monotonepngtest ARGS ${OPENSCAD_ARG} --format=3MF)
 add_cmdline_test(objpngtest    SCRIPT ${EX_IM_PNGTEST_PY} SUFFIX png FILES ${EXP_IMP_3D_TEST} EXPECTEDDIR monotonepngtest ARGS ${OPENSCAD_ARG} --format=OBJ)
-add_cmdline_test(dxfpngtest    SCRIPT ${EX_IM_PNGTEST_PY} SUFFIX png FILES ${EXP_IMP_2D_TEST} EXPECTEDDIR monotonepngtest ARGS ${OPENSCAD_ARG} --format=DXF --render=cgal)
-add_cmdline_test(svgpngtest    SCRIPT ${EX_IM_PNGTEST_PY} SUFFIX png FILES ${EXP_IMP_2D_TEST} EXPECTEDDIR monotonepngtest ARGS ${OPENSCAD_ARG} --format=SVG --render=cgal)
+add_cmdline_test(dxfpngtest    SCRIPT ${EX_IM_PNGTEST_PY} SUFFIX png FILES ${EXP_IMP_2D_TEST} EXPECTEDDIR monotonepngtest ARGS ${OPENSCAD_ARG} --format=DXF --render=force)
+add_cmdline_test(svgpngtest    SCRIPT ${EX_IM_PNGTEST_PY} SUFFIX png FILES ${EXP_IMP_2D_TEST} EXPECTEDDIR monotonepngtest ARGS ${OPENSCAD_ARG} --format=SVG --render=force)
 add_cmdline_test(pdfexporttest SCRIPT ${EXPORT_PNGTEST_PY} SUFFIX png FILES ${SCAD_PDF_FILES} EXPECTEDDIR pdfexporttest ARGS ${OPENSCAD_ARG} --format=PDF KERNEL Square:2)
 
 # Corner-case Export/Import tests
@@ -1037,14 +1037,14 @@ add_cmdline_test(stlpngtest            SCRIPT ${EX_IM_PNGTEST_PY} ARGS ${OPENSCA
 # cgalstlpngtest: CGAL STL output, normal rendering
 add_cmdline_test(stlcgalpngtest        SCRIPT ${EX_IM_PNGTEST_PY} ARGS ${OPENSCAD_ARG} --format=STL --require-manifold --render EXPECTEDDIR monotonepngtest SUFFIX png FILES ${EXPORT3D_CGAL_TEST_FILES})
 # cgalstlcgalpngtest: CGAL STL output, CGAL rendering
-add_cmdline_test(cgalstlcgalpngtest    SCRIPT ${EX_IM_PNGTEST_PY} ARGS ${OPENSCAD_ARG} --format=ASCIISTL --require-manifold --render=cgal EXPECTEDDIR monotonepngtest SUFFIX png FILES ${EXPORT3D_CGALCGAL_TEST_FILES})
+add_cmdline_test(cgalstlcgalpngtest    SCRIPT ${EX_IM_PNGTEST_PY} ARGS ${OPENSCAD_ARG} --format=ASCIISTL --require-manifold --render=force EXPECTEDDIR monotonepngtest SUFFIX png FILES ${EXPORT3D_CGALCGAL_TEST_FILES})
 
 # cgalbinstlcgalpngtest: CGAL binary STL output, CGAL rendering
-add_cmdline_test(cgalbinstlcgalpngtest SCRIPT ${EX_IM_PNGTEST_PY} ARGS ${OPENSCAD_ARG} --format=BINSTL --require-manifold --render=cgal EXPECTEDDIR monotonepngtest SUFFIX png FILES ${EXPORT3D_CGALCGAL_TEST_FILES})
+add_cmdline_test(cgalbinstlcgalpngtest SCRIPT ${EX_IM_PNGTEST_PY} ARGS ${OPENSCAD_ARG} --format=BINSTL --require-manifold --render=force EXPECTEDDIR monotonepngtest SUFFIX png FILES ${EXPORT3D_CGALCGAL_TEST_FILES})
 add_cmdline_test(offpngtest            SCRIPT ${EX_IM_PNGTEST_PY} ARGS ${OPENSCAD_ARG} --format=OFF --render EXPECTEDDIR monotonepngtest SUFFIX png FILES ${EXPORT3D_TEST_FILES})
-add_cmdline_test(offcgalpngtest        SCRIPT ${EX_IM_PNGTEST_PY} ARGS ${OPENSCAD_ARG} --format=OFF --render=cgal EXPECTEDDIR monotonepngtest SUFFIX png FILES ${EXPORT3D_CGAL_TEST_FILES})
-add_cmdline_test(dxfpngtest            SCRIPT ${EX_IM_PNGTEST_PY} ARGS ${OPENSCAD_ARG} --format=DXF --render=cgal EXPECTEDDIR cgalpngtest SUFFIX png FILES ${FILES_2D} ${SCAD_DXF_FILES})
-add_cmdline_test(svgpngtest            SCRIPT ${EX_IM_PNGTEST_PY} ARGS ${OPENSCAD_ARG} --format=SVG --render=cgal EXPECTEDDIR cgalpngtest SUFFIX png FILES ${FILES_2D} ${SCAD_SVG_FILES})
+add_cmdline_test(offcgalpngtest        SCRIPT ${EX_IM_PNGTEST_PY} ARGS ${OPENSCAD_ARG} --format=OFF --render=force EXPECTEDDIR monotonepngtest SUFFIX png FILES ${EXPORT3D_CGAL_TEST_FILES})
+add_cmdline_test(dxfpngtest            SCRIPT ${EX_IM_PNGTEST_PY} ARGS ${OPENSCAD_ARG} --format=DXF --render=force EXPECTEDDIR cgalpngtest SUFFIX png FILES ${FILES_2D} ${SCAD_DXF_FILES})
+add_cmdline_test(svgpngtest            SCRIPT ${EX_IM_PNGTEST_PY} ARGS ${OPENSCAD_ARG} --format=SVG --render=force EXPECTEDDIR cgalpngtest SUFFIX png FILES ${FILES_2D} ${SCAD_SVG_FILES})
 
 # Failing tests
 add_failing_test(stlfailedtest         SUFFIX stl  FILES ${TEST_SCAD_DIR}/misc/empty-union.scad ARGS --retval=1)
@@ -1175,8 +1175,8 @@ add_cmdline_test(opencsgtest        EXPERIMENTAL OPENSCAD FILES ${EXPERIMENTAL_T
 add_cmdline_test(throwntogethertest EXPERIMENTAL OPENSCAD FILES ${EXPERIMENTAL_TEXTMETRICS_FILES} ARGS --preview=throwntogether --enable=textmetrics SUFFIX png)
 add_cmdline_test(csgpngtest         EXPERIMENTAL SCRIPT ${EX_IM_PNGTEST_PY} SUFFIX png FILES ${EXPERIMENTAL_TEXTMETRICS_FILES} EXPECTEDDIR cgalpngtest ARGS ${OPENSCAD_ARG} --format=csg --render --enable=textmetrics)
 add_cmdline_test(cgalpngtest        EXPERIMENTAL OPENSCAD FILES ${EXPERIMENTAL_TEXTMETRICS_FILES} SUFFIX png ARGS --render --enable=textmetrics)
-add_cmdline_test(dxfpngtest         EXPERIMENTAL SCRIPT ${EX_IM_PNGTEST_PY} ARGS ${OPENSCAD_ARG} --format=DXF --render=cgal --enable=textmetrics EXPECTEDDIR cgalpngtest SUFFIX png FILES ${EXPERIMENTAL_TEXTMETRICS_FILES})
-add_cmdline_test(svgpngtest         EXPERIMENTAL SCRIPT ${EX_IM_PNGTEST_PY} ARGS ${OPENSCAD_ARG} --format=SVG --render=cgal --enable=textmetrics EXPECTEDDIR cgalpngtest SUFFIX png FILES ${EXPERIMENTAL_TEXTMETRICS_FILES})
+add_cmdline_test(dxfpngtest         EXPERIMENTAL SCRIPT ${EX_IM_PNGTEST_PY} ARGS ${OPENSCAD_ARG} --format=DXF --render=force --enable=textmetrics EXPECTEDDIR cgalpngtest SUFFIX png FILES ${EXPERIMENTAL_TEXTMETRICS_FILES})
+add_cmdline_test(svgpngtest         EXPERIMENTAL SCRIPT ${EX_IM_PNGTEST_PY} ARGS ${OPENSCAD_ARG} --format=SVG --render=force --enable=textmetrics EXPECTEDDIR cgalpngtest SUFFIX png FILES ${EXPERIMENTAL_TEXTMETRICS_FILES})
 
 
 ############################

--- a/tests/export_import_pngtest.py
+++ b/tests/export_import_pngtest.py
@@ -14,7 +14,7 @@
 #
 # All the optional openscad args are passed on to OpenSCAD both in step 2 and 4.
 # Exception: In any --render arguments are passed, the first pass (step 2) will always
-# be run with --render=cgal while the second pass (step 4) will use the passed --render
+# be run with --render=force while the second pass (step 4) will use the passed --render
 # argument.
 #
 # This script should return 0 on success, not-0 on error.
@@ -99,9 +99,9 @@ if inputsuffix != '.scad' and inputsuffix != '.csg':
 
 #
 # First run: Just export the given filetype
-# For any --render arguments to --render=cgal
+# For any --render arguments to --render=force
 #
-tmpargs =  ['--render=cgal' if arg.startswith('--render') else arg for arg in remaining_args]
+tmpargs =  ['--render=force' if arg.startswith('--render') else arg for arg in remaining_args]
 
 if export_format is not None:
     tmpargs.extend(['--export-format', export_format])


### PR DESCRIPTION
`--render=cgal` was really meant for converting to the internal format of the current geometry engine to utilize any of its built-in mesh validation and repair tools. When using another geometry backend, we're changing this to `--render=force` to force conversion into the current backend-specific geometry.

`--render=cgal` is still useable for backwards compatibility, but not sure for how much longer we need to support it.

Also added some opportunistic refactoring.