### PR TITLE
Clean up LOG/PRINT functions.  Fixes #5004.

### DIFF
--- a/src/core/Expression.cc
+++ b/src/core/Expression.cc
@@ -424,10 +424,10 @@ void FunctionDefinition::print(std::ostream& stream, const std::string& indent) 
 }
 
 /**
- * This is separated because PRINTB uses quite a lot of stack space
- * and the method using it evaluate()
+ * This is separated because LOG uses quite a lot of stack space
+ * and the method using it, evaluate(),
  * is called often when recursive functions are evaluated.
- * noinline is required, as we here specifically optimize for stack usage
+ * NOINLINE is required, as we here specifically optimize for stack usage
  * during normal operating, not runtime during error handling.
  */
 static void NOINLINE print_err(const char *name, const Location& loc, const std::shared_ptr<const Context>& context){
@@ -435,10 +435,10 @@ static void NOINLINE print_err(const char *name, const Location& loc, const std:
 }
 
 /**
- * This is separated because PRINTB uses quite a lot of stack space
- * and the method using it evaluate()
+ * This is separated because LOG uses quite a lot of stack space
+ * and the method using it, evaluate(),
  * is called often when recursive functions are evaluated.
- * noinline is required, as we here specifically optimize for stack usage
+ * NOINLINE is required, as we here specifically optimize for stack usage
  * during normal operating, not runtime during error handling.
  */
 static void NOINLINE print_trace(const FunctionCall *val, const std::shared_ptr<const Context>& context){

--- a/src/core/ModuleInstantiation.cc
+++ b/src/core/ModuleInstantiation.cc
@@ -48,10 +48,10 @@ void IfElseModuleInstantiation::print(std::ostream& stream, const std::string& i
 }
 
 /**
- * This is separated because PRINTB uses quite a lot of stack space
- * and the method using it evaluate()
+ * This is separated because LOG uses quite a lot of stack space
+ * and the method using it, evaluate(),
  * is called often when recursive modules are evaluated.
- * noinline is required, as we here specifically optimize for stack usage
+ * NOINLINE is required, as we here specifically optimize for stack usage
  * during normal operating, not runtime during error handling.
  */
 static void NOINLINE print_trace(const ModuleInstantiation *mod, const std::shared_ptr<const Context>& context){

--- a/src/core/parser.y
+++ b/src/core/parser.y
@@ -779,7 +779,7 @@ bool parse(SourceFile *&file, const std::string& text, const std::string &filena
 
   rootfile = new SourceFile(parser_sourcefile.parent_path().string(), parser_sourcefile.filename().string());
   scope_stack.push(&rootfile->scope);
-  //        PRINTB_NOCACHE("New module: %s %p", "root" % rootfile);
+  //        PRINTD("New module: %s %p", "root" % rootfile);
 
   parserdebug = debug;
   int parserretval = -1;

--- a/src/utils/printutils.h
+++ b/src/utils/printutils.h
@@ -101,13 +101,9 @@ void print_messages_pop();
 void resetSuppressedMessages();
 
 
-/* PRINT statements come out in same window as ECHO.
-   usage: PRINTB("Var1: %s Var2: %i", var1 % var2 ); */
+/* PRINT statements come out in same window as ECHO. */
 void PRINT(const Message& msgObj);
-
-void PRINT_NOCACHE(const Message& msgObj);
-#define PRINTB_NOCACHE(_fmt, _arg) do { } while (0)
-// #define PRINTB_NOCACHE(_fmt, _arg) do { PRINT_NOCACHE(str(boost::format(_fmt) % _arg)); } while (0)
+void MAYBETHROW(const Message& msgObj);
 
 /*PRINTD: debugging/verbose output. Usage in code:
    CGAL_Point_3 p0(0,0,0),p1(1,0,0),p2(0,1,0);
@@ -226,6 +222,7 @@ void LOG(const message_group& msgGroup, Location loc, std::string docPath, std::
   Message msgObj{std::move(formatted), msgGroup, std::move(loc), std::move(docPath)};
 
   PRINT(msgObj);
+  MAYBETHROW(msgObj);
 }
 
 template <typename ... Args>


### PR DESCRIPTION
Move the error-log output next to the console output.  (This means that error-log entries are suppressed after five identical ones.  Is that good?)

Move throwing on hardwarning/error out of the `PRINT()` functions and into its own function, and have LOG() call that function.  (Fixes #5004.)

Along the way, clean up a little:  nobody outside of printutils.cc should be calling `PRINT_NOCACHE()`, so scope it static.  Remove PRINTB_NOCACHE since it's unused and its one pseudo-use in a comment looks like the intent is the same as `PRINTD()`.