### PR TITLE
Remove GL check from Renderer glLinkProgram()

### DIFF
--- a/src/glview/Renderer.cc
+++ b/src/glview/Renderer.cc
@@ -81,7 +81,7 @@ void Renderer::setupShader() {
   auto edgeshader_prog = glCreateProgram();
   glAttachShader(edgeshader_prog, vs);
   glAttachShader(edgeshader_prog, fs);
-  IF_GL_CHECK(glLinkProgram(edgeshader_prog)) return;
+  glLinkProgram(edgeshader_prog);
   GLint status;
   glGetProgramiv(edgeshader_prog, GL_LINK_STATUS, &status);
   if (!status) {


### PR DESCRIPTION
Was catching spurious Qt 6.6.2 error:
GL_INVALID_OPERATION in glDrawBuffers(unsupported buffer GL_BACK_LEFT)

https://bugreports.qt.io/browse/QTBUG-122819