### PR TITLE
Fix initial GUI setup.

### DIFF
--- a/src/gui/MainWindow.cc
+++ b/src/gui/MainWindow.cc
@@ -665,7 +665,6 @@ MainWindow::MainWindow(const QStringList& filenames)
   const auto windowState = settings.value("window/state", QByteArray()).toByteArray();
   restoreGeometry(settings.value("window/geometry", QByteArray()).toByteArray());
   restoreState(windowState);
-  updateWindowSettings(hideConsole, hideEditor, hideCustomizer, hideErrorLog, hideEditorToolbar, hide3DViewToolbar, hideAnimate, hideViewportControl);
 
   if (windowState.size() == 0) {
     /*
@@ -681,6 +680,11 @@ MainWindow::MainWindow(const QStringList& filenames)
      * fill the available space.
      */
     activeEditor->setInitialSizeHint(QSize((5 * this->width() / 11), 100));
+    tabifyDockWidget(consoleDock, errorLogDock);
+    tabifyDockWidget(errorLogDock, animateDock);
+    showConsole();
+    hideCustomizer = true;
+    hideViewportControl = true;
   } else {
 #ifdef Q_OS_WIN
     // Try moving the main window into the display range, this
@@ -700,6 +704,8 @@ MainWindow::MainWindow(const QStringList& filenames)
     }
 #endif // ifdef Q_OS_WIN
   }
+
+  updateWindowSettings(hideConsole, hideEditor, hideCustomizer, hideErrorLog, hideEditorToolbar, hide3DViewToolbar, hideAnimate, hideViewportControl);
 
   connect(this->editorDock, SIGNAL(topLevelChanged(bool)), this, SLOT(editorTopLevelChanged(bool)));
   connect(this->consoleDock, SIGNAL(topLevelChanged(bool)), this, SLOT(consoleTopLevelChanged(bool)));

--- a/src/gui/MainWindow.cc
+++ b/src/gui/MainWindow.cc
@@ -906,7 +906,7 @@ void MainWindow::loadViewSettings(){
 void MainWindow::loadDesignSettings()
 {
   QSettingsCached settings;
-  if (settings.value("design/autoReload", true).toBool()) {
+  if (settings.value("design/autoReload", false).toBool()) {
     designActionAutoReload->setChecked(true);
   }
   auto polySetCacheSizeMB = Preferences::inst()->getValue("advanced/polysetCacheSizeMB").toUInt();

--- a/src/gui/Preferences.cc
+++ b/src/gui/Preferences.cc
@@ -124,7 +124,12 @@ void Preferences::init() {
   this->defaultmap["advanced/enableTraceUsermoduleParameters"] = true;
   this->defaultmap["advanced/enableParameterCheck"] = true;
   this->defaultmap["advanced/enableParameterRangeCheck"] = false;
-
+  this->defaultmap["view/hideConsole"] = false;
+  this->defaultmap["view/hideEditor"] = false;
+  this->defaultmap["view/hideErrorLog"] = false;
+  this->defaultmap["view/hideAnimate"] = false;
+  this->defaultmap["view/hideCustomizer"] = true;
+  this->defaultmap["view/hideViewportControl"] = true;
   this->defaultmap["editor/enableAutocomplete"] = true;
   this->defaultmap["editor/characterThreshold"] = 1;
   this->defaultmap["editor/stepSize"] = 1;


### PR DESCRIPTION
Change default for "Auto-Reload and Preview" to false, so new installations have to manually turn it on.

The initial GUI state (new install / cleared configuration) is very messy:
<img src="https://github.com/openscad/openscad/assets/1330241/8bd20878-b72e-4e04-be04-a6dd73f46059" width="600">

This changes the default to dock Console/ErrorLog/Animate as tabs and hide the Customizer and ViewportControl docks:
<img src="https://github.com/openscad/openscad/assets/1330241/c4262b29-272b-42b6-aac7-3b29ee42a2e3" width="600">
