### PR TITLE
Show STL files to import in Open File dialog #5172

### DIFF
--- a/src/gui/UIUtils.cc
+++ b/src/gui/UIUtils.cc
@@ -60,8 +60,11 @@ QFileInfoList UIUtils::openFiles(QWidget *parent)
 {
   QSettingsCached settings;
   QString last_dirname = settings.value("lastOpenDirName").toString();
+  static constexpr QLatin1String defaultSelectedFilter {"OpenSCAD Designs (*.scad *.csg)"};
+  static QString filters = QString("Supported Filetypes (*.scad, *.csg, *.stl);;%1;;STL Files (*.stl)").arg(defaultSelectedFilter);
+  static QString lastSelectedFilter(defaultSelectedFilter);
   QStringList new_filenames = QFileDialog::getOpenFileNames(parent, "Open File",
-                                                            last_dirname, "OpenSCAD Designs (*.scad *.csg)");
+                                                            last_dirname, filters, &lastSelectedFilter);
 
   QFileInfoList fileInfoList;
   for (const QString& filename: new_filenames) {


### PR DESCRIPTION
OpenSCAD supports opening STL files from the file open dialog - doing so will add an import line into the project for that stl file.

However, you have to know exactly what he file's name is and type it exactly to actually get the file open dialog to load it. There is no way to set a filter to show STL files. This adds some additional filters to the file open dialog - one for all supported filetypes (.scad, .csg., .stl), one for just the project files (.scad, .csg), and one for just STLs (*.stl).

Additionally, it supports saving the selected filter between calls to openFileDialog, so the next time you open the file dialog, it shows the last filter you selected.

This is to fix #5172