### PR TITLE
PolySetBuilder refactoring

### DIFF
--- a/src/core/SurfaceNode.cc
+++ b/src/core/SurfaceNode.cc
@@ -317,7 +317,7 @@ const Geometry *SurfaceNode::createGeometry() const
       builder.prependVertex(builder.vertexIndex(Vector3d(ox + 0, oy + i, min_val)));
   }
 
-  return builder.build();
+  return builder.build().release();
 }
 
 std::string SurfaceNode::toString() const

--- a/src/core/primitives.cc
+++ b/src/core/primitives.cc
@@ -142,7 +142,7 @@ const Geometry *CubeNode::createGeometry() const
   builder.appendPoly({corner[1],corner[3],corner[7], corner[5]}); // right
   builder.appendPoly({corner[3],corner[2],corner[6], corner[7]}); // back
   builder.appendPoly({corner[2],corner[0],corner[4], corner[6]}); // left
-  return builder.build();									   
+  return builder.build().release();
 }
 
 static std::shared_ptr<AbstractNode> builtin_cube(const ModuleInstantiation *inst, Arguments arguments, const Children& children)
@@ -251,7 +251,7 @@ sphere_next_r2:
     builder.prependVertex( builder.vertexIndex(Vector3d(ring[rings - 1].points[i][0], ring[rings - 1].points[i][1], ring[rings - 1].z)));
   }
 
-  return builder.build();
+  return builder.build().release();
 }
 
 static std::shared_ptr<AbstractNode> builtin_sphere(const ModuleInstantiation *inst, Arguments arguments, const Children& children)
@@ -346,7 +346,7 @@ const Geometry *CylinderNode::createGeometry() const
       builder.appendVertex(builder.vertexIndex(Vector3d(circle2[i][0], circle2[i][1], z2)));
   }
 
-  return builder.build();
+  return builder.build().release();
 }
 
 static std::shared_ptr<AbstractNode> builtin_cylinder(const ModuleInstantiation *inst, Arguments arguments, const Children& children)

--- a/src/geometry/GeometryEvaluator.cc
+++ b/src/geometry/GeometryEvaluator.cc
@@ -1207,7 +1207,7 @@ static Geometry *extrudePolygon(const LinearExtrudeNode& node, const Polygon2d& 
     delete ps_top;
   }
 
