### PR TITLE
Stop installing qt5-default on Debian based OS's

### DIFF
--- a/.github/workflows/linux-tests.yml
+++ b/.github/workflows/linux-tests.yml
@@ -21,13 +21,6 @@ jobs:
           - os: ubuntu-22.04
             # libqscintilla2-qt6-dev not packaged
             qt: qt6
-        include:
-          - os: ubuntu-20.04
-            qt5default: true
-          - os: ubuntu-22.04
-            qt5default: false
-          - os: ubuntu-24.04
-            qt5default: false
 
     runs-on: ${{ matrix.os }}
 
@@ -39,9 +32,6 @@ jobs:
         submodules: 'recursive'
     - name: Install dependencies
       run: ./scripts/github-ci-linux-get-dependencies.sh ${{ matrix.qt }}
-    - name: Make Qt5 the default
-      if: ${{ matrix.qt5default }}
-      run: sudo apt-get install qt5-default
     - uses: actions/setup-python@v5
       with:
         python-version: '3.x'

--- a/scripts/uni-get-dependencies.sh
+++ b/scripts/uni-get-dependencies.sh
@@ -114,13 +114,6 @@ get_qt5_deps_debian()
 {
   # OpenSCAD requires Qt5
   apt-get -y install qtbase5-dev libqt5scintilla2-dev libqt5opengl5-dev libqt5svg5-dev qtmultimedia5-dev libqt5multimedia5-plugins qt5-qmake
-  if [ ! "`command -v qmake`" ]; then
-    apt-get -y install qt5-default
-    echo "installed qt5-default to enable qmake"
-  elif [ ! "`qmake --version | grep qmake.version`" ]; then
-    apt-get -y install qt5-default
-    echo "installed qt5qt-default to enable qmake"
-  fi
 }
 
 get_debian_8_deps()


### PR DESCRIPTION
Only still available on Ubuntu 20.04 which has neither Qt 4 or Qt 6.