### PR TITLE
Update build_bison to version 3.8.2

### DIFF
--- a/scripts/uni-build-dependencies.sh
+++ b/scripts/uni-build-dependencies.sh
@@ -763,7 +763,7 @@ if [ ! "`command -v curl`" ]; then
 fi
 
 if [ ! "`command -v bison`" ]; then
-  build_bison 2.6.1
+  build_bison 3.8.2
 fi
 
 # NB! For cmake, also update the actual download URL in the function


### PR DESCRIPTION
Bison 2.6.1 is twelve years old and fails to build on Ubuntu 20.04.

---

On Ubuntu 20.04:

```
  CC       fseterr.o
fseterr.c: In function 'fseterr':
fseterr.c:77:3: error: #error "Please port gnulib fseterr.c to your platform! Look at the definitions of ferror and clearerr on your system, then report this to bug-gnulib."
   77 |  #error "Please port gnulib fseterr.c to your platform! Look at the definitions of ferror and clearerr on your system, then report this to bug-gnulib."
```

3.8.2 compiles fine, and is itself 3 years old so should be widely compatible.

Unlikely anyone will hit this if everything else is working, but it is an easy update and still functions.

Closes #5186.

