### PR TITLE
chore(python): remove redundant open modes

### DIFF
--- a/scripts/git-archive-all.py
+++ b/scripts/git-archive-all.py
@@ -187,7 +187,7 @@ class GitArchiver:
         def read_attributes(attributes_abspath):
             patterns = []
             if path.isfile(attributes_abspath):
-                attributes = open(attributes_abspath, 'r').readlines()
+                attributes = open(attributes_abspath).readlines()
                 patterns = []
                 for line in attributes:
                     tokens = line.strip().split()

--- a/tests/mingw_convert_ctest.py
+++ b/tests/mingw_convert_ctest.py
@@ -136,7 +136,7 @@ def processfile(infilename, winconv):
     debug ('wrote backup of ',infilename,' to ',backup_filename)
 
     outfilename = infilename.replace('.cmake','.win.cmake')
-    fin=open(infilename,'r')
+    fin=open(infilename)
     lines=fin.readlines()
     fout=open(outfilename,'w')
     fout.write('#'+os.linesep)
@@ -194,7 +194,7 @@ def process_templates():
             if scadpath is not None:
                 print('Ovewriting ' + scadpath + ' based on ' + filename + ' using path ' + cmakebase)
                 fout = open(scadpath, 'w')
-                fin = open(templatepath + '\\' + filename, 'r')
+                fin = open(templatepath + '\\' + filename)
                 for line in fin.readlines():
                     line = line.replace("@CMAKE_CURRENT_SOURCE_DIR@", cmakebase)
                     fout.write(line)

--- a/tests/validatestl.py
+++ b/tests/validatestl.py
@@ -31,7 +31,7 @@ def read_stl(filename):
     print(start)
 
     if stl_type == 'ascii':
-        with open(filename, "r") as fd:
+        with open(filename) as fd:
             triangle = {
                 'normal': [0, 0, 0],
                 'points': list()


### PR DESCRIPTION
`open` always uses read in utf8 mode.

### Reference

Mentioned in #5040