### PR TITLE
Uniform support for \n, \r\n, \r as line breaks.  Fixes #4882.

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.bin.scad -text diff

--- a/src/core/lexer.l
+++ b/src/core/lexer.l
@@ -83,21 +83,29 @@ extern SourceFile *rootfile;
   Handle locations.
   Since flex doesn't handle column numbers, we deal with those manually.
   See "Advanced Use of Flex" / "Advanced Use of Bison"
+  https://www.lrde.epita.fr/~akim/ccmp/doc/gnuprog2/Advanced-Use-of-Flex.html
+  https://www.lrde.epita.fr/~akim/ccmp/doc/gnuprog2/Advanced-Use-of-Bison.html
 */
 extern YYLTYPE parserlloc;
 
 #define LOCATION(loc) Location(loc.first_line, loc.first_column, loc.last_line, loc.last_column, sourcefile())
 #define LOCATION_INIT(loc) do { (loc).first_line = (loc).first_column = (loc).last_line = (loc).last_column = yylineno = 1; } while (0)
-#define LOCATION_NEXT(loc) do { (loc).first_column = (loc).last_column; (loc).first_line = (loc).last_line; } while (0)
+#define LOCATION_NEXT(loc) do { (loc).first_column = (loc).last_column; (loc).first_line = yylineno = (loc).last_line; } while (0)
 #define LOCATION_ADD_LINES(loc, cnt) do { (loc).last_column = 1; (loc).last_line += cnt; LOCATION_NEXT(loc); } while (0)
 
-#define LOCATION_COUNT_LINES(loc, text) \
-    for(int i = 0; (text[i]) != '\0'; i++) { \
-        if((text[i]) == '\n') { \
-            (loc).last_line++; \
-            (loc).last_column = 1; \
-        } \
-    } 
+#define LOCATION_COUNT_LINES(loc, text)                     \
+    do {                                                    \
+        for(int i = 0; (text)[i] != '\0'; i++) {            \
+            if((text)[i] == '\r' && (text)[i+1] == '\n') {  \
+                i++;                                        \
+            }                                               \
+            if((text)[i] == '\n' || (text)[i] == '\r') {    \
+                (loc).last_line++;                          \
+                (loc).last_column = 1;                      \
+            }                                               \
+        }                                                   \
+        LOCATION_NEXT(loc);                                 \
+    } while (0)
 
 #ifdef DEBUG
 #define YY_USER_ACTION parserlloc.last_column += yyleng; \
@@ -123,7 +131,7 @@ std::string filename;
 std::string filepath;
 %}
 
-%option yylineno
+    /* Note:  no option yylineno; we update yylineno on our own. */
 %option noyywrap
 
 %x cond_comment cond_lcomment cond_string
@@ -139,6 +147,7 @@ U2      [\xc2-\xdf]
 U3      [\xe0-\xef]
 U4      [\xf0-\xf4]
 UNICODE {U2}{U}|{U3}{U}{U}|{U4}{U}{U}{U}
+NL      \n|\r\n|\r
 
 %%
 
