### PR TITLE
Viewport-Control widget: Limit width to at least dynamic minimum size of widget. Add tab order back in.  Fixes #5116

### DIFF
--- a/src/gui/ViewportControl.cc
+++ b/src/gui/ViewportControl.cc
@@ -106,6 +106,11 @@ void ViewportControl::resizeEvent(QResizeEvent *event)
         gridLayout->addWidget(labelFOV, 3, 0, 1, 1);
         gridLayout->addWidget(doubleSpinBox_fov, 3, 1, 1, 1);
         scrollAreaWidgetContents->layout()->invalidate();
+      } else {
+        const auto width = scrollAreaWidgetContents->minimumSizeHint().width();
+        if (scrollArea->minimumSize().width() != width) {
+          scrollArea->setMinimumSize(QSize(width,0));
+        }
       }
     }
   }

--- a/src/gui/ViewportControl.ui
+++ b/src/gui/ViewportControl.ui
@@ -331,6 +331,19 @@
    </property>
   </action>
  </widget>
+ <tabstops>
+  <tabstop>spinBoxWidth</tabstop>
+  <tabstop>spinBoxHeight</tabstop>
+  <tabstop>checkBoxAspecRatioLock</tabstop>
+  <tabstop>doubleSpinBox_tx</tabstop>
+  <tabstop>doubleSpinBox_ty</tabstop>
+  <tabstop>doubleSpinBox_tz</tabstop>
+  <tabstop>doubleSpinBox_rx</tabstop>
+  <tabstop>doubleSpinBox_ry</tabstop>
+  <tabstop>doubleSpinBox_rz</tabstop>
+  <tabstop>doubleSpinBox_d</tabstop>
+  <tabstop>doubleSpinBox_fov</tabstop>
+ </tabstops>
  <resources/>
  <connections/>
 </ui>


### PR DESCRIPTION
Addresses #5116 - Viewport-Control widget can be made too narrow & tab order was lost is now weird.

PR #5107 improved the Viewport-Control widget by allowing it to morph to a vertical layout when the widget became too narrow for the original horizontal layout.  Very nice!

However, after that change the widget could be made too narrow and look bad because the controls were "cut off" and only partially visible.  #5107 also lost the left-to-right top-to-bottom tab order within the widget. This PR fixes both of these issues.  See #5116 for screenshots and detailed steps.