### PR TITLE
Add daylight gem and nocturnal gem color schemes

### DIFF
--- a/color-schemes/render/daylight-gem.json
+++ b/color-schemes/render/daylight-gem.json
@@ -1,0 +1,19 @@
+{
+    "name" : "Daylight Gem",
+    "index" : 1540,
+    "show-in-gui" : true,
+
+    "colors" : {
+        "background" :         "#f0f0f0",
+        "axes-color" :         "#373947",
+        "opencsg-face-front" : "#02daf7",
+        "opencsg-face-back" :  "#014da1",
+        "cgal-face-front" :    "#02daf7",
+        "cgal-face-back" :     "#014da1",
+        "cgal-face-2d" :       "#0498cf",
+        "cgal-edge-front" :    "#b8f3f7",
+        "cgal-edge-back" :     "#0fb7e8",
+        "cgal-edge-2d" :       "#b6f1eb",
+        "crosshair" :          "#5a73ba"
+    }
+}

--- a/color-schemes/render/nocturnal-gem.json
+++ b/color-schemes/render/nocturnal-gem.json
@@ -1,0 +1,19 @@
+{
+    "name" : "Nocturnal Gem",
+    "index" : 1550,
+    "show-in-gui" : true,
+
+    "colors" : {
+        "background" :         "#0c0c0c",
+        "axes-color" :         "#a7a9b7",
+        "opencsg-face-front" : "#02daf7",
+        "opencsg-face-back" :  "#014da1",
+        "cgal-face-front" :    "#02daf7",
+        "cgal-face-back" :     "#014da1",
+        "cgal-face-2d" :       "#0498cf",
+        "cgal-edge-front" :    "#b8f3f7",
+        "cgal-edge-back" :     "#0fb7e8",
+        "cgal-edge-2d" :       "#b6f1eb",
+        "crosshair" :          "#8aa3da"
+    }
+}


### PR DESCRIPTION
This adds two new color schemes, paired for dark and light background preferences, for an overall prettier OpenSCAD render.

The nocturnal gem color scheme:
![demo_nocturnal_gem](https://github.com/openscad/openscad/assets/1266642/d86f3802-1835-405e-82c9-461e9b1e9db9)

The daylight gem color scheme:
![demo_daylight_gem](https://github.com/openscad/openscad/assets/1266642/ebf1c353-b688-4088-a217-e995ce1c14a7)
