### PR TITLE
Adjust Debian dependencies

### DIFF
--- a/scripts/uni-get-dependencies.sh
+++ b/scripts/uni-get-dependencies.sh
@@ -100,14 +100,13 @@ get_mageia_deps()
 get_debian_deps()
 {
  apt-get update
- apt-get -y install \
-  build-essential curl ninja-build libffi-dev \
+ for i in build-essential curl ninja-build libffi-dev \
   libxmu-dev cmake bison flex git-core gnulib libboost-all-dev \
   libmpfr-dev libboost-dev libglew-dev libcairo2-dev \
   libeigen3-dev libcgal-dev libopencsg-dev libgmp3-dev libgmp-dev \
   imagemagick libfreetype6-dev libdouble-conversion-dev \
   gtk-doc-tools libglib2.0-dev gettext xvfb pkg-config ragel libtbb-dev \
-  libgl1-mesa-dev libxi-dev libfontconfig-dev libzip-dev libglm-dev
+  libgl1-mesa-dev libxi-dev libfontconfig-dev libzip-dev libglm-dev; do apt-get install -y $i; done
 }
 
 get_qt5_deps_debian()

--- a/scripts/uni-get-dependencies.sh
+++ b/scripts/uni-get-dependencies.sh
@@ -102,7 +102,7 @@ get_debian_deps()
  apt-get update
  apt-get -y install \
   build-essential curl ninja-build libffi-dev \
-  libxmu-dev cmake bison flex git-core libboost-all-dev \
+  libxmu-dev cmake bison flex git-core gnulib libboost-all-dev \
   libmpfr-dev libboost-dev libglew-dev libcairo2-dev \
   libeigen3-dev libcgal-dev libopencsg-dev libgmp3-dev libgmp-dev \
   imagemagick libfreetype6-dev libdouble-conversion-dev \


### PR DESCRIPTION
Building on a freshly installed Debian testing system, I discovered that I needed gnuib to advance while building dependencies.  Without it, I get an error about missing fseterr.c

I also hit #4903 and #4741.  So I dug into uni-get-dependencies and saw that it is stalling on a missing installation candidate for "qt5-default" among other dependency issues.  This commit installs the debian packages one at a time instead of all at once.  That way one problem doesn't sink the whole apt-get command.

After making this switch, I still get the missing qt5-default error but `check-dependencies.sh` shows a solid list of OK and the build runs just fine.