### PR TITLE
Issue3649 export filename not remembered

### DIFF
--- a/src/gui/Editor.h
+++ b/src/gui/Editor.h
@@ -75,6 +75,7 @@ public:
   bool contentsRendered; // Set if the source code has changes since the last render (F6)
   int findState;
   QString filepath;
+  std::unordered_map<std::string, QString> exportPaths; // for each file type, where it was exported to last
   std::string autoReloadId;
   std::vector<IndicatorData> indicatorData;
   ParameterWidget *parameterWidget;

--- a/src/gui/MainWindow.cc
+++ b/src/gui/MainWindow.cc
@@ -3644,8 +3644,10 @@ QString MainWindow::exportPath(const char *suffix) {
     QString default_dir = QString::fromStdString(Settings::Settings::defaultExportDir.value());
     if (!default_dir.isEmpty()) {
         default_dir = QDir(default_dir).canonicalPath(); // validate the path
-        if (default_dir.isEmpty())
-            qWarning() << "invalid defaultExporDir";
+        if (default_dir.isEmpty()) {
+            std::string std_dir = default_dir.toStdString();
+            LOG(message_group::UI_Warning, "Default Export Directory '%1$d' preference is invalid.", std_dir);
+        }
     }
 
     // filename

--- a/src/gui/MainWindow.cc
+++ b/src/gui/MainWindow.cc
@@ -2685,7 +2685,8 @@ void MainWindow::actionExport(FileFormat format, const char *type_name, const ch
     clearCurrentOutput();
     return;
   }
-  this->export_paths[suffix] = exportFilename;
+//  this->export_paths[suffix] = exportFilename;
+  this->activeEditor->exportPaths[suffix] = exportFilename;
 
   ExportInfo exportInfo = createExportInfo(format, exportFilename, activeEditor->filepath);
   // Add options
@@ -2812,7 +2813,8 @@ void MainWindow::actionExportCSG()
     fstream << this->tree.getString(*this->root_node, "\t") << "\n";
     fstream.close();
     fileExportedMessage("CSG", csg_filename);
-    this->export_paths[suffix] = csg_filename;
+    //this->export_paths[suffix] = csg_filename;
+    this->activeEditor->exportPaths[suffix] = csg_filename;
   }
 
   clearCurrentOutput();
