### PR TITLE
Make customizer font and size selectable.

### DIFF
--- a/src/gui/Preferences.cc
+++ b/src/gui/Preferences.cc
@@ -88,33 +88,19 @@ void Preferences::init() {
   this->defaultmap["advanced/consoleFontFamily"] = font2.family();
   this->defaultmap["advanced/consoleFontSize"] = font2.pointSize();
 
+  // Leave Customizer font with default if user has not chosen another.
+  this->defaultmap["advanced/customizerFontFamily"] = font2.family();
+  this->defaultmap["advanced/customizerFontSize"] = font2.pointSize();
+
 #if defined (Q_OS_MAC)
   this->defaultmap["editor/ctrlmousewheelzoom"] = false;
 #else
   this->defaultmap["editor/ctrlmousewheelzoom"] = true;
 #endif
 
-  uint savedsize = getValue("editor/fontsize").toUInt();
-  const QFontDatabase db;
-  BlockSignals<QComboBox *> fontSize{this->fontSize};
-  for (auto size : db.standardSizes()) {
-    fontSize->addItem(QString::number(size));
-    if (static_cast<uint>(size) == savedsize) {
-      fontSize->setCurrentIndex(this->fontSize->count() - 1);
-    }
-  }
-  // reset GUI fontsize if fontSize->addItem emitted signals that changed it.
-  this->fontSize->setEditText(QString("%1").arg(savedsize) );
-
-  uint consavedsize = getValue("advanced/consoleFontSize").toUInt();
-  BlockSignals<QComboBox *> consoleFontSize{this->consoleFontSize};
-  for (auto size : db.standardSizes()) {
-    consoleFontSize->addItem(QString::number(size));
-    if (static_cast<uint>(size) == consavedsize) {
-      consoleFontSize->setCurrentIndex(this->consoleFontSize->count() - 1);
-    }
-  }
-  this->consoleFontSize->setEditText(QString("%1").arg(consavedsize) );
+  createFontSizeMenu(fontSize, "editor/fontsize");
+  createFontSizeMenu(consoleFontSize, "advanced/consoleFontSize");
+  createFontSizeMenu(customizerFontSize, "advanced/customizerFontSize");
 
   // Setup default settings
   this->defaultmap["advanced/opencsg_show_warning"] = true;
@@ -647,11 +633,26 @@ void Preferences::on_consoleFontChooser_currentFontChanged(const QFont& font)
 }
 
 void Preferences::on_consoleFontSize_currentIndexChanged(int index)