-  return builder.build();
+  return builder.build().release();
 }
 
 /*!
@@ -1364,7 +1364,7 @@ static Geometry *rotatePolygon(const RotateExtrudeNode& node, const Polygon2d& p
     }
   }
 
-  return builder.build();
+  return builder.build().release();
 }
 
 /*!

--- a/src/geometry/PolySetBuilder.cc
+++ b/src/geometry/PolySetBuilder.cc
@@ -38,26 +38,34 @@
 #endif
 
 PolySetBuilder::PolySetBuilder(int vertices_count, int indices_count, int dim, boost::tribool convex)
+  : dim_(dim), convex_(convex)
 {
-  ps = new PolySet(dim, convex);
-  if(vertices_count != 0) ps->vertices.reserve(vertices_count);
-  if(indices_count != 0) ps->indices.reserve(indices_count);
+  if (vertices_count != 0) vertices_.reserve(vertices_count);
+  if (indices_count != 0) indices_.reserve(indices_count);
 }
 
-PolySetBuilder::PolySetBuilder(const Polygon2d &pol)
+PolySetBuilder::PolySetBuilder(const Polygon2d& polygon2d)
+  : polygon2d_(polygon2d), dim_(2), convex_(unknown)
 {
-  ps = new PolySet(pol);
-  ps->dirty = false;
 }
 
-int PolySetBuilder::vertexIndex(const Vector3d &pt)
-{
-  return allVertices.lookup(pt);
+
+void PolySetBuilder::setConvexity(int convexity){
+  convexity_ = convexity;
 }
 
-void PolySetBuilder::appendPoly(const std::vector<int> &inds)
+int PolySetBuilder::numVertices() const {
+  return vertices_.size();
+}
+
+int PolySetBuilder::vertexIndex(const Vector3d& pt)
 {
-  auto& face = ps->indices.emplace_back();
+  return vertices_.lookup(pt);
+}
+
+void PolySetBuilder::appendPoly(const std::vector<int>& inds)
+{
+  auto& face = indices_.emplace_back();
   face.insert(face.begin(), inds.begin(), inds.end());
 }
 
@@ -72,7 +80,7 @@ void PolySetBuilder::appendGeometry(const shared_ptr<const Geometry>& geom)
 #ifdef ENABLE_CGAL
   } else if (const auto N = dynamic_pointer_cast<const CGAL_Nef_polyhedron>(geom)) {
     PolySet ps(3);
-    bool err = CGALUtils::createPolySetFromNefPolyhedron3(*(N->p3), ps);
+    const bool err = CGALUtils::createPolySetFromNefPolyhedron3(*(N->p3), ps);
     if (err) {
       LOG(message_group::Error, "Nef->PolySet failed");
     } else {
@@ -81,10 +89,10 @@ void PolySetBuilder::appendGeometry(const shared_ptr<const Geometry>& geom)
   } else if (const auto hybrid = dynamic_pointer_cast<const CGALHybridPolyhedron>(geom)) {
     // TODO(ochafik): Implement appendGeometry(Surface_mesh) instead of converting to PolySet
     append(hybrid->toPolySet().get());
-#endif
+#endif // ifdef ENABLE_CGAL
 #ifdef ENABLE_MANIFOLD
   } else if (const auto mani = dynamic_pointer_cast<const ManifoldGeometry>(geom)) {
-   append(mani->toPolySet().get());
+    append(mani->toPolySet().get());
 #endif
   } else if (dynamic_pointer_cast<const Polygon2d>(geom)) { // NOLINT(bugprone-branch-clone)
     assert(false && "Unsupported file format");
@@ -95,49 +103,50 @@ void PolySetBuilder::appendGeometry(const shared_ptr<const Geometry>& geom)
 }
 
 
-void PolySetBuilder::appendPoly(const std::vector<Vector3d> &v)
+void PolySetBuilder::appendPoly(const std::vector<Vector3d>& v)
 {
   IndexedFace inds;
   inds.reserve(v.size());
-  for(const auto &pt: v)
-    inds.push_back(vertexIndex(pt));  
-  ps->indices.push_back(inds);        
+  for (const auto& pt: v)
+    inds.push_back(vertexIndex(pt));
+  indices_.push_back(inds);
 }
 
 void PolySetBuilder::appendPoly(int nvertices){
-  ps->indices.emplace_back().reserve(nvertices);
+  indices_.emplace_back().reserve(nvertices);
 }
 
-void PolySetBuilder::appendVertex(int ind){
-  ps->indices.back().push_back(ind);
+void PolySetBuilder::appendVertex(int ind)
+{
+  indices_.back().push_back(ind);
 }
 
-void PolySetBuilder::prependVertex(int ind){
-  ps->indices.back().insert(ps->indices.back().begin(), ind);
-}
-
-int PolySetBuilder::numVertices() {
-  return allVertices.size();
+void PolySetBuilder::prependVertex(int ind)
+{
+  indices_.back().insert(indices_.back().begin(), ind);
 }
 
 void PolySetBuilder::append(const PolySet *ps)
 {
-  for(const auto &poly : ps->indices) {
+  for (const auto& poly : ps->indices) {
     appendPoly(poly.size());
-    for(const auto &ind: poly) {
+    for (const auto& ind: poly) {
       appendVertex(vertexIndex(ps->vertices[ind]));
     }
   }
 }
 
-PolySet *PolySetBuilder::build()
+std::unique_ptr<PolySet> PolySetBuilder::build()
 {
-  ps->dirty = true;
-  ps->vertices = allVertices.getArray();
-  return ps;
+  std::unique_ptr<PolySet> polyset;
+  if (!polygon2d_.isEmpty()) {
+    polyset = std::make_unique<PolySet>(polygon2d_);
+  }
+  else {
+    polyset = std::make_unique<PolySet>(dim_, convex_);
+  }
+  vertices_.copy(std::back_inserter(polyset->vertices));
+  polyset->indices = std::move(indices_);
+  polyset->dirty = true;
+  return polyset;
 }
-
-void PolySetBuilder::setConvexity(int convexity){
-  ps->convexity = convexity;
-}
-

--- a/src/geometry/PolySetBuilder.cc
+++ b/src/geometry/PolySetBuilder.cc
@@ -147,6 +147,7 @@ std::unique_ptr<PolySet> PolySetBuilder::build()
   }
   vertices_.copy(std::back_inserter(polyset->vertices));
   polyset->indices = std::move(indices_);
+  polyset->setConvexity(convexity_);
   polyset->dirty = true;
   return polyset;
 }

--- a/src/geometry/PolySetBuilder.h
+++ b/src/geometry/PolySetBuilder.h
@@ -1,28 +1,35 @@
 #pragma once
 
+#include <memory>
+
 #include <Reindexer.h>
 #include "Polygon2d.h"
-#include <memory>
 #include "boost-utils.h"
+#include "GeometryUtils.h"
+
 class PolySet;
 
 class PolySetBuilder
 {
 public:
-  PolySetBuilder(int vertices_count=0, int indices_count=0, int dim=3, boost::tribool convex=unknown);
-  PolySetBuilder(const Polygon2d &pol);
+  PolySetBuilder(int vertices_count = 0, int indices_count = 0, int dim = 3, boost::tribool convex = unknown);
+  PolySetBuilder(const Polygon2d& polygon2d);
   void setConvexity(int n);
-  int vertexIndex(const Vector3d &coord);
-  int numVertices();
+  int vertexIndex(const Vector3d& coord);
+  int numVertices() const;
   void appendPoly(int nvertices);
   void append(const PolySet *ps);
-  void appendPoly(const std::vector<int> &inds);
+  void appendPoly(const std::vector<int>& inds);
   void appendGeometry(const shared_ptr<const Geometry>& geom);
-  void appendPoly(const std::vector<Vector3d> &v);
+  void appendPoly(const std::vector<Vector3d>& v);
   void appendVertex(int n);
   void prependVertex(int n);
-  PolySet *build();
-private:  
-  PolySet *ps;
-  Reindexer<Vector3d> allVertices;
+  std::unique_ptr<PolySet> build();
+private:
+  Reindexer<Vector3d> vertices_;
+  PolygonIndices indices_;
+  Polygon2d polygon2d_;
+  int convexity_{1};
+  int dim_;
+  boost::tribool convex_;
 };

--- a/src/geometry/PolySetUtils.cc
+++ b/src/geometry/PolySetUtils.cc
@@ -120,7 +120,7 @@ void tessellate_faces(const PolySet& inps, PolySet& outps)
       }
     }
   }
-  outps.reset(builder.build());
+  outps.reset(builder.build().release());
   if (degeneratePolygons > 0) {
     LOG(message_group::Warning, "PolySet has degenerate polygons");
   }

--- a/src/geometry/cgal/Polygon2d-CGAL.cc
+++ b/src/geometry/cgal/Polygon2d-CGAL.cc
@@ -127,5 +127,5 @@ PolySet *Polygon2d::tessellate() const
       }
     }
   }
-  return builder.build();
+  return builder.build().release();
 }

--- a/src/geometry/cgal/cgalutils-mesh.cc
+++ b/src/geometry/cgal/cgalutils-mesh.cc
@@ -64,7 +64,7 @@ bool createPolySetFromMesh(const TriangleMesh& mesh, PolySet& ps)
     }
   }
   builder.append(&ps);
-  ps.reset(builder.build());
+  ps.reset(builder.build().release());
   return err;
 }
 

--- a/src/geometry/cgal/cgalutils-polyhedron.cc
+++ b/src/geometry/cgal/cgalutils-polyhedron.cc
@@ -300,7 +300,7 @@ bool createPolySetFromPolyhedron(const Polyhedron& p, PolySet& ps)
       builder.appendVertex(builder.vertexIndex(Vector3d(x, y, z)));
     } while (hc != hc_end);
   }
-  ps.reset(builder.build());
+  ps.reset(builder.build().release());
   return err;
 }
 

--- a/src/geometry/cgal/cgalutils.cc
+++ b/src/geometry/cgal/cgalutils.cc
@@ -388,7 +388,7 @@ bool createPolySetFromNefPolyhedron3(const CGAL::Nef_polyhedron_3<K>& N, PolySet
 	const auto &tri=allTriangles[i];
 	builder.appendPoly({indMap[tri[0]],indMap[tri[1]],indMap[tri[2]]});
   }
-  ps.reset(builder.build());
+  ps.reset(builder.build().release());
 
 #if 0 // For debugging
   std::cerr.precision(20);

--- a/src/geometry/manifold/ManifoldGeometry.cc
+++ b/src/geometry/manifold/ManifoldGeometry.cc
@@ -4,10 +4,7 @@
 #include "PolySet.h"
 #include "PolySetBuilder.h"
 #include "PolySetUtils.h"
-#include "cgalutils.h"
 #include "manifoldutils.h"
-#include "PolySet.h"
-#include "PolySetUtils.h"
 #ifdef ENABLE_CGAL
 #include "cgal.h"
 #include "cgalutils.h"

--- a/src/geometry/manifold/ManifoldGeometry.cc
+++ b/src/geometry/manifold/ManifoldGeometry.cc
@@ -91,21 +91,21 @@ std::string ManifoldGeometry::dump() const {
 
 std::shared_ptr<const PolySet> ManifoldGeometry::toPolySet() const {
   manifold::MeshGL mesh = getManifold().GetMeshGL();
-  PolySet ps(3);
-  ps.vertices.reserve(mesh.NumVert());
-  ps.indices.reserve(mesh.NumTri());
+  auto ps = std::make_shared<PolySet>(3);
+  ps->vertices.reserve(mesh.NumVert());
+  ps->indices.reserve(mesh.NumTri());
   // first 3 channels are xyz coordinate
   for (int i = 0; i < mesh.vertProperties.size(); i += mesh.numProp)
-    ps.vertices.push_back({
+    ps->vertices.push_back({
         mesh.vertProperties[i],
         mesh.vertProperties[i+1],
         mesh.vertProperties[i+2]});
   for (int i = 0; i < mesh.triVerts.size(); i += 3)
-    ps.indices.push_back({
+    ps->indices.push_back({
         static_cast<int>(mesh.triVerts[i]),
         static_cast<int>(mesh.triVerts[i+1]),
         static_cast<int>(mesh.triVerts[i+2])});
-  return std::make_shared<const PolySet>(std::move(ps));
+  return ps;
 }
 
 #ifdef ENABLE_CGAL

--- a/src/geometry/roof_ss.cc
+++ b/src/geometry/roof_ss.cc
@@ -146,7 +146,7 @@ PolySet *straight_skeleton_roof(const Polygon2d& poly)
 
     delete poly_sanitized;
 
-    return hatbuilder.build();
+    return hatbuilder.build().release();
   } catch (RoofNode::roof_exception& e) {
     throw;
   }

--- a/src/geometry/roof_vd.cc
+++ b/src/geometry/roof_vd.cc
@@ -412,7 +412,7 @@ PolySet *voronoi_diagram_roof(const Polygon2d& poly, double fa, double fs)
     throw;
   }
 
-  return hatbuilder.build();
+  return hatbuilder.build().release();
 }
 
 } // roof_vd

--- a/src/io/export_obj.cc
+++ b/src/io/export_obj.cc
@@ -34,7 +34,7 @@ void export_obj(const shared_ptr<const Geometry>& geom, std::ostream& output)
 {
   PolySetBuilder builder;
   builder.appendGeometry(geom);
-  auto *ps = builder.build();
+  auto *ps = builder.build().release();
 
   output << "# OpenSCAD obj exporter\n";
 

--- a/src/io/export_off.cc
+++ b/src/io/export_off.cc
@@ -34,7 +34,7 @@ void export_off(const shared_ptr<const Geometry>& geom, std::ostream& output)
 {
   PolySetBuilder builder;
   builder.appendGeometry(geom);
-  auto *ps = builder.build();
+  auto *ps = builder.build().release();
 
   output << "OFF " << ps->vertices.size() << " " << ps->indices.size() << " 0\n";
   const auto& v = ps->vertices;

--- a/src/io/export_wrl.cc
+++ b/src/io/export_wrl.cc
@@ -32,8 +32,8 @@ void export_wrl(const shared_ptr<const Geometry>& geom, std::ostream& output)
 {
   PolySetBuilder builder;
   builder.appendGeometry(geom);
-  auto *ps = builder.build();
-	
+  auto *ps = builder.build().release();
+
   output << "#VRML V2.0 utf8\n\n";
 
   output << "Shape {\n\n";

--- a/src/io/export_wrl.cc
+++ b/src/io/export_wrl.cc
@@ -32,7 +32,7 @@ void export_wrl(const shared_ptr<const Geometry>& geom, std::ostream& output)
 {
   PolySetBuilder builder;
   builder.appendGeometry(geom);
-  auto *ps = builder.build().release();
+  auto ps = builder.build();
 
   output << "#VRML V2.0 utf8\n\n";
 
@@ -66,8 +66,8 @@ void export_wrl(const shared_ptr<const Geometry>& geom, std::ostream& output)
   for (size_t i = 0; i < numindices; ++i) {
     const auto &poly=ps->indices[i];
     for(int j=0;j<poly.size();j++) {
-      output << poly[i];
-        if (i < poly.size() - 1) output << ",";
+      output << poly[j];
+        if (j < poly.size() - 1) output << ",";
       output << "\n";
     }
   }

--- a/src/io/import_3mf.cc
+++ b/src/io/import_3mf.cc
@@ -172,7 +172,7 @@ Geometry *import_3mf(const std::string& filename, const Location& loc)
     if (first_mesh) {
       meshes.push_back(std::shared_ptr<PolySet>(builder.build()));
     } else {
-      first_mesh = builder.build();
+      first_mesh = builder.build().release();
     }
     mesh_idx++;
   }
@@ -344,7 +344,7 @@ Geometry *import_3mf(const std::string& filename, const Location& loc)
     if (first_mesh) {
       meshes.push_back(std::shared_ptr<PolySet>(builder.build()));
     } else {
-      first_mesh = builder.build();
+      first_mesh = builder.build().release();
     }
     mesh_idx++;
     has_next = object_it->MoveNext();

--- a/src/io/import_amf.cc
+++ b/src/io/import_amf.cc
@@ -143,7 +143,7 @@ void AmfImporter::start_object(AmfImporter *importer, const xmlChar *)
 void AmfImporter::end_object(AmfImporter *importer, const xmlChar *)
 {
   PRINTDB("AMF: add object %d", importer->polySets.size());
-importer->polySets.push_back(importer->builder->build());
+  importer->polySets.push_back(importer->builder->build().release());
   importer->vertex_list.clear();
   delete importer->builder;
   importer->builder = nullptr;

--- a/src/io/import_obj.cc
+++ b/src/io/import_obj.cc
@@ -87,5 +87,5 @@ PolySet *import_obj(const std::string& filename, const Location& loc) {
       LOG(message_group::Warning, "Unrecognized Line  %1$s in line Line %2$d", line, lineno);
     }
   }
-  return builder.build();
+  return builder.build().release();
 }

--- a/src/io/import_stl.cc
+++ b/src/io/import_stl.cc
@@ -195,5 +195,5 @@ PolySet *import_stl(const std::string& filename, const Location& loc) {
         "STL format not recognized in '%1$s'.", filename);
     return new PolySet(3);
   }
-  return builder.build();
+  return builder.build().release();
 }


### PR DESCRIPTION
Smallish refactoring of PolySetBuilder:
* Move all PolySet allocation to the `build()` method
* Return a unique_ptr. Some mess (releasing unique_ptr) moved to the call site, which will be cleaned up next
* Allow building without CGAL
* Coding style fixes
* Fixes an indexing bug in export_wrl.cc