### PR TITLE
SVG import: Add normalize_coordinates option

### DIFF
--- a/src/core/ImportNode.h
+++ b/src/core/ImportNode.h
@@ -36,6 +36,7 @@ public:
   boost::optional<std::string> layer;
   int convexity;
   bool center;
+  bool normalize_coordinates;
   double dpi;
   double fn, fs, fa;
   double origin_x, origin_y, scale;

--- a/src/io/import.h
+++ b/src/io/import.h
@@ -16,7 +16,7 @@ std::unique_ptr<class PolySet> import_3mf(const std::string&, const Location& lo
 std::unique_ptr<class Polygon2d> import_svg(double fn, double fs, double fa,
 					  const std::string& filename,
 					  const boost::optional<std::string>& id, const boost::optional<std::string>& layer,
-					  const double dpi, const bool center, const Location& loc);
+					  const double dpi, const bool center, const Location& loc, const bool normalize_coordinates);
 
 #ifdef ENABLE_CGAL
 std::unique_ptr<class CGALNefGeometry> import_nef3(const std::string& filename, const Location& loc);

--- a/src/io/import_svg.cc
+++ b/src/io/import_svg.cc
@@ -95,7 +95,7 @@ double calc_alignment(const libsvg::align_t alignment, double page_mm, double sc
 std::unique_ptr<Polygon2d> import_svg(double fn, double fs, double fa,
 				      const std::string& filename,
 				      const boost::optional<std::string>& id, const boost::optional<std::string>& layer,
-				      const double dpi, const bool center, const Location& loc)
+				      const double dpi, const bool center, const Location& loc, const bool normalize_coordinates)
 {
   try {
     fnContext scadContext(fn, fs, fa);
@@ -205,8 +205,8 @@ std::unique_ptr<Polygon2d> import_svg(double fn, double fs, double fa,
         for (const auto& p : s.get_path_list()) {
           Outline2d outline;
           for (const auto& v : p) {
-            const double x = scale.x() * (-viewbox.x() + v.x()) - cx;
-            const double y = scale.y() * (-viewbox.y() - v.y()) + cy;
+            const double x = normalize_coordinates ? scale.x() * (-viewbox.x() + v.x()) - cx : v.x();
+            const double y = normalize_coordinates ? scale.y() * (-viewbox.y() - v.y()) + cy : v.y();
             outline.vertices.emplace_back(x, y);
             outline.positive = true;
           }


### PR DESCRIPTION
This adds an option as described in https://github.com/openscad/openscad/issues/3460#issuecomment-1996843751, closing https://github.com/openscad/openscad/issues/3460:

> * **literal_coordinate**
   Boolean. If set to true, the numeric values of x and y coordinates are used without format specific transformations.
>
>   This argument only applies to SVG (or similar future formats): SVG's coordinate system applies the *y* value toward the bottom of the screen on the drawing plane, whereas in OpenSCAD's top view, *y* points toward the top of the screen. By default (i.e., when literal_coordinate=false), the import command flips an SVG file's *y* coordinates, and shifts the whole drawing into the positive area.
>
>   Using literal_coordinate=true is particularly useful when the OpenSCAD script has additional information about positions inside the SVG file's coordinate system.
>
>   This is mutually exclusive with the "center" argument.

There is open point from https://github.com/openscad/openscad/issues/3460#issuecomment-1996843751: Should literal_coordinate also disregard scaling and force the import units to be SVG units, or is it fine as it is (and the documentation just needs slight adjustment)?