### PR TITLE
Segmentation fault with VBO rendering on Qt 6

### DIFF
--- a/src/glview/VertexArray.cc
+++ b/src/glview/VertexArray.cc
@@ -13,12 +13,18 @@ void addAttributeValues(IAttributeData&) {}
 
 void VertexData::getLastVertex(std::vector<GLbyte>& interleaved_buffer) const
 {
+  size_t size = 0, last_size = 0, stride = stride_;
   GLbyte *dst_start = interleaved_buffer.data();
   for (const auto& data : attributes_) {
-    size_t size = data->sizeofAttribute();
+    size = data->sizeofAttribute();
+    last_size = data->size() / data->count();
     GLbyte *dst = dst_start;
-    const GLbyte *src = data->toBytes() + data->sizeInBytes() - data->sizeofAttribute();
-    std::memcpy((void *)dst, (void *)src, size);
+    const GLbyte *src = data->toBytes();
+    for (size_t i = 0; i < last_size; ++i) {
+      std::memcpy((void *)dst, (void *)src, size);
+      src += size;
+      dst += stride;
+    }
     dst_start += size;
   }
 }


### PR DESCRIPTION
Every time on opening a scad file, OpenSCAD dd2da9e2908e8 built with Qt 6 using #4929 crashes. Compiling the same commit for Qt 5 works fine, as does using the legacy renderer on Qt 6.

Backtrace from opening examples/Basics/logo.scad:

