### PR TITLE
#3781 Proof of Concept

### DIFF
--- a/src/core/Context.cc
+++ b/src/core/Context.cc
@@ -63,10 +63,10 @@ std::vector<const std::shared_ptr<const Context> *> Context::list_referenced_con
   return output;
 }
 
-boost::optional<const Value&> Context::try_lookup_variable(const std::string& name) const
+boost::optional<const Value&> Context::try_lookup_variable(const std::string& name, const Location& loc) const
 {
   if (is_config_variable(name)) {
-    return session()->try_lookup_special_variable(name);
+    return session()->try_lookup_special_variable(name, loc);
   }
   for (const Context *context = this; context != nullptr; context = context->getParent().get()) {
     boost::optional<const Value&> result = context->lookup_local_variable(name);
@@ -79,7 +79,7 @@ boost::optional<const Value&> Context::try_lookup_variable(const std::string& na
 
 const Value& Context::lookup_variable(const std::string& name, const Location& loc) const
 {
-  boost::optional<const Value&> result = try_lookup_variable(name);
+  boost::optional<const Value&> result = try_lookup_variable(name, loc);
   if (!result) {
     LOG(message_group::Warning, loc, documentRoot(), "Ignoring unknown variable '%1$s'", name);
     return Value::undefined;

--- a/src/core/Context.h
+++ b/src/core/Context.h
@@ -79,7 +79,7 @@ public:
   virtual const class Children *user_module_children() const;
   virtual std::vector<const std::shared_ptr<const Context> *> list_referenced_contexts() const;
 
-  boost::optional<const Value&> try_lookup_variable(const std::string& name) const;
+  boost::optional<const Value&> try_lookup_variable(const std::string& name, const Location& loc) const;
   const Value& lookup_variable(const std::string& name, const Location& loc) const;
   boost::optional<CallableFunction> lookup_function(const std::string& name, const Location& loc) const;
   boost::optional<InstantiableModule> lookup_module(const std::string& name, const Location& loc) const;

--- a/src/core/EvaluationSession.cc
+++ b/src/core/EvaluationSession.cc
@@ -69,6 +69,11 @@ boost::optional<const Value&> EvaluationSession::try_lookup_special_variable(con
         EvaluationSession dummy(documentRoot());
         auto dummyContext = Context::create<Context>(&dummy);
         auto filecontext = Context::create<FileContext>(dummyContext->get_shared_ptr(), file);
+        // copy config variables from the stack
+        for (const ContextFrame* frame : stack) {
+          filecontext->apply_config_variables(*frame);
+        }
+
         Value result = assignment->getExpr()->evaluate(filecontext->get_shared_ptr());
         // set it in the top level context, so it is cleared when the frame is popped
         stack.back()->set_variable(name, std::move(result));

--- a/src/core/EvaluationSession.h
+++ b/src/core/EvaluationSession.h
@@ -23,7 +23,7 @@ public:
   void replace_frame(size_t index, ContextFrame *frame);
   void pop_frame(size_t index);
 
-  [[nodiscard]] boost::optional<const Value&> try_lookup_special_variable(const std::string& name) const;
+  [[nodiscard]] boost::optional<const Value&> try_lookup_special_variable(const std::string& name, const Location& loc) const;
   [[nodiscard]] const Value& lookup_special_variable(const std::string& name, const Location& loc) const;
   [[nodiscard]] boost::optional<CallableFunction> lookup_special_function(const std::string& name, const Location& loc) const;
   [[nodiscard]] boost::optional<InstantiableModule> lookup_special_module(const std::string& name, const Location& loc) const;

--- a/src/core/Parameters.cc
+++ b/src/core/Parameters.cc
@@ -45,7 +45,7 @@ Parameters::Parameters(Parameters&& other) noexcept :
 boost::optional<const Value&> Parameters::lookup(const std::string& name) const
 {
   if (ContextFrame::is_config_variable(name)) {
-    return frame.session()->try_lookup_special_variable(name);
+    return frame.session()->try_lookup_special_variable(name, loc);
   } else {
     return frame.lookup_local_variable(name);
   }

--- a/src/core/builtin_functions.cc
+++ b/src/core/builtin_functions.cc
@@ -868,7 +868,7 @@ Value builtin_is_undef(const std::shared_ptr<const Context>& context, const Func
     return Value::undefined.clone();
   }
   if (auto lookup = dynamic_pointer_cast<Lookup>(call->arguments[0]->getExpr())) {
-    auto result = context->try_lookup_variable(lookup->get_name());
+    auto result = context->try_lookup_variable(lookup->get_name(), call->location());
     return !result || result->isUndefined();
   } else {
     return call->arguments[0]->getExpr()->evaluate(context).isUndefined();


### PR DESCRIPTION
It is unfortunate that #3781 sits here for 2 years without any progress, breaking some user code and blocking release. This is an attempt to fix the behavior by adding a fallback to file scope when lookup to config variables failed. This is definitely not fast nor clean code (I don't understand much about the codebase), but I think the behavior should be fine.

```
// dollars.scad
$v = 0;
$v1 = $v;

module showv() {
    echo($v);
    echo($v1);
}

// test_dollars.scad
use <dollars.scad>
showv();
// output:
// ECHO: 0
// ECHO: 0

// test_dollars1.scad
use <dollars.scad>
$v = 1;
showv();
// output:
// ECHO: 1
// ECHO: 1

// test_dollars2.scad
use <dollars.scad>
$v = 1;
$v1 = 0;
showv();
// output:
// ECHO: 1
// ECHO: 0
```

Basically, in the above examples, if a config variable is not being overridden in the dynamic scope, it will try to use the value in the file scope (and can lookup other config variables in the stack). If the value is being overridden, it will use the overriden value.
