### PR TITLE
Replace deprecated Q_OS_MAC and Q_OS_MACX

### DIFF
--- a/src/gui/MainWindow.cc
+++ b/src/gui/MainWindow.cc
@@ -66,7 +66,7 @@
 #include "CSGTreeNormalizer.h"
 #include "QGLView.h"
 #include "MouseSelector.h"
-#ifdef Q_OS_MAC
+#ifdef Q_OS_MACOS
 #include "CocoaUtils.h"
 #endif
 #ifdef Q_OS_WIN
@@ -3557,7 +3557,7 @@ void MainWindow::quit()
   QApplication::sendEvent(QApplication::instance(), &ev);
   if (ev.isAccepted()) QApplication::instance()->quit();
   // FIXME: Cancel any CGAL calculations
-#ifdef Q_OS_MAC
+#ifdef Q_OS_MACOS
   CocoaUtils::endApplication();
 #endif
 }

--- a/src/gui/OpenSCADApp.cc
+++ b/src/gui/OpenSCADApp.cc
@@ -1,6 +1,6 @@
 #include "OpenSCADApp.h"
 #include "MainWindow.h"
-#ifdef Q_OS_MAC
+#ifdef Q_OS_MACOS
 #include "EventFilter.h"
 #endif
 
@@ -12,7 +12,7 @@
 OpenSCADApp::OpenSCADApp(int& argc, char **argv)
   : QApplication(argc, argv)
 {
-#ifdef Q_OS_MAC
+#ifdef Q_OS_MACOS
   this->installEventFilter(new SCADEventFilter(this));
 #endif
 }

