### PR TITLE
`build`: move WASM build options into CMakeLists.txt, remove unneeded steps

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -88,27 +88,13 @@ jobs:
               export OPENSCAD_COMMIT=$(git log -1 --pretty=format:%h)
               export OPENSCAD_VERSION="$(date +%Y.%m.%d).wasm${CIRCLE_BUILD_NUM}"
               if [ x"${CIRCLE_BRANCH}" = xmaster ]; then export SUFFIX=""; else export SUFFIX="_$(echo ${CIRCLE_BRANCH} | sed -e 's,pull/,PR,; s,/head,h,; s,/merge,m,; s,/,.,g')"; fi
-              export PKG_CONFIG_PATH="/emsdk/upstream/emscripten/cache/sysroot/lib/pkgconfig"
               git submodule update --init --recursive
               emcmake cmake -B ../build . \
-                  -DWASM=ON \
                   -DSNAPSHOT=ON \
                   -DEXPERIMENTAL=ON \
-                  -DENABLE_TBB=OFF \
-                  -DENABLE_CAIRO=OFF \
-                  -DUSE_MIMALLOC=OFF \
-                  -DBoost_USE_STATIC_RUNTIME=ON \
-                  -DBoost_USE_STATIC_LIBS=ON \
                   -DCMAKE_BUILD_TYPE=Release \
                   -DOPENSCAD_COMMIT="$OPENSCAD_COMMIT" \
-                  -DOPENSCAD_VERSION="$OPENSCAD_VERSION" \
-                  -DHARFBUZZ_INCLUDE_DIRS=/emsdk/upstream/emscripten/cache/sysroot/include/harfbuzz \
-                  -DFONTCONFIG_INCLUDE_DIR=/emsdk/upstream/emscripten/cache/sysroot/include/fontconfig \
-                  -DFONTCONFIG_LIBRARIES=libfontconfig.a
-              sed -e "s|-isystem /emsdk/upstream/emscripten/cache/sysroot/include[^/]||g" -i ../build/CMakeFiles/OpenSCAD.dir/includes_C.rsp
-              sed -e "s|-isystem /emsdk/upstream/emscripten/cache/sysroot/include[^/]||g" -i ../build/CMakeFiles/OpenSCAD.dir/includes_CXX.rsp
-              sed -e "s|-lfontconfig|/emsdk/upstream/emscripten/cache/sysroot/lib/libglib-2.0.a /emsdk/upstream/emscripten/cache/sysroot/lib/libzip.a /emsdk/upstream/emscripten/cache/sysroot/lib/libz.a /emsdk/upstream/emscripten/cache/sysroot/lib/libfontconfig.a|g" -i ../build/CMakeFiles/OpenSCAD.dir/linklibs.rsp
-              sed -e "s|em++|em++ ${EMXX_FLAGS} -s USE_PTHREADS=0 -s NO_DISABLE_EXCEPTION_CATCHING -s FORCE_FILESYSTEM=1 -s ALLOW_MEMORY_GROWTH=1 -s EXPORTED_RUNTIME_METHODS=['FS','callMain'] -s EXPORT_ES6=1 -s ENVIRONMENT=web,worker -s MODULARIZE=1 -s EXPORT_NAME=OpenSCAD -s EXIT_RUNTIME=1|g" -i ../build/CMakeFiles/OpenSCAD.dir/link.txt
+                  -DOPENSCAD_VERSION="$OPENSCAD_VERSION"
               cd ../build
               make -j4 VERBOSE=1
               mkdir -p /tmp/out

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -145,6 +145,7 @@ if (CMAKE_SYSTEM_NAME STREQUAL Emscripten)
   set(USE_MIMALLOC OFF CACHE BOOL "" FORCE)
   set(ENV{PKG_CONFIG_PATH} "/emsdk/upstream/emscripten/cache/sysroot/lib/pkgconfig")
   target_compile_definitions(OpenSCAD PRIVATE CGAL_DISABLE_ROUNDING_MATH_CHECK)