@@ -148,10 +157,10 @@ LOCATION_NEXT(parserlloc);
 
 include[ \t\r\n]*"<"    { BEGIN(cond_include); filepath = filename = ""; LOCATION_COUNT_LINES(parserlloc, yytext); }
 <cond_include>{
-[\n\r]                  {
-                            LOCATION_ADD_LINES(parserlloc, yyleng);
+{NL}                    {
                             // see merge request #4221
                             LOG(message_group::Warning,LOCATION(parserlloc),"","new lines in 'include<>'-statement is not defined - behavior may change in the future");
+                            LOCATION_ADD_LINES(parserlloc, yyleng);
 }
 [^\t\r\n>]*"/"          { filepath = yytext; }
 [^\t\r\n>/]+            { filename = yytext; }
@@ -162,10 +171,10 @@ include[ \t\r\n]*"<"    { BEGIN(cond_include); filepath = filename = ""; LOCATIO
 
 use[ \t\r\n]*"<"        { BEGIN(cond_use); LOCATION_COUNT_LINES(parserlloc, yytext); }
 <cond_use>{
-[\n\r]                  {
-                            LOCATION_ADD_LINES(parserlloc, yyleng);
+{NL}                    {
                             // see merge request #4221
                             LOG(message_group::Warning,LOCATION(parserlloc),"","new lines 'use<>'-statement is not defined - behavior may change in the future");
+                            LOCATION_ADD_LINES(parserlloc, yyleng);
 }
 [^\t\r\n>]+             { filename = yytext; }
  ">"                    {
@@ -193,28 +202,28 @@ use[ \t\r\n]*"<"        { BEGIN(cond_use); LOCATION_COUNT_LINES(parserlloc, yyte
 {UNICODE}               { /* parser_error_pos -= strlen(lexertext) - 1; */ stringcontents += lexertext; }
 \\x[0-7]{H}             { unsigned long i = strtoul(lexertext + 2, NULL, 16); stringcontents += (i == 0 ? ' ' : (unsigned char)(i & 0xff)); }
 \\u{H}{4}|\\U{H}{6}     { const auto c = strtoul(lexertext + 2, NULL, 16); stringcontents += str_utf8_wrapper(c).toString(); }
-[^\\\n\"]               { stringcontents += lexertext; }
-[\n\r]                  { LOCATION_ADD_LINES(parserlloc, yyleng); }
+[^\\\r\n\"]             { stringcontents += lexertext; }
+{NL}                    { LOCATION_ADD_LINES(parserlloc, yyleng); }
 \"                      { BEGIN(INITIAL); parserlval.text = strdup(stringcontents.c_str()); return TOK_STRING; }
 <<EOF>>                 { parsererror("Unterminated string"); return TOK_ERROR; }
 }
 
 [\t ]                   { LOCATION_NEXT(parserlloc); }
-[\n\r]                  { LOCATION_ADD_LINES(parserlloc, yyleng); }
+{NL}                    { LOCATION_ADD_LINES(parserlloc, yyleng); }
 
 \/\/                    { BEGIN(cond_lcomment); }
 <cond_lcomment>{
-\n                      { BEGIN(INITIAL); LOCATION_ADD_LINES(parserlloc, yyleng); }
+{NL}                    { BEGIN(INITIAL); LOCATION_ADD_LINES(parserlloc, yyleng); }
 {UNICODE}               { /* parser_error_pos -= strlen(lexertext) - 1; */ }
-[^\n]
+.
 }
 
 "/*"                    BEGIN(cond_comment);
 <cond_comment>{
 "*/"                    { BEGIN(INITIAL); }
 {UNICODE}               { /* parser_error_pos -= strlen(lexertext) - 1; */ }
+{NL}                    { LOCATION_ADD_LINES(parserlloc, yyleng); }
 .
-[\n]                    { LOCATION_ADD_LINES(parserlloc, yyleng); }
 <<EOF>>                 { parsererror("Unterminated comment"); return TOK_ERROR; }
 }
 

--- a/src/core/lexer.l
+++ b/src/core/lexer.l
@@ -91,7 +91,7 @@ extern YYLTYPE parserlloc;
 #define LOCATION(loc) Location(loc.first_line, loc.first_column, loc.last_line, loc.last_column, sourcefile())
 #define LOCATION_INIT(loc) do { (loc).first_line = (loc).first_column = (loc).last_line = (loc).last_column = yylineno = 1; } while (0)
 #define LOCATION_NEXT(loc) do { (loc).first_column = (loc).last_column; (loc).first_line = yylineno = (loc).last_line; } while (0)
-#define LOCATION_ADD_LINES(loc, cnt) do { (loc).last_column = 1; (loc).last_line += cnt; LOCATION_NEXT(loc); } while (0)
+#define LOCATION_ADD_LINE(loc) do { (loc).last_column = 1; (loc).last_line++; LOCATION_NEXT(loc); } while (0)
 
 #define LOCATION_COUNT_LINES(loc, text)                     \
     do {                                                    \
@@ -160,7 +160,7 @@ include[ \t\r\n]*"<"    { BEGIN(cond_include); filepath = filename = ""; LOCATIO
 {NL}                    {
                             // see merge request #4221
                             LOG(message_group::Warning,LOCATION(parserlloc),"","new lines in 'include<>'-statement is not defined - behavior may change in the future");
-                            LOCATION_ADD_LINES(parserlloc, yyleng);
+                            LOCATION_ADD_LINE(parserlloc);
 }
 [^\t\r\n>]*"/"          { filepath = yytext; }
 [^\t\r\n>/]+            { filename = yytext; }
@@ -174,7 +174,7 @@ use[ \t\r\n]*"<"        { BEGIN(cond_use); LOCATION_COUNT_LINES(parserlloc, yyte
 {NL}                    {
                             // see merge request #4221
                             LOG(message_group::Warning,LOCATION(parserlloc),"","new lines 'use<>'-statement is not defined - behavior may change in the future");
-                            LOCATION_ADD_LINES(parserlloc, yyleng);
+                            LOCATION_ADD_LINE(parserlloc);
 }
 [^\t\r\n>]+             { filename = yytext; }
  ">"                    {
@@ -203,17 +203,17 @@ use[ \t\r\n]*"<"        { BEGIN(cond_use); LOCATION_COUNT_LINES(parserlloc, yyte
 \\x[0-7]{H}             { unsigned long i = strtoul(lexertext + 2, NULL, 16); stringcontents += (i == 0 ? ' ' : (unsigned char)(i & 0xff)); }
 \\u{H}{4}|\\U{H}{6}     { const auto c = strtoul(lexertext + 2, NULL, 16); stringcontents += str_utf8_wrapper(c).toString(); }
 [^\\\r\n\"]             { stringcontents += lexertext; }
-{NL}                    { LOCATION_ADD_LINES(parserlloc, yyleng); }
+{NL}                    { LOCATION_ADD_LINE(parserlloc); }
 \"                      { BEGIN(INITIAL); parserlval.text = strdup(stringcontents.c_str()); return TOK_STRING; }
 <<EOF>>                 { parsererror("Unterminated string"); return TOK_ERROR; }
 }
 
 [\t ]                   { LOCATION_NEXT(parserlloc); }
-{NL}                    { LOCATION_ADD_LINES(parserlloc, yyleng); }
+{NL}                    { LOCATION_ADD_LINE(parserlloc); }
 
 \/\/                    { BEGIN(cond_lcomment); }
 <cond_lcomment>{
-{NL}                    { BEGIN(INITIAL); LOCATION_ADD_LINES(parserlloc, yyleng); }
+{NL}                    { BEGIN(INITIAL); LOCATION_ADD_LINE(parserlloc); }
 {UNICODE}               { /* parser_error_pos -= strlen(lexertext) - 1; */ }
 .
 }
@@ -222,7 +222,7 @@ use[ \t\r\n]*"<"        { BEGIN(cond_use); LOCATION_COUNT_LINES(parserlloc, yyte
 <cond_comment>{
 "*/"                    { BEGIN(INITIAL); }
 {UNICODE}               { /* parser_error_pos -= strlen(lexertext) - 1; */ }
-{NL}                    { LOCATION_ADD_LINES(parserlloc, yyleng); }
+{NL}                    { LOCATION_ADD_LINE(parserlloc); }
 .
 <<EOF>>                 { parsererror("Unterminated comment"); return TOK_ERROR; }
 }

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -296,11 +296,12 @@ endfunction()
 #                        [SCRIPT <script>]
 #                        [EXPECTEDDIR <shared dir>] SUFFIX <suffix> FILES <test files>
 #                        [EXPERIMENTAL])
+#                        [RETVAL <n>]
 #
 # EXPERIMENTAL: If set, tag all tests as experimental
 #
 function(add_cmdline_test TESTCMD_BASENAME)
-  cmake_parse_arguments(TESTCMD "OPENSCAD;STDIO;EXPERIMENTAL" "EXE;SCRIPT;SUFFIX;KERNEL;EXPECTEDDIR" "FILES;ARGS" ${ARGN})
+  cmake_parse_arguments(TESTCMD "OPENSCAD;STDIO;EXPERIMENTAL" "EXE;SCRIPT;SUFFIX;KERNEL;EXPECTEDDIR;RETVAL" "FILES;ARGS" ${ARGN})
 
   set(EXTRA_OPTIONS "")
 
@@ -315,6 +316,10 @@ function(add_cmdline_test TESTCMD_BASENAME)
 
   if (TESTCMD_STDIO)
     list(APPEND EXTRA_OPTIONS --stdin --stdout)
+  endif()
+
+  if (TESTCMD_RETVAL)
+    list(APPEND EXTRA_OPTIONS --retval=${TESTCMD_RETVAL})
   endif()
 
   if ((TESTCMD_EXE OR TESTCMD_SCRIPT) AND TESTCMD_OPENSCAD)
@@ -657,6 +662,7 @@ list(APPEND ECHO_FILES ${FUNCTION_FILES} ${MISC_FILES} ${REDEFINITION_FILES}
   ${TEST_DATA_DIR}/use-order-test/use-order-test.scad
   ${TEST_SCAD_DIR}/misc/vector-swizzling.scad
   ${TEST_SCAD_DIR}/misc/linenumber.scad
+  ${TEST_SCAD_DIR}/misc/linenumber-NL-1.bin.scad
 )
 
 list(APPEND ASTDUMPTEST_FILES ${MISC_FILES}
@@ -958,6 +964,7 @@ add_cmdline_test(csgtermtest      OPENSCAD SUFFIX term FILES
 )
 
 add_cmdline_test(echotest         OPENSCAD SUFFIX echo FILES ${ECHO_FILES})
+add_cmdline_test(echotest         OPENSCAD SUFFIX echo RETVAL 1 FILES ${TEST_SCAD_DIR}/misc/linenumber-NL-2.bin.scad)
 # trace-usermodule-parameters is on by default,
 # but can generate very long outputs and potentially
 # unstable outputs, when combined with recursive tests.

--- a/tests/data/scad/misc/linenumber-NL-1.bin.scad
+++ b/tests/data/scad/misc/linenumber-NL-1.bin.scad
@@ -1,0 +1,93 @@
+// BE VERY CAREFUL MODIFYING THIS FILE.  It has downright peculiar line
+// endings and editors and other tools are likely to damage it.
+// Also, line numbers must match both the internal tests and the
+// expected-output file.
+
+// linenumber-NL-1.bin.scad tests runtime errors.
+// linenumber-NL-2.bin.scad tests parse errors.
+// The two files are identical except that -2 has a syntax error at the
+// very end.  The commented-out syntaxXX lines can be used to isolate
+// problems.
+
+// Following lines are terminated by LF alone (UNIX standard).
+
+// This comment tests line number tracking in C++ comments.
+
+echo(line16);
+// syntax17;
+
+/*
+ * This comment tests line number tracking in old-school comments.
+ */
+
+echo(line23);
+// syntax24;
+
+// The following tests line number tracking in include and use.
+include
+<
+line29
+line30
+>
+
+echo(line33);
+// syntax34;
+
+use
+<
+line38
+line39
+>
+
+echo(line42);
+// syntax43;
+
+// The following tests line number tracking in strings.
+group() { x="
+"; }
+echo(line48);
+// syntax49;
+
+
+// Following lines are terminated by CRLF (Windows standard).
+
+// This comment tests line number tracking in C++ comments.
+
+echo(line56);
+// syntax57;
+
+/*
+ * This comment tests line number tracking in old-school comments.
+ */
+
+echo(line63);
+// syntax64;
+
+// The following tests line number tracking in include and use.
+include
+<
+line69
+line70
+>
+
+echo(line73);
+// syntax74;
+
+use
+<
+line78
+line79
+>
+
+echo(line82);
+// syntax83;
+
+// The following tests line number tracking in strings.
+group() { x="
+"; }
+echo(line88);
+// syntax89;
+
+
+// Get exotic:  lines terminated by CR alone (Old MacOS, obscure systems).
+// This comment tests line number tracking in C++ comments.echo(line96);// syntax97;/* * This comment tests line number tracking in old-school comments. */echo(line103);// syntax104;// The following tests line number tracking in include and use.include<line109line110>echo(line113);// syntax114;use<line118line119>echo(line122);// syntax123;// The following tests line number tracking in strings.group() { x=""; }echo(line128);// syntax129;

--- a/tests/data/scad/misc/linenumber-NL-2.bin.scad
+++ b/tests/data/scad/misc/linenumber-NL-2.bin.scad
@@ -1,0 +1,93 @@
+// BE VERY CAREFUL MODIFYING THIS FILE.  It has downright peculiar line
+// endings and editors and other tools are likely to damage it.
+// Also, line numbers must match both the internal tests and the
+// expected-output file.
+
+// linenumber-NL-1.bin.scad tests runtime errors.
+// linenumber-NL-2.bin.scad tests parse errors.
+// The two files are identical except that -2 has a syntax error at the
+// very end.  The commented-out syntaxXX lines can be used to isolate
+// problems.
+
+// Following lines are terminated by LF alone (UNIX standard).
+
+// This comment tests line number tracking in C++ comments.
+
+echo(line16);
+// syntax17;
+
+/*
+ * This comment tests line number tracking in old-school comments.
+ */
+
+echo(line23);
+// syntax24;
+
+// The following tests line number tracking in include and use.
+include
+<
+line29
+line30
+>
+
+echo(line33);
+// syntax34;
+
+use
+<
+line38
+line39
+>
+
+echo(line42);
+// syntax43;
+
+// The following tests line number tracking in strings.
+group() { x="
+"; }
+echo(line48);
+// syntax49;
+
+
+// Following lines are terminated by CRLF (Windows standard).
+
+// This comment tests line number tracking in C++ comments.
+
+echo(line56);
+// syntax57;
+
+/*
+ * This comment tests line number tracking in old-school comments.
+ */
+
+echo(line63);
+// syntax64;
+
+// The following tests line number tracking in include and use.
+include
+<
+line69
+line70
+>
+
+echo(line73);
+// syntax74;
+
+use
+<
+line78
+line79
+>
+
+echo(line82);
+// syntax83;
+
+// The following tests line number tracking in strings.
+group() { x="
+"; }
+echo(line88);
+// syntax89;
+
+
+// Get exotic:  lines terminated by CR alone (Old MacOS, obscure systems).
+// This comment tests line number tracking in C++ comments.echo(line96);// syntax97;/* * This comment tests line number tracking in old-school comments. */echo(line103);// syntax104;// The following tests line number tracking in include and use.include<line109line110>echo(line113);// syntax114;use<line118line119>echo(line122);// syntax123;// The following tests line number tracking in strings.group() { x=""; }echo(line128);syntax129;

--- a/tests/regression/echotest/linenumber-NL-1-expected.echo
+++ b/tests/regression/echotest/linenumber-NL-1-expected.echo
@@ -1,0 +1,54 @@
+WARNING: new lines in 'include<>'-statement is not defined - behavior may change in the future in file ../../tests/data/scad/misc/linenumber-NL-1.bin.scad, line 28
+WARNING: new lines in 'include<>'-statement is not defined - behavior may change in the future in file ../../tests/data/scad/misc/linenumber-NL-1.bin.scad, line 29
+WARNING: new lines in 'include<>'-statement is not defined - behavior may change in the future in file ../../tests/data/scad/misc/linenumber-NL-1.bin.scad, line 30
+WARNING: Can't open include file 'line30'. in file ../../tests/data/scad/misc/linenumber-NL-1.bin.scad, line 31
+WARNING: new lines 'use<>'-statement is not defined - behavior may change in the future in file ../../tests/data/scad/misc/linenumber-NL-1.bin.scad, line 37
+WARNING: new lines 'use<>'-statement is not defined - behavior may change in the future in file ../../tests/data/scad/misc/linenumber-NL-1.bin.scad, line 38
+WARNING: new lines 'use<>'-statement is not defined - behavior may change in the future in file ../../tests/data/scad/misc/linenumber-NL-1.bin.scad, line 39
+WARNING: Can't open library 'line39'. in file ../../tests/data/scad/misc/linenumber-NL-1.bin.scad, line 40
+WARNING: new lines in 'include<>'-statement is not defined - behavior may change in the future in file ../../tests/data/scad/misc/linenumber-NL-1.bin.scad, line 68
+WARNING: new lines in 'include<>'-statement is not defined - behavior may change in the future in file ../../tests/data/scad/misc/linenumber-NL-1.bin.scad, line 69
+WARNING: new lines in 'include<>'-statement is not defined - behavior may change in the future in file ../../tests/data/scad/misc/linenumber-NL-1.bin.scad, line 70
+WARNING: Can't open include file 'line70'. in file ../../tests/data/scad/misc/linenumber-NL-1.bin.scad, line 71
+WARNING: new lines 'use<>'-statement is not defined - behavior may change in the future in file ../../tests/data/scad/misc/linenumber-NL-1.bin.scad, line 77
+WARNING: new lines 'use<>'-statement is not defined - behavior may change in the future in file ../../tests/data/scad/misc/linenumber-NL-1.bin.scad, line 78
+WARNING: new lines 'use<>'-statement is not defined - behavior may change in the future in file ../../tests/data/scad/misc/linenumber-NL-1.bin.scad, line 79
+WARNING: Can't open library 'line79'. in file ../../tests/data/scad/misc/linenumber-NL-1.bin.scad, line 80
+WARNING: new lines in 'include<>'-statement is not defined - behavior may change in the future in file ../../tests/data/scad/misc/linenumber-NL-1.bin.scad, line 108
+WARNING: new lines in 'include<>'-statement is not defined - behavior may change in the future in file ../../tests/data/scad/misc/linenumber-NL-1.bin.scad, line 109
+WARNING: new lines in 'include<>'-statement is not defined - behavior may change in the future in file ../../tests/data/scad/misc/linenumber-NL-1.bin.scad, line 110
+WARNING: Can't open include file 'line110'. in file ../../tests/data/scad/misc/linenumber-NL-1.bin.scad, line 111
+WARNING: new lines 'use<>'-statement is not defined - behavior may change in the future in file ../../tests/data/scad/misc/linenumber-NL-1.bin.scad, line 117
+WARNING: new lines 'use<>'-statement is not defined - behavior may change in the future in file ../../tests/data/scad/misc/linenumber-NL-1.bin.scad, line 118
+WARNING: new lines 'use<>'-statement is not defined - behavior may change in the future in file ../../tests/data/scad/misc/linenumber-NL-1.bin.scad, line 119
+WARNING: Can't open library 'line119'. in file ../../tests/data/scad/misc/linenumber-NL-1.bin.scad, line 120
+WARNING: Ignoring unknown variable 'line16' in file linenumber-NL-1.bin.scad, line 16
+ECHO: undef
+WARNING: Ignoring unknown variable 'line23' in file linenumber-NL-1.bin.scad, line 23
+ECHO: undef
+WARNING: Ignoring unknown variable 'line33' in file linenumber-NL-1.bin.scad, line 33
+ECHO: undef
+WARNING: Ignoring unknown variable 'line42' in file linenumber-NL-1.bin.scad, line 42
+ECHO: undef
+WARNING: Ignoring unknown variable 'line48' in file linenumber-NL-1.bin.scad, line 48
+ECHO: undef
+WARNING: Ignoring unknown variable 'line56' in file linenumber-NL-1.bin.scad, line 56
+ECHO: undef
+WARNING: Ignoring unknown variable 'line63' in file linenumber-NL-1.bin.scad, line 63
+ECHO: undef
+WARNING: Ignoring unknown variable 'line73' in file linenumber-NL-1.bin.scad, line 73
+ECHO: undef
+WARNING: Ignoring unknown variable 'line82' in file linenumber-NL-1.bin.scad, line 82
+ECHO: undef
+WARNING: Ignoring unknown variable 'line88' in file linenumber-NL-1.bin.scad, line 88
+ECHO: undef
+WARNING: Ignoring unknown variable 'line96' in file linenumber-NL-1.bin.scad, line 96
+ECHO: undef
+WARNING: Ignoring unknown variable 'line103' in file linenumber-NL-1.bin.scad, line 103
+ECHO: undef
+WARNING: Ignoring unknown variable 'line113' in file linenumber-NL-1.bin.scad, line 113
+ECHO: undef
+WARNING: Ignoring unknown variable 'line122' in file linenumber-NL-1.bin.scad, line 122
+ECHO: undef
+WARNING: Ignoring unknown variable 'line128' in file linenumber-NL-1.bin.scad, line 128
+ECHO: undef

--- a/tests/regression/echotest/linenumber-NL-2-expected.echo
+++ b/tests/regression/echotest/linenumber-NL-2-expected.echo
@@ -1,0 +1,27 @@
+WARNING: new lines in 'include<>'-statement is not defined - behavior may change in the future in file ../../tests/data/scad/misc/linenumber-NL-2.bin.scad, line 28
+WARNING: new lines in 'include<>'-statement is not defined - behavior may change in the future in file ../../tests/data/scad/misc/linenumber-NL-2.bin.scad, line 29
+WARNING: new lines in 'include<>'-statement is not defined - behavior may change in the future in file ../../tests/data/scad/misc/linenumber-NL-2.bin.scad, line 30
+WARNING: Can't open include file 'line30'. in file ../../tests/data/scad/misc/linenumber-NL-2.bin.scad, line 31
+WARNING: new lines 'use<>'-statement is not defined - behavior may change in the future in file ../../tests/data/scad/misc/linenumber-NL-2.bin.scad, line 37
+WARNING: new lines 'use<>'-statement is not defined - behavior may change in the future in file ../../tests/data/scad/misc/linenumber-NL-2.bin.scad, line 38
+WARNING: new lines 'use<>'-statement is not defined - behavior may change in the future in file ../../tests/data/scad/misc/linenumber-NL-2.bin.scad, line 39
+WARNING: Can't open library 'line39'. in file ../../tests/data/scad/misc/linenumber-NL-2.bin.scad, line 40
+WARNING: new lines in 'include<>'-statement is not defined - behavior may change in the future in file ../../tests/data/scad/misc/linenumber-NL-2.bin.scad, line 68
+WARNING: new lines in 'include<>'-statement is not defined - behavior may change in the future in file ../../tests/data/scad/misc/linenumber-NL-2.bin.scad, line 69
+WARNING: new lines in 'include<>'-statement is not defined - behavior may change in the future in file ../../tests/data/scad/misc/linenumber-NL-2.bin.scad, line 70
+WARNING: Can't open include file 'line70'. in file ../../tests/data/scad/misc/linenumber-NL-2.bin.scad, line 71
+WARNING: new lines 'use<>'-statement is not defined - behavior may change in the future in file ../../tests/data/scad/misc/linenumber-NL-2.bin.scad, line 77
+WARNING: new lines 'use<>'-statement is not defined - behavior may change in the future in file ../../tests/data/scad/misc/linenumber-NL-2.bin.scad, line 78
+WARNING: new lines 'use<>'-statement is not defined - behavior may change in the future in file ../../tests/data/scad/misc/linenumber-NL-2.bin.scad, line 79
+WARNING: Can't open library 'line79'. in file ../../tests/data/scad/misc/linenumber-NL-2.bin.scad, line 80
+WARNING: new lines in 'include<>'-statement is not defined - behavior may change in the future in file ../../tests/data/scad/misc/linenumber-NL-2.bin.scad, line 108
+WARNING: new lines in 'include<>'-statement is not defined - behavior may change in the future in file ../../tests/data/scad/misc/linenumber-NL-2.bin.scad, line 109
+WARNING: new lines in 'include<>'-statement is not defined - behavior may change in the future in file ../../tests/data/scad/misc/linenumber-NL-2.bin.scad, line 110
+WARNING: Can't open include file 'line110'. in file ../../tests/data/scad/misc/linenumber-NL-2.bin.scad, line 111
+WARNING: new lines 'use<>'-statement is not defined - behavior may change in the future in file ../../tests/data/scad/misc/linenumber-NL-2.bin.scad, line 117
+WARNING: new lines 'use<>'-statement is not defined - behavior may change in the future in file ../../tests/data/scad/misc/linenumber-NL-2.bin.scad, line 118
+WARNING: new lines 'use<>'-statement is not defined - behavior may change in the future in file ../../tests/data/scad/misc/linenumber-NL-2.bin.scad, line 119
+WARNING: Can't open library 'line119'. in file ../../tests/data/scad/misc/linenumber-NL-2.bin.scad, line 120
+ERROR: Parser error: syntax error in file ../../tests/data/scad/misc/linenumber-NL-2.bin.scad, line 129
+Can't parse file 'C:/msys64/home/jordan/openscad/4882a-CRLF/tests/data/scad/misc/linenumber-NL-2.bin.scad'!
+

--- a/tests/regression/echotest/linenumber-expected.echo
+++ b/tests/regression/echotest/linenumber-expected.echo
@@ -1,11 +1,11 @@
 WARNING: Can't open library 'line 1'. in file ../../tests/data/scad/misc/linenumber.scad, line 1
 WARNING: Can't open include file 'line 1'. in file ../../tests/data/scad/misc/linenumber.scad, line 1
+WARNING: new lines in 'include<>'-statement is not defined - behavior may change in the future in file ../../tests/data/scad/misc/linenumber.scad, line 6
 WARNING: new lines in 'include<>'-statement is not defined - behavior may change in the future in file ../../tests/data/scad/misc/linenumber.scad, line 7
 WARNING: new lines in 'include<>'-statement is not defined - behavior may change in the future in file ../../tests/data/scad/misc/linenumber.scad, line 8
 WARNING: new lines in 'include<>'-statement is not defined - behavior may change in the future in file ../../tests/data/scad/misc/linenumber.scad, line 9
-WARNING: new lines in 'include<>'-statement is not defined - behavior may change in the future in file ../../tests/data/scad/misc/linenumber.scad, line 10
 WARNING: Can't open include file 'line 9'. in file ../../tests/data/scad/misc/linenumber.scad, line 10
-WARNING: new lines 'use<>'-statement is not defined - behavior may change in the future in file ../../tests/data/scad/misc/linenumber.scad, line 16
+WARNING: new lines 'use<>'-statement is not defined - behavior may change in the future in file ../../tests/data/scad/misc/linenumber.scad, line 15
 WARNING: Can't open library 'line 16'. in file ../../tests/data/scad/misc/linenumber.scad, line 16
 WARNING: Unable to convert cube(size="line 3", ...) parameter to a number or a vec3 of numbers in file linenumber.scad, line 3
 WARNING: Unable to convert cube(size="line 12", ...) parameter to a number or a vec3 of numbers in file linenumber.scad, line 12


### PR DESCRIPTION
Fixes lexer to count lines properly in files with \n, \r\n, and \r line breaks.  (\r line breaks are used only in some old or obscure systems, but what the heck.)

Tweaks existing line number counting for (bad but legacy) include/use cases:
```
include <
line2>
```
reports a warning.  Old behavior was to report it on line 2, but really the error (the unexpected end-of-line) is on line 1 so the new behavior (and tweak to existing test) makes it report line 1.

Adds a new `RETVAL` argument to `add_cmdline_test()` to allow tests where execution is expected to fail to still get expected-output comparison, to check that the right errors (and line numbers!) are reported.  We should probably eventually move the existing add_failing_test cases to use this mechanism instead, so that they can check the error reported.

Adds a gitattributes file that suppresses text processing for the new `*.bin.scad` test files.  Those files have sections that are UNIX-style, sections that are Windows-style, and an obscure \r-only section.  In theory I think git will preserve them, but they may be too fragile for long-term use.  We'll see.
