### PR TITLE
manifold.h is a library outside openscad, use canonical include path.

### DIFF
--- a/src/RenderStatistic.cc
+++ b/src/RenderStatistic.cc
@@ -38,8 +38,8 @@
 #endif // ENABLE_CGAL
 
 #ifdef ENABLE_MANIFOLD
+#include <manifold/manifold.h>
 #include "ManifoldGeometry.h"
-#include "manifold.h"
 #include "manifoldutils.h"
 #endif // ENABLE_MANIFOLD
 

--- a/src/geometry/manifold/ManifoldGeometry.cc
+++ b/src/geometry/manifold/ManifoldGeometry.cc
@@ -1,7 +1,7 @@
 // Portions of this file are Copyright 2023 Google LLC, and licensed under GPL2+. See COPYING.
+#include <manifold/manifold.h>
 #include "ManifoldGeometry.h"
 #include "Polygon2d.h"
-#include "manifold.h"
 #include "PolySet.h"
 #include "Feature.h"
 #include "PolySetBuilder.h"

--- a/src/geometry/manifold/ManifoldGeometry.h
+++ b/src/geometry/manifold/ManifoldGeometry.h
@@ -1,10 +1,12 @@
 // Portions of this file are Copyright 2023 Google LLC, and licensed under GPL2+. See COPYING.
 #pragma once
 
+#include <manifold/manifold.h>
+
 #include "Geometry.h"
 #include <glm/glm.hpp>
 #include "linalg.h"
-#include "manifold.h"
+
 #include <map>
 #include <set>
 

--- a/src/geometry/manifold/manifoldutils.cc
+++ b/src/geometry/manifold/manifoldutils.cc
@@ -1,9 +1,11 @@
 // Portions of this file are Copyright 2023 Google LLC, and licensed under GPL2+. See COPYING.
+#include <manifold/manifold.h>
+#include <manifold/polygon.h>
+
 #include "manifoldutils.h"
 #include "ManifoldGeometry.h"
 #include "PolySetBuilder.h"
 #include "Feature.h"
-#include "manifold.h"
 #include "printutils.h"
 #ifdef ENABLE_CGAL
 #include "cgalutils.h"
@@ -13,7 +15,7 @@
 #endif
 #include "PolySetUtils.h"
 #include "PolySet.h"
-#include "polygon.h"
+
 
 using Error = manifold::Manifold::Error;
 

--- a/src/geometry/manifold/manifoldutils.h
+++ b/src/geometry/manifold/manifoldutils.h
@@ -1,9 +1,11 @@
 #pragma once
 
+#include <manifold/manifold.h>
+
 #include "Geometry.h"
 #include "enums.h"
 #include "ManifoldGeometry.h"
-#include "manifold.h"
+
 
 namespace ManifoldUtils {
 


### PR DESCRIPTION
This means that
  * Use the 'system' include angle brackets not the double-quote include used for local projects.
  * Use the canonical location under manifold/manifold.h (which is where manifold installs its headers. By accident, cmake search also allowed to leave out the prefix, which is of course not desirable).