```
Thread 1 "openscad" received signal SIGSEGV, Segmentation fault.
0x00007ffff5576895 in ?? () from /usr/lib64/libc.so.6
#0  0x00007ffff5576895 in  () at /usr/lib64/libc.so.6
#1  0x00005555564d66c4 in VertexData::getLastVertex(std::vector<signed char, std::allocator<signed char> >&) const (this=0x5555595cfb90, interleaved_buffer=std::vector of length 44, capacity 44 = {...}) at openscad-dd2da9e2908e881af6cb1fe90306fe6004081cb6/src/glview/VertexArray.cc:21
#2  0x00005555564d7810 in VertexArray::createVertex(std::array<Eigen::Matrix<double, 3, 1, 0, 3, 1>, 3ul> const&, std::array<Eigen::Matrix<double, 3, 1, 0, 3, 1>, 3ul> const&, Color4f const&, unsigned long, unsigned long, double, unsigned long, unsigned long, bool, bool, std::function<void (VertexArray&, std::array<Eigen::Matrix<double, 3, 1, 0, 3, 1>, 3ul> const&, std::array<Eigen::Matrix<double, 3, 1, 0, 3, 1>, 3ul> const&, Color4f const&, unsigned long, unsigned long, double, unsigned long, unsigned long, bool, bool)> const&) (this=0x7fffffffa9e0, points=..., normals=..., color=..., active_point_index=0, primitive_index=0, z_offset=0, shape_size=100, shape_dimensions=3, outlines=false, mirror=false, vertex_callback=...) at openscad-dd2da9e2908e881af6cb1fe90306fe6004081cb6/src/glview/VertexArray.cc:139
#3  0x00005555564f6fbc in VBORenderer::create_vertex(VertexArray&, Color4f const&, std::array<Eigen::Matrix<double, 3, 1, 0, 3, 1>, 3ul> const&, std::array<Eigen::Matrix<double, 3, 1, 0, 3, 1>, 3ul> const&, unsigned long, unsigned long, double, unsigned long, unsigned long, bool, bool) const (this=0x55555904baf0, vertex_array=..., color=..., points=..., normals=..., active_point_index=0, primitive_index=0, z_offset=0, shape_size=100, shape_dimensions=3, outlines=false, mirror=false) at openscad-dd2da9e2908e881af6cb1fe90306fe6004081cb6/src/glview/VBORenderer.cc:188
#4  0x00005555564f74c5 in VBORenderer::create_triangle(VertexArray&, Color4f const&, Eigen::Matrix<double, 3, 1, 0, 3, 1> const&, Eigen::Matrix<double, 3, 1, 0, 3, 1> const&, Eigen::Matrix<double, 3, 1, 0, 3, 1> const&, unsigned long, double, unsigned long, unsigned long, bool, bool) const (this=0x55555904baf0, vertex_array=..., color=..., p0=..., p1=..., p2=..., primitive_index=0, z_offset=0, shape_size=100, shape_dimensions=3, outlines=false, mirror=false) at openscad-dd2da9e2908e881af6cb1fe90306fe6004081cb6/src/glview/VBORenderer.cc:226
#5  0x00005555564f853c in VBORenderer::create_surface(PolySet const&, VertexArray&, Renderer::csgmode_e, Eigen::Transform<double, 3, 2, 0> const&, Color4f const&) const (this=0x55555904baf0, ps=..., vertex_array=..., csgmode=Renderer::CSGMODE_NORMAL, m=..., color=...) at openscad-dd2da9e2908e881af6cb1fe90306fe6004081cb6/src/glview/VBORenderer.cc:314
#6  0x0000555556534ee4 in OpenCSGRenderer::createCSGVBOProducts(CSGProducts const&, Renderer::shaderinfo_t const*, bool, bool) (this=0x55555904baf0, products=..., highlight_mode=false, background_mode=false) at openscad-dd2da9e2908e881af6cb1fe90306fe6004081cb6/src/glview/preview/OpenCSGRenderer.cc:187
#7  0x0000555556532e5c in OpenCSGRenderer::prepare(bool, bool, Renderer::shaderinfo_t const*) (this=0x55555904baf0, shaderinfo=0x0) at openscad-dd2da9e2908e881af6cb1fe90306fe6004081cb6/src/glview/preview/OpenCSGRenderer.cc:69
#8  0x00005555565045a6 in GLView::paintGL() (this=0x555557291d68) at openscad-dd2da9e2908e881af6cb1fe90306fe6004081cb6/src/glview/GLView.cc:172
#9  0x00005555565ebf8d in QGLView::paintGL() (this=0x555557291d40) at openscad-dd2da9e2908e881af6cb1fe90306fe6004081cb6/src/gui/QGLView.cc:174
#10 0x00007ffff7674815 in  () at /usr/lib64/libQt6OpenGLWidgets.so.6
#11 0x00007ffff61dcc48 in QWidget::event(QEvent*) () at /usr/lib64/libQt6Widgets.so.6
#12 0x00007ffff617a2a1 in QApplicationPrivate::notify_helper(QObject*, QEvent*) () at /usr/lib64/libQt6Widgets.so.6
#13 0x00005555565bda0b in OpenSCADApp::notify(QObject*, QEvent*) (this=0x7fffffffca20, object=0x555557291d40, event=0x7fffffffb240) at openscad-dd2da9e2908e881af6cb1fe90306fe6004081cb6/src/gui/OpenSCADApp.cc:57
#14 0x00007ffff4f62d78 in QCoreApplication::notifyInternal2(QObject*, QEvent*) () at /usr/lib64/libQt6Core.so.6
#15 0x00007ffff61d45e5 in QWidgetPrivate::sendPaintEvent(QRegion const&) () at /usr/lib64/libQt6Widgets.so.6
#16 0x00007ffff61d4fd1 in QWidgetPrivate::drawWidget(QPaintDevice*, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) () at /usr/lib64/libQt6Widgets.so.6
#17 0x00007ffff61d64a1 in QWidgetPrivate::paintSiblingsRecursive(QPaintDevice*, QList<QObject*> const&, int, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) () at /usr/lib64/libQt6Widgets.so.6
#18 0x00007ffff61d4be4 in QWidgetPrivate::drawWidget(QPaintDevice*, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) () at /usr/lib64/libQt6Widgets.so.6
#19 0x00007ffff61d64a1 in QWidgetPrivate::paintSiblingsRecursive(QPaintDevice*, QList<QObject*> const&, int, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) () at /usr/lib64/libQt6Widgets.so.6
#20 0x00007ffff61d4be4 in QWidgetPrivate::drawWidget(QPaintDevice*, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) () at /usr/lib64/libQt6Widgets.so.6
#21 0x00007ffff61d64a1 in QWidgetPrivate::paintSiblingsRecursive(QPaintDevice*, QList<QObject*> const&, int, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) () at /usr/lib64/libQt6Widgets.so.6
#22 0x00007ffff61d62d6 in QWidgetPrivate::paintSiblingsRecursive(QPaintDevice*, QList<QObject*> const&, int, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) () at /usr/lib64/libQt6Widgets.so.6
#23 0x00007ffff61d62d6 in QWidgetPrivate::paintSiblingsRecursive(QPaintDevice*, QList<QObject*> const&, int, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) () at /usr/lib64/libQt6Widgets.so.6
#24 0x00007ffff61d4be4 in QWidgetPrivate::drawWidget(QPaintDevice*, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) () at /usr/lib64/libQt6Widgets.so.6
#25 0x00007ffff61e9a80 in QWidgetRepaintManager::paintAndFlush() () at /usr/lib64/libQt6Widgets.so.6
#26 0x00007ffff61dce18 in QWidget::event(QEvent*) () at /usr/lib64/libQt6Widgets.so.6
#27 0x00005555565799f7 in MainWindow::event(QEvent*) (this=0x555557347d00, event=0x5555580df1d0) at openscad-dd2da9e2908e881af6cb1fe90306fe6004081cb6/src/gui/MainWindow.cc:1782
#28 0x00007ffff617a2a1 in QApplicationPrivate::notify_helper(QObject*, QEvent*) () at /usr/lib64/libQt6Widgets.so.6
#29 0x00005555565bda0b in OpenSCADApp::notify(QObject*, QEvent*) (this=0x7fffffffca20, object=0x555557347d00, event=0x5555580df1d0) at openscad-dd2da9e2908e881af6cb1fe90306fe6004081cb6/src/gui/OpenSCADApp.cc:57
#30 0x00007ffff4f62d78 in QCoreApplication::notifyInternal2(QObject*, QEvent*) () at /usr/lib64/libQt6Core.so.6
#31 0x00007ffff4f667fe in QCoreApplicationPrivate::sendPostedEvents(QObject*, int, QThreadData*) () at /usr/lib64/libQt6Core.so.6
#32 0x00007ffff51e5733 in  () at /usr/lib64/libQt6Core.so.6
#33 0x00007ffff7ca84f2 in  () at /usr/lib64/libglib-2.0.so.0
#34 0x00007ffff7cab6a7 in  () at /usr/lib64/libglib-2.0.so.0
#35 0x00007ffff7cabccc in g_main_context_iteration () at /usr/lib64/libglib-2.0.so.0
#36 0x00007ffff51e50bc in QEventDispatcherGlib::processEvents(QFlags<QEventLoop::ProcessEventsFlag>) () at /usr/lib64/libQt6Core.so.6
#37 0x00007ffff4f6f07b in QEventLoop::exec(QFlags<QEventLoop::ProcessEventsFlag>) () at /usr/lib64/libQt6Core.so.6
#38 0x00007ffff4f6ab83 in QCoreApplication::exec() () at /usr/lib64/libQt6Core.so.6
#39 0x0000555555f4eda7 in gui(std::vector<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::allocator<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > > >&, boost::filesystem::path const&, int, char**) (inputFiles=std::vector of length 1, capacity 1 = {...}, original_path=..., argc=1, argv=0x7fffffffd508) at openscad-dd2da9e2908e881af6cb1fe90306fe6004081cb6/src/openscad.cc:860
#40 0x0000555555f52bb0 in main(int, char**) (argc=1, argv=0x7fffffffd508) at openscad-dd2da9e2908e881af6cb1fe90306fe6004081cb6/src/openscad.cc:1248

```

