### PR TITLE
Test on Ubuntu 24.04 and Qt 6

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -37,7 +37,7 @@ jobs:
         # queries: ./path/to/local/query, your-org/your-repo/queries@main
 
     - name: Install dependencies
-      run: ./scripts/github-ci-linux-get-dependencies.sh bionic
+      run: ./scripts/github-ci-linux-get-dependencies.sh jammy
     - name: Build
       run: ./scripts/github-ci.sh experimental build
 

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -37,7 +37,7 @@ jobs:
         # queries: ./path/to/local/query, your-org/your-repo/queries@main
 
     - name: Install dependencies
-      run: ./scripts/github-ci-linux-get-dependencies.sh jammy
+      run: ./scripts/github-ci-linux-get-dependencies.sh
     - name: Build
       run: ./scripts/github-ci.sh experimental build
 

--- a/.github/workflows/linux-tests.yml
+++ b/.github/workflows/linux-tests.yml
@@ -18,7 +18,7 @@ jobs:
             distro: focal
             qt5default: true
           - os: ubuntu-22.04
-            distro: kinetic
+            distro: jammy
             qt5default: false
 
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/linux-tests.yml
+++ b/.github/workflows/linux-tests.yml
@@ -12,7 +12,13 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ ubuntu-20.04, ubuntu-22.04 ]
+        os: [ ubuntu-20.04, ubuntu-22.04, ubuntu-24.04 ]
+        qt: [ qt5, qt6 ]
+        exclude:
+          - os: ubuntu-20.04
+            qt: qt6
+          - os: ubuntu-22.04
+            qt: qt6
         include:
           - os: ubuntu-20.04
             distro: focal
@@ -20,17 +26,20 @@ jobs:
           - os: ubuntu-22.04
             distro: jammy
             qt5default: false
+          - os: ubuntu-24.04
+            distro: noble
+            qt5default: false
 
     runs-on: ${{ matrix.os }}
 
-    name: ${{ matrix.os }}
+    name: ${{ matrix.os }} ${{ matrix.qt }}
 
     steps:
     - uses: actions/checkout@v4
       with:
         submodules: 'recursive'
     - name: Install dependencies
-      run: ./scripts/github-ci-linux-get-dependencies.sh ${{ matrix.distro }}
+      run: ./scripts/github-ci-linux-get-dependencies.sh ${{ matrix.distro }} ${{ matrix.qt }}
     - name: Dependency fixup
       run: sudo apt-get install gcovr
     - name: Make Qt5 the default
@@ -40,17 +49,17 @@ jobs:
       with:
         python-version: '3.11'
     - name: Build and test
-      run: ./scripts/github-ci.sh experimental enable_python build test coverage
+      run: ./scripts/github-ci.sh experimental enable_python ${{ matrix.qt == 'qt6' && 'qt6' || '' }} build test coverage
     - name: Upload Test Result Report
       uses: actions/upload-artifact@v4
       if: ${{ always() }}
       with:
