### PR TITLE
Rewrite OFF import

### DIFF
--- a/src/io/import_off.cc
+++ b/src/io/import_off.cc
@@ -87,7 +87,7 @@ std::unique_ptr<PolySet> import_off(const std::string& filename, const Location&
   std::vector<std::string> words;
 
   if (has_ndim) {
-    boost::split(words, line, boost::is_any_of(" \t"));
+    boost::split(words, line, boost::is_any_of(" \t"), boost::token_compress_on);
     if (f.eof() || words.size() < 1) {
       AsciiError("bad header: missing Ndim");
       return std::make_unique<PolySet>(3);
@@ -119,7 +119,7 @@ std::unique_ptr<PolySet> import_off(const std::string& filename, const Location&
       line = line.erase(results.position(), results[0].length());
   }
 
-  boost::split(words, line, boost::is_any_of(" \t"));
+  boost::split(words, line, boost::is_any_of(" \t"), boost::token_compress_on);
   if (f.eof() || words.size() < 3) {
     AsciiError("bad header: missing data");
     return std::make_unique<PolySet>(3);
@@ -158,7 +158,7 @@ std::unique_ptr<PolySet> import_off(const std::string& filename, const Location&
       continue;
 
     boost::trim(line);
-    boost::split(words, line, boost::is_any_of(" \t"));
+    boost::split(words, line, boost::is_any_of(" \t"), boost::token_compress_on);
     if (words.size() < 3) {
       AsciiError("can't parse vertex: not enough data");
       return std::make_unique<PolySet>(3);
@@ -197,7 +197,7 @@ std::unique_ptr<PolySet> import_off(const std::string& filename, const Location&
       continue;
 
     boost::trim(line);
-    boost::split(words, line, boost::is_any_of(" \t"));
+    boost::split(words, line, boost::is_any_of(" \t"), boost::token_compress_on);
     if (words.size() < 1) {
       AsciiError("can't parse face: not enough data");
       return std::make_unique<PolySet>(3);

--- a/src/io/import_off.cc
+++ b/src/io/import_off.cc
@@ -221,9 +221,11 @@ std::unique_ptr<PolySet> import_off(const std::string& filename, const Location&
       }
       if (words.size() >= n + 4) {
         // TODO: handle optional color info
+        /*
         int r=boost::lexical_cast<int>(words[n+1]);
         int g=boost::lexical_cast<int>(words[n+2]);
         int b=boost::lexical_cast<int>(words[n+3]);
+        */
       }
     } catch (const boost::bad_lexical_cast& blc) {
       AsciiError("can't parse face: bad data");

--- a/src/io/import_off.cc
+++ b/src/io/import_off.cc
@@ -73,13 +73,13 @@ std::unique_ptr<PolySet> import_off(const std::string& filename, const Location&
     got_magic = true;
     // Remove the matched part, we might have numbers next.
     line = line.erase(0, results[0].length());
-    has_normals = results[3].length() > 0;
-    has_color = results[2].length() > 0;
-    has_textures = results[1].length() > 0;
-    is_binary = results[6].length() > 0;
-    if (results[4].length())
+    has_normals = results[3].matched;
+    has_color = results[2].matched;
+    has_textures = results[1].matched;
+    is_binary = results[6].matched;
+    if (results[4].matched)
       dimension = 4;
-    has_ndim = results[5].length() > 0;
+    has_ndim = results[5].matched;
   }
 
   // TODO: handle binary format

--- a/src/io/import_off.cc
+++ b/src/io/import_off.cc
@@ -34,7 +34,7 @@ std::unique_ptr<PolySet> import_off(const std::string& filename, const Location&
     do {
       lineno++;
       std::getline(f, line);
-      if (f.eof()) {
+      if (line.empty() && f.eof()) {
         AsciiError(errstr);
         return false;
       }

--- a/src/io/import_off.cc
+++ b/src/io/import_off.cc
@@ -70,8 +70,10 @@ std::unique_ptr<PolySet> import_off(const std::string& filename, const Location&
   }
 
   // TODO: handle comments in the header
-  if (line.length() < 1)
+  if (line.length() < 1) {
+    lineno++;
     std::getline(f, line);
+  }
   std::vector<std::string> words;
 
   if (has_ndim) {
@@ -92,8 +94,10 @@ std::unique_ptr<PolySet> import_off(const std::string& filename, const Location&
   }
 
   // TODO: handle comments in the header
-  if (line.length() < 1)
+  if (line.length() < 1) {
+    lineno++;
     std::getline(f, line);
+  }
 
   boost::split(words, line, boost::is_any_of(" \t"));
   if (f.eof() || words.size() < 3) {

--- a/src/io/import_off.cc
+++ b/src/io/import_off.cc
@@ -87,7 +87,12 @@ std::unique_ptr<PolySet> import_off(const std::string& filename, const Location&
       return std::make_unique<PolySet>(3);
     }
     line = line.erase(0, words[0].length() + ((words.size() > 1) ? 1 : 0));
-    dimension = boost::lexical_cast<unsigned int>(words[0]) + dimension - 3;
+    try {
+      dimension = boost::lexical_cast<unsigned int>(words[0]) + dimension - 3;
+    } catch (const boost::bad_lexical_cast& blc) {
+      AsciiError("bad header: bad data for Ndim");
+      return std::make_unique<PolySet>(3);
+    }
   }
 
   PRINTDB("Header flags: N:%d C:%d ST:%d Ndim:%d B:%d", has_normals % has_color % has_textures % dimension % is_binary);

--- a/src/io/import_off.cc
+++ b/src/io/import_off.cc
@@ -46,6 +46,7 @@ std::unique_ptr<PolySet> import_off(const std::string& filename, const Location&
       if (boost::regex_search(line, results, ex_comment)) {
         line = line.erase(results.position(), results[0].length());
       }
+      boost::trim(line);
     } while (line.empty());
 
     return true;
@@ -156,7 +157,6 @@ std::unique_ptr<PolySet> import_off(const std::string& filename, const Location&
       return std::make_unique<PolySet>(3);
     }
 
-    boost::trim(line);
     boost::split(words, line, boost::is_any_of(" \t"), boost::token_compress_on);
     if (words.size() < 3) {
       AsciiError("can't parse vertex: not enough data");
@@ -193,7 +193,6 @@ std::unique_ptr<PolySet> import_off(const std::string& filename, const Location&
       return std::make_unique<PolySet>(3);
     }
 
-    boost::trim(line);
     boost::split(words, line, boost::is_any_of(" \t"), boost::token_compress_on);
     if (words.size() < 1) {
       AsciiError("can't parse face: not enough data");

--- a/src/io/import_off.cc
+++ b/src/io/import_off.cc
@@ -46,7 +46,7 @@ std::unique_ptr<PolySet> import_off(const std::string& filename, const Location&
 
   std::getline(f, line);
   if (f.eof()) {
-    AsciiError("bad header");
+    AsciiError("bad header: end of file");
     return std::make_unique<PolySet>(3);
   }
   if (boost::regex_search(line, results, ex_magic) > 0) {
@@ -74,12 +74,16 @@ std::unique_ptr<PolySet> import_off(const std::string& filename, const Location&
     lineno++;
     std::getline(f, line);
   }
+  if (f.eof()) {
+    AsciiError("bad header: end of file");
+    return std::make_unique<PolySet>(3);
+  }
   std::vector<std::string> words;
 
   if (has_ndim) {
     boost::split(words, line, boost::is_any_of(" \t"));
     if (f.eof() || words.size() < 1) {
-      AsciiError("bad header");
+      AsciiError("bad header: missing Ndim");
       return std::make_unique<PolySet>(3);
     }
     line = line.erase(0, words[0].length() + ((words.size() > 1) ? 1 : 0));
@@ -98,10 +102,14 @@ std::unique_ptr<PolySet> import_off(const std::string& filename, const Location&
     lineno++;
     std::getline(f, line);
   }
+  if (f.eof()) {
+    AsciiError("bad header: end of file");
+    return std::make_unique<PolySet>(3);
+  }
 
   boost::split(words, line, boost::is_any_of(" \t"));
   if (f.eof() || words.size() < 3) {
-    AsciiError("bad header");
+    AsciiError("bad header: missing data");
     return std::make_unique<PolySet>(3);
   }
 
@@ -114,12 +122,12 @@ std::unique_ptr<PolySet> import_off(const std::string& filename, const Location&
     edges_count = boost::lexical_cast<unsigned long>(words[2]);
     (void)edges_count; // ignored
   } catch (const boost::bad_lexical_cast& blc) {
-    AsciiError("bad header");
+    AsciiError("bad header: bad data");
     return std::make_unique<PolySet>(3);
   }
 
   if (f.eof() || vertices_count < 1 || faces_count < 1) {
-    AsciiError("bad header");
+    AsciiError("bad header: not enough data");
     return std::make_unique<PolySet>(3);
   }
 
@@ -138,7 +146,7 @@ std::unique_ptr<PolySet> import_off(const std::string& filename, const Location&
     boost::trim(line);
     boost::split(words, line, boost::is_any_of(" \t"));
     if (words.size() < 3) {
-      AsciiError("can't parse vertex");
+      AsciiError("can't parse vertex: not enough data");
       return std::make_unique<PolySet>(3);
     }
 
@@ -161,7 +169,7 @@ std::unique_ptr<PolySet> import_off(const std::string& filename, const Location&
       }
       ps->vertices.push_back(v);
     } catch (const boost::bad_lexical_cast& blc) {
-      AsciiError("can't parse vertex");
+      AsciiError("can't parse vertex: bad data");
       return std::make_unique<PolySet>(3);
     }
   }
@@ -175,14 +183,14 @@ std::unique_ptr<PolySet> import_off(const std::string& filename, const Location&
     boost::trim(line);
     boost::split(words, line, boost::is_any_of(" \t"));
     if (words.size() < 1) {
-      AsciiError("can't parse face");
+      AsciiError("can't parse face: not enough data");
       return std::make_unique<PolySet>(3);
     }
 
     try {
       unsigned long n=boost::lexical_cast<unsigned long>(words[0]);
       if (words.size() - 1 < n) {
-        AsciiError("can't parse face");
+        AsciiError("can't parse face: missing indices");
         return std::make_unique<PolySet>(3);
       }
       ps->indices.emplace_back().reserve(n);
@@ -199,7 +207,7 @@ std::unique_ptr<PolySet> import_off(const std::string& filename, const Location&
         int b=boost::lexical_cast<int>(words[n+3]);
       }
     } catch (const boost::bad_lexical_cast& blc) {
-      AsciiError("can't parse vertex");
+      AsciiError("can't parse vertex: bad data");
       return std::make_unique<PolySet>(3);
     }
   }

--- a/src/io/import_off.cc
+++ b/src/io/import_off.cc
@@ -17,7 +17,6 @@ std::unique_ptr<PolySet> import_off(const std::string& filename, const Location&
 
   int lineno = 1;
   std::string line;
-  double scale = 1000.0;
 
   auto AsciiError = [&](const auto& errstr){
     LOG(message_group::Error, loc, "",
@@ -119,7 +118,7 @@ std::unique_ptr<PolySet> import_off(const std::string& filename, const Location&
     try {
       Vector3d v;
       for (int i = 0; i < 3; i++) {
-        v[i]= boost::lexical_cast<double>(words[i]) * scale;
+        v[i]= boost::lexical_cast<double>(words[i]);
       }
       int o = dimension;
       if (has_normals) {

--- a/src/io/import_off.cc
+++ b/src/io/import_off.cc
@@ -149,13 +149,14 @@ std::unique_ptr<PolySet> import_off(const std::string& filename, const Location&
   ps->vertices.reserve(vertices_count);
   ps->indices.reserve(faces_count);
 
-  while ((!f.eof()) && (vertices_count--)) {
+  while ((!f.eof()) && vertices_count) {
     lineno++;
     std::getline(f, line);
     if (boost::regex_search(line, results, ex_comment))
       line = line.erase(results.position(), results[0].length());
     if (line.length() == 0)
       continue;
+    vertices_count--;
 
     boost::trim(line);
     boost::split(words, line, boost::is_any_of(" \t"), boost::token_compress_on);
@@ -169,6 +170,7 @@ std::unique_ptr<PolySet> import_off(const std::string& filename, const Location&
       for (int i = 0; i < 3; i++) {
         v[i]= boost::lexical_cast<double>(words[i]);
       }
+      //PRINTDB("Vertex[] = { %f, %f, %f }", v[0] % v[1] % v[2]);
       int o = dimension;
       if (has_normals) {
         ; // TODO words[o++]
@@ -188,13 +190,14 @@ std::unique_ptr<PolySet> import_off(const std::string& filename, const Location&
     }
   }
 
-  while (!f.eof() && faces_count--) {
+  while (!f.eof() && faces_count) {
     lineno++;
     std::getline(f, line);
     if (boost::regex_search(line, results, ex_comment))
       line = line.erase(results.position(), results[0].length());
     if (line.length() == 0)
       continue;
+    faces_count--;
 
     boost::trim(line);
     boost::split(words, line, boost::is_any_of(" \t"), boost::token_compress_on);
@@ -223,7 +226,7 @@ std::unique_ptr<PolySet> import_off(const std::string& filename, const Location&
         int b=boost::lexical_cast<int>(words[n+3]);
       }
     } catch (const boost::bad_lexical_cast& blc) {
-      AsciiError("can't parse vertex: bad data");
+      AsciiError("can't parse face: bad data");
       return std::make_unique<PolySet>(3);
     }
   }

--- a/src/io/import_off.cc
+++ b/src/io/import_off.cc
@@ -1,25 +1,138 @@
 #include "import.h"
 #include "PolySet.h"
+#include "PolySetBuilder.h"
 #include "printutils.h"
 #include "AST.h"
-#ifdef ENABLE_CGAL
-#include "cgalutils.h"
-#endif
+#include <fstream>
+#include <boost/regex.hpp>
+#include <boost/lexical_cast.hpp>
+#include <boost/algorithm/string.hpp>
+#include <boost/algorithm/string/split.hpp>
 
 std::unique_ptr<PolySet> import_off(const std::string& filename, const Location& loc)
 {
-#ifdef ENABLE_CGAL
-  CGAL_Polyhedron poly;
-  std::ifstream file(filename.c_str(), std::ios::in | std::ios::binary);
-  if (!file.good()) {
-    LOG(message_group::Warning, "Can't open import file '%1$s', import() at line %2$d", filename, loc.firstLine());
-  } else {
-    file >> poly;
-    file.close();
-    return CGALUtils::createPolySetFromPolyhedron(poly);
+  std::ifstream f(filename.c_str(), std::ios::in | std::ios::binary);
+
+  int lineno = 1;
+  std::string line;
+  //boost::smatch results;
+
+  auto AsciiError = [&](const auto& errstr){
+    LOG(message_group::Error, loc, "",
+    "OFF File line %1$s, %2$s line '%3$s' importing file '%4$s'",
+    lineno, errstr, line, filename);
+  };
+
+  if (!f.good()) {
+    AsciiError("File error");
+    return std::make_unique<PolySet>(3);
   }
-#else
-  LOG(message_group::Warning, "OFF import requires CGAL, import() at line %2$d", filename, loc.firstLine());
-#endif // ifdef ENABLE_CGAL
-  return std::make_unique<PolySet>(3);
+
+  boost::regex ex_magic(R"(^OFF$|^COFF$)"); // TODO: 4OFF?
+  boost::regex ex_comment(R"(^\s*#)");
+
+
+
+  std::getline(f, line);
+  if (f.eof() || !boost::regex_search(line, ex_magic)) {
+    AsciiError("bad header");
+    return std::make_unique<PolySet>(3);
+  }
+
+  std::getline(f, line);
+  std::vector<std::string> words;
+
+  boost::split(words, line, boost::is_any_of(" \t"));
+  if (f.eof() || words.size() < 3) {
+    AsciiError("bad header");
+    return std::make_unique<PolySet>(3);
+  }
+
+  unsigned long vertices_count;
+  unsigned long faces_count;
+  unsigned long edges_count;
+  try {
+    vertices_count = boost::lexical_cast<unsigned long>(words[0]);
+    faces_count = boost::lexical_cast<unsigned long>(words[1]);
+    edges_count = boost::lexical_cast<unsigned long>(words[2]);
+    (void)edges_count; // ignored
+    fprintf(stderr, __FILE__ ": OFF: %d %d %d\n\n", vertices_count, faces_count, edges_count);
+  } catch (const boost::bad_lexical_cast& blc) {
+    AsciiError("bad header");
+    return std::make_unique<PolySet>(3);
+  }
+  PolySetBuilder builder(vertices_count, faces_count);
+  // The builder merges identical vertices, so just keep a table around
+  //std::array<Vector3d, vertices_count> vertices;
+
+  while ((!f.eof()) && (vertices_count--)) {
+    lineno++;
+    std::getline(f, line);
+    if (line.length() == 0 || boost::regex_search(line, ex_comment))
+      continue;
+
+    boost::trim(line);
+    boost::split(words, line, boost::is_any_of(" \t"));
+    if (words.size() < 3) {
+      AsciiError("can't parse vertex");
+      return std::make_unique<PolySet>(3);
+    }
+
+    try {
+      Vector3d v;
+      for (int i = 0; i < 3; i++) {
+        v[i]= boost::lexical_cast<double>(words[i]);
+      }
+      // TODO: Meshlab appends color there, probably to allow gradients
+      fprintf(stderr, __FILE__ ": v: %f %f %f\n\n", v[0], v[1], v[2]);
+      builder.vertexIndex(v); // expect to get subsequent numbers starting from zero
+    } catch (const boost::bad_lexical_cast& blc) {
+      AsciiError("can't parse vertex");
+      return std::make_unique<PolySet>(3);
+    }
+  }
+
+  while (!f.eof() && faces_count--) {
+    lineno++;
+    std::getline(f, line);
+    if (line.length() == 0 || boost::regex_search(line, ex_comment))
+      continue;
+
+    boost::trim(line);
+    boost::split(words, line, boost::is_any_of(" \t"));
+    if (words.size() < 1) {
+      AsciiError("can't parse face");
+      return std::make_unique<PolySet>(3);
+    }
+
+    try {
+      unsigned long n=boost::lexical_cast<unsigned long>(words[0]);
+      if (words.size() - 1 < n) {
+        AsciiError("can't parse face");
+        return std::make_unique<PolySet>(3);
+      }
+      fprintf(stderr, __FILE__ ": F: %d\n", n);
+      builder.appendPoly(n);
+
+      for (int i = 0; i < n; i++) {
+        int ind=boost::lexical_cast<int>(words[i+1]);
+        fprintf(stderr, __FILE__ ": f: %d %d\n\n", ind, builder.numVertices());
+        if(ind >= 0 && ind < builder.numVertices())
+          builder.appendVertex(ind);
+      }
+      if (words.size() >= n + 4) {
+        // optional color info
+        int r=boost::lexical_cast<int>(words[n+1]);
+        int g=boost::lexical_cast<int>(words[n+2]);
+        int b=boost::lexical_cast<int>(words[n+3]);
+        // TODO: handle this somehow?
+      }
+    } catch (const boost::bad_lexical_cast& blc) {
+      AsciiError("can't parse vertex");
+      return std::make_unique<PolySet>(3);
+    }
+  }
+
+  f.close();
+  return builder.build();
 }


### PR DESCRIPTION
Rewrote the OFF import as I initially thought it didn't work, because of a badly scaled KiCad export converted through MeshLab.

This version removes the dependency on CGAL, and should be at feature parity.

Still missing is color support but we miss the API for that, and binary format support as I couldn't find any sample file.