I haven't got Qt built with debug symbols at this time. I can if it would be useful.

Qt 6.6.1 and building on Gentoo Linux with:

-DCLANG_TIDY=OFF -DENABLE_CAIRO=yes -DENABLE_EGL=ON -DENABLE_GLX=OFF -DENABLE_TBB=yes -DENABLE_TESTS=no -DEXPERIMENTAL=yes -DHEADLESS=no -DUSE_CCACHE=OFF -DUSE_GLAD=ON -DUSE_MIMALLOC=OFF -DUSE_QT6=yes -DENABLE_GAMEPAD=no -DENABLE_HIDAPI=yes -DENABLE_QTDBUS=yes -DENABLE_SPNAV=yes -DCMAKE_BUILD_TYPE=RelWithDebInfo

I am obtaining and building the dependencies myself (some more CMake patching for that):

opencsg 1.6.0
manifold 3b8282e1d5cd3d
sanitizers-cmake 3f0542e4e034
tbb 2021.9.0

and running on Wayland.

I'm not saying this is a suitable fix - I do not understand what the code is doing.
I just went to the final piece of code that is leading to the segfault and experimented with reverting its last major change 8b12a3078 ("Performance fixes, add vertex options", 2020-11-29) to find something that compiles, doesn't crash and renders images that basically look OK.
