### PR TITLE
Temporarily downgrade to macos-13

### DIFF
--- a/.github/workflows/macos-tests.yml
+++ b/.github/workflows/macos-tests.yml
@@ -8,8 +8,8 @@ on:
 
 jobs:
   build:
-    runs-on: macos-latest
-    name: macos-latest
+    runs-on: macos-13
+    name: macos-13
     # If it's not done in 60 minutes, something is wrong.
     # Default is 6 hours, which is a bit long to wait.
     timeout-minutes: 60


### PR DESCRIPTION
..since github upgraded to a broken macos-14 runner.

Upstream issue: https://github.com/actions/runner-images/issues/9712