### PR TITLE
Stop using + operator when creating QKeySequence

### DIFF
--- a/src/gui/MainWindow.cc
+++ b/src/gui/MainWindow.cc
@@ -454,7 +454,7 @@ MainWindow::MainWindow(const QStringList& filenames)
   connect(this->editActionFind, SIGNAL(triggered()), this, SLOT(showFind()));
   connect(this->editActionFindAndReplace, SIGNAL(triggered()), this, SLOT(showFindAndReplace()));
 #ifdef Q_OS_WIN
-  this->editActionFindAndReplace->setShortcut(QKeySequence(Qt::CTRL + Qt::SHIFT + Qt::Key_F));
+  this->editActionFindAndReplace->setShortcut(QKeySequence(Qt::CTRL, Qt::SHIFT, Qt::Key_F));
 #endif
   connect(this->editActionFindNext, SIGNAL(triggered()), this, SLOT(findNext()));
   connect(this->editActionFindPrevious, SIGNAL(triggered()), this, SLOT(findPrev()));


### PR DESCRIPTION
Dropped in Qt 6:

 D:/a/openscad/openscad/src/gui/MainWindow.cc:457: error: use of deleted
function 'constexpr void Qt::operator+(QFlags<Modifier>::enum_type, QFlags<Modifier>::enum_type)'

---

Compiles on Qt 6, let's see if it does so on Qt 5. Haven't run it (MS Windows only).
