### PR TITLE
Added 3Dconnexion Space Mouse Wireless BT USB ID

### DIFF
--- a/src/input/HidApiInputDriver.cc
+++ b/src/input/HidApiInputDriver.cc
@@ -58,6 +58,7 @@ static const struct device_id device_ids[] = {
     { 0x256f, 0xc631, &HidApiInputDriver::hidapi_decode_axis2, &HidApiInputDriver::hidapi_decode_button2, "3Dconnexion Space Mouse Pro Wireless (cabled)"},
     { 0x256f, 0xc632, &HidApiInputDriver::hidapi_decode_axis2, &HidApiInputDriver::hidapi_decode_button2, "3Dconnexion Space Mouse Pro Wireless"},
     { 0x256f, 0xc635, &HidApiInputDriver::hidapi_decode_axis2, &HidApiInputDriver::hidapi_decode_button2, "3Dconnexion Space Mouse Compact"},
+    { 0x256f, 0xc63a, &HidApiInputDriver::hidapi_decode_axis2, &HidApiInputDriver::hidapi_decode_button2, "3Dconnexion Space Mouse Wireless BT"},
     { -1, -1, NULL, NULL, NULL},
 };
 


### PR DESCRIPTION
Following up on #5153 - I cannot currently build this, but the USB ID should be of use to everyone.