### PR TITLE
Preferences typo and Capitalisation

### DIFF
--- a/locale/ru.po
+++ b/locale/ru.po
@@ -1855,7 +1855,7 @@ msgid "(max. number or trace messages)"
 msgstr ""
 
 #: build/OpenSCAD_autogen/include/ui_Preferences.h:1997
-msgid "show parameters of usermodul calls in trace"
+msgid "show parameters of usermodule calls in trace"
 msgstr ""
 
 #: build/OpenSCAD_autogen/include/ui_Preferences.h:1998

--- a/locale/ru.po
+++ b/locale/ru.po
@@ -1763,7 +1763,7 @@ msgid "Console"
 msgstr "Консоль"
 
 #: build/OpenSCAD_autogen/include/ui_Preferences.h:1971
-msgid "clear console before Preview/Render"
+msgid "Clear console before Preview/Render"
 msgstr ""
 
 #: build/OpenSCAD_autogen/include/ui_Preferences.h:1972
@@ -1855,7 +1855,7 @@ msgid "(max. number or trace messages)"
 msgstr ""
 
 #: build/OpenSCAD_autogen/include/ui_Preferences.h:1997
-msgid "show parameters of usermodule calls in trace"
+msgid "Show parameters of usermodule calls in trace"
 msgstr ""
 
 #: build/OpenSCAD_autogen/include/ui_Preferences.h:1998

--- a/src/gui/Preferences.ui
+++ b/src/gui/Preferences.ui
@@ -2281,7 +2281,7 @@
                <item>
                 <widget class="QCheckBox" name="enableTraceUsermoduleParametersCheckBox">
                  <property name="text">
-                  <string>show parameters of usermodul calls in trace</string>
+                  <string>show parameters of usermodule calls in trace</string>
                  </property>
                  <property name="checked">
                   <bool>false</bool>

--- a/src/gui/Preferences.ui
+++ b/src/gui/Preferences.ui
@@ -1976,7 +1976,7 @@
                <item>
                 <widget class="QCheckBox" name="enableClearConsoleCheckBox">
                  <property name="text">
-                  <string>clear console before Preview/Render</string>
+                  <string>Clear console before Preview/Render</string>
                  </property>
                  <property name="checked">
                   <bool>false</bool>
@@ -2281,7 +2281,7 @@
                <item>
                 <widget class="QCheckBox" name="enableTraceUsermoduleParametersCheckBox">
                  <property name="text">
-                  <string>show parameters of usermodule calls in trace</string>
+                  <string>Show parameters of usermodule calls in trace</string>
                  </property>
                  <property name="checked">
                   <bool>false</bool>

--- a/tests/data/scad/issues/issue4172-echo-vector-stack-exhaust.scad
+++ b/tests/data/scad/issues/issue4172-echo-vector-stack-exhaust.scad
@@ -5,7 +5,7 @@
 
 //As the implementation is recursive and adds multiple dimension per call,
 //it should run into stack exhaust trying to create the echo string
-//(and not into a stack exhaust due to recursive usermodul call).
+//(and not into a stack exhaust due to recursive usermodule call).
 
 rec();
 


### PR DESCRIPTION
Some trivial updates to preferences. All the other advanced preferences start with a capital letter.