### PR TITLE
Increase minimum Qt version to 5.12.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -591,7 +591,7 @@ if(NOT HEADLESS)
       message(STATUS "DBus input driver disabled per user request.")
     endif()
   else()
-    find_package(Qt5 5.4 COMPONENTS Core Widgets Multimedia OpenGL Concurrent Network Svg REQUIRED QUIET)
+    find_package(Qt5 5.12 COMPONENTS Core Widgets Multimedia OpenGL Concurrent Network Svg REQUIRED QUIET)
     message(STATUS "Qt5: ${Qt5_VERSION}")
 
     if (Qt5_POSITION_INDEPENDENT_CODE)

--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ Follow the instructions for the platform you're compiling on below.
 
 * A C++ compiler supporting C++17
 * [cmake (3.5 ->)](https://cmake.org/)
-* [Qt (5.4 ->)](https://qt.io/)
+* [Qt (5.12 ->)](https://qt.io/)
 * [QScintilla2 (2.9 ->)](https://riverbankcomputing.com/software/qscintilla/)
 * [CGAL (5.4 ->)](https://www.cgal.org/)
  * [GMP (5.x)](https://gmplib.org/)

--- a/src/gui/OpenSCADApp.cc
+++ b/src/gui/OpenSCADApp.cc
@@ -24,36 +24,10 @@ OpenSCADApp::~OpenSCADApp()
 
 #include <QMessageBox>
 
-// See: https://bugreports.qt.io/browse/QTBUG-65592
-#if (QT_VERSION >= QT_VERSION_CHECK(5, 10, 0))
-void OpenSCADApp::workaround_QTBUG_65592(QObject *o, QEvent *e)
-{
-  QMainWindow *mw;
-  if (o->isWidgetType() && e->type() == QEvent::MouseButtonPress && (mw = qobject_cast<QMainWindow *>(o))) {
-    for (auto& ch : mw->children()) {
-      if (auto dw = qobject_cast<QDockWidget *>(ch)) {
-        auto pname = "_wa-QTBUG-65592";
-        auto v = dw->property(pname);
-        if (v.isNull()) {
-          dw->setProperty(pname, true);
-          mw->restoreDockWidget(dw);
-          auto area = mw->dockWidgetArea(dw);
-          auto orient = area == Qt::TopDockWidgetArea || area == Qt::BottomDockWidgetArea ? Qt::Horizontal : Qt::Vertical;
-          mw->resizeDocks({dw}, {orient == Qt::Horizontal ? dw->width() : dw->height() }, orient);
-        }
-      }
-    }
-  }
-}
-#else
-void OpenSCADApp::workaround_QTBUG_65592(QObject *, QEvent *) { }
-#endif // if (QT_VERSION >= QT_VERSION_CHECK(5, 10, 0))
-
 bool OpenSCADApp::notify(QObject *object, QEvent *event)
 {
   QString msg;
   try {
-    workaround_QTBUG_65592(object, event);
     return QApplication::notify(object, event);
   } catch (const std::exception& e) {
     msg = e.what();

--- a/src/gui/OpenSCADApp.h
+++ b/src/gui/OpenSCADApp.h
@@ -14,7 +14,6 @@ public:
   ~OpenSCADApp() override;
 
   bool notify(QObject *object, QEvent *event) override;
-  void workaround_QTBUG_65592(QObject *object, QEvent *event);
   void requestOpenFile(const QString& filename);
 
 public slots:

--- a/src/gui/qt-obsolete.h
+++ b/src/gui/qt-obsolete.h
@@ -1,9 +1,5 @@
 #pragma once
 
-#if (QT_VERSION < QT_VERSION_CHECK(5, 10, 0))
-#define setTabStopDistance setTabStopWidth
-#endif
-
 #if (QT_VERSION < QT_VERSION_CHECK(5, 14, 0))
 #define Q_WHEEL_EVENT_POSITION(e) ((e)->pos())
 #else

--- a/src/utils/version_check.h
+++ b/src/utils/version_check.h
@@ -76,7 +76,7 @@
 
 #ifndef OPENSCAD_NOGUI
 #include <QtCore/qglobal.h>
-#if QT_VERSION < QT_VERSION_CHECK(5, 4, 0)
+#if QT_VERSION < QT_VERSION_CHECK(5, 12, 0)
 #error QT library missing or version too old. See README.md. To force compile, run qmake CONFIG+=skip-version-check
 #endif // QT
 #endif


### PR DESCRIPTION
https://bugreports.qt.io/browse/QTBUG-65592
was duplicated by:
https://bugreports.qt.io/browse/QTBUG-67069
and then by:
https://bugreports.qt.io/browse/QTBUG-70571
which was fixed by:
https://code.qt.io/cgit/qt/qtbase.git/commit/?id=e2d79b496335e8d8666014e900930c66cf722eb6

Reverts:
36bc309a7 ("Add workaround for jumping dock widgets.", 2018-12-08)

---

I can't recreate the problem on Linux with Qt 5 or 6 with this patch.
On QTBUG-65592 ? and macOS users reported the bug fixed.
There was a late comment from a Windows user however, but that was 5 years ago and I can't find any subsequent bugs plus there have been 3 more Qt 5 releases since.

Ubuntu 20.04 has Qt 5.12.