### PR TITLE
Simplify Debian dependencies

### DIFF
--- a/scripts/github-ci-linux-get-dependencies.sh
+++ b/scripts/github-ci-linux-get-dependencies.sh
@@ -4,10 +4,10 @@ QT="$1"
 
 DIST=$(. /etc/os-release; echo $VERSION_CODENAME)
 
-PACKAGES1="build-essential bison cmake curl flex gettext git-core imagemagick ghostscript"
-PACKAGES2="libboost-all-dev libboost-dev libeigen3-dev libzip-dev libcrypto++-dev"
-PACKAGES3="libxi-dev libxmu-dev qtbase5-dev qtmultimedia5-dev libqt5opengl5-dev libqt5svg5-dev libqt5scintilla2-dev"
-PACKAGES4="libcairo2-dev libcgal-dev libglew-dev libgmp3-dev libgmp-dev libmpfr-dev libegl-dev libegl1-mesa-dev"
+PACKAGES1="build-essential bison cmake curl flex gettext git imagemagick ghostscript"
+PACKAGES2="libboost-all-dev libeigen3-dev libzip-dev libcrypto++-dev"
+PACKAGES3="libxi-dev libxmu-dev qtbase5-dev qtmultimedia5-dev libqt5opengl5-dev libqt5svg5-dev libqscintilla2-qt5-dev"
+PACKAGES4="libcairo2-dev libcgal-dev libglew-dev libgmp-dev libmpfr-dev libegl-dev libegl1-mesa-dev"
 PACKAGES5="libdouble-conversion-dev libfontconfig-dev libharfbuzz-dev libopencsg-dev lib3mf-dev libtbb-dev"
 PACKAGES6="libthrust-dev libglm-dev libxml2-dev"
 

--- a/scripts/uni-get-dependencies.sh
+++ b/scripts/uni-get-dependencies.sh
@@ -101,26 +101,20 @@ get_debian_deps()
 {
  apt-get update
  apt-get -y install \
-  build-essential curl ninja-build libffi-dev \
-  libxmu-dev cmake bison flex git-core libboost-all-dev \
-  libmpfr-dev libboost-dev libglew-dev libcairo2-dev \
-  libeigen3-dev libcgal-dev libopencsg-dev libgmp3-dev libgmp-dev \
+  build-essential curl ninja-build libffi-dev libxml2-dev \
+  libxmu-dev cmake bison flex git libboost-all-dev \
+  libmpfr-dev libglew-dev libcairo2-dev libharfbuzz-dev \
+  libeigen3-dev libcgal-dev libopencsg-dev libgmp-dev \
   imagemagick libfreetype6-dev libdouble-conversion-dev \
   gtk-doc-tools libglib2.0-dev gettext xvfb pkg-config ragel libtbb-dev \
   libgl1-mesa-dev libxi-dev libfontconfig-dev libzip-dev libglm-dev
+ get_qt5_deps_debian
 }
 
 get_qt5_deps_debian()
 {
-  # OpenSCAD requires Qt5
-  apt-get -y install qtbase5-dev libqt5scintilla2-dev libqt5opengl5-dev libqt5svg5-dev qtmultimedia5-dev libqt5multimedia5-plugins qt5-qmake
-}
-
-get_debian_8_deps()
-{
-  get_debian_deps
-  apt-get -y install libharfbuzz-dev libxml2-dev
-  get_qt5_deps_debian
+ apt-get -y install qtbase5-dev libqscintilla2-qt5-dev libqt5opengl5-dev \
+  libqt5svg5-dev qtmultimedia5-dev libqt5multimedia5-plugins qt5-qmake
 }
 
 get_arch_deps()
@@ -130,19 +124,6 @@ get_arch_deps()
 	qt5 qscintilla-qt5 cgal gmp mpfr boost opencsg \
 	glew eigen glib2 fontconfig freetype2 harfbuzz \
 	double-conversion imagemagick tbb
-}
-
-get_ubuntu_16_deps()
-{
-  get_debian_8_deps
-  apt-get -y install libxi-dev libxml2-dev libfontconfig1-dev
-  # https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=804539
-  apt-get -y install libcgal-qt5-dev
-}
-
-get_neon_deps()
-{
-  get_debian_8_deps
 }
 
 get_solus_deps()
@@ -163,20 +144,18 @@ unknown()
 }
 
 if [ -e /etc/issue ]; then
- if [ "`grep -i ubuntu.2[0-4] /etc/issue`" ]; then
-  get_ubuntu_16_deps
- elif [ "`grep -i ubuntu /etc/issue`" ]; then
+ if [ "`grep -i ubuntu /etc/issue`" ]; then
   get_debian_deps
  elif [ "`grep -i KDE.neon /etc/issue`" ]; then
-  get_neon_deps
+  get_debian_deps
  elif [ "`grep ID=.solus /etc/os-release`" ]; then
   get_solus_deps
  elif [ "`grep -i debian /etc/issue`" ]; then
-  get_debian_8_deps
+  get_debian_deps
  elif [ "`grep -i raspbian /etc/issue`" ]; then
   get_debian_deps
- elif [ "`grep -i linux.mint.1[89] /etc/issue`" ]; then
-  get_ubuntu_16_deps
+ elif [ "`grep -i linux.mint /etc/issue`" ]; then
+  get_debian_deps
  elif [ "`grep -i suse /etc/issue`" ]; then
   get_opensuse_deps
  elif [ "`grep -i fedora.release.2[2-9] /etc/issue`" ]; then
@@ -213,4 +192,3 @@ elif [ "`uname | grep -i netbsd`" ]; then
 else
  unknown
 fi
-


### PR DESCRIPTION
Linux Mint 18 & 19 are EOL

git-core is a virtual package provided by git
libboost-dev installed by libboost-all-dev
libcgal-qt5-dev related bug was resolved in libcgal-dev-4.8-1
libfontconfig1-dev is installed by a virtual package in Ubuntu 20.04, subsequently a dummy package
libgmp3-dev is a dummy package
libqt5scintilla2-dev is a virtual package provided by libqscintilla2-qt5-dev
