### PR TITLE
Bugfix: Color scheme changes didn't affect rendered polysets

### DIFF
--- a/src/glview/cgal/CGALRenderer.cc
+++ b/src/glview/cgal/CGALRenderer.cc
@@ -131,6 +131,7 @@ void CGALRenderer::setColorScheme(const ColorScheme &cs) {
 #ifdef ENABLE_CGAL
   this->polyhedrons.clear(); // Mark as dirty
 #endif
+  this->vertex_states.clear(); // Mark as dirty
   PRINTD("setColorScheme done");
 }
 


### PR DESCRIPTION
When rendering geometry resulting in pure PolySets (primitives or anything rendered using `manifold` or `fast-csg`), and change the color scheme afterwards, this geometry would _not_ change color. Only CGAL Nef polyhedrons would.

This fixes this by forcing VBO rebuild from PolySets.