### PR TITLE
Clean up Toolbar Export 3D/2D preferences

### DIFF
--- a/src/gui/Preferences.ui
+++ b/src/gui/Preferences.ui
@@ -1910,60 +1910,6 @@
                  </item>
                 </layout>
                </item>
-               <item>
-                <layout class="QHBoxLayout" name="horizontalLayoutToolbarExport3D">
-                 <item>
-                  <widget class="QLabel" name="labelToolbarExport3D">
-                   <property name="text">
-                    <string>Toolbar Export 3D</string>
-                   </property>
-                  </widget>
-                 </item>
-                 <item>
-                  <widget class="QComboBox" name="comboBoxToolbarExport3D"/>
-                 </item>
-                 <item>
-                  <spacer name="horizontalSpacerToolbarExport3D">
-                   <property name="orientation">
-                    <enum>Qt::Horizontal</enum>
-                   </property>
-                   <property name="sizeHint" stdset="0">
-                    <size>
-                     <width>40</width>
-                     <height>20</height>
-                    </size>
-                   </property>
-                  </spacer>
-                 </item>
-                </layout>
-               </item>
-               <item>
-                <layout class="QHBoxLayout" name="horizontalLayoutToolbarExport2D">
-                 <item>
-                  <widget class="QLabel" name="labelToolbarExport2D">
-                   <property name="text">
-                    <string>Toolbar Export 2D</string>
-                   </property>
-                  </widget>
-                 </item>
-                 <item>
-                  <widget class="QComboBox" name="comboBoxToolbarExport2D"/>
-                 </item>
-                 <item>
-                  <spacer name="horizontalSpacerToolbarExport2D">
-                   <property name="orientation">
-                    <enum>Qt::Horizontal</enum>
-                   </property>
-                   <property name="sizeHint" stdset="0">
-                    <size>
-                     <width>40</width>
-                     <height>20</height>
-                    </size>
-                   </property>
-                  </spacer>
-                 </item>
-                </layout>
-               </item>
               </layout>
              </widget>
             </item>
@@ -2061,112 +2007,6 @@
                  </item>
                  <item>
                   <spacer name="horizontalSpacer_35">
-                   <property name="orientation">
-                    <enum>Qt::Horizontal</enum>
-                   </property>
-                   <property name="sizeHint" stdset="0">
-                    <size>
-                     <width>40</width>
-                     <height>20</height>
-                    </size>
-                   </property>
-                  </spacer>
-                 </item>
-                </layout>
-               </item>
-               <item>
-                <layout class="QHBoxLayout" name="horizontalLayoutExport3D">
-                 <item>
-                  <widget class="QLabel" name="labelExport3D">
-                   <property name="text">
-                    <string>Toolbar Export Format 3D</string>
-                   </property>
-                  </widget>
-                 </item>
-                 <item>
-                  <widget class="QComboBox" name="comboBoxExport3D">
-                   <item>
-                    <property name="text">
-                     <string>STL</string>
-                    </property>
-                   </item>
-                   <item>
-                    <property name="text">
-                     <string>OBJ</string>
-                    </property>
-                   </item>
-                   <item>
-                    <property name="text">
-                     <string>OFF</string>
-                    </property>
-                   </item>
-                   <item>
-                    <property name="text">
-                     <string>WRL</string>
-                    </property>
-                   </item>
-                   <item>
-                    <property name="text">
-                     <string>AMF</string>
-                    </property>
-                   </item>
-                   <item>
-                    <property name="text">
-                     <string>3MF</string>
-                    </property>
-                   </item>
-                  </widget>
-                 </item>
-                 <item>
-                  <spacer name="horizontalSpacerExport3D">
-                   <property name="orientation">
-                    <enum>Qt::Horizontal</enum>
-                   </property>
-                   <property name="sizeHint" stdset="0">
-                    <size>
-                     <width>40</width>
-                     <height>20</height>
-                    </size>
-                   </property>
-                  </spacer>
-                 </item>
-                </layout>
-               </item>
-               <item>
-                <layout class="QHBoxLayout" name="horizontalLayoutExport2D">
-                 <item>
-                  <widget class="QLabel" name="labelExport2D">
-                   <property name="text">
-                    <string>Toolbar Export Format 2D</string>
-                   </property>
-                  </widget>
-                 </item>
-                 <item>
-                  <widget class="QComboBox" name="comboBoxExport2D">
-                   <item>
-                    <property name="text">
-                     <string>none</string>
-                    </property>
-                   </item>
-                   <item>
-                    <property name="text">
-                     <string>DXF</string>
-                    </property>
-                   </item>
-                   <item>
-                    <property name="text">
-                     <string>SVG</string>
-                    </property>
-                   </item>
-                   <item>
-                    <property name="text">
-                     <string>PDF</string>
-                    </property>
-                   </item>
-                  </widget>
-                 </item>
-                 <item>
-                  <spacer name="horizontalSpacerExport2D">
                    <property name="orientation">
                     <enum>Qt::Horizontal</enum>
                    </property>
@@ -2349,6 +2189,60 @@
                   <string>Default to ASCII STL export</string>
                  </property>
                 </widget>
+               </item>
+               <item>
+                <layout class="QHBoxLayout" name="horizontalLayoutToolbarExport3D">
+                 <item>
+                  <widget class="QLabel" name="labelToolbarExport3D">
+                   <property name="text">
+                    <string>Toolbar Export 3D</string>
+                   </property>
+                  </widget>
+                 </item>
+                 <item>
+                  <widget class="QComboBox" name="comboBoxToolbarExport3D"/>
+                 </item>
+                 <item>
+                  <spacer name="horizontalSpacerToolbarExport3D">
+                   <property name="orientation">
+                    <enum>Qt::Horizontal</enum>
+                   </property>
+                   <property name="sizeHint" stdset="0">
+                    <size>
+                     <width>40</width>
+                     <height>20</height>
+                    </size>
+                   </property>
+                  </spacer>
+                 </item>
+                </layout>
+               </item>
+               <item>
+                <layout class="QHBoxLayout" name="horizontalLayoutToolbarExport2D">
+                 <item>
+                  <widget class="QLabel" name="labelToolbarExport2D">
+                   <property name="text">
+                    <string>Toolbar Export 2D</string>
+                   </property>
+                  </widget>
+                 </item>
+                 <item>
+                  <widget class="QComboBox" name="comboBoxToolbarExport2D"/>
+                 </item>
+                 <item>
+                  <spacer name="horizontalSpacerToolbarExport2D">
+                   <property name="orientation">
+                    <enum>Qt::Horizontal</enum>
+                   </property>
+                   <property name="sizeHint" stdset="0">
+                    <size>
+                     <width>40</width>
+                     <height>20</height>
+                    </size>
+                   </property>
+                  </spacer>
+                 </item>
+                </layout>
                </item>
               </layout>
              </widget>


### PR DESCRIPTION
Remove duplicate (and non-operative) Toolbar Export 3D/2D options from "Console" section.
Move working Toolbar Export 3D/2D options from "User Interface" to "Export Features".

Before (note that bottom one does not match toolbar buttons):
![image](https://github.com/openscad/openscad/assets/31949071/4af62b83-ecc0-402b-8b46-c93430a5355d)

After:
![image](https://github.com/openscad/openscad/assets/31949071/ae4bfa98-fec6-43f0-a265-340164698189)

Note:  There's one section of the file that's just deleted; there's another that's moved unchanged from one place to another.