@@ -2828,7 +2830,8 @@ void MainWindow::actionExportImage()
   if (!img_filename.isEmpty()) {
     bool saveResult = qglview->save(img_filename.toLocal8Bit().constData());
     if (saveResult) {
-      this->export_paths[suffix] = img_filename;
+      //this->export_paths[suffix] = img_filename;
+      this->activeEditor->exportPaths[suffix] = img_filename;
       setCurrentOutput();
       fileExportedMessage("PNG", img_filename);
       clearCurrentOutput();
@@ -3633,8 +3636,8 @@ void MainWindow::processEvents()
 
 QString MainWindow::exportPath(const char *suffix) {
   QString path;
-  auto path_it = this->export_paths.find(suffix);
-  if (path_it != export_paths.end()) {
+  auto path_it = this->activeEditor->exportPaths.find(suffix);
+  if (path_it != this->activeEditor->exportPaths.end()) {
     path = QFileInfo(path_it->second).absolutePath() + QString("/");
     if (activeEditor->filepath.isEmpty()) path += QString(_("Untitled")) + suffix;
     else path += QFileInfo(activeEditor->filepath).completeBaseName() + suffix;

--- a/src/gui/MainWindow.h
+++ b/src/gui/MainWindow.h
@@ -377,7 +377,6 @@ private:
   EditorInterface *renderedEditor; // stores pointer to editor which has been most recently rendered
   time_t includes_mtime{0}; // latest include mod time
   time_t deps_mtime{0}; // latest dependency mod time
-  std::unordered_map<std::string, QString> export_paths; // for each file type, where it was exported to last
   QString exportPath(const char *suffix); // look up the last export path and generate one if not found
   int last_parser_error_pos{-1}; // last highlighted error position
   int tabCount = 0;

--- a/src/gui/Preferences.cc
+++ b/src/gui/Preferences.cc
@@ -1025,6 +1025,7 @@ void Preferences::updateGUI()
   updateComboBox(this->comboBoxOctoPrintAction, Settings::Settings::octoPrintAction);
   updateComboBox(this->comboBoxOctoPrintSlicingEngine, Settings::Settings::octoPrintSlicerEngine.value());
   updateComboBox(this->comboBoxOctoPrintSlicingProfile, Settings::Settings::octoPrintSlicerProfile.value());
+  BlockSignals<QLineEdit *>(this->lineEditDefaultExportDir)->setText(QString::fromStdString(Settings::Settings::defaultExportDir.value()));
 }
 
 void Preferences::applyComboBox(QComboBox * /*comboBox*/, int val, Settings::SettingsEntryEnum& entry)
@@ -1101,3 +1102,10 @@ void Preferences::updateGUIFontSize(QComboBox *fsSelector, const QString &settin
     BlockSignals<QComboBox *>(fsSelector)->setEditText(fontsize);
   }
 }
+
+void Preferences::on_lineEditDefaultExportDir_editingFinished()
+{
+    Settings::Settings::defaultExportDir.setValue(this->lineEditDefaultExportDir->text().toStdString());
+    writeSettings();
+}
+

--- a/src/gui/Preferences.cc
+++ b/src/gui/Preferences.cc
@@ -35,6 +35,7 @@
 #include <QStatusBar>
 #include <QSettings>
 #include <QTextDocument>
+#include <QFileDialog>
 #include <boost/algorithm/string.hpp>
 #include "GeometryCache.h"
 #include "AutoUpdater.h"
@@ -1107,5 +1108,21 @@ void Preferences::on_lineEditDefaultExportDir_editingFinished()
 {
     Settings::Settings::defaultExportDir.setValue(this->lineEditDefaultExportDir->text().toStdString());
     writeSettings();
+}
+
+
+void Preferences::on_browseExportDirPushButton_clicked()
+{
+    // start browsing from defaultExportDir if present, or fall back to PlatformUtils::userDocumentsPath()
+    QString startDir = this->lineEditDefaultExportDir->text();
+    if (startDir.isEmpty())
+        startDir = QString(PlatformUtils::userDocumentsPath().c_str());
+
+    QString selectedDir = QFileDialog::getExistingDirectory(this, "Choose directory", startDir, QFileDialog::ShowDirsOnly);
+    if (!selectedDir.isEmpty())
+    {
+        this->lineEditDefaultExportDir->setText(selectedDir);
+        emit this->lineEditDefaultExportDir->editingFinished(); // simulate typing to textbox  i.e. persist to Settings
+    }
 }
 

--- a/src/gui/Preferences.h
+++ b/src/gui/Preferences.h
@@ -55,6 +55,7 @@ public slots:
   void on_useAsciiSTLCheckBox_toggled(bool);
   void on_comboBoxToolbarExport3D_activated(int);
   void on_comboBoxToolbarExport2D_activated(int);
+  void on_lineEditDefaultExportDir_editingFinished();
   void on_checkBoxSummaryCamera_toggled(bool);
   void on_checkBoxSummaryArea_toggled(bool);
   void on_checkBoxSummaryBoundingBox_toggled(bool);
@@ -129,6 +130,7 @@ signals:
   void characterThresholdChanged(int val) const;
   void stepSizeChanged(int val) const;
   void toolbarExportChanged() const;
+
 
 private slots:
   void on_lineEditStepSize_textChanged(const QString& arg1);

--- a/src/gui/Preferences.h
+++ b/src/gui/Preferences.h
@@ -56,6 +56,7 @@ public slots:
   void on_comboBoxToolbarExport3D_activated(int);
   void on_comboBoxToolbarExport2D_activated(int);
   void on_lineEditDefaultExportDir_editingFinished();
+  void on_browseExportDirPushButton_clicked();
   void on_checkBoxSummaryCamera_toggled(bool);
   void on_checkBoxSummaryArea_toggled(bool);
   void on_checkBoxSummaryBoundingBox_toggled(bool);

--- a/src/gui/Preferences.ui
+++ b/src/gui/Preferences.ui
@@ -2303,6 +2303,20 @@
                  </item>
                 </layout>
                </item>
+               <item>
+                <layout class="QHBoxLayout" name="horizontalLayoutDefaultExportDir">
+                 <item>
+                  <widget class="QLabel" name="labelDefaultExportDir">
+                   <property name="text">
+                    <string>Default Export Directory</string>
+                   </property>
+                  </widget>
+                 </item>
+                 <item>
+                  <widget class="QLineEdit" name="lineEditDefaultExportDir"/>
+                 </item>
+                </layout>
+               </item>
               </layout>
              </widget>
             </item>

--- a/src/gui/Preferences.ui
+++ b/src/gui/Preferences.ui
@@ -1274,7 +1274,6 @@
            <widget class="QLabel" name="labelFeatures">
             <property name="font">
              <font>
-              <weight>75</weight>
               <bold>true</bold>
              </font>
             </property>
@@ -2314,6 +2313,13 @@
                  </item>
                  <item>
                   <widget class="QLineEdit" name="lineEditDefaultExportDir"/>
+                 </item>
+                 <item>
+                  <widget class="QPushButton" name="browseExportDirPushButton">
+                   <property name="text">
+                    <string>Browse</string>
+                   </property>
+                  </widget>
                  </item>
                 </layout>
                </item>

--- a/src/gui/Settings.cc
+++ b/src/gui/Settings.cc
@@ -127,6 +127,7 @@ SettingsEntryString Settings::octoPrintSlicerProfileDesc("printing", "octoPrintS
 SettingsEntryBool Settings::exportUseAsciiSTL("export", "useAsciiSTL", false);
 SettingsEntryEnum Settings::toolbarExport3D("advanced", "toolbarExport3D", {{"none", "none"}, {"STL", "STL"}, {"OFF", "OFF"}, {"WRL", "WRL"}, {"AMF", "AMF"}, {"3MF", "3MF"}}, "STL");
 SettingsEntryEnum Settings::toolbarExport2D("advanced", "toolbarExport2D", {{"none", "none"}, {"DXF", "DXF"}, {"SVG", "SVG"}, {"PDF", "PDF"}}, "none");
+SettingsEntryString Settings::defaultExportDir("advanced", "defaultExportDir", "");
 
 SettingsEntryBool Settings::summaryCamera("summary", "camera", false);
 SettingsEntryBool Settings::summaryArea("summary", "measurementArea", false);

--- a/src/gui/Settings.h
+++ b/src/gui/Settings.h
@@ -190,6 +190,7 @@ public:
   static SettingsEntryBool exportUseAsciiSTL;
   static SettingsEntryEnum toolbarExport3D;
   static SettingsEntryEnum toolbarExport2D;
+  static SettingsEntryString defaultExportDir;
 
   static SettingsEntryBool summaryCamera;
   static SettingsEntryBool summaryArea;


### PR DESCRIPTION
Reviewed the proposed export path algorithm to work better per-tab (#3649)

    * Use previous export path for this suffix and tab if available.
    * Fallback to "defaultExportDir" preference.
    * If this is not available either use same path as .scad file.
    * Fallback to system wide setting if .scad has not been saved yet.

Also adds "advanced/defaultExportDir" preference option.

This partly fixes #3649. It covers only the "path" part. Suggesting also the previous _basename_ remains to be done (discussed further etc.).


