### PR TITLE
Run apt-get update for Debian based OS's in uni-get-dependencies.sh

### DIFF
--- a/scripts/uni-get-dependencies.sh
+++ b/scripts/uni-get-dependencies.sh
@@ -129,11 +129,6 @@ get_debian_8_deps()
   get_qt5_deps_debian
 }
 
-get_ubuntu_14_deps()
-{
-  get_debian_8_deps
-}
-
 get_arch_deps()
 {
   pacman -S --noconfirm \
@@ -174,28 +169,18 @@ unknown()
 }
 
 if [ -e /etc/issue ]; then
- if [ "`grep -i ubuntu.1[4-5] /etc/issue`" ]; then
-  get_ubuntu_14_deps
- elif [ "`grep -i ubuntu.1[6-9] /etc/issue`" ]; then
-  get_ubuntu_16_deps
- elif [ "`grep -i ubuntu.2[0-4] /etc/issue`" ]; then
+ if [ "`grep -i ubuntu.2[0-4] /etc/issue`" ]; then
   get_ubuntu_16_deps
  elif [ "`grep -i ubuntu /etc/issue`" ]; then
   get_debian_deps
  elif [ "`grep -i KDE.neon /etc/issue`" ]; then
   get_neon_deps
- elif [ "`grep -i elementary.*freya /etc/issue`" ]; then
-  get_ubuntu_14_deps
  elif [ "`grep ID=.solus /etc/os-release`" ]; then
   get_solus_deps
  elif [ "`grep -i debian /etc/issue`" ]; then
   get_debian_8_deps
  elif [ "`grep -i raspbian /etc/issue`" ]; then
   get_debian_deps
- elif [ "`grep -i linux.mint.2 /etc/issue`" ]; then
-  get_ubuntu_14_deps
- elif [ "`grep -i linux.mint.17 /etc/issue`" ]; then
-  get_ubuntu_14_deps
  elif [ "`grep -i linux.mint.1[89] /etc/issue`" ]; then
   get_ubuntu_16_deps
  elif [ "`grep -i suse /etc/issue`" ]; then

--- a/scripts/uni-get-dependencies.sh
+++ b/scripts/uni-get-dependencies.sh
@@ -99,6 +99,7 @@ get_mageia_deps()
 
 get_debian_deps()
 {
+ apt-get update
  apt-get -y install \
   build-essential curl ninja-build libffi-dev \
   libxmu-dev cmake bison flex git-core libboost-all-dev \
@@ -124,8 +125,8 @@ get_qt5_deps_debian()
 
 get_debian_8_deps()
 {
-  apt-get -y install libharfbuzz-dev libxml2-dev
   get_debian_deps
+  apt-get -y install libharfbuzz-dev libxml2-dev
   get_qt5_deps_debian
 }
 
@@ -140,10 +141,10 @@ get_arch_deps()
 
 get_ubuntu_16_deps()
 {
+  get_debian_8_deps
   apt-get -y install libxi-dev libxml2-dev libfontconfig1-dev
   # https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=804539
   apt-get -y install libcgal-qt5-dev
-  get_debian_8_deps
 }
 
 get_neon_deps()


### PR DESCRIPTION
Hopefully (= I have tested. But it won't show in the PR checks) this fixes the recent linux-build-matrix.yml failures. Also removes some code for long unsupported distros.