-        name: Test Result Report (${{ matrix.os }})
+        name: Test Result Report (${{ matrix.os }} ${{ matrix.qt }})
         path: |
           b/Testing/Temporary/*_report.html
           b/Testing/Temporary/LastTest.log
     - name: Upload Code Coverage Report
       uses: actions/upload-artifact@v4
       with:
-        name: Code Coverage Report (${{ matrix.os }})
+        name: Code Coverage Report (${{ matrix.os }} ${{ matrix.qt }})
         path: c/coverage*.html

--- a/.github/workflows/linux-tests.yml
+++ b/.github/workflows/linux-tests.yml
@@ -16,8 +16,10 @@ jobs:
         qt: [ qt5, qt6 ]
         exclude:
           - os: ubuntu-20.04
+            # Qt 6 not packaged
             qt: qt6
           - os: ubuntu-22.04
+            # libqscintilla2-qt6-dev not packaged
             qt: qt6
         include:
           - os: ubuntu-20.04

--- a/.github/workflows/linux-tests.yml
+++ b/.github/workflows/linux-tests.yml
@@ -40,14 +40,14 @@ jobs:
         submodules: 'recursive'
     - name: Install dependencies
       run: ./scripts/github-ci-linux-get-dependencies.sh ${{ matrix.distro }} ${{ matrix.qt }}
-    - name: Dependency fixup
-      run: sudo apt-get install gcovr
     - name: Make Qt5 the default
       if: ${{ matrix.qt5default }}
       run: sudo apt-get install qt5-default
     - uses: actions/setup-python@v5
       with:
-        python-version: '3.11'
+        python-version: '3.x'
+    - name: Install gcovr
+      run: python -m pip install -U gcovr
     - name: Build and test
       run: ./scripts/github-ci.sh experimental enable_python ${{ matrix.qt == 'qt6' && 'qt6' || '' }} build test coverage
     - name: Upload Test Result Report

--- a/.github/workflows/manual.yml
+++ b/.github/workflows/manual.yml
@@ -132,7 +132,7 @@ jobs:
       with:
         submodules: 'recursive'
     - name: Install dependencies
-      run: ./scripts/github-ci-linux-get-dependencies.sh jammy
+      run: ./scripts/github-ci-linux-get-dependencies.sh
     - uses: actions/setup-python@v5
       with:
         python-version: '3.11'

--- a/.github/workflows/manual.yml
+++ b/.github/workflows/manual.yml
@@ -132,7 +132,7 @@ jobs:
       with:
         submodules: 'recursive'
     - name: Install dependencies
-      run: ./scripts/github-ci-linux-get-dependencies.sh kinetic
+      run: ./scripts/github-ci-linux-get-dependencies.sh jammy
     - uses: actions/setup-python@v5
       with:
         python-version: '3.11'

--- a/.github/workflows/non-experimental.yml
+++ b/.github/workflows/non-experimental.yml
@@ -17,7 +17,7 @@ jobs:
       with:
         submodules: 'recursive'
     - name: Install dependencies
-      run: ./scripts/github-ci-linux-get-dependencies.sh jammy
+      run: ./scripts/github-ci-linux-get-dependencies.sh
     - name: Dependency fixup
       run: sudo apt-get install gcovr
     - uses: actions/setup-python@v5

--- a/.github/workflows/non-experimental.yml
+++ b/.github/workflows/non-experimental.yml
@@ -17,7 +17,7 @@ jobs:
       with:
         submodules: 'recursive'
     - name: Install dependencies
-      run: ./scripts/github-ci-linux-get-dependencies.sh kinetic
+      run: ./scripts/github-ci-linux-get-dependencies.sh jammy
     - name: Dependency fixup
       run: sudo apt-get install gcovr
     - uses: actions/setup-python@v5

--- a/.github/workflows/non-experimental.yml
+++ b/.github/workflows/non-experimental.yml
@@ -18,11 +18,11 @@ jobs:
         submodules: 'recursive'
     - name: Install dependencies
       run: ./scripts/github-ci-linux-get-dependencies.sh
-    - name: Dependency fixup
-      run: sudo apt-get install gcovr
     - uses: actions/setup-python@v5
       with:
-        python-version: '3.11'
+        python-version: '3.x'
+    - name: Install gcovr
+      run: python -m pip install -U gcovr
     - name: Build and test
       run: ./scripts/github-ci.sh enable_python build test coverage
     - name: Upload Test Result Report

--- a/scripts/github-ci-linux-get-dependencies.sh
+++ b/scripts/github-ci-linux-get-dependencies.sh
@@ -9,17 +9,7 @@ PACKAGES4="libcgal-dev libglew-dev libgmp3-dev libgmp-dev libmpfr-dev libegl-dev
 PACKAGES5="libdouble-conversion-dev libfontconfig-dev libharfbuzz-dev libopencsg-dev lib3mf-dev libtbb-dev"
 PACKAGES6="libthrust-dev libglm-dev"
 
-if [[ "$DIST" == "xenial" ]]; then
-
-    LIB3MF_REPO="http://download.opensuse.org/repositories/home:/t-paul:/lib3mf/xUbuntu_16.04/"
-    LIBCGAL_REPO="http://download.opensuse.org/repositories/home:/t-paul:/cgal/xUbuntu_16.04/"
-
-elif [[ "$DIST" == "bionic" ]]; then
-
-    LIB3MF_REPO="https://download.opensuse.org/repositories/home:/t-paul:/lib3mf/xUbuntu_18.04/"
-    LIBCGAL_REPO="https://download.opensuse.org/repositories/home:/t-paul:/cgal/xUbuntu_18.04/"
-
-elif [[ "$DIST" == "focal" ]]; then
+if [[ "$DIST" == "focal" ]]; then
 
     LIB3MF_REPO="https://download.opensuse.org/repositories/home:/t-paul:/lib3mf/xUbuntu_20.04/"
     LIBCGAL_REPO="https://download.opensuse.org/repositories/home:/t-paul:/cgal/xUbuntu_20.04/"

--- a/scripts/github-ci-linux-get-dependencies.sh
+++ b/scripts/github-ci-linux-get-dependencies.sh
@@ -1,15 +1,16 @@
 #!/bin/bash
 
 DIST="$1"
+QT="$2"
 
 [[ -z "$DIST" ]] && DIST="jammy"  # ubuntu-latest
 
 PACKAGES1="build-essential bison cmake curl flex gettext git-core imagemagick ghostscript"
 PACKAGES2="libboost-all-dev libboost-dev libeigen3-dev libzip-dev libcrypto++-dev"
 PACKAGES3="libxi-dev libxmu-dev qtbase5-dev qtmultimedia5-dev libqt5opengl5-dev libqt5svg5-dev libqt5scintilla2-dev"
-PACKAGES4="libcgal-dev libglew-dev libgmp3-dev libgmp-dev libmpfr-dev libegl-dev libegl1-mesa-dev"
+PACKAGES4="libcairo2-dev libcgal-dev libglew-dev libgmp3-dev libgmp-dev libmpfr-dev libegl-dev libegl1-mesa-dev"
 PACKAGES5="libdouble-conversion-dev libfontconfig-dev libharfbuzz-dev libopencsg-dev lib3mf-dev libtbb-dev"
-PACKAGES6="libthrust-dev libglm-dev"
+PACKAGES6="libthrust-dev libglm-dev libxml2-dev"
 
 if [[ "$DIST" == "focal" ]]; then
 
@@ -21,6 +22,14 @@ elif [[ "$DIST" == "jammy" ]]; then
     LIB3MF_REPO="https://download.opensuse.org/repositories/home:/t-paul:/lib3mf/xUbuntu_22.04/"
     LIBCGAL_REPO="https://download.opensuse.org/repositories/home:/t-paul:/cgal/xUbuntu_22.04/"
 
+elif [[ "$DIST" == "noble" ]]; then
+
+    if [[ "$QT" == "qt6" ]]; then
+
+      PACKAGES3="libxi-dev libxmu-dev qt6-base-dev qt6-multimedia-dev libqt6core5compat6-dev libqt6svg6-dev libqscintilla2-qt6-dev"
+
+    fi
+
 else
 
     echo "ERROR: unhandled DIST: $DIST"
@@ -28,18 +37,26 @@ else
 
 fi
 
-echo "Selected distribution: $DIST"
+echo "Selected distribution: $DIST $QT"
 
-wget -qO - https://files.openscad.org/OBS-Repository-Key.pub | sudo apt-key add -
-echo yes | sudo add-apt-repository "deb $LIB3MF_REPO ./"
-echo yes | sudo add-apt-repository "deb $LIBCGAL_REPO ./"
-sudo apt-get update -qq
-sudo apt-get purge -qq fglrx || true
+if [[ "$DIST" == "noble" ]]; then
 
-# Workaround for issue installing libzip-dev on github
-# E: Unable to correct problems, you have held broken packages.
-# libzip-dev : Depends: libzip4 (= 1.1.2-1.1) but 1.7.3-1+ubuntu18.04.1+deb.sury.org+2 is to be installed
-sudo apt-cache rdepends libzip4 || true
-sudo apt-get purge -qq libzip4 $(apt-cache rdepends --installed libzip4 | tail -n+3)
+  sudo apt-get update -qq
+
+else
+
+  wget -qO - https://files.openscad.org/OBS-Repository-Key.pub | sudo apt-key add -
+  echo yes | sudo add-apt-repository "deb $LIB3MF_REPO ./"
+  echo yes | sudo add-apt-repository "deb $LIBCGAL_REPO ./"
+  sudo apt-get update -qq
+  sudo apt-get purge -qq fglrx || true
+
+  # Workaround for issue installing libzip-dev on github
+  # E: Unable to correct problems, you have held broken packages.
+  # libzip-dev : Depends: libzip4 (= 1.1.2-1.1) but 1.7.3-1+ubuntu18.04.1+deb.sury.org+2 is to be installed
+  sudo apt-cache rdepends libzip4 || true
+  sudo apt-get purge -qq libzip4 $(apt-cache rdepends --installed libzip4 | tail -n+3)
+
+fi
 
 sudo apt-get install -qq $PACKAGES1 $PACKAGES2 $PACKAGES3 $PACKAGES4 $PACKAGES5 $PACKAGES6

--- a/scripts/github-ci-linux-get-dependencies.sh
+++ b/scripts/github-ci-linux-get-dependencies.sh
@@ -24,7 +24,7 @@ elif [[ "$DIST" == "focal" ]]; then
     LIB3MF_REPO="https://download.opensuse.org/repositories/home:/t-paul:/lib3mf/xUbuntu_20.04/"
     LIBCGAL_REPO="https://download.opensuse.org/repositories/home:/t-paul:/cgal/xUbuntu_20.04/"
 
-elif [[ "$DIST" == "kinetic" ]]; then
+elif [[ "$DIST" == "jammy" ]]; then
 
     LIB3MF_REPO="https://download.opensuse.org/repositories/home:/t-paul:/lib3mf/xUbuntu_22.04/"
     LIBCGAL_REPO="https://download.opensuse.org/repositories/home:/t-paul:/cgal/xUbuntu_22.04/"

--- a/scripts/github-ci-linux-get-dependencies.sh
+++ b/scripts/github-ci-linux-get-dependencies.sh
@@ -2,6 +2,8 @@
 
 DIST="$1"
 
+[[ -z "$DIST" ]] && DIST="jammy"  # ubuntu-latest
+
 PACKAGES1="build-essential bison cmake curl flex gettext git-core imagemagick ghostscript"
 PACKAGES2="libboost-all-dev libboost-dev libeigen3-dev libzip-dev libcrypto++-dev"
 PACKAGES3="libxi-dev libxmu-dev qtbase5-dev qtmultimedia5-dev libqt5opengl5-dev libqt5svg5-dev libqt5scintilla2-dev"

--- a/scripts/github-ci.sh
+++ b/scripts/github-ci.sh
@@ -5,6 +5,7 @@ set -e
 PARALLEL=2
 PARALLEL_MAKE=-j"$PARALLEL"
 PARALLEL_CTEST=-j"$PARALLEL"
+PARALLEL_GCOVR=-j"$PARALLEL"
 
 BUILDDIR=b
 GCOVRDIR=c
@@ -61,21 +62,12 @@ do_test() {
 do_coverage() {
 	echo "do_coverage()"
 
-	case $(gcovr --version | head -n1 | awk '{ print $2 }') in
-	    [4-9].*)
-		PARALLEL_GCOVR=-j"$PARALLEL"
-		;;
-	    *)
-		PARALLEL_GCOVR=
-		;;
-	esac
-
 	rm -rf "$GCOVRDIR"
 	mkdir "$GCOVRDIR"
 	(
 		cd "$BUILDDIR"
 		echo "Generating code coverage report..."
-		gcovr -r .. $PARALLEL_GCOVR --html --html-details -p -o coverage.html
+		gcovr -r .. $PARALLEL_GCOVR --html --html-details --sort uncovered-percent -o coverage.html
 		if [[ $? != 0 ]]; then
 			exit 1
 		fi

--- a/scripts/github-ci.sh
+++ b/scripts/github-ci.sh
@@ -19,6 +19,11 @@ do_enable_python() {
 	PYTHON_DEFINE="-DENABLE_PYTHON=ON"
 }
 
+do_qt6() {
+	echo "do_qt6()"
+	USE_QT6="-DUSE_QT6=ON"
+}
+
 do_build() {
 	echo "do_build()"
 
@@ -26,7 +31,7 @@ do_build() {
 	mkdir "$BUILDDIR"
 	(
 		cd "$BUILDDIR"
-		cmake -DCMAKE_BUILD_TYPE=Release -DCMAKE_UNITY_BUILD=ON -DPROFILE=ON -DUSE_BUILTIN_OPENCSG=1 ${EXPERIMENTAL} ${PYTHON_DEFINE} .. && make $PARALLEL_MAKE
+		cmake -DCMAKE_BUILD_TYPE=Release -DCMAKE_UNITY_BUILD=ON -DPROFILE=ON -DUSE_BUILTIN_OPENCSG=1 ${EXPERIMENTAL} ${PYTHON_DEFINE} ${USE_QT6} .. && make $PARALLEL_MAKE
 	)
 	if [[ $? != 0 ]]; then
 		echo "Build failure"

--- a/scripts/github-ci.sh
+++ b/scripts/github-ci.sh
@@ -49,9 +49,6 @@ do_test() {
 		if [[ $? != 0 ]]; then
 			exit 1
 		fi
-		if [ -d tests/.gcov ]; then
-			tar -C tests/.gcov -c -f - . | tar -x -f -
-		fi
 	)
 	if [[ $? != 0 ]]; then
 		echo "Test failure"
@@ -67,7 +64,7 @@ do_coverage() {
 	(
 		cd "$BUILDDIR"
 		echo "Generating code coverage report..."
-		gcovr -r .. $PARALLEL_GCOVR --html --html-details --sort uncovered-percent -o coverage.html
+		gcovr -r ../src CMakeFiles/OpenSCAD.dir $PARALLEL_GCOVR --html --html-details --sort uncovered-percent -o coverage.html
 		if [[ $? != 0 ]]; then
 			exit 1
 		fi


### PR DESCRIPTION
Some tidying up of github-ci-linux-get-dependencies.sh and its use with old and misnamed Ubuntus and an attempt to avoid similar problems in future by defaulting to ubuntu-latest (although that still does have to be defined in one place).

gcovr completes, but the reports show no coverage - which actually isn't any different to the existing tests on other PRs as far as I can see.

`gcovr -r ../src` does seem an improvement on `gcovr -r ..` in that it doesn't collect source files from the build directory or submodules.