-{ 
+{
   uint intsize = this->consoleFontSize->itemText(index).toUInt();
   QSettingsCached settings;
   settings.setValue("advanced/consoleFontSize", intsize);
   emit consoleFontChanged(getValue("advanced/consoleFontFamily").toString(), intsize);
+}
+
+void Preferences::on_customizerFontChooser_currentFontChanged(const QFont& font)
+{
+  QSettingsCached settings;
+  settings.setValue("advanced/customizerFontFamily", font.family());
+  emit customizerFontChanged(font.family(), getValue("advanced/customizerFontSize").toUInt());
+}
+
+void Preferences::on_customizerFontSize_currentIndexChanged(int index)
+{
+  uint intsize = this->customizerFontSize->itemText(index).toUInt();
+  QSettingsCached settings;
+  settings.setValue("advanced/customizerFontSize", intsize);
+  emit customizerFontChanged(getValue("advanced/customizerFontFamily").toString(), intsize);
 }
 
 void Preferences::on_checkBoxEnableAutocomplete_toggled(bool state)
@@ -928,19 +929,8 @@ void Preferences::updateGUI()
   const auto found = this->colorSchemeChooser->findItems(getValue("3dview/colorscheme").toString(), Qt::MatchExactly);
   if (!found.isEmpty()) BlockSignals<QListWidget *>(this->colorSchemeChooser)->setCurrentItem(found.first());
 
-  const auto fontfamily = getValue("editor/fontfamily").toString();
-  const auto fidx = this->fontChooser->findText(fontfamily, Qt::MatchContains);
-  if (fidx >= 0) {
-    BlockSignals<QFontComboBox *>(this->fontChooser)->setCurrentIndex(fidx);
-  }
-
-  const auto fontsize = getValue("editor/fontsize").toString();
-  const auto sidx = this->fontSize->findText(fontsize);
-  if (sidx >= 0) {
-    BlockSignals<QComboBox *>(this->fontSize)->setCurrentIndex(sidx);
-  } else {
-    BlockSignals<QComboBox *>(this->fontSize)->setEditText(fontsize);
-  }
+  updateGUIFontFamily(fontChooser, "editor/fontfamily");
+  updateGUIFontSize(fontSize, "editor/fontsize");
 
   const auto shighlight = getValue("editor/syntaxhighlight").toString();
   const auto shidx = this->syntaxHighlight->findText(shighlight);
@@ -971,20 +961,13 @@ void Preferences::updateGUI()
   BlockSignals<QLineEdit *>(this->timeThresholdOnRenderCompleteSoundEdit)->setText(getValue("advanced/timeThresholdOnRenderCompleteSound").toString());
   BlockSignals<QCheckBox *>(this->enableClearConsoleCheckBox)->setChecked(getValue("advanced/consoleAutoClear").toBool());
   BlockSignals<QLineEdit *>(this->consoleMaxLinesEdit)->setText(getValue("advanced/consoleMaxLines").toString());
-  {
-    const auto fontfamily = getValue("advanced/consoleFontFamily").toString();
-    const auto fidx = this->consoleFontChooser->findText(fontfamily, Qt::MatchContains);
-    if (fidx >= 0) {
-      BlockSignals<QFontComboBox *>(this->consoleFontChooser)->setCurrentIndex(fidx);
-    }
-    const auto fontsize = getValue("advanced/consoleFontSize").toString();
-    const auto sidx = this->consoleFontSize->findText(fontsize);
-    if (sidx >= 0) {
-      BlockSignals<QComboBox *>(this->consoleFontSize)->setCurrentIndex(sidx);
-    } else {
-      BlockSignals<QComboBox *>(this->consoleFontSize)->setEditText(fontsize);
-    }
-  }
+
+  updateGUIFontFamily(consoleFontChooser, "advanced/consoleFontFamily");
+  updateGUIFontSize(consoleFontSize, "advanced/consoleFontSize");
+
+  updateGUIFontFamily(customizerFontChooser, "advanced/customizerFontFamily");
+  updateGUIFontSize(customizerFontSize, "advanced/customizerFontSize");
+
   BlockSignals<QCheckBox *>(this->enableHardwarningsCheckBox)->setChecked(getValue("advanced/enableHardwarnings").toBool());
   BlockSignals<QLineEdit *>(this->traceDepthEdit)->setText(getValue("advanced/traceDepth").toString());
   BlockSignals<QCheckBox *>(this->enableTraceUsermoduleParametersCheckBox)->setChecked(getValue("advanced/enableTraceUsermoduleParameters").toBool());
@@ -1088,3 +1071,37 @@ Preferences *Preferences::inst() {
 }
 
 
+void Preferences::createFontSizeMenu(QComboBox *boxarg, const QString &setting)
+{
+  uint savedsize = getValue(setting).toUInt();
+  const QFontDatabase db;
+  BlockSignals<QComboBox *> box{boxarg};
+  for (auto size : db.standardSizes()) {
+    box->addItem(QString::number(size));
+    if (static_cast<uint>(size) == savedsize) {
+      box->setCurrentIndex(box->count() - 1);
+    }
+  }
+  // reset GUI fontsize if fontSize->addItem emitted signals that changed it.
+  box->setEditText(QString("%1").arg(savedsize) );
+}
+
+void Preferences::updateGUIFontFamily(QFontComboBox *ffSelector, const QString &setting)
+{
+    const auto fontfamily = getValue(setting).toString();
+    const auto fidx = ffSelector->findText(fontfamily, Qt::MatchContains);
+    if (fidx >= 0) {
+      BlockSignals<QFontComboBox *>(ffSelector)->setCurrentIndex(fidx);
+    }
+}
+
+void Preferences::updateGUIFontSize(QComboBox *fsSelector, const QString &setting)
+{
+  const auto fontsize = getValue(setting).toString();
+  const auto sidx = fsSelector->findText(fontsize);
+  if (sidx >= 0) {
+    BlockSignals<QComboBox *>(fsSelector)->setCurrentIndex(sidx);
+  } else {
+    BlockSignals<QComboBox *>(fsSelector)->setEditText(fontsize);
+  }
+}

--- a/src/gui/Preferences.h
+++ b/src/gui/Preferences.h
@@ -67,6 +67,8 @@ public slots:
   void on_consoleMaxLinesEdit_textChanged(const QString&);
   void on_consoleFontChooser_currentFontChanged(const QFont&);
   void on_consoleFontSize_currentIndexChanged(int);
+  void on_customizerFontChooser_currentFontChanged(const QFont&);
+  void on_customizerFontSize_currentIndexChanged(int);
   void on_checkBoxEnableAutocomplete_toggled(bool);
   void on_lineEditCharacterThreshold_textChanged(const QString&);
   //
@@ -115,6 +117,7 @@ signals:
   void updateReorderMode(bool undockMode) const;
   void fontChanged(const QString& family, uint size) const;
   void consoleFontChanged(const QString& family, uint size) const;
+  void customizerFontChanged(const QString& family, uint size) const;
   void colorSchemeChanged(const QString& scheme) const;
   void openCSGSettingsChanged() const;
   void syntaxHighlightChanged(const QString& s) const;
@@ -142,6 +145,9 @@ private:
   void writeSettings();
   void hidePasswords();
   void addPrefPage(QActionGroup *group, QAction *action, QWidget *widget);
+  void createFontSizeMenu(QComboBox *box, const QString &setting);
+  void updateGUIFontFamily(QFontComboBox *fontSelector, const QString &setting);
+  void updateGUIFontSize(QComboBox *fsSelector, const QString &setting);
 
   /** Set value from combobox to settings */
   void applyComboBox(QComboBox *comboBox, int val, Settings::SettingsEntryEnum& entry);

--- a/src/gui/Preferences.ui
+++ b/src/gui/Preferences.ui
@@ -2024,6 +2024,65 @@
              </widget>
             </item>
             <item>
+             <widget class="QGroupBox" name="groupBox_Customizer">
+              <property name="title">
+               <string>Customizer</string>
+              </property>
+              <layout class="QVBoxLayout" name="verticalLayout_Customizer">
+               <item>
+                <layout class="QHBoxLayout" name="horizontalLayout_customizerFont" stretch="0,0,0,0">
+                 <property name="spacing">
+                  <number>6</number>
+                 </property>
+                 <item>
+                  <widget class="QLabel" name="label_customizerFont">
+                   <property name="text">
+                    <string>Font</string>
+                   </property>
+                   <property name="scaledContents">
+                    <bool>true</bool>
+                   </property>
+                   <property name="alignment">
+                    <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
+                   </property>
+                  </widget>
+                 </item>
+                 <item>
+                  <widget class="QFontComboBox" name="customizerFontChooser">
+                   <property name="customizerCurrentFont" stdset="0">
+                    <font>
+                     <family>DejaVu Sans</family>
+                     <pointsize>12</pointsize>
+                    </font>
+                   </property>
+                  </widget>
+                 </item>
+                 <item>
+                  <widget class="QComboBox" name="customizerFontSize">
+                   <property name="editable">
+                    <bool>true</bool>
+                   </property>
+                  </widget>
+                 </item>
+                 <item>
+                  <spacer name="horizontalSpacer_36">
+                   <property name="orientation">
+                    <enum>Qt::Horizontal</enum>
+                   </property>
+                   <property name="sizeHint" stdset="0">
+                    <size>
+                     <width>40</width>
+                     <height>20</height>
+                    </size>
+                   </property>
+                  </spacer>
+                 </item>
+                </layout>
+               </item>
+              </layout>
+             </widget>
+            </item>
+            <item>
              <widget class="QGroupBox" name="groupBox_lang">
               <property name="title">
                <string>OpenSCAD Language Features</string>

--- a/src/gui/TabManager.cc
+++ b/src/gui/TabManager.cc
@@ -165,6 +165,7 @@ void TabManager::createTab(const QString& filename)
   assert(par != nullptr);
 
   editor = new ScintillaEditor(tabWidget);
+  Preferences::create(editor->colorSchemes()); // needs to be done only once, however handled
   par->activeEditor = editor;
   editor->parameterWidget = new ParameterWidget(par->parameterDock);
   connect(editor->parameterWidget, SIGNAL(parametersChanged()), par, SLOT(actionRenderPreview()));
@@ -176,8 +177,6 @@ void TabManager::createTab(const QString& filename)
   qcmd->setKey(0);
   qcmd = qcmdset->boundTo(Qt::ControlModifier | Qt::Key_Minus);
   qcmd->setKey(0);
-
-  Preferences::create(editor->colorSchemes()); // needs to be done only once, however handled
 
   connect(editor, SIGNAL(uriDropped(const QUrl&)), par, SLOT(handleFileDrop(const QUrl&)));
   connect(editor, SIGNAL(previewRequest()), par, SLOT(actionRenderPreview()));

--- a/src/gui/parameter/ParameterWidget.cc
+++ b/src/gui/parameter/ParameterWidget.cc
@@ -34,6 +34,7 @@
 #include "ParameterCheckBox.h"
 #include "ParameterText.h"
 #include "ParameterVector.h"
+#include "Preferences.h"
 
 #include <boost/filesystem.hpp>
 
@@ -58,6 +59,13 @@ ParameterWidget::ParameterWidget(QWidget *parent) : QWidget(parent)
   //connect(comboBoxPreset, SIGNAL(editTextChanged(const QString&)), this, SLOT(onSetNameChanged()));
   connect(addButton, SIGNAL(clicked()), this, SLOT(onSetAdd()));
   connect(deleteButton, SIGNAL(clicked()), this, SLOT(onSetDelete()));
+
+  QString fontfamily = Preferences::inst()->getValue("advanced/customizerFontFamily").toString();
+  uint fontsize = Preferences::inst()->getValue("advanced/customizerFontSize").toUInt();
+  setFontFamilySize(fontfamily, fontsize);
+
+  connect(Preferences::inst(), SIGNAL(customizerFontChanged(const QString&, uint)), this,
+    SLOT(setFontFamilySize(const QString&, uint)));
 }
 
 // Can only be called before the initial setParameters().
