### PR TITLE
Use Manifold's Slice() and Project() to implement projection()

### DIFF
--- a/src/geometry/GeometryEvaluator.cc
+++ b/src/geometry/GeometryEvaluator.cc
@@ -1376,6 +1376,16 @@ std::shared_ptr<const Geometry> GeometryEvaluator::projectionCut(const Projectio
   std::shared_ptr<const Geometry> geom;
   std::shared_ptr<const Geometry> newgeom = applyToChildren3D(node, OpenSCADOperator::UNION).constptr();
   if (newgeom) {
+#ifdef ENABLE_MANIFOLD
+    if (Feature::ExperimentalManifold.is_enabled()) {
+      auto manifold = ManifoldUtils::createManifoldFromGeometry(newgeom);
+      if (node.cut_mode) {
+        return std::make_shared<const Polygon2d>(manifold->slice());
+      } else {
+        return std::make_shared<const Polygon2d>(manifold->project());
+      }
+    }
+#endif
 #ifdef ENABLE_CGAL
     auto Nptr = CGALUtils::getNefPolyhedronFromGeometry(newgeom);
     if (Nptr && !Nptr->isEmpty()) {

--- a/src/geometry/GeometryEvaluator.cc
+++ b/src/geometry/GeometryEvaluator.cc
@@ -1379,11 +1379,8 @@ std::shared_ptr<const Geometry> GeometryEvaluator::projectionCut(const Projectio
 #ifdef ENABLE_MANIFOLD
     if (Feature::ExperimentalManifold.is_enabled()) {
       auto manifold = ManifoldUtils::createManifoldFromGeometry(newgeom);
-      if (node.cut_mode) {
-        return std::make_shared<const Polygon2d>(manifold->slice());
-      } else {
-        return std::make_shared<const Polygon2d>(manifold->project());
-      }
+      auto poly2d = manifold->slice();
+      return std::shared_ptr<const Polygon2d>(ClipperUtils::sanitize(poly2d));
     }
 #endif
 #ifdef ENABLE_CGAL
@@ -1402,6 +1399,7 @@ std::shared_ptr<const Geometry> GeometryEvaluator::projectionCut(const Projectio
 
 std::shared_ptr<const Geometry> GeometryEvaluator::projectionNoCut(const ProjectionNode& node)
 {
+  // TODO(kintel): Measure this approach vs. manifold::Project()
   std::shared_ptr<const Geometry> geom;
   std::vector<std::unique_ptr<Polygon2d>> tmp_geom;
   BoundingBox bounds;

--- a/src/geometry/GeometryEvaluator.cc
+++ b/src/geometry/GeometryEvaluator.cc
@@ -1399,6 +1399,19 @@ std::shared_ptr<const Geometry> GeometryEvaluator::projectionCut(const Projectio
 
 std::shared_ptr<const Geometry> GeometryEvaluator::projectionNoCut(const ProjectionNode& node)
 {
+#ifdef ENABLE_MANIFOLD
+  if (Feature::ExperimentalManifold.is_enabled()) {
+    std::shared_ptr<const Geometry> newgeom = applyToChildren3D(node, OpenSCADOperator::UNION).constptr();
+    if (newgeom) {
+        auto manifold = ManifoldUtils::createManifoldFromGeometry(newgeom);
+        auto poly2d = manifold->project();
+        return std::shared_ptr<const Polygon2d>(ClipperUtils::sanitize(poly2d));
+    } else {
+      return std::make_shared<Polygon2d>();
+    }
+  }
+#endif
+
   // TODO(kintel): Measure this approach vs. manifold::Project()
   std::shared_ptr<const Geometry> geom;
   std::vector<std::unique_ptr<Polygon2d>> tmp_geom;

--- a/src/geometry/GeometryEvaluator.cc
+++ b/src/geometry/GeometryEvaluator.cc
@@ -1412,7 +1412,6 @@ std::shared_ptr<const Geometry> GeometryEvaluator::projectionNoCut(const Project
   }
 #endif
 
-  // TODO(kintel): Measure this approach vs. manifold::Project()
   std::shared_ptr<const Geometry> geom;
   std::vector<std::unique_ptr<Polygon2d>> tmp_geom;
   BoundingBox bounds;

--- a/src/geometry/cgal/cgalutils-project.cc
+++ b/src/geometry/cgal/cgalutils-project.cc
@@ -194,7 +194,7 @@ std::unique_ptr<Polygon2d> project(const CGAL_Nef_polyhedron& N, bool cut)
         CGAL_Point_3 maxpt(inf,  inf,  eps);
         CGAL_Iso_cuboid_3 bigcuboid(minpt, maxpt);
         pts.reserve(8);
-for (int i = 0; i < 8; ++i) pts.push_back(bigcuboid.vertex(i));
+        for (int i = 0; i < 8; ++i) pts.push_back(bigcuboid.vertex(i));
         CGAL_Polyhedron bigbox;
         CGAL::convex_hull_3(pts.begin(), pts.end(), bigbox);
         CGAL_Nef_polyhedron3 nef_bigbox(bigbox);

--- a/src/geometry/manifold/ManifoldGeometry.cc
+++ b/src/geometry/manifold/ManifoldGeometry.cc
@@ -1,5 +1,6 @@
 // Portions of this file are Copyright 2023 Google LLC, and licensed under GPL2+. See COPYING.
 #include "ManifoldGeometry.h"
+#include "Polygon2d.h"
 #include "manifold.h"
 #include "PolySet.h"
 #include "PolySetUtils.h"
@@ -197,6 +198,16 @@ ManifoldGeometry ManifoldGeometry::operator-(const ManifoldGeometry& other) cons
 
 ManifoldGeometry ManifoldGeometry::minkowski(const ManifoldGeometry& other) const {
   return {*minkowskiOp(*this, other)};
+}
+
+Polygon2d ManifoldGeometry::slice() const {
+  auto cross_section = manifold_->Slice();
+  return ManifoldUtils::polygonsToPolygon2d(cross_section.ToPolygons());
+}
+
+Polygon2d ManifoldGeometry::project() const {
+  auto cross_section = manifold_->Project();
+  return ManifoldUtils::polygonsToPolygon2d(cross_section.ToPolygons());
 }
 
 void ManifoldGeometry::transform(const Transform3d& mat) {

--- a/src/geometry/manifold/ManifoldGeometry.h
+++ b/src/geometry/manifold/ManifoldGeometry.h
@@ -48,6 +48,8 @@ public:
   /*! minkowksi operation. */
   ManifoldGeometry minkowski(const ManifoldGeometry& other) const;
 
+  Polygon2d slice() const;
+  Polygon2d project() const;
 
   void transform(const Transform3d& mat) override;
   void resize(const Vector3d& newsize, const Eigen::Matrix<bool, 3, 1>& autosize) override;

--- a/src/geometry/manifold/manifoldutils.cc
+++ b/src/geometry/manifold/manifoldutils.cc
@@ -177,7 +177,7 @@ Polygon2d polygonsToPolygon2d(const manifold::Polygons& polygons) {
     for (const auto& v : polygon) {
       outline.vertices.emplace_back(v[0], v[1]);
     }
-    poly2d.addOutline(outline);
+    poly2d.addOutline(std::move(outline));
   }
   return std::move(poly2d);
 }

--- a/src/geometry/manifold/manifoldutils.cc
+++ b/src/geometry/manifold/manifoldutils.cc
@@ -170,4 +170,16 @@ std::shared_ptr<const ManifoldGeometry> createManifoldFromGeometry(const std::sh
   return nullptr;
 }
 
+Polygon2d polygonsToPolygon2d(const manifold::Polygons& polygons) {
+  Polygon2d poly2d;
+  for (const auto& polygon : polygons) {
+    Outline2d outline;
+    for (const auto& v : polygon) {
+      outline.vertices.emplace_back(v[0], v[1]);
+    }
+    poly2d.addOutline(outline);
+  }
+  return std::move(poly2d);
+}
+
 }; // namespace ManifoldUtils

--- a/src/geometry/manifold/manifoldutils.h
+++ b/src/geometry/manifold/manifoldutils.h
@@ -5,13 +5,6 @@
 #include "ManifoldGeometry.h"
 #include "manifold.h"
 
-class PolySet;
-
-namespace manifold {
-  class Manifold;
-  struct Mesh;
-};
-
 namespace ManifoldUtils {
 
   const char* statusToString(manifold::Manifold::Error status);
@@ -23,6 +16,8 @@ namespace ManifoldUtils {
   std::shared_ptr<ManifoldGeometry> createManifoldFromSurfaceMesh(const TriangleMesh& mesh);
 
   std::shared_ptr<ManifoldGeometry> applyOperator3DManifold(const Geometry::Geometries& children, OpenSCADOperator op);
+
+  Polygon2d polygonsToPolygon2d(const manifold::Polygons& polygons);
 
 #ifdef ENABLE_CGAL
   // FIXME: This shouldn't return const, but it does due to internal implementation details.

--- a/tests/data/scad/2D/features/projection-cut-tests.scad
+++ b/tests/data/scad/2D/features/projection-cut-tests.scad
@@ -4,7 +4,7 @@ projection(cut=true) { square(); }
 projection(cut=true) translate([20,0,0]) cube(10, center=true);
 
 // Boundary case: clipping the top of a cube
-translate([0,20,0]) projection(cut=true) translate([0,0,-4.999999]) cube(10, center=true);
+translate([0,20,0]) projection(cut=true) translate([0,0,-4.99999]) cube(10, center=true);
 
 // Empty cut
 projection(cut=true) translate([0,0,5]) cube(5, center=true);

--- a/tests/regression/dumptest/projection-cut-tests-expected.csg
+++ b/tests/regression/dumptest/projection-cut-tests-expected.csg
@@ -8,7 +8,7 @@ projection(cut = true, convexity = 0) {
 }
 multmatrix([[1, 0, 0, 0], [0, 1, 0, 20], [0, 0, 1, 0], [0, 0, 0, 1]]) {
 	projection(cut = true, convexity = 0) {
-		multmatrix([[1, 0, 0, 0], [0, 1, 0, 0], [0, 0, 1, -5], [0, 0, 0, 1]]) {
+		multmatrix([[1, 0, 0, 0], [0, 1, 0, 0], [0, 0, 1, -4.99999], [0, 0, 0, 1]]) {
 			cube(size = [10, 10, 10], center = true);
 		}
 	}
@@ -45,3 +45,4 @@ multmatrix([[1, 0, 0, -15], [0, 1, 0, 0], [0, 0, 1, 0], [0, 0, 0, 1]]) {
 		square(size = [1, 1], center = false);
 	}
 }
+


### PR DESCRIPTION
This should give `projection(cut=true)` a few orders of magniture speed boost.

Also fixes #2584
