### PR TITLE
use newer tbb for mxe build

### DIFF
--- a/scripts/release-common.sh
+++ b/scripts/release-common.sh
@@ -171,6 +171,45 @@ echo "Checking pre-requisites..."
 
 git submodule update --init --recursive
 
+if [ "$OS" = "UNIX_CROSS_WIN" ]; then
+  cd submodules/manifold
+  echo "Patching manifold to use newer TBB version"
+  # The MXE provided TBB is too old and somehow causes linker problem.
+  # The latest version cannot compile on MXE due to compiler internal error,
+  # so we use v2021.8.0.
+  git apply << EOF
+diff --git a/src/utilities/CMakeLists.txt b/src/utilities/CMakeLists.txt
+index b1cf20a..235fb8c 100644
+--- a/src/utilities/CMakeLists.txt
++++ b/src/utilities/CMakeLists.txt
+@@ -52,10 +52,10 @@ if (TRACY_ENABLE)
+ endif()
+
+ if(MANIFOLD_PAR STREQUAL "TBB")
+-    find_package(PkgConfig)
+-    if (PKG_CONFIG_FOUND)
+-        pkg_check_modules(TBB tbb)
+-    endif()
++       #find_package(PkgConfig)
++       #if (PKG_CONFIG_FOUND)
++       #    pkg_check_modules(TBB tbb)
++       #endif()
+     if(NOT TBB_FOUND)
+         message(STATUS "tbb not found, downloading from source")
+         include(FetchContent)
+@@ -63,7 +63,7 @@ if(MANIFOLD_PAR STREQUAL "TBB")
+         set(TBB_STRICT OFF CACHE INTERNAL "" FORCE)
+         FetchContent_Declare(TBB
+             GIT_REPOSITORY https://github.com/oneapi-src/oneTBB.git
+-            GIT_TAG        v2021.10.0
++            GIT_TAG        v2021.8.0
+             GIT_SHALLOW    TRUE
+             GIT_PROGRESS   TRUE
+         )
+
+EOF
+fi
+
 echo "Building openscad-$VERSION ($VERSIONDATE)"
 echo "  CMake args: $CMAKE_CONFIG"
 echo "  DEPLOYDIR: " $DEPLOYDIR
@@ -275,7 +314,7 @@ if [ -n $FONTDIR ]; then
   cp -a fonts/10-liberation.conf $FONTDIR
   cp -a fonts/Liberation-2.00.1 $FONTDIR
   case $OS in
-    MACOSX) 
+    MACOSX)
       cp -a fonts/05-osx-fonts.conf $FONTDIR
       cp -a fonts-osx/* $FONTDIR
       ;;


### PR DESCRIPTION
Closes #4814 #4815.

For some reason tbb is linked differently after manifold update, and causes segfault/infinite loop on Windows for MXE builds. The build log shows
```
/mxe/usr/x86_64-w64-mingw32.static.posix/lib/libtbb_static.a(task.cpp.obj): duplicate section `.rdata$_ZTIN3tbb4taskE[_ZTIN3tbb4taskE]' has different size
/mxe/usr/x86_64-w64-mingw32.static.posix/lib/libtbb_static.a(scheduler.cpp.obj): duplicate section `.rdata$_ZTIN3tbb4taskE[_ZTIN3tbb4taskE]' has different size
/mxe/usr/x86_64-w64-mingw32.static.posix/lib/libtbb_static.a(arena.cpp.obj): duplicate section `.rdata$_ZTIN3tbb4taskE[_ZTIN3tbb4taskE]' has different size
```

This patch will patch manifold to ignore the system tbb package, and use a newer version of tbb. As the latest version is not working on MXE due to compiler internal error, I chose v2021.8.0 which does work. Not sure if the bug is caused by tbb being too old, or just some compiler options. Anyway I think there is no harm in updating the tbb version, considering the MXE one is already 5+ years old.

The build is working on Virtual Box but I have yet tried it on real windows machine. Build artifacts: https://app.circleci.com/pipelines/github/openscad/openscad/4216/workflows/f892a61f-bae6-47e6-a428-b773a12067c6/jobs/17006/artifacts

@donovansmith @owebeeone maybe you can give this a try.