### PR TITLE
Changes to allow building with Qt 6

### DIFF
--- a/src/gui/Animate.cc
+++ b/src/gui/Animate.cc
@@ -308,18 +308,18 @@ void Animate::resizeEvent(QResizeEvent *event)
     if (sizeEvent.height() > 140) {
       mainLayout->setDirection(QBoxLayout::TopToBottom);
       if (sizeEvent.height() > 250 && sizeEvent.width() > 200) {
-        mainLayout->setMargin(10);
+        mainLayout->setContentsMargins(10, 10, 10, 10);
         mainLayout->setSpacing(10);
         iconSize = 32;
       } else {
-        mainLayout->setMargin(0);
+        mainLayout->setContentsMargins(0, 0, 0, 0);
         mainLayout->setSpacing(0);
       }
       this->vcr_controls->show();
     } else {
       mainLayout->setDirection(QBoxLayout::LeftToRight);
 
-      mainLayout->setMargin(0);
+      mainLayout->setContentsMargins(0, 0, 0, 0);
       mainLayout->setSpacing(0);
       if (sizeEvent.width() > 720) {
         this->vcr_controls->show();

--- a/src/gui/ErrorLog.cc
+++ b/src/gui/ErrorLog.cc
@@ -113,7 +113,7 @@ int ErrorLog::getLine(int row, int col)
   return logTable->model()->index(row, col).data().toInt();
 }
 
-void ErrorLog::on_errorLogComboBox_currentIndexChanged(const QString& group)
+void ErrorLog::on_errorLogComboBox_currentTextChanged(const QString& group)
 {
   errorLogModel->clear();
   initGUI();

--- a/src/gui/ErrorLog.h
+++ b/src/gui/ErrorLog.h
@@ -44,7 +44,7 @@ signals:
 
 private slots:
   void on_logTable_doubleClicked(const QModelIndex& index);
-  void on_errorLogComboBox_currentIndexChanged(const QString& arg1);
+  void on_errorLogComboBox_currentTextChanged(const QString& arg1);
   void on_actionRowSelected_triggered(bool);
   void onSectionResized(int, int, int);
 };

--- a/src/gui/MainWindow.cc
+++ b/src/gui/MainWindow.cc
@@ -63,6 +63,9 @@
 #ifdef Q_OS_MAC
 #include "CocoaUtils.h"
 #endif
+#ifdef Q_OS_WIN
+#include <QScreen>
+#endif
 #include "PlatformUtils.h"
 #ifdef OPENSCAD_UPDATER
 #include "AutoUpdater.h"

--- a/src/gui/MainWindow.cc
+++ b/src/gui/MainWindow.cc
@@ -679,8 +679,8 @@ MainWindow::MainWindow(const QStringList& filenames)
     // again.
     // On Windows that causes the main window to open in a not
     // easily reachable place.
-    auto desktop = QApplication::desktop();
-    auto desktopRect = desktop->frameGeometry().adjusted(250, 150, -250, -150).normalized();
+    auto primaryScreen = QApplication::primaryScreen();
+    auto desktopRect = primaryScreen->availableGeometry().adjusted(250, 150, -250, -150).normalized();
     auto windowRect = frameGeometry();
     if (!desktopRect.intersects(windowRect)) {
       windowRect.moveCenter(desktopRect.center());

--- a/src/gui/MainWindow.h
+++ b/src/gui/MainWindow.h
@@ -19,6 +19,7 @@
 #include <QIcon>
 #include <QIODevice>
 #include <QMutex>
+#include <QSoundEffect>
 #include <QTime>
 
 #ifdef STATIC_QT_SVG_PLUGIN
@@ -375,7 +376,9 @@ private:
   int tabCount = 0;
   paperSizes sizeString2Enum(QString current);
   paperOrientations orientationsString2Enum(QString current);
-  
+
+  QSoundEffect *renderCompleteSoundEffect;
+
 signals:
   void highlightError(int);
   void unhighlightLastError();

--- a/src/gui/Preferences.cc
+++ b/src/gui/Preferences.cc
@@ -26,9 +26,12 @@
 
 #include "Preferences.h"
 
+#include <QActionGroup>
 #include <QMessageBox>
 #include <QFontDatabase>
 #include <QKeyEvent>
+#include <QRegularExpression>
+#include <QRegularExpressionValidator>
 #include <QStatusBar>
 #include <QSettings>
 #include <QTextDocument>
@@ -174,7 +177,7 @@ void Preferences::init() {
   QValidator *memvalidator = new QIntValidator(1, absolute_max, this);
   auto *uintValidator = new QIntValidator(this);
   uintValidator->setBottom(0);
-  QValidator *validator1 = new QRegExpValidator(QRegExp("[1-9][0-9]{0,1}"), this); // range between 1-99 both inclusive
+  QValidator *validator1 = new QRegularExpressionValidator(QRegularExpression("[1-9][0-9]{0,1}"), this); // range between 1-99 both inclusive
 #ifdef ENABLE_CGAL
   this->cgalCacheSizeMBEdit->setValidator(memvalidator);
 #endif

--- a/src/gui/Preferences.cc
+++ b/src/gui/Preferences.cc
@@ -356,22 +356,22 @@ void Preferences::on_colorSchemeChooser_itemSelectionChanged()
   emit colorSchemeChanged(scheme);
 }
 
-void Preferences::on_fontChooser_activated(const QString& family)
+void Preferences::on_fontChooser_currentFontChanged(const QFont& font)
 {
   QSettingsCached settings;
-  settings.setValue("editor/fontfamily", family);
-  emit fontChanged(family, getValue("editor/fontsize").toUInt());
+  settings.setValue("editor/fontfamily", font.family());
+  emit fontChanged(font.family(), getValue("editor/fontsize").toUInt());
 }
 
-void Preferences::on_fontSize_currentIndexChanged(const QString& size)
+void Preferences::on_fontSize_currentIndexChanged(int index)
 {
-  uint intsize = size.toUInt();
+  uint intsize = this->fontSize->itemText(index).toUInt();
   QSettingsCached settings;
   settings.setValue("editor/fontsize", intsize);
   emit fontChanged(getValue("editor/fontfamily").toString(), intsize);
 }
 
-void Preferences::on_syntaxHighlight_activated(const QString& s)
+void Preferences::on_syntaxHighlight_currentTextChanged(const QString& s)
 {
   QSettingsCached settings;
   settings.setValue("editor/syntaxhighlight", s);
@@ -639,16 +639,16 @@ void Preferences::on_consoleMaxLinesEdit_textChanged(const QString& text)
   settings.setValue("advanced/consoleMaxLines", text);
 }
 
-void Preferences::on_consoleFontChooser_activated(const QString& family)
+void Preferences::on_consoleFontChooser_currentFontChanged(const QFont& font)
 {
   QSettingsCached settings;
-  settings.setValue("advanced/consoleFontFamily", family);
-  emit consoleFontChanged(family, getValue("advanced/consoleFontSize").toUInt());
+  settings.setValue("advanced/consoleFontFamily", font.family());
+  emit consoleFontChanged(font.family(), getValue("advanced/consoleFontSize").toUInt());
 }
 
-void Preferences::on_consoleFontSize_currentIndexChanged(const QString& size)
-{
-  uint intsize = size.toUInt();
+void Preferences::on_consoleFontSize_currentIndexChanged(int index)
+{ 
+  uint intsize = this->consoleFontSize->itemText(index).toUInt();
   QSettingsCached settings;
   settings.setValue("advanced/consoleFontSize", intsize);
   emit consoleFontChanged(getValue("advanced/consoleFontFamily").toString(), intsize);

--- a/src/gui/Preferences.h
+++ b/src/gui/Preferences.h
@@ -29,9 +29,9 @@ public slots:
   void featuresCheckBoxToggled(bool);
   void on_stackedWidget_currentChanged(int);
   void on_colorSchemeChooser_itemSelectionChanged();
-  void on_fontChooser_activated(const QString&);
-  void on_fontSize_currentIndexChanged(const QString&);
-  void on_syntaxHighlight_activated(const QString&);
+  void on_fontChooser_currentFontChanged(const QFont&);
+  void on_fontSize_currentIndexChanged(int);
+  void on_syntaxHighlight_currentTextChanged(const QString&);
   void on_openCSGWarningBox_toggled(bool);
   void on_cgalCacheSizeMBEdit_textChanged(const QString&);
   void on_polysetCacheSizeMBEdit_textChanged(const QString&);
@@ -65,8 +65,8 @@ public slots:
   void on_timeThresholdOnRenderCompleteSoundEdit_textChanged(const QString&);
   void on_enableClearConsoleCheckBox_toggled(bool);
   void on_consoleMaxLinesEdit_textChanged(const QString&);
-  void on_consoleFontChooser_activated(const QString&);
-  void on_consoleFontSize_currentIndexChanged(const QString&);
+  void on_consoleFontChooser_currentFontChanged(const QFont&);
+  void on_consoleFontSize_currentIndexChanged(int);
   void on_checkBoxEnableAutocomplete_toggled(bool);
   void on_lineEditCharacterThreshold_textChanged(const QString&);
   //

--- a/src/gui/ScadLexer.cc
+++ b/src/gui/ScadLexer.cc
@@ -397,7 +397,7 @@ QString ScadLexer2::description(int style) const
   case Comment:
     return "Comment";
   }
-  return {style};
+  return {QString::number(style)};
 }
 
 const char *ScadLexer2::language() const

--- a/src/gui/ScintillaEditor.cc
+++ b/src/gui/ScintillaEditor.cc
@@ -6,6 +6,8 @@
 #include <boost/property_tree/json_parser.hpp>
 #include <QString>
 #include <QChar>
+#include <QRegExp>
+#include <QRegularExpression>
 #include <QShortcut>
 #include <Qsci/qscicommandset.h>
 
@@ -1155,11 +1157,11 @@ void ScintillaEditor::navigateOnNumber(int key)
   qsci->getCursorPosition(&line, &index);
   auto text = qsci->text(line);
   auto left = text.left(index);
-  auto dotOnLeft = left.contains(QRegExp("\\.\\d*$"));
+  auto dotOnLeft = left.contains(QRegularExpression("\\.\\d*$"));
   auto dotJustLeft = index > 1 && text[index - 2] == '.';
   auto dotJustRight = text[index] == '.';
-  auto numOnLeft = left.contains(QRegExp("\\d\\.?$")) || left.endsWith("-.");
-  auto numOnRight = text.indexOf(QRegExp("\\.?\\d"), index) == index;
+  auto numOnLeft = left.contains(QRegularExpression("\\d\\.?$")) || left.endsWith("-.");
+  auto numOnRight = text.indexOf(QRegularExpression("\\.?\\d"), index) == index;
 
   switch (key) {
   case Qt::Key_Left:
@@ -1199,10 +1201,10 @@ bool ScintillaEditor::modifyNumber(int key)
   auto check = text.mid(begin - 1, 1);
   if (rx.exactMatch(check)) return false;
 
-  auto end = text.indexOf(QRegExp("[^0-9.]"), index);
+  auto end = text.indexOf(QRegularExpression("[^0-9.]"), index);
   if (end < 0) end = text.length();
   auto nr = text.mid(begin, end - begin);
-  if (!(nr.contains(QRegExp(R"(^[-+]?\d*\.?\d+$)")) && nr.contains(QRegExp("\\d"))) ) return false;
+  if (!(nr.contains(QRegularExpression(R"(^[-+]?\d*\.?\d+$)")) && nr.contains(QRegularExpression("\\d"))) ) return false;
   auto sign = nr[0] == '+'||nr[0] == '-';
   if (nr.endsWith('.')) nr = nr.left(nr.length() - 1);
   auto curpos = index - begin;
@@ -1414,7 +1416,7 @@ void ScintillaEditor::findMarker(int findStartOffset, int wrapStart, const std::
   }
   if (line != -1) {
     // make sure we don't wrap into new line
-    int len = qsci->text(line).remove(QRegExp("[\n\r]$")).length();
+    int len = qsci->text(line).remove(QRegularExpression("[\n\r]$")).length();
     int col = std::min(index, len);
     qsci->setCursorPosition(line, col);
   }

--- a/src/gui/TabManager.cc
+++ b/src/gui/TabManager.cc
@@ -547,7 +547,9 @@ bool TabManager::refreshDocument()
           editor->filepath.toLocal8Bit().constData(), file.errorString().toLocal8Bit().constData());
     } else {
       QTextStream reader(&file);
+#if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
       reader.setCodec("UTF-8");
+#endif
       auto text = reader.readAll();
       LOG("Loaded design '%1$s'.", editor->filepath.toLocal8Bit().constData());
       if (editor->toPlainText() != text) {
@@ -665,7 +667,9 @@ bool TabManager::save(EditorInterface *edt, const QString& path)
   }
 
   QTextStream writer(&file);
+#if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
   writer.setCodec("UTF-8");
+#endif
   writer << edt->toPlainText();
   writer.flush();
   bool saveOk = writer.status() == QTextStream::Ok;

--- a/src/gui/ViewportControl.cc
+++ b/src/gui/ViewportControl.cc
@@ -5,7 +5,6 @@
 #include <boost/filesystem.hpp>
 #include <cfloat>
 #include <QDoubleSpinBox>
-#include <QDesktopWidget>
 
 ViewportControl::ViewportControl(QWidget *parent) : QWidget(parent)
 {

--- a/src/gui/parameter/ParameterVirtualWidget.cc
+++ b/src/gui/parameter/ParameterVirtualWidget.cc
@@ -1,5 +1,7 @@
 #include "ParameterVirtualWidget.h"
 
+#include <QRegularExpression>
+
 ParameterDescriptionWidget::ParameterDescriptionWidget(QWidget *parent) :
   QWidget(parent)
 {
@@ -8,7 +10,7 @@ ParameterDescriptionWidget::ParameterDescriptionWidget(QWidget *parent) :
 
 void ParameterDescriptionWidget::setDescription(ParameterObject *parameter, DescriptionStyle descriptionStyle)
 {
-  labelParameter->setText(QString::fromStdString(parameter->name()).replace(QRegExp("([_]+)"), " "));
+  labelParameter->setText(QString::fromStdString(parameter->name()).replace(QRegularExpression("([_]+)"), " "));
   if (parameter->description().empty()) {
     labelDescription->hide();
     labelInline->setText("");

--- a/src/openscad.cc
+++ b/src/openscad.cc
@@ -655,7 +655,6 @@ int do_export(const CommandLine& cmd, const RenderVariables& render_variables, F
 #include <QDir>
 #include <QFileInfo>
 #include <QMetaType>
-#include <QTextCodec>
 #include <QProgressDialog>
 #include <QFutureWatcher>
 #include <QtConcurrentRun>


### PR DESCRIPTION
With Qt5Compat and without gamepad support.

and Fix slots not matching signals with Qt 6

---

These changes allow me to do a non-experimental build and run OpenSCAD on Qt 6 (and still with Qt 5 too).

N.B. I am really a Python person so do please check carefully - especially the use of QSoundEffect, and I kinda guessed what the return value of `ScadLexer2::description()` should be.
