### PR TITLE
Fix syntax highlight colorscheme persistence (#4992 and #4920)

### DIFF
--- a/src/gui/Preferences.cc
+++ b/src/gui/Preferences.cc
@@ -355,7 +355,7 @@ void Preferences::on_fontSize_currentIndexChanged(int index)
   emit fontChanged(getValue("editor/fontfamily").toString(), intsize);
 }
 
-void Preferences::on_syntaxHighlight_currentTextChanged(const QString& s)
+void Preferences::on_syntaxHighlight_textActivated(const QString & s)
 {
   QSettingsCached settings;
   settings.setValue("editor/syntaxhighlight", s);

--- a/src/gui/Preferences.h
+++ b/src/gui/Preferences.h
@@ -31,7 +31,7 @@ public slots:
   void on_colorSchemeChooser_itemSelectionChanged();
   void on_fontChooser_currentFontChanged(const QFont&);
   void on_fontSize_currentIndexChanged(int);
-  void on_syntaxHighlight_currentTextChanged(const QString&);
+  void on_syntaxHighlight_textActivated(const QString & s);
   void on_openCSGWarningBox_toggled(bool);
   void on_cgalCacheSizeMBEdit_textChanged(const QString&);
   void on_polysetCacheSizeMBEdit_textChanged(const QString&);


### PR DESCRIPTION
The currentTextChanged signal triggered at the wrong moment, overwriting the syntaxhighlight setting in OpenScad.conf; this is solved by using the textActivated signal.

This fixes the issues mentioned in #4992 and #4920.