+  target_link_libraries(OpenSCAD PRIVATE /emsdk/upstream/emscripten/cache/sysroot/lib/libz.a)
   target_link_options(OpenSCAD PUBLIC
     -sALLOW_MEMORY_GROWTH=1
     -sENVIRONMENT=web,worker

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -41,7 +41,6 @@ option(ENABLE_GLX "Enable GLX support if available" ON)
 # For now, we'll default to whatever OpenCSG uses (>=1.6 -> GLAD, <1.6 -> GLEW)
 option(USE_GLAD "Use GLAD. Mutually exclusive from USE_GLEW" OFF)
 option(USE_GLEW "Use GLEW. Mutually exclusive from USE_GLEW" OFF)
-option(WASM "Build WebAssembly, (implies NULLGL=ON) " OFF)
 option(NULLGL "Build without OpenGL, (implies HEADLESS=ON) " OFF)
 option(IDPREFIX "Prefix CSG nodes with index # (debugging purposes only, will break node cache)" OFF)
 option(PROFILE "Enable compiling with profiling / test coverage instrumentation" OFF)
@@ -137,10 +136,27 @@ if(PROFILE)
   SET(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} ${GCC_COVERAGE_LINK_FLAGS}")
 endif()
 
-if(WASM)
+if (CMAKE_SYSTEM_NAME STREQUAL Emscripten)
+  set(Boost_USE_STATIC_LIBS ON CACHE BOOL "" FORCE)
+  set(Boost_USE_STATIC_RUNTIME ON CACHE BOOL "" FORCE)
+  set(ENABLE_CAIRO OFF CACHE BOOL "" FORCE)
+  set(ENABLE_TBB OFF CACHE BOOL "" FORCE)
   set(NULLGL ON CACHE BOOL "" FORCE)
+  set(USE_MIMALLOC OFF CACHE BOOL "" FORCE)
   set(ENV{PKG_CONFIG_PATH} "/emsdk/upstream/emscripten/cache/sysroot/lib/pkgconfig")
   target_compile_definitions(OpenSCAD PRIVATE CGAL_DISABLE_ROUNDING_MATH_CHECK)
+  target_link_options(OpenSCAD PUBLIC
+    -sALLOW_MEMORY_GROWTH=1
+    -sENVIRONMENT=web,worker
+    -sEXIT_RUNTIME=1
+    -sEXPORT_ES6=1
+    -sEXPORT_NAME=OpenSCAD
+    -sEXPORTED_RUNTIME_METHODS=['FS','ENV','callMain','ERRNO_CODES']
+    -sFORCE_FILESYSTEM=1
+    -sMODULARIZE=1
+    -sNO_DISABLE_EXCEPTION_CATCHING
+    -sUSE_PTHREADS=0
+  )
 endif()
 
 if(NULLGL)

--- a/README.md
+++ b/README.md
@@ -239,11 +239,9 @@ We support building OpenSCAD headless for WebAssembly using Emscripten inside a 
 
 ```bash
 docker run --rm -it -v $PWD:/src:rw --platform=linux/amd64 openscad/wasm-base:latest \
-  emcmake cmake -B build \
-    -DCMAKE_BUILD_TYPE=Release \
-    -DEXPERIMENTAL=ON && \
+  emcmake cmake -B build -DEXPERIMENTAL=ON -DCMAKE_BUILD_TYPE=Release && \
 docker run --rm -it -v $PWD:/src:rw --platform=linux/amd64 openscad/wasm-base:latest \
-   cmake --build build -j10
+  cmake --build build -j10
 ```
 
 This creates `openscad.wasm` & `openscad.js` in the `build/` folder.

--- a/README.md
+++ b/README.md
@@ -233,11 +233,30 @@ installer:
 
 For a 32-bit Windows cross-build, replace 64 with 32 in the above instructions. 
 
+### Building for WebAssembly
+
+We support building OpenSCAD headless for WebAssembly using Emscripten inside a premade Docker image:
+
+```bash
+docker run --rm -it -v $PWD:/src:rw --platform=linux/amd64 openscad/wasm-base:latest \
+  emcmake cmake -B build \
+    -DCMAKE_BUILD_TYPE=Release \
+    -DEXPERIMENTAL=ON && \
+docker run --rm -it -v $PWD:/src:rw --platform=linux/amd64 openscad/wasm-base:latest \
+   cmake --build build -j10
+```
+
+This creates `openscad.wasm` & `openscad.js` in the `build/` folder.
+
+[openscad/openscad-wasm](https://github.com/openscad/openscad-wasm) shows how the Docker image is built and has usage examples.
+
+[openscad/openscad-playground](https://github.com/openscad/openscad-playground) uses the WASM build to provide a Web UI with a subset of features of OpenSCAD.
+
 ### Compilation
 
-First, run `mkdir build && cd build && cmake .. -DEXPERIMENTAL=1` to generate a Makefile.
+First, run `cmake -B build -DEXPERIMENTAL=1` to generate a Makefile in the `build` folder.
 
-Then run `make`. Finally, on Linux you might run `make install` as root.
+Then run `cmake --build build -j`. Finally, on Linux you might run `cmake --install build` as root.
 
 If you had problems compiling from source, raise a new issue in the
 [issue tracker on the github page](https://github.com/openscad/openscad/issues).
@@ -245,9 +264,9 @@ If you had problems compiling from source, raise a new issue in the
 This site and it's subpages can also be helpful:
 https://en.wikibooks.org/wiki/OpenSCAD_User_Manual/Building_OpenSCAD_from_Sources
 
-Once built, you can run tests with `ctest` from the build directory.
+Once built, you can run tests with `ctest` from the `build` directory.
 
-Note: Both `make` and `ctest` accepts a `-j N` argument for distributing the load over `N` parallel processes.
+Note: Both `cmake --build` and `ctest` accepts a `-j N` argument for distributing the load over `N` parallel processes.
 
 ### Running CI workflows locally
 

--- a/README.md
+++ b/README.md
@@ -235,7 +235,7 @@ For a 32-bit Windows cross-build, replace 64 with 32 in the above instructions.
 
 ### Building for WebAssembly
 
-We support building OpenSCAD headless for WebAssembly using Emscripten inside a premade Docker image:
+We support building OpenSCAD headless for WebAssembly w/ Emscripten, using a premade Docker image built in [openscad/openscad-wasm](https://github.com/openscad/openscad-wasm) (which also has usage examples):
 
 ```bash
 docker run --rm -it -v $PWD:/src:rw --platform=linux/amd64 openscad/wasm-base:latest \
@@ -245,8 +245,6 @@ docker run --rm -it -v $PWD:/src:rw --platform=linux/amd64 openscad/wasm-base:la
 ```
 
 This creates `openscad.wasm` & `openscad.js` in the `build/` folder.
-
-[openscad/openscad-wasm](https://github.com/openscad/openscad-wasm) shows how the Docker image is built and has usage examples.
 
 [openscad/openscad-playground](https://github.com/openscad/openscad-playground) uses the WASM build to provide a Web UI with a subset of features of OpenSCAD.
 


### PR DESCRIPTION
As part of deploying development versions of https://github.com/openscad/openscad/pull/5180 to the web playground, I struggled a bit to build for WASM. This PR should improve the DX (and allow incremental WASM builds).

(preparing changes to the wasm image too [here](https://github.com/openscad/openscad-wasm/compare/master...ochafik:openscad-wasm:simpler-wasm))

cc/ @t-paul @DSchroer