### PR TITLE
Reseed rng at compile for unseeded initial vals

### DIFF
--- a/src/core/Builtins.h
+++ b/src/core/Builtins.h
@@ -8,6 +8,8 @@
 class AbstractModule;
 class BuiltinFunction;
 
+void initialize_rng();
+
 class Builtins
 {
 public:

--- a/src/core/builtin_functions.cc
+++ b/src/core/builtin_functions.cc
@@ -57,6 +57,14 @@ int process_id = getpid();
 #endif
 
 std::mt19937 deterministic_rng(std::time(nullptr) + process_id);
+void initialize_rng() {
+  static uint64_t seed_val = 0;
+  seed_val ^= uint64_t(std::time(nullptr) + process_id);
+  deterministic_rng.seed(seed_val);
+  std::uniform_int_distribution<uint64_t> distributor(0);
+  seed_val ^= distributor(deterministic_rng);
+}
+
 #include <array>
 
 static inline bool check_arguments(const char *function_name, const Arguments& arguments, const Location& loc, unsigned int expected_count, bool warn = true)

--- a/src/gui/MainWindow.cc
+++ b/src/gui/MainWindow.cc
@@ -27,6 +27,7 @@
 #include <memory>
 
 #include "boost-utils.h"
+#include "Builtins.h"
 #include "BuiltinContext.h"
 #include "CommentParser.h"
 #include "RenderVariables.h"
@@ -1093,6 +1094,7 @@ void MainWindow::compile(bool reload, bool forcedone)
     // reload picking up where it left off, thwarting the stop, so we turn off exceptions in PRINT.
     no_exceptions_for_warnings();
     if (shouldcompiletoplevel) {
+      initialize_rng();
       this->errorLogWidget->clearModel();
       if (Preferences::inst()->getValue("advanced/consoleAutoClear").toBool()) {
         this->console->actionClearConsole_triggered();


### PR DESCRIPTION
The following code should have random values at each run for the first 3 sets of values output, so that unseeded random values can be utilized easily in combination with seeded random values, without the seed sticking BETWEEN runs.  This PR resolves this by calling a new initialize_rng function when a compile is done, restoring the prior behavior of reliably having randomness before a seed is used.

```
echo(rands(0, 100, 3));
echo(rands(0, 1, 1, 42));
echo(rands(0, 100, 3));
```