### PR TITLE
[WIP] Implements a two pass rendering in OpenCSGRenderer to fix z-fighting issue (issue #4595)

### DIFF
--- a/shaders/Preview.frag
+++ b/shaders/Preview.frag
@@ -32,10 +32,7 @@ void main(void) {
   }
 
   // otherwise we need to test the depth buffer to select the appropriate fragment
-  //vec2 resolution = vec2(694,471);
-  vec2 fragCoords = gl_FragCoord.xy;
-  fragCoords = fragCoords / resolution;
-  vec2 screenCoords = fragCoords;
+  vec2 screenCoords = gl_FragCoord.xy / resolution;
   float surface_depth = texture2D(depth_buffer, screenCoords).x;
 
   // nearly-equal z-depth

--- a/src/glview/Renderer.cc
+++ b/src/glview/Renderer.cc
@@ -104,9 +104,12 @@ void Renderer::setupShader() {
 
   renderer_shader.progid = edgeshader_prog;
   renderer_shader.type = EDGE_RENDERING;
-  renderer_shader.data.csg_rendering.color_area = glGetUniformLocation(edgeshader_prog, "color1"); // 1
-  renderer_shader.data.csg_rendering.color_edge = glGetUniformLocation(edgeshader_prog, "color2"); // 2
-  renderer_shader.data.csg_rendering.barycentric = glGetAttribLocation(edgeshader_prog, "barycentric"); // 3
+  renderer_shader.data.rendering_mode = glGetUniformLocation(edgeshader_prog, "rendering_mode");
+  renderer_shader.data.resolution = glGetUniformLocation(edgeshader_prog, "resolution");
+
+  renderer_shader.data.csg_rendering.color_area = glGetUniformLocation(edgeshader_prog, "color1");
+  renderer_shader.data.csg_rendering.color_edge = glGetUniformLocation(edgeshader_prog, "color2");
+  renderer_shader.data.csg_rendering.barycentric = glGetAttribLocation(edgeshader_prog, "barycentric");
 }
 
 void Renderer::resize(int /*w*/, int /*h*/)

--- a/src/glview/Renderer.h
+++ b/src/glview/Renderer.h
@@ -24,17 +24,21 @@ public:
   struct shaderinfo_t {
     int progid = 0;
     shader_type_t type;
-    union {
-      struct {
-        int color_area;
-        int color_edge;
-        // barycentric coordinates of the current vertex
-        int barycentric;
-      } csg_rendering;
-      struct {
-        int identifier;
-      } select_rendering;
-    } data;
+    struct {
+        int rendering_mode {-1};
+        int resolution {-1};
+        union {
+            struct {
+                int color_area;
+                int color_edge;
+                // barycentric coordinates of the current vertex
+                int barycentric;
+            } csg_rendering;
+            struct {
+                int identifier;
+            } select_rendering;
+        };
+    }data;
   };
 
 

--- a/src/glview/fbo.cc
+++ b/src/glview/fbo.cc
@@ -25,7 +25,7 @@ bool use_ext()
   }
 }
 