@@ -420,4 +428,9 @@ void ParameterWidget::cleanSets()
       }
     }
   }
+}
+
+void ParameterWidget::setFontFamilySize(const QString &fontFamily, uint fontSize)
+{
+  scrollArea->setStyleSheet(QString("font-family: \"%1\"; font-size: %2pt;").arg(fontFamily).arg(fontSize));
 }

--- a/src/gui/parameter/ParameterWidget.h
+++ b/src/gui/parameter/ParameterWidget.h
@@ -59,6 +59,7 @@ public:
 
 public slots:
   void setModified(bool modified = true);
+  void setFontFamilySize(const QString &fontfamily, uint fontsize);
 
 protected slots:
   void autoPreview(bool immediate = false);


### PR DESCRIPTION
This (probably) isn't ready to be merged.

It adds entries to Preferences/Advanced allowing control of the font and size used in the customizer data pane.

It mostly works, but:
* Some aspects are stretching my knowledge of C++ and there might be better answers.
* The text inside spinboxes resizes dynamically, but the box around the text doesn't.

I considered trying to control the stuff *above* the data pane, the preset control stuff, and decided that that should be part of a more general "UI font size" control that would affect all text in forms, menus, et cetera.

Review comments solicited.  I'll write something up tomorrow about the areas that I'm not happy with, but right now it's bedtime.
