### PR TITLE
Replace zip_get_num_files() with zip_get_num_entries().

### DIFF
--- a/src/io/import_amf.cc
+++ b/src/io/import_amf.cc
@@ -325,7 +325,7 @@ xmlTextReaderPtr AmfImporterZIP::createXmlReader(const char *filepath)
     if (zipfile == nullptr) {
       LOG(message_group::Warning, "Can't read file '%1$s' from zipped AMF '%2$s', import() at line %3$d", filename, filepath, this->loc.firstLine());
     }
-    if ((zipfile == nullptr) && (zip_get_num_files(archive) == 1)) {
+    if ((zipfile == nullptr) && (zip_get_num_entries(archive, 0) == 1)) {
       LOG(message_group::Warning, "Trying to read single entry '%1$s'", zip_get_name(archive, 0, 0));
       zipfile = zip_fopen_index(archive, 0, 0);
     }


### PR DESCRIPTION
```
[ 25%] Building CXX object CMakeFiles/OpenSCAD.dir/src/io/import_amf.cc.obj
C:/msys64/home/jordan/openscad/binary-arithmetic/src/io/import_amf.cc: In member function 'virtual xmlTextReader* AmfImporterZIP::createXmlReader(const char*)':
C:/msys64/home/jordan/openscad/binary-arithmetic/src/io/import_amf.cc:328:51: warning: 'int zip_get_num_files(zip_t*)' is deprecated: use 'zip_get_num_entries' instead [-Wdeprecated-declarations]
  328 |     if ((zipfile == nullptr) && (zip_get_num_files(archive) == 1)) {
      |                                  ~~~~~~~~~~~~~~~~~^~~~~~~~~
In file included from C:/msys64/home/jordan/openscad/binary-arithmetic/src/io/import_amf.cc:282:
C:/msys64/mingw64/include/zip.h:383:68: note: declared here
  383 | ZIP_DEPRECATED("use 'zip_get_num_entries' instead") ZIP_EXTERN int zip_get_num_files(zip_t *_Nonnull);
      |                                                                    ^~~~~~~~~~~~~~~~~
```

So I did that, and the warning went away.