-bool check_fbo_status()
+bool fbo_check_status()
 {
   /* This code is based on user V-man code from
      http://www.opengl.org/wiki/GL_EXT_framebuffer_multisample
@@ -81,7 +81,7 @@ bool fbo_ext_init(fbo_t *fbo, size_t width, size_t height)
     return false;
   }
 
-  if (!check_fbo_status()) {
+  if (!fbo_check_status()) {
     cerr << "Problem with OpenGL EXT framebuffer after specifying color render buffer.\n";
     return false;
   }
@@ -97,7 +97,7 @@ bool fbo_ext_init(fbo_t *fbo, size_t width, size_t height)
       return false;
     }
 
-    if (!check_fbo_status()) {
+    if (!fbo_check_status()) {
       cerr << "Problem with OpenGL EXT framebuffer after specifying depth render buffer.\n";
       return false;
     }
@@ -108,7 +108,7 @@ bool fbo_ext_init(fbo_t *fbo, size_t width, size_t height)
       return false;
     }
 
-    if (!check_fbo_status()) {
+    if (!fbo_check_status()) {
       cerr << "Problem with OpenGL EXT framebuffer after specifying depth stencil render buffer.\n";
       return false;
     }
@@ -136,7 +136,7 @@ bool fbo_arb_init(fbo_t *fbo, size_t width, size_t height)
     return false;
   }
 
-  if (!check_fbo_status()) {
+  if (!fbo_check_status()) {
     cerr << "Problem with OpenGL framebuffer after specifying color render buffer.\n";
     return false;
   }
@@ -151,7 +151,7 @@ bool fbo_arb_init(fbo_t *fbo, size_t width, size_t height)
     return false;
   }
 
-  if (!check_fbo_status()) {
+  if (!fbo_check_status()) {
     cerr << "Problem with OpenGL framebuffer after specifying depth render buffer.\n";
     return false;
   }

--- a/src/glview/fbo.h
+++ b/src/glview/fbo.h
@@ -18,5 +18,6 @@ bool fbo_resize(fbo_t *fbo, size_t width, size_t height);
 void fbo_delete(fbo_t *fbo);
 GLuint fbo_bind(fbo_t *fbo);
 void fbo_unbind(fbo_t *fbo);
+bool fbo_check_status();
 
 bool REPORTGLERROR(const char *task);

--- a/src/glview/preview/OpenCSGRenderer.h
+++ b/src/glview/preview/OpenCSGRenderer.h
@@ -13,6 +13,7 @@ class CSGChainObject;
 class CSGProducts;
 class OpenCSGPrim;
 class OpenCSGVBOPrim;
+class OpenCSGVBORendererFBO;
 
 class OpenCSGVertexState : public VertexState
 {
@@ -79,14 +80,10 @@ public:
   OpenCSGRenderer(std::shared_ptr<CSGProducts> root_products,
                   std::shared_ptr<CSGProducts> highlights_products,
                   std::shared_ptr<CSGProducts> background_products);
-  ~OpenCSGRenderer() override {
-    if (all_vbos_.size()) {
-      glDeleteBuffers(all_vbos_.size(), all_vbos_.data());
-    }
-  }
+  ~OpenCSGRenderer() override;
   void prepare(bool showfaces, bool showedges, const shaderinfo_t *shaderinfo = nullptr) override;
   void draw(bool showfaces, bool showedges, const shaderinfo_t *shaderinfo = nullptr) const override;
-
+  void resize(int width, int height) override;
   BoundingBox getBoundingBox() const override;
 private:
 #ifdef ENABLE_OPENCSG
@@ -102,4 +99,7 @@ private:
   std::shared_ptr<CSGProducts> root_products_;
   std::shared_ptr<CSGProducts> highlights_products_;
   std::shared_ptr<CSGProducts> background_products_;
+
+  std::unique_ptr<OpenCSGVBORendererFBO> pass1_fbo;
+  int width_, height_;
 };


### PR DESCRIPTION
Problem summary (issue  #4595):
When using OpenCSGRenderer with shaders there are depth tests failures because of small calculation difference between the fixed pipeline vertex processing (the one used in OpenCSG) and the programmable shader based pipeline.

Here is an example of the gitchy rendering when using  the edges rendering (using preview.frag shader)
![Example of rendering issue](https://github.com/user-attachments/assets/2c377906-d9b5-4435-b5b5-a947a707c499)

This is not only an edge preview rendering issue as the areas that are not properly rendered with the edges visualization are also not returning a valid object id when right clicking on the 3d view and thus the corresponding popup menu does not shows up as it should. This is because the mouse picking implementation also use a custom shader. 

Proposed solution:
Use a two pass rendering approach using FBO. The first pass renders the depth values in a buffer while the second is in charge of setting the color or discards the fragment using a custom depth test using the previously computed depth buffer to detect nearly equality to handle the small differences in calculation. The advantage of the proposed approach is that it does not imply to change OpenCSG's code.  

Example of default & edge rendering with this PR : 
![image](https://github.com/user-attachments/assets/13771000-05de-4f3c-a46f-8a1302392df6)


Roadmap:
- [X] drafted version with the fix implemented for the edge visualization shader 
- [ ] validate general design  (using a two pass rendering with FBO), 
- [ ] merge the FBO code with fbo.cc/fbo.cc (which probably requires big refactoring of fbo.cc/h)
- [ ] implement proper de-allocation re-init of FBO when the rendering size change or when OpenCSGRender is detroyed
- [ ] understand why in some case there is GL_FRAMEBUFFER errors message 
- [ ] implement the mouse selection shader  


Poke: @lakfel
