### PR TITLE
Look up the Ubuntu code name in github-ci-linux-get-dependencies.sh

### DIFF
--- a/.github/workflows/linux-tests.yml
+++ b/.github/workflows/linux-tests.yml
@@ -23,13 +23,10 @@ jobs:
             qt: qt6
         include:
           - os: ubuntu-20.04
-            distro: focal
             qt5default: true
           - os: ubuntu-22.04
-            distro: jammy
             qt5default: false
           - os: ubuntu-24.04
-            distro: noble
             qt5default: false
 
     runs-on: ${{ matrix.os }}
@@ -41,7 +38,7 @@ jobs:
       with:
         submodules: 'recursive'
     - name: Install dependencies
-      run: ./scripts/github-ci-linux-get-dependencies.sh ${{ matrix.distro }} ${{ matrix.qt }}
+      run: ./scripts/github-ci-linux-get-dependencies.sh ${{ matrix.qt }}
     - name: Make Qt5 the default
       if: ${{ matrix.qt5default }}
       run: sudo apt-get install qt5-default

--- a/scripts/github-ci-linux-get-dependencies.sh
+++ b/scripts/github-ci-linux-get-dependencies.sh
@@ -1,9 +1,8 @@
 #!/bin/bash
 
-DIST="$1"
-QT="$2"
+QT="$1"
 
-[[ -z "$DIST" ]] && DIST="jammy"  # ubuntu-latest
+DIST=$(. /etc/os-release; echo $VERSION_CODENAME)
 
 PACKAGES1="build-essential bison cmake curl flex gettext git-core imagemagick ghostscript"
 PACKAGES2="libboost-all-dev libboost-dev libeigen3-dev libzip-dev libcrypto++-dev"


### PR DESCRIPTION
Save an additional change every time ubuntu-latest is updated.

An unknown code name causes an error.

---

OK it's only every 2 years but this felt a bit half-done at the time.