--- a/src/gui/Preferences.cc
+++ b/src/gui/Preferences.cc
@@ -92,7 +92,7 @@ void Preferences::init() {
   this->defaultmap["advanced/customizerFontFamily"] = font2.family();
   this->defaultmap["advanced/customizerFontSize"] = font2.pointSize();
 
-#if defined (Q_OS_MAC)
+#ifdef Q_OS_MACOS
   this->defaultmap["editor/ctrlmousewheelzoom"] = false;
 #else
   this->defaultmap["editor/ctrlmousewheelzoom"] = true;
@@ -874,7 +874,7 @@ void Preferences::fireEditorConfigChanged() const
 
 void Preferences::keyPressEvent(QKeyEvent *e)
 {
-#ifdef Q_OS_MAC
+#ifdef Q_OS_MACOS
   if (e->modifiers() == Qt::ControlModifier && e->key() == Qt::Key_Period) {
     close();
   } else

--- a/src/gui/QGLView.cc
+++ b/src/gui/QGLView.cc
@@ -298,7 +298,7 @@ void QGLView::mouseMoveEvent(QMouseEvent *event)
     mouse_drag_moved = true;
     auto button_compare = this->mouseSwapButtons?Qt::RightButton : Qt::LeftButton;
     if (event->buttons() & button_compare
-#ifdef Q_OS_MAC
+#ifdef Q_OS_MACOS
         && !(event->modifiers() & Qt::MetaModifier)
 #endif
         ) {

--- a/src/gui/ScintillaEditor.cc
+++ b/src/gui/ScintillaEditor.cc
@@ -138,7 +138,7 @@ ScintillaEditor::ScintillaEditor(QWidget *parent) : EditorInterface(parent)
   //
   QsciCommand *c;
   // NOLINTBEGIN(bugprone-suspicious-enum-usage)
-#ifdef Q_OS_MAC
+#ifdef Q_OS_MACOS
   // Alt-Backspace should delete left word (Alt-Delete already deletes right word)
   c = qsci->standardCommands()->find(QsciCommand::DeleteWordLeft);
   c->setKey(Qt::Key_Backspace | Qt::ALT);
@@ -154,7 +154,7 @@ ScintillaEditor::ScintillaEditor(QWidget *parent) : EditorInterface(parent)
   c->setKey(Qt::Key_Z | Qt::CTRL | Qt::SHIFT);
   c->setAlternateKey(Qt::Key_Y | Qt::CTRL);
 
-#ifdef Q_OS_MAC
+#ifdef Q_OS_MACOS
   const unsigned long modifier = Qt::META;
 #else
   const unsigned long modifier = Qt::CTRL;
@@ -1079,7 +1079,7 @@ bool ScintillaEditor::handleKeyEventNavigateNumber(QKeyEvent *keyEvent)
 {
   static bool previewAfterUndo = false;
 
-#ifdef Q_OS_MAC
+#ifdef Q_OS_MACOS
   unsigned int navigateOnNumberModifiers = Qt::AltModifier | Qt::ShiftModifier | Qt::KeypadModifier;
 #else
   unsigned int navigateOnNumberModifiers = Qt::AltModifier;

--- a/src/gui/TabManager.cc
+++ b/src/gui/TabManager.cc
@@ -573,7 +573,7 @@ bool TabManager::maybeSave(int x)
     box.setDefaultButton(QMessageBox::Save);
     box.setIcon(QMessageBox::Warning);
     box.setWindowModality(Qt::ApplicationModal);
-#ifdef Q_OS_MAC
+#ifdef Q_OS_MACOS
     // Cmd-D is the standard shortcut for this button on Mac
     box.button(QMessageBox::Discard)->setShortcut(QKeySequence("Ctrl+D"));
     box.button(QMessageBox::Discard)->setShortcutEnabled(true);
@@ -605,7 +605,7 @@ bool TabManager::shouldClose()
     box.setDefaultButton(QMessageBox::SaveAll);
     box.setIcon(QMessageBox::Warning);
     box.setWindowModality(Qt::ApplicationModal);
-#ifdef Q_OS_MAC
+#ifdef Q_OS_MACOS
     // Cmd-D is the standard shortcut for this button on Mac
     box.button(QMessageBox::Discard)->setShortcut(QKeySequence("Ctrl+D"));
     box.button(QMessageBox::Discard)->setShortcutEnabled(true);

--- a/src/openscad.cc
+++ b/src/openscad.cc
@@ -745,7 +745,7 @@ int gui(vector<string>& inputFiles, const fs::path& original_path, int argc, cha
   QGuiApplication::setApplicationDisplayName("OpenSCAD");
   QGuiApplication::setDesktopFileName(DESKTOP_FILENAME);
   QCoreApplication::setAttribute(Qt::AA_UseHighDpiPixmaps);
-#ifdef Q_OS_MAC
+#ifdef Q_OS_MACOS
   app.setWindowIcon(QIcon(":/icon-macos.png"));
 #else
   app.setWindowIcon(QIcon(":/logo.png"));
@@ -764,7 +764,7 @@ int gui(vector<string>& inputFiles, const fs::path& original_path, int argc, cha
     localization_init();
   }
 
-#ifdef Q_OS_MAC
+#ifdef Q_OS_MACOS
   installAppleEventHandlers();
 #endif
 
@@ -868,7 +868,7 @@ int gui(const vector<string>& inputFiles, const fs::path& original_path, int arg
 }
 #endif // OPENSCAD_QTGUI
 
-#if defined(Q_OS_MACX)
+#ifdef Q_OS_MACOS
 std::pair<string, string> customSyntax(const string& s)
 {
   if (s.find("-psn_") == 0) return {"psn", s.substr(5)};
@@ -932,7 +932,7 @@ int main(int argc, char **argv)
   PlatformUtils::registerApplicationPath(fs::absolute(boost::filesystem::path(argv[0]).parent_path()).generic_string());
 #endif
 
-#ifdef Q_OS_MAC
+#ifdef Q_OS_MACOS
   bool isGuiLaunched = getenv("GUI_LAUNCHED") != nullptr;
   auto nslog = [](const Message& msg, void *userdata) {
       CocoaUtils::nslog(msg.msg, userdata);
@@ -1011,7 +1011,7 @@ int main(int argc, char **argv)
 
   po::options_description hidden("Hidden options");
   hidden.add_options()
-#ifdef Q_OS_MACX
+#ifdef Q_OS_MACOS
   ("psn", po::value<string>(), "process serial number")
 #endif
   ("input-file", po::value<vector<string>>(), "input file");


### PR DESCRIPTION
Only the Q_OS_MACX ones are creating deprecation warnings at the moment, but that is something anyway. But get ahead and be consistent.

Deprecated in Qt 5:

https://doc.qt.io/qt-5/qtglobal.html#Q_OS_MAC
https://doc.qt.io/qt-5/qtglobal.html#Q_OS_OSX
