### PR TITLE
Show save dialog when exiting via shortcut or menu item

### DIFF
--- a/src/gui/MainWindow.cc
+++ b/src/gui/MainWindow.cc
@@ -3558,7 +3558,7 @@ void MainWindow::setFont(const QString& family, uint size)
 void MainWindow::quit()
 {
   QCloseEvent ev;
-  QApplication::sendEvent(QApplication::instance(), &ev);
+  MainWindow::closeEvent(&ev);
   if (ev.isAccepted()) QApplication::instance()->quit();
   // FIXME: Cancel any CGAL calculations
 #ifdef Q_OS_MACOS

--- a/src/gui/MainWindow.cc
+++ b/src/gui/MainWindow.cc
@@ -979,8 +979,11 @@ MainWindow::~MainWindow()
   if (scadApp->windowManager.getWindows().size() == 0) {
     // Quit application even in case some other windows like
     // Preferences are still open.
-    this->quit();
+    QApplication::instance()->quit();
   }
+#ifdef Q_OS_MACOS
+  CocoaUtils::endApplication();
+#endif
 }
 
 void MainWindow::showProgress()
@@ -3557,13 +3560,7 @@ void MainWindow::setFont(const QString& family, uint size)
 
 void MainWindow::quit()
 {
-  QCloseEvent ev;
-  MainWindow::closeEvent(&ev);
-  if (ev.isAccepted()) QApplication::instance()->quit();
-  // FIXME: Cancel any CGAL calculations
-#ifdef Q_OS_MACOS
-  CocoaUtils::endApplication();
-#endif
+  QMainWindow::close();
 }
 
 void MainWindow::consoleOutput(const Message& msgObj, void *userdata)


### PR DESCRIPTION
Ctrl-Q on Linux doesn't prompt to save files like the normal window close button, and I managed to lose work several times over it.

Digging into the openscad (and Qt) source code revealed that File -> Quit has the same behaviour, and it most likely happens on OS X too (Cmd-Q).

I'm no C++ developer, but the fix appeared to be relatively simple once I found it.