### PR TITLE
fix manifold stuff

### DIFF
--- a/src/geometry/GeometryEvaluator.cc
+++ b/src/geometry/GeometryEvaluator.cc
@@ -80,9 +80,12 @@ std::shared_ptr<const Geometry> GeometryEvaluator::evaluateGeometry(const Abstra
     // We cannot render concave polygons, so tessellate any 3D PolySets
     auto ps = PolySetUtils::getGeometryAsPolySet(this->root);
     if (ps && !ps->isEmpty()) {
+      this->root = ps;
       // Since is_convex() doesn't handle non-planar faces, we need to tessellate
       // also in the indeterminate state so we cannot just use a boolean comparison. See #1061
       bool convex = bool(ps->convexValue()); // bool is true only if tribool is true, (not indeterminate and not false)
+      if (std::dynamic_pointer_cast<const ManifoldGeometry>(ps))
+        convex = true; // manifold only have triangles, which are convex
       if (!convex) {
         assert(ps->getDimension() == 3);
         this->root = PolySetUtils::tessellate_faces(*ps);


### PR DESCRIPTION
Closes #4732, resolves #4753, and also update manifold to get the performance improvement on windows.

For the `GeometryEvaluator`, do we really need the `getGeometryAsPolySet` for `ManifoldGeometry` regardless of whether or not `allownef` is set? I removed that part of the code and it seems fine, and I don't understand why we need that. Btw, we probably want to rename `allownef` into `asConvexPolySet` or something? The `convex` part is weird anyway (it is asking for convex polygons, not convex in the 3D sense).

Btw, this depends on #4990 or some tests will not pass because we are attempting to export an STL file with `ManifoldGeometry`. The flaky nature of #4990 is caused by the cache issue, which is fixed in this PR.