### PR TITLE
chore(python): remove py2 compatibility imports

### DIFF
--- a/scripts/git-archive-all.py
+++ b/scripts/git-archive-all.py
@@ -1,8 +1,4 @@
 #! /usr/bin/env python3
-# coding=utf-8
-
-from __future__ import print_function
-from __future__ import unicode_literals
 
 __version__ = "1.7"
 

--- a/tests/data/python/gen_issue2342-template.py
+++ b/tests/data/python/gen_issue2342-template.py
@@ -2,7 +2,6 @@
 # # This python script generates a large output .scad file (3.1MB) for stress testing the parser.
 # See Issue #2342 / Pull Request #2343
 
-from __future__ import print_function
 
 xcount = 100
 ycount = 100

--- a/tests/data/python/gen_svg_viewbox_tests-template.py
+++ b/tests/data/python/gen_svg_viewbox_tests-template.py
@@ -1,6 +1,5 @@
 #! ${PYTHON_EXECUTABLE}
 
-from __future__ import print_function
 
 import sys
 

--- a/tests/export_import_pngtest.py
+++ b/tests/export_import_pngtest.py
@@ -25,7 +25,6 @@
 #
 # Authors: Torsten Paul, Don Bright, Marius Kintel
 
-from __future__ import print_function
 
 import sys, os, re, subprocess, argparse
 from validatestl import validateSTL

--- a/tests/export_pngtest.py
+++ b/tests/export_pngtest.py
@@ -14,7 +14,6 @@
 #
 # Authors: Torsten Paul, Don Bright, Marius Kintel
 
-from __future__ import print_function
 
 import sys, os, re, subprocess, argparse
 

--- a/tests/test_cmdline_tool.py
+++ b/tests/test_cmdline_tool.py
@@ -22,7 +22,6 @@
 # Author: Marius Kintel <marius@kintel.net>
 #
 
-from __future__ import print_function
 
 import sys
 import os

--- a/tests/test_pretty_print.py
+++ b/tests/test_pretty_print.py
@@ -27,7 +27,6 @@
 #
 # 1. why is hash differing
 
-from __future__ import print_function
 
 import string, sys, re, os, hashlib, subprocess, time, platform, html, base64
 


### PR DESCRIPTION
### Reference

Mentioned in #5040