### PR TITLE
Add interactive visual feedback when selecting object using the rightClick menu in the 3D view

### DIFF
--- a/src/gui/Editor.h
+++ b/src/gui/Editor.h
@@ -9,6 +9,12 @@
 #include "IndicatorData.h"
 #include "parameter/ParameterWidget.h"
 
+enum class EditorSelectionIndicatorStatus
+{
+    SELECTED,
+    IMPACTED
+};
+
 class EditorInterface : public QWidget
 {
   Q_OBJECT
@@ -50,6 +56,8 @@ public slots:
   virtual void commentSelection() = 0;
   virtual void uncommentSelection() = 0;
   virtual void setPlainText(const QString&) = 0;
+  virtual void setSelectionIndicatorStatus(EditorSelectionIndicatorStatus status, int level, int lineFrom, int colFrom, int lineTo, int colTo) = 0;
+  virtual void clearAllSelectionIndicators() = 0;
   virtual void highlightError(int) = 0;
   virtual void unhighlightLastError() = 0;
   virtual void setHighlightScheme(const QString&) = 0;

--- a/src/gui/Editor.h
+++ b/src/gui/Editor.h
@@ -11,8 +11,8 @@
 
 enum class EditorSelectionIndicatorStatus
 {
-    SELECTED,
-    IMPACTED
+  SELECTED,
+  IMPACTED
 };
 
 class EditorInterface : public QWidget

--- a/src/gui/MainWindow.cc
+++ b/src/gui/MainWindow.cc
@@ -109,7 +109,7 @@
 
 #ifdef ENABLE_PYTHON
 extern std::shared_ptr<AbstractNode> python_result_node;
-std::string evaluatePython(const std::string &code, double time);
+std::string evaluatePython(const std::string& code, double time);
 extern bool python_trusted;
 
 #include "cryptopp/sha.h"
@@ -117,18 +117,18 @@ extern bool python_trusted;
 #include "cryptopp/base64.h"
 
 std::string SHA256HashString(std::string aString){
-    std::string digest;
-    CryptoPP::SHA256 hash;
+  std::string digest;
+  CryptoPP::SHA256 hash;
 
-    CryptoPP::StringSource foo(aString, true,
-    new CryptoPP::HashFilter(hash,
-      new CryptoPP::Base64Encoder (
-         new CryptoPP::StringSink(digest))));
+  CryptoPP::StringSource foo(aString, true,
+                             new CryptoPP::HashFilter(hash,
+                                                      new CryptoPP::Base64Encoder(
+                                                        new CryptoPP::StringSink(digest))));
 
-    return digest;
+  return digest;
 }
 
-#endif
+#endif // ifdef ENABLE_PYTHON
 
 #define ENABLE_3D_PRINTING
 #include "OctoPrint.h"
@@ -1399,10 +1399,10 @@ void MainWindow::compileCSG()
 #else
       this->opencsgRenderer = std::make_shared<OpenCSGRenderer>(this->root_products,
                                                                 this->highlights_products,
-                                                						    this->background_products);
+                                                                this->background_products);
 #endif
     }
-#endif
+#endif // ifdef ENABLE_OPENCSG
 #ifdef USE_LEGACY_RENDERERS
     this->thrownTogetherRenderer = std::make_shared<LegacyThrownTogetherRenderer>(this->root_products,
                                                                                   this->highlights_products,
@@ -1563,10 +1563,10 @@ void MainWindow::actionSaveAs()
 void MainWindow::actionRevokeTrustedFiles()
 {
   QSettingsCached settings;
-#ifdef ENABLE_PYTHON  
+#ifdef ENABLE_PYTHON
   python_trusted = false;
-  this->trusted_edit_document_name="";
-#endif  
+  this->trusted_edit_document_name = "";
+#endif
   settings.remove("python_hash");
   QMessageBox::information(this, _("Trusted Files"), "All trusted python files revoked", QMessageBox::Ok);
 
@@ -1840,59 +1840,59 @@ bool MainWindow::fileChangedOnDisk()
  */
 
 #ifdef ENABLE_PYTHON
-bool MainWindow::trust_python_file(const std::string &file,  const std::string &content) {
+bool MainWindow::trust_python_file(const std::string& file,  const std::string& content) {
   QSettingsCached settings;
   char setting_key[256];
-  if(python_trusted) return true;
+  if (python_trusted) return true;
 
   std::string act_hash, ref_hash;
-  snprintf(setting_key,sizeof(setting_key)-1,"python_hash/%s",file.c_str());
+  snprintf(setting_key, sizeof(setting_key) - 1, "python_hash/%s", file.c_str());
   act_hash = SHA256HashString(content);
 
-  if(file == this->untrusted_edit_document_name) return false;
-  
-  if(file == this->trusted_edit_document_name) {
-    settings.setValue(setting_key,act_hash.c_str());
+  if (file == this->untrusted_edit_document_name) return false;
+
+  if (file == this->trusted_edit_document_name) {
+    settings.setValue(setting_key, act_hash.c_str());
     return true;
   }
 
-  if(content.size() <= 1) { // 1st character already typed
-    this->trusted_edit_document_name=file;
+  if (content.size() <= 1) { // 1st character already typed
+    this->trusted_edit_document_name = file;
     return true;
   }
 
-  if(settings.contains(setting_key)) {
-    QString str=settings.value(setting_key).toString();
+  if (settings.contains(setting_key)) {
+    QString str = settings.value(setting_key).toString();
     QByteArray ba = str.toLocal8Bit();
     ref_hash = std::string(ba.data());
   }
- 
-  if(act_hash == ref_hash) {
-	  this->trusted_edit_document_name=file;
-	  return true;
+
+  if (act_hash == ref_hash) {
+    this->trusted_edit_document_name = file;
+    return true;
   }
 
   auto ret = QMessageBox::warning(this, "Application",
-    _( "Python files can potentially contain harmful stuff.\n"
-    "Do you trust this file ?\n"), QMessageBox::Yes  | QMessageBox::YesAll | QMessageBox::No);
-  if (ret == QMessageBox::YesAll)  {
+                                  _("Python files can potentially contain harmful stuff.\n"
+                                    "Do you trust this file ?\n"), QMessageBox::Yes | QMessageBox::YesAll | QMessageBox::No);
+  if (ret == QMessageBox::YesAll) {
     python_trusted = true;
     return true;
   }
-  if (ret == QMessageBox::Yes)  {
-    this->trusted_edit_document_name=file;
-    settings.setValue(setting_key,act_hash.c_str());
+  if (ret == QMessageBox::Yes) {
+    this->trusted_edit_document_name = file;
+    settings.setValue(setting_key, act_hash.c_str());
     return true;
   }
 
   if (ret == QMessageBox::No) {
-    this->untrusted_edit_document_name=file;
+    this->untrusted_edit_document_name = file;
     return false;
   }
   return false;
 }
-#endif
-	
+#endif // ifdef ENABLE_PYTHON
+
 void MainWindow::parseTopLevelDocument()
 {
   resetSuppressedMessages();
@@ -1909,11 +1909,11 @@ void MainWindow::parseTopLevelDocument()
 #ifdef ENABLE_PYTHON
   this->python_active = false;
   if (fname != NULL) {
-    if(boost::algorithm::ends_with(fname, ".py")) {
-	    std::string content = std::string(this->last_compiled_doc.toUtf8().constData());
+    if (boost::algorithm::ends_with(fname, ".py")) {
+      std::string content = std::string(this->last_compiled_doc.toUtf8().constData());
       if (
-        Feature::ExperimentalPythonEngine.is_enabled() 
-		&& trust_python_file(std::string(fname), content)) this->python_active = true;
+        Feature::ExperimentalPythonEngine.is_enabled()
+        && trust_python_file(std::string(fname), content)) this->python_active = true;
       else LOG(message_group::Warning, Location::NONE, "", "Python is not enabled");
     }
   }
@@ -1922,7 +1922,7 @@ void MainWindow::parseTopLevelDocument()
     auto fulltext_py =
       std::string(this->last_compiled_doc.toUtf8().constData());
 
-    auto error = evaluatePython(fulltext_py,this->animateWidget->getAnim_tval());
+    auto error = evaluatePython(fulltext_py, this->animateWidget->getAnim_tval());
     if (error.size() > 0) LOG(message_group::Error, Location::NONE, "", error.c_str());
     fulltext = "\n";
   }
@@ -2342,10 +2342,10 @@ void MainWindow::actionMeasureAngle()
   meas.startMeasureAngle();
 }
 
-void MainWindow::leftClick(QPoint mouse) 
+void MainWindow::leftClick(QPoint mouse)
 {
   QString str = meas.statemachine(mouse);
-  if(str.size() > 0) {
+  if (str.size() > 0) {
     this->qglview->measure_state = MEASURE_IDLE;
     QMenu resultmenu(this);
     auto action = resultmenu.addAction(str);
@@ -2405,8 +2405,7 @@ void MainWindow::rightClick(QPoint mouse)
 
       // It happens that the verbose_name is empty (eg: in for loops), when this happens instead of letting
       // empty entry in the menu we prefer using the name in the modinstanciation.
-      if(step->verbose_name().empty())
-          name = step->modinst->name();
+      if (step->verbose_name().empty()) name = step->modinst->name();
 
       // Check if the path is contained in a library (using parsersettings.h)
       fs::path libpath = get_library_for_path(location.filePath());
@@ -2416,9 +2415,9 @@ void MainWindow::rightClick(QPoint mouse)
            << location.fileName().substr(libpath.string().length() + 1) << ":"
            << location.firstLine() << ")";
       } else if (activeEditor->filepath.toStdString() == location.fileName()) {
-          // removes the "module" prefix if any as it makes it not clear if it is module declaration or call.
-          ss << name << " (" << location.filePath().filename().string() << ":"
-                     << location.firstLine() << ")";
+        // removes the "module" prefix if any as it makes it not clear if it is module declaration or call.
+        ss << name << " (" << location.filePath().filename().string() << ":"
+           << location.firstLine() << ")";
       } else {
         auto relative_filename = boostfs_uncomplete(location.filePath(), fs::path(activeEditor->filepath.toStdString()).parent_path())
           .generic_string();
@@ -2436,7 +2435,7 @@ void MainWindow::rightClick(QPoint mouse)
 
     tracemenu.exec(this->qglview->mapToGlobal(mouse));
   } else {
-      clearAllSelectionIndicators();
+    clearAllSelectionIndicators();
   }
 }
 void MainWindow::measureFinished(void)
@@ -2449,73 +2448,58 @@ void MainWindow::measureFinished(void)
 
 void MainWindow::clearAllSelectionIndicators()
 {
-    this->activeEditor->clearAllSelectionIndicators();
+  this->activeEditor->clearAllSelectionIndicators();
 }
 
 void findNodesWithSameMod(std::shared_ptr<const AbstractNode> tree,
                           std::shared_ptr<const AbstractNode> node_mod,
                           std::vector<std::shared_ptr<const AbstractNode>>& nodes){
-    if(node_mod->modinst == tree->modinst){
-      nodes.push_back(tree);
-    }
-    for(auto step : tree->children){
-      findNodesWithSameMod(step,node_mod,nodes);
-    }
+  if (node_mod->modinst == tree->modinst) {
+    nodes.push_back(tree);
+  }
+  for (auto step : tree->children) {
+    findNodesWithSameMod(step, node_mod, nodes);
+  }
 }
 
-void getCodeLocation(const AbstractNode* self, int currentLevel,  int includeLevel, int * firstLine, int * firstColumn, int * lastLine, int * lastColumn, int nestedModuleDepth)
+void getCodeLocation(const AbstractNode *self, int currentLevel,  int includeLevel, int *firstLine, int *firstColumn, int *lastLine, int *lastColumn, int nestedModuleDepth)
 {
   auto location = self->modinst->location();
-  if(currentLevel >= includeLevel && nestedModuleDepth == 0)
-  {
-    if(*firstLine < 0 || *firstLine > location.firstLine())
-    {
+  if (currentLevel >= includeLevel && nestedModuleDepth == 0) {
+    if (*firstLine < 0 || *firstLine > location.firstLine()) {
       *firstLine = location.firstLine();
       *firstColumn = location.firstColumn();
-    }
-    else if(*firstLine ==  location.firstLine() && *firstColumn > location.firstColumn())
-    {
+    } else if (*firstLine == location.firstLine() && *firstColumn > location.firstColumn())   {
       *firstColumn = location.firstColumn();
     }
 
-    if(*lastLine < 0 || *lastLine < location.lastLine())
-    {
+    if (*lastLine < 0 || *lastLine < location.lastLine()) {
       *lastLine = location.lastLine();
       *lastColumn = location.lastColumn();
-    }
-    else{
-      if(*firstLine < 0 || *firstLine > location.firstLine())
-      {
+    } else {
+      if (*firstLine < 0 || *firstLine > location.firstLine()) {
         *firstLine = location.firstLine();
         *firstColumn = location.firstColumn();
-      }
-      else if(*firstLine ==  location.firstLine() && *firstColumn > location.firstColumn())
-      {
+      } else if (*firstLine == location.firstLine() && *firstColumn > location.firstColumn())   {
         *firstColumn = location.firstColumn();
       }
-      if(*lastLine < 0 || *lastLine < location.lastLine())
-      {
+      if (*lastLine < 0 || *lastLine < location.lastLine()) {
         *lastLine = location.lastLine();
         *lastColumn = location.lastColumn();
-      }
-      else if( *lastLine ==  location.lastLine() && *lastColumn < location.lastColumn())
-      {
+      } else if (*lastLine == location.lastLine() && *lastColumn < location.lastColumn())   {
         *lastColumn = location.lastColumn();
       }
     }
   }
 
-  if(self->verbose_name().rfind("module", 0) == 0)
-  {
+  if (self->verbose_name().rfind("module", 0) == 0) {
     nestedModuleDepth++;
   }
-  if(self->modinst->name() == "children")
-  {
+  if (self->modinst->name() == "children") {
     nestedModuleDepth--;
   }
 
-  if(nestedModuleDepth >= 0 )
-  {
+  if (nestedModuleDepth >= 0) {
     for (const auto& node : self->children) {
       getCodeLocation(node.get(), currentLevel + 1, includeLevel, firstLine,  firstColumn, lastLine, lastColumn, nestedModuleDepth);
     }
@@ -2532,25 +2516,22 @@ void MainWindow::setSelectionIndicatorStatus(int nodeIndex, EditorSelectionIndic
   // first we flags all the nodes in the stack of the provided index
   // ends at size - 1 because we are not doing anything for the root node.
   // starts at 1 because we will process this one after later
-  for(int i = 1; i < stack.size()-1; i++)
-  {
+  for (int i = 1; i < stack.size() - 1; i++) {
     auto node = stack[i];
 
     auto& location = node->modinst->location();
-    if(location.filePath().compare(activeEditor->filepath.toStdString()) != 0  )
-    {
-      std::cout<<"--->>> Line of code in a different file -- PATH -- "<<location.fileName()<<std::endl;
-      node->modinst->print(std::cout,"");
+    if (location.filePath().compare(activeEditor->filepath.toStdString()) != 0) {
+      std::cout << "--->>> Line of code in a different file -- PATH -- " << location.fileName() << std::endl;
+      node->modinst->print(std::cout, "");
       level++;
       continue;
     }
 
-    if(node->verbose_name().rfind("module", 0) == 0 || node->modinst->name() == "children")
-    {
-        this->activeEditor->setSelectionIndicatorStatus(
-                        status, level,
-                        location.firstLine() - 1,location.firstColumn() - 1,location.lastLine() - 1,location.lastColumn()- 1);
-        level++;
+    if (node->verbose_name().rfind("module", 0) == 0 || node->modinst->name() == "children") {
+      this->activeEditor->setSelectionIndicatorStatus(
+        status, level,
+        location.firstLine() - 1, location.firstColumn() - 1, location.lastLine() - 1, location.lastColumn() - 1);
+      level++;
     }
   }
 
@@ -2562,53 +2543,51 @@ void MainWindow::setSelectionIndicatorStatus(int nodeIndex, EditorSelectionIndic
   auto lastColumn = location.lastColumn();
 
   // Update the location returned by location to cover the whole section.
-  getCodeLocation(node.get(), 0,0,&line,&column,&lastLine,&lastColumn,0);
+  getCodeLocation(node.get(), 0, 0, &line, &column, &lastLine, &lastColumn, 0);
 
-  this->activeEditor->setSelectionIndicatorStatus(status, 0, line - 1 , column - 1, lastLine - 1, lastColumn - 1);
- }
+  this->activeEditor->setSelectionIndicatorStatus(status, 0, line - 1, column - 1, lastLine - 1, lastColumn - 1);
+}
 
 void MainWindow::setSelection(int index)
 {
-    if(currently_selected_object == index)
-      return;
+  if (currently_selected_object == index) return;
 
-    std::deque<std::shared_ptr<const AbstractNode>> path;
-    std::shared_ptr<const AbstractNode> selected_node = root_node->getNodeByID(index, path);
+  std::deque<std::shared_ptr<const AbstractNode>> path;
+  std::shared_ptr<const AbstractNode> selected_node = root_node->getNodeByID(index, path);
 
-    if(!selected_node)
-        return;
+  if (!selected_node) return;
 
-    currently_selected_object = index;
+  currently_selected_object = index;
 
-    auto location = selected_node->modinst->location();
-    auto file = location.fileName();
-    auto line = location.firstLine();
-    auto column = location.firstColumn();
+  auto location = selected_node->modinst->location();
+  auto file = location.fileName();
+  auto line = location.firstLine();
+  auto column = location.firstColumn();
 
-    // Unsaved files do have the pwd as current path, therefore we will not open a new
-    // tab on click
-    if (!fs::is_directory(fs::path(file))) {
-      tabManager->open(QString::fromStdString(file));
+  // Unsaved files do have the pwd as current path, therefore we will not open a new
+  // tab on click
+  if (!fs::is_directory(fs::path(file))) {
+    tabManager->open(QString::fromStdString(file));
+  }
+
+  // removes all previsly configure selection indicators.
+  clearAllSelectionIndicators();
+
+  std::vector<std::shared_ptr<const AbstractNode>> nodesSameModule{};
+  findNodesWithSameMod(root_node, selected_node, nodesSameModule);
+
+  // highlight in the text editor all the text fragment of the hierarchy of object with same mode.
+  for (auto element : nodesSameModule) {
+    if (element->index() != currently_selected_object) {
+      setSelectionIndicatorStatus(element->index(), EditorSelectionIndicatorStatus::IMPACTED);
     }
+  }
 
-    // removes all previsly configure selection indicators.
-    clearAllSelectionIndicators();
+  // highlight in the text editor only the fragment correponding to the selected stack.
+  // this step must be done after all the impacted element have been marked.
+  setSelectionIndicatorStatus(currently_selected_object, EditorSelectionIndicatorStatus::SELECTED);
 
-    std::vector<std::shared_ptr<const AbstractNode>> nodesSameModule{};
-    findNodesWithSameMod(root_node, selected_node, nodesSameModule);
-
-    // highlight in the text editor all the text fragment of the hierarchy of object with same mode.
-    for(auto element : nodesSameModule) {
-        if(element->index() != currently_selected_object) {
-            setSelectionIndicatorStatus(element->index(), EditorSelectionIndicatorStatus::IMPACTED);
-        }
-    }
-
-    // highlight in the text editor only the fragment correponding to the selected stack.
-    // this step must be done after all the impacted element have been marked.
-    setSelectionIndicatorStatus(currently_selected_object, EditorSelectionIndicatorStatus::SELECTED);
-
-    activeEditor->setCursorPosition(line - 1, column - 1);
+  activeEditor->setCursorPosition(line - 1, column - 1);
 }
 
 /**
@@ -2831,9 +2810,9 @@ bool MainWindow::canExport(unsigned int dim)
 }
 
 void MainWindow::actionExport(FileFormat format, const char *type_name, const char *suffix, unsigned int dim){
-  ExportPdfOptions* empty = nullptr;
+  ExportPdfOptions *empty = nullptr;
   actionExport(format, type_name, suffix, dim, empty);
-};
+}
 
 void MainWindow::actionExport(FileFormat format, const char *type_name, const char *suffix, unsigned int dim, ExportPdfOptions *options)
 {
@@ -2845,7 +2824,7 @@ void MainWindow::actionExport(FileFormat format, const char *type_name, const ch
 
   //Return if something is wrong and we can't export.
   if (!canExport(dim)) return;
-  
+
   auto title = QString(_("Export %1 File")).arg(type_name);
   auto filter = QString(_("%1 Files (*%2)")).arg(type_name, suffix);
   auto exportFilename = QFileDialog::getSaveFileName(this, title, exportPath(suffix), filter);
@@ -2857,8 +2836,8 @@ void MainWindow::actionExport(FileFormat format, const char *type_name, const ch
 
   ExportInfo exportInfo = createExportInfo(format, exportFilename, activeEditor->filepath);
   // Add options
-exportInfo.options=options;
-  
+  exportInfo.options = options;
+
   bool exportResult = exportFileByName(this->root_geom, exportInfo);
 
   if (exportResult) fileExportedMessage(type_name, exportFilename);
@@ -2912,46 +2891,46 @@ void MainWindow::actionExportSVG()
 void MainWindow::actionExportPDF()
 {
 
-ExportPdfOptions exportPdfOptions;
-QSettingsCached settings;
+  ExportPdfOptions exportPdfOptions;
+  QSettingsCached settings;
 
 // Prepopulated with default values in export.h
-auto exportPdfDialog = new ExportPdfDialog();
+  auto exportPdfDialog = new ExportPdfDialog();
 
 // Get current settings or defaults
 //  modify the two enums (next two rows) to explicitly use default by lookup to string (see the later set methods).
-exportPdfDialog->setPaperSize(sizeString2Enum(settings.value("exportPdfOpts/paperSize",
-	QString::fromStdString(paperSizeStrings[static_cast<int>(exportPdfOptions.paperSize)])).toString()));  // enum map
-exportPdfDialog->setOrientation(orientationsString2Enum(settings.value("exportPdfOpts/orientation",
-	QString::fromStdString(paperOrientationsStrings[static_cast<int>(exportPdfOptions.Orientation)])).toString()));  // enum map
-exportPdfDialog->setShowDsnFn(settings.value("exportPdfOpts/showDsgnFN",exportPdfOptions.showDsgnFN).toBool());
-exportPdfDialog->setShowScale(settings.value("exportPdfOpts/showScale",exportPdfOptions.showScale).toBool());
-exportPdfDialog->setShowScaleMsg(settings.value("exportPdfOpts/showScaleMsg",exportPdfOptions.showScaleMsg).toBool());
-exportPdfDialog->setShowGrid(settings.value("exportPdfOpts/showGrid",exportPdfOptions.showGrid).toBool());
-exportPdfDialog->setGridSize(settings.value("exportPdfOpts/gridSize",exportPdfOptions.gridSize).toDouble());
+  exportPdfDialog->setPaperSize(sizeString2Enum(settings.value("exportPdfOpts/paperSize",
+                                                               QString::fromStdString(paperSizeStrings[static_cast<int>(exportPdfOptions.paperSize)])).toString())); // enum map
+  exportPdfDialog->setOrientation(orientationsString2Enum(settings.value("exportPdfOpts/orientation",
+                                                                         QString::fromStdString(paperOrientationsStrings[static_cast<int>(exportPdfOptions.Orientation)])).toString())); // enum map
+  exportPdfDialog->setShowDsnFn(settings.value("exportPdfOpts/showDsgnFN", exportPdfOptions.showDsgnFN).toBool());
+  exportPdfDialog->setShowScale(settings.value("exportPdfOpts/showScale", exportPdfOptions.showScale).toBool());
+  exportPdfDialog->setShowScaleMsg(settings.value("exportPdfOpts/showScaleMsg", exportPdfOptions.showScaleMsg).toBool());
+  exportPdfDialog->setShowGrid(settings.value("exportPdfOpts/showGrid", exportPdfOptions.showGrid).toBool());
+  exportPdfDialog->setGridSize(settings.value("exportPdfOpts/gridSize", exportPdfOptions.gridSize).toDouble());
 
 
-if (exportPdfDialog->exec() == QDialog::Rejected) {
-  return;
-}; 
+  if (exportPdfDialog->exec() == QDialog::Rejected) {
+    return;
+  }
 
-exportPdfOptions.paperSize=exportPdfDialog->getPaperSize();
-exportPdfOptions.Orientation=exportPdfDialog->getOrientation();
-exportPdfOptions.showDsgnFN=exportPdfDialog->getShowDsnFn();
-exportPdfOptions.showScale=exportPdfDialog->getShowScale();
-exportPdfOptions.showScaleMsg=exportPdfDialog->getShowScaleMsg();
-exportPdfOptions.showGrid=exportPdfDialog->getShowGrid();
-exportPdfOptions.gridSize=exportPdfDialog->getGridSize();
+  exportPdfOptions.paperSize = exportPdfDialog->getPaperSize();
+  exportPdfOptions.Orientation = exportPdfDialog->getOrientation();
+  exportPdfOptions.showDsgnFN = exportPdfDialog->getShowDsnFn();
+  exportPdfOptions.showScale = exportPdfDialog->getShowScale();
+  exportPdfOptions.showScaleMsg = exportPdfDialog->getShowScaleMsg();
+  exportPdfOptions.showGrid = exportPdfDialog->getShowGrid();
+  exportPdfOptions.gridSize = exportPdfDialog->getGridSize();
 
-settings.setValue("exportPdfOpts/paperSize",QString::fromStdString(paperSizeStrings[static_cast<int>( exportPdfDialog->getPaperSize())]));
-settings.setValue("exportPdfOpts/orientation",QString::fromStdString(paperOrientationsStrings[static_cast<int>(exportPdfDialog->getOrientation())]));
-settings.setValue("exportPdfOpts/showDsgnFN",exportPdfDialog->getShowDsnFn());
-settings.setValue("exportPdfOpts/showScale",exportPdfDialog->getShowScale());
-settings.setValue("exportPdfOpts/showScaleMsg",exportPdfDialog->getShowScaleMsg());
-settings.setValue("exportPdfOpts/showGrid",exportPdfDialog->getShowGrid());
-settings.setValue("exportPdfOpts/gridSize",exportPdfDialog->getGridSize());
+  settings.setValue("exportPdfOpts/paperSize", QString::fromStdString(paperSizeStrings[static_cast<int>(exportPdfDialog->getPaperSize())]));
+  settings.setValue("exportPdfOpts/orientation", QString::fromStdString(paperOrientationsStrings[static_cast<int>(exportPdfDialog->getOrientation())]));
+  settings.setValue("exportPdfOpts/showDsgnFN", exportPdfDialog->getShowDsnFn());
+  settings.setValue("exportPdfOpts/showScale", exportPdfDialog->getShowScale());
+  settings.setValue("exportPdfOpts/showScaleMsg", exportPdfDialog->getShowScaleMsg());
+  settings.setValue("exportPdfOpts/showGrid", exportPdfDialog->getShowGrid());
+  settings.setValue("exportPdfOpts/gridSize", exportPdfDialog->getGridSize());
 
-actionExport(FileFormat::PDF, "PDF", ".pdf", 2, &exportPdfOptions);
+  actionExport(FileFormat::PDF, "PDF", ".pdf", 2, &exportPdfOptions);
 
 }
 
@@ -3824,16 +3803,16 @@ void MainWindow::jumpToLine(int line, int col)
 }
 
 paperSizes MainWindow::sizeString2Enum(QString current){
-   for(size_t i = 0; i < paperSizeStrings.size(); i++){
-       if (current.toStdString()==paperSizeStrings[i]) return static_cast<paperSizes>(i);
-   };
-   return paperSizes::A4;
-};
+  for (size_t i = 0; i < paperSizeStrings.size(); i++) {
+    if (current.toStdString() == paperSizeStrings[i]) return static_cast<paperSizes>(i);
+  }
+  return paperSizes::A4;
+}
 
 paperOrientations MainWindow::orientationsString2Enum(QString current){
-   for(size_t i = 0; i < paperOrientationsStrings.size(); i++){
-       if (current.toStdString()==paperOrientationsStrings[i]) return static_cast<paperOrientations>(i);
-   };
-   return paperOrientations::PORTRAIT;
-};
+  for (size_t i = 0; i < paperOrientationsStrings.size(); i++) {
+    if (current.toStdString() == paperOrientationsStrings[i]) return static_cast<paperOrientations>(i);
+  }
+  return paperOrientations::PORTRAIT;
+}
 

--- a/src/gui/MainWindow.cc
+++ b/src/gui/MainWindow.cc
@@ -2399,35 +2399,44 @@ void MainWindow::rightClick(QPoint mouse)
       auto location = step->modinst->location();
       ss.str("");
 
+      // Remove the "module" prefix if any as it induce confusion between the module declaration and instanciation
+      int first_position = (step->verbose_name().find("module") == std::string::npos)? 0 : 7;
+      std::string name = step->verbose_name().substr(first_position);
+
+      // It happens that the verbose_name is empty (eg: in for loops), when this happens instead of letting
+      // empty entry in the menu we prefer using the name in the modinstanciation.
+      if(step->verbose_name().empty())
+          name = step->modinst->name();
+
       // Check if the path is contained in a library (using parsersettings.h)
       fs::path libpath = get_library_for_path(location.filePath());
       if (!libpath.empty()) {
         // Display the library (without making the window too wide!)
-        ss << step->verbose_name() << " (library "
+        ss << name << " (library "
            << location.fileName().substr(libpath.string().length() + 1) << ":"
            << location.firstLine() << ")";
       } else if (activeEditor->filepath.toStdString() == location.fileName()) {
-        ss << step->verbose_name() << " (" << location.filePath().filename().string() << ":"
-           << location.firstLine() << ")";
+          // removes the "module" prefix if any as it makes it not clear if it is module declaration or call.
+          ss << name << " (" << location.filePath().filename().string() << ":"
+                     << location.firstLine() << ")";
       } else {
-        auto relname = boostfs_uncomplete(location.filePath(), fs::path(activeEditor->filepath.toStdString()).parent_path())
+        auto relative_filename = boostfs_uncomplete(location.filePath(), fs::path(activeEditor->filepath.toStdString()).parent_path())
           .generic_string();
         // Set the displayed name relative to the active editor window
-        ss << step->verbose_name() << " (" << relname << ":" << location.firstLine() << ")";
+        ss << name << " (" << relative_filename << ":" << location.firstLine() << ")";
       }
 
       // Prepare the action to be sent
       auto action = tracemenu.addAction(QString::fromStdString(ss.str()));
       if (editorDock->isVisible()) {
-        action->setProperty("file", QString::fromStdString(location.fileName()));
-        action->setProperty("line", location.firstLine());
-        action->setProperty("column", location.firstColumn());
-
-        connect(action, SIGNAL(triggered()), this, SLOT(setCursor()));
+        action->setProperty("id", step->idx);
+        connect(action, SIGNAL(hovered()), this, SLOT(onHoveredObjectInSelectionMenu()));
       }
     }
 
     tracemenu.exec(this->qglview->mapToGlobal(mouse));
+  } else {
+      clearAllSelectionIndicators();
   }
 }
 void MainWindow::measureFinished(void)
@@ -2438,29 +2447,181 @@ void MainWindow::measureFinished(void)
   this->qglview->measure_state = MEASURE_IDLE;
 }
 
+void MainWindow::clearAllSelectionIndicators()
+{
+    this->activeEditor->clearAllSelectionIndicators();
+}
+
+void findNodesWithSameMod(std::shared_ptr<const AbstractNode> tree,
+                          std::shared_ptr<const AbstractNode> node_mod,
+                          std::vector<std::shared_ptr<const AbstractNode>>& nodes){
+    if(node_mod->modinst == tree->modinst){
+      nodes.push_back(tree);
+    }
+    for(auto step : tree->children){
+      findNodesWithSameMod(step,node_mod,nodes);
+    }
+}
+
+void getCodeLocation(const AbstractNode* self, int currentLevel,  int includeLevel, int * firstLine, int * firstColumn, int * lastLine, int * lastColumn, int nestedModuleDepth)
+{
+  auto location = self->modinst->location();
+  if(currentLevel >= includeLevel && nestedModuleDepth == 0)
+  {
+    if(*firstLine < 0 || *firstLine > location.firstLine())
+    {
+      *firstLine = location.firstLine();
+      *firstColumn = location.firstColumn();
+    }
+    else if(*firstLine ==  location.firstLine() && *firstColumn > location.firstColumn())
+    {
+      *firstColumn = location.firstColumn();
+    }
+
+    if(*lastLine < 0 || *lastLine < location.lastLine())
+    {
+      *lastLine = location.lastLine();
+      *lastColumn = location.lastColumn();
+    }
+    else{
+      if(*firstLine < 0 || *firstLine > location.firstLine())
+      {
+        *firstLine = location.firstLine();
+        *firstColumn = location.firstColumn();
+      }
+      else if(*firstLine ==  location.firstLine() && *firstColumn > location.firstColumn())
+      {
+        *firstColumn = location.firstColumn();
+      }
+      if(*lastLine < 0 || *lastLine < location.lastLine())
+      {
+        *lastLine = location.lastLine();
+        *lastColumn = location.lastColumn();
+      }
+      else if( *lastLine ==  location.lastLine() && *lastColumn < location.lastColumn())
+      {
+        *lastColumn = location.lastColumn();
+      }
+    }
+  }
+
+  if(self->verbose_name().rfind("module", 0) == 0)
+  {
+    nestedModuleDepth++;
+  }
+  if(self->modinst->name() == "children")
+  {
+    nestedModuleDepth--;
+  }
+
+  if(nestedModuleDepth >= 0 )
+  {
+    for (const auto& node : self->children) {
+      getCodeLocation(node.get(), currentLevel + 1, includeLevel, firstLine,  firstColumn, lastLine, lastColumn, nestedModuleDepth);
+    }
+  }
+}
+
+void MainWindow::setSelectionIndicatorStatus(int nodeIndex, EditorSelectionIndicatorStatus status)
+{
+  std::deque<std::shared_ptr<const AbstractNode>> stack;
+  this->root_node->getNodeByID(nodeIndex, stack);
+
+  int level = 1;
+
+  // first we flags all the nodes in the stack of the provided index
+  // ends at size - 1 because we are not doing anything for the root node.
+  // starts at 1 because we will process this one after later
+  for(int i = 1; i < stack.size()-1; i++)
+  {
+    auto node = stack[i];
+
+    auto& location = node->modinst->location();
+    if(location.filePath().compare(activeEditor->filepath.toStdString()) != 0  )
+    {
+      std::cout<<"--->>> Line of code in a different file -- PATH -- "<<location.fileName()<<std::endl;
+      node->modinst->print(std::cout,"");
+      level++;
+      continue;
+    }
+
+    if(node->verbose_name().rfind("module", 0) == 0 || node->modinst->name() == "children")
+    {
+        this->activeEditor->setSelectionIndicatorStatus(
+                        status, level,
+                        location.firstLine() - 1,location.firstColumn() - 1,location.lastLine() - 1,location.lastColumn()- 1);
+        level++;
+    }
+  }
+
+  auto& node = stack[0];
+  auto location = node->modinst->location();
+  auto line = location.firstLine();
+  auto column = location.firstColumn();
+  auto lastLine = location.lastLine();
+  auto lastColumn = location.lastColumn();
+
+  // Update the location returned by location to cover the whole section.
+  getCodeLocation(node.get(), 0,0,&line,&column,&lastLine,&lastColumn,0);
+
+  this->activeEditor->setSelectionIndicatorStatus(status, 0, line - 1 , column - 1, lastLine - 1, lastColumn - 1);
+ }
+
+void MainWindow::setSelection(int index)
+{
+    if(currently_selected_object == index)
+      return;
+
+    std::deque<std::shared_ptr<const AbstractNode>> path;
+    std::shared_ptr<const AbstractNode> selected_node = root_node->getNodeByID(index, path);
+
+    if(!selected_node)
+        return;
+
+    currently_selected_object = index;
+
+    auto location = selected_node->modinst->location();
+    auto file = location.fileName();
+    auto line = location.firstLine();
+    auto column = location.firstColumn();
+
+    // Unsaved files do have the pwd as current path, therefore we will not open a new
+    // tab on click
+    if (!fs::is_directory(fs::path(file))) {
+      tabManager->open(QString::fromStdString(file));
+    }
+
+    // removes all previsly configure selection indicators.
+    clearAllSelectionIndicators();
+
+    std::vector<std::shared_ptr<const AbstractNode>> nodesSameModule{};
+    findNodesWithSameMod(root_node, selected_node, nodesSameModule);
+
+    // highlight in the text editor all the text fragment of the hierarchy of object with same mode.
+    for(auto element : nodesSameModule) {
+        if(element->index() != currently_selected_object) {
+            setSelectionIndicatorStatus(element->index(), EditorSelectionIndicatorStatus::IMPACTED);
+        }
+    }
+
+    // highlight in the text editor only the fragment correponding to the selected stack.
+    // this step must be done after all the impacted element have been marked.
+    setSelectionIndicatorStatus(currently_selected_object, EditorSelectionIndicatorStatus::SELECTED);
+
+    activeEditor->setCursorPosition(line - 1, column - 1);
+}
+
 /**
- * Expects the sender to have properties "file", "line" and "column" defined
+ * Expects the sender to have properties "id" defined
  */
-void MainWindow::setCursor()
+void MainWindow::onHoveredObjectInSelectionMenu()
 {
   auto *action = qobject_cast<QAction *>(sender());
-  if (!action || !action->property("file").isValid() || !action->property("line").isValid() ||
-      !action->property("column").isValid()) {
+  if (!action || !action->property("id").isValid()) {
     return;
   }
 
-  auto file = action->property("file").toString();
-  auto line = action->property("line").toInt();
-  auto column = action->property("column").toInt();
-
-  // Unsaved files do have the pwd as current path, therefore we will not open a new
-  // tab on click
-  if (!fs::is_directory(fs::path(file.toStdString()))) {
-    this->tabManager->open(file);
-  }
-
-  // move the cursor, the editor is 0 based whereby location is 1 based
-  this->activeEditor->setCursorPosition(line - 1, column - 1);
+  setSelection(action->property("id").toInt());
 }
 
 void MainWindow::setLastFocus(QWidget *widget) {
@@ -2976,6 +3137,9 @@ void MainWindow::editorContentChanged()
   auto current_doc = activeEditor->toPlainText();
   if (current_doc != last_compiled_doc) {
     animateWidget->editorContentChanged();
+
+    // removes the live selection feedbacks in both the 3d view and editor.
+    clearAllSelectionIndicators();
   }
 }
 

--- a/src/gui/MainWindow.h
+++ b/src/gui/MainWindow.h
@@ -99,6 +99,8 @@ public:
 private:
   volatile bool isClosing = false;
   void consoleOutputRaw(const QString& msg);
+  void clearAllSelectionIndicators();
+  void setSelectionIndicatorStatus(int nodeIndex, EditorSelectionIndicatorStatus status);
 
 protected:
   void closeEvent(QCloseEvent *event) override;
@@ -112,7 +114,8 @@ private slots:
   void showProgress();
   void openCSGSettingsChanged();
   void consoleOutput(const Message& msgObj);
-  void setCursor();
+  void setSelection(int index);
+  void onHoveredObjectInSelectionMenu();
   void measureFinished();
   void errorLogOutput(const Message& log_msg);
 
@@ -367,6 +370,7 @@ private:
   std::shared_ptr<CSGProducts> root_products;
   std::shared_ptr<CSGProducts> highlights_products;
   std::shared_ptr<CSGProducts> background_products;
+  int currently_selected_object {-1};
 
   char const *afterCompileSlot;
   bool procevents{false};

--- a/src/gui/MainWindow.h
+++ b/src/gui/MainWindow.h
@@ -61,7 +61,7 @@ public:
   bool python_active;
   std::string trusted_edit_document_name;
   std::string untrusted_edit_document_name;
-  bool trust_python_file(const std::string &file, const std::string &content);
+  bool trust_python_file(const std::string& file, const std::string& content);
 #endif
   Tree tree;
   EditorInterface *activeEditor;

--- a/src/gui/ScintillaEditor.cc
+++ b/src/gui/ScintillaEditor.cc
@@ -182,8 +182,22 @@ ScintillaEditor::ScintillaEditor(QWidget *parent) : EditorInterface(parent)
 
   qsci->indicatorDefine(QsciScintilla::RoundBoxIndicator, errorIndicatorNumber);
   qsci->indicatorDefine(QsciScintilla::RoundBoxIndicator, findIndicatorNumber);
+  qsci->indicatorDefine(QsciScintilla::RoundBoxIndicator, selectionIndicatorIsActiveNumber);
+  qsci->indicatorDefine(QsciScintilla::RoundBoxIndicator, selectionIndicatorIsActiveNumber + 1);
+  qsci->indicatorDefine(QsciScintilla::RoundBoxIndicator, selectionIndicatorIsImpactedNumber);
+  qsci->indicatorDefine(QsciScintilla::RoundBoxIndicator, selectionIndicatorIsImpactedNumber + 1);
+  qsci->indicatorDefine(QsciScintilla::RoundBoxIndicator, selectionIndicatorIsImpactedNumber + 2);
+
   qsci->markerDefine(QsciScintilla::Circle, errMarkerNumber);
   qsci->markerDefine(QsciScintilla::Bookmark, bmMarkerNumber);
+
+  qsci->markerDefine('1', selectionMarkerLevelNumber);
+  qsci->markerDefine('2', selectionMarkerLevelNumber + 1);
+  qsci->markerDefine('3', selectionMarkerLevelNumber + 2);
+  qsci->markerDefine('4', selectionMarkerLevelNumber + 3);
+  qsci->markerDefine('5', selectionMarkerLevelNumber + 4);
+  qsci->markerDefine('+', selectionMarkerLevelNumber + 5);
+
 
   qsci->setMarginType(numberMargin, QsciScintilla::NumberMargin);
   qsci->setMarginLineNumbers(numberMargin, true);
@@ -192,7 +206,7 @@ ScintillaEditor::ScintillaEditor(QWidget *parent) : EditorInterface(parent)
   qsci->setMarginType(symbolMargin, QsciScintilla::SymbolMargin);
   qsci->setMarginLineNumbers(symbolMargin, false);
   qsci->setMarginWidth(symbolMargin, 0);
-  qsci->setMarginMarkerMask(symbolMargin, 1 << errMarkerNumber | 1 << bmMarkerNumber);
+  qsci->setMarginMarkerMask(symbolMargin, 1 << errMarkerNumber | 1 << bmMarkerNumber | 1 << selectionMarkerLevelNumber | 1 << (selectionMarkerLevelNumber + 1) | 1 << (selectionMarkerLevelNumber + 2) | 1 << (selectionMarkerLevelNumber + 3) | 1 << (selectionMarkerLevelNumber + 4) | 1 << (selectionMarkerLevelNumber + 5));
 
 #if ENABLE_LEXERTL
   auto newLexer = new ScadLexer2(this);
@@ -557,6 +571,23 @@ void ScintillaEditor::setColormap(const EditorColorScheme *colorScheme)
 
     qsci->setMarkerBackgroundColor(readColor(colors, "error-marker", QColor(255, 0, 0, 100)), errMarkerNumber);
     qsci->setMarkerBackgroundColor(readColor(colors, "bookmark-marker", QColor(150, 200, 255, 100)), bmMarkerNumber); // light blue
+    qsci->setMarkerBackgroundColor(readColor(colors, "reference-marker1", QColor(11, 156, 49, 100)), selectionMarkerLevelNumber);
+    qsci->setMarkerBackgroundColor(readColor(colors, "reference-marker2", QColor(11, 156, 49, 50)), selectionMarkerLevelNumber + 1);
+    qsci->setMarkerBackgroundColor(readColor(colors, "reference-marker3", QColor(11, 156, 49, 50)), selectionMarkerLevelNumber + 2);
+    qsci->setMarkerBackgroundColor(readColor(colors, "reference-marker4", QColor(11, 156, 49, 50)), selectionMarkerLevelNumber + 3);
+    qsci->setMarkerBackgroundColor(readColor(colors, "reference-marker5", QColor(11, 156, 49, 50)), selectionMarkerLevelNumber + 4);
+    qsci->setMarkerBackgroundColor(readColor(colors, "reference-marker6", QColor(11, 156, 49, 50)), selectionMarkerLevelNumber + 5);
+    qsci->setMarkerBackgroundColor(readColor(colors, "bookmark-marker", QColor(150, 200, 255, 50)), bmMarkerNumber); // light blue
+    qsci->setIndicatorForegroundColor(readColor(colors, "selected-highlight-indicator", QColor(11, 156, 49, 100)), selectionIndicatorIsActiveNumber); //light green
+    qsci->setIndicatorOutlineColor(readColor(colors, "selected-highlight-indicator-outline", QColor(11, 156, 49, 100)), selectionIndicatorIsActiveNumber); //light green
+    qsci->setIndicatorForegroundColor(readColor(colors, "selected-highlight1-indicator", QColor(11, 156, 49, 50)), selectionIndicatorIsActiveNumber + 1); //light green
+    qsci->setIndicatorOutlineColor(readColor(colors, "selected-highlight1-indicator-outline", QColor(11, 156, 49, 50)), selectionIndicatorIsActiveNumber + 1); //light green
+    qsci->setIndicatorForegroundColor(readColor(colors, "referenced-highlight0-indicator", QColor(255, 128, 128, 100)), selectionIndicatorIsImpactedNumber); //light green
+    qsci->setIndicatorOutlineColor(readColor(colors, "referenced-highlight0-indicator-outline", QColor(255, 128, 128, 100)), selectionIndicatorIsImpactedNumber); //light green
+    qsci->setIndicatorForegroundColor(readColor(colors, "referenced-highlight1-indicator", QColor(255, 128, 128, 100)), selectionIndicatorIsImpactedNumber + 1); //light green
+    qsci->setIndicatorOutlineColor(readColor(colors, "referenced-highlight1-indicator-outline", QColor(255, 128, 128, 80)), selectionIndicatorIsImpactedNumber + 1); //light green
+    qsci->setIndicatorForegroundColor(readColor(colors, "referenced-highlight2-indicator", QColor(255, 128, 128, 100)), selectionIndicatorIsImpactedNumber + 2); //light green
+    qsci->setIndicatorOutlineColor(readColor(colors, "referenced-highlight2-indicator-outline", QColor(255, 128, 128, 60)), selectionIndicatorIsImpactedNumber + 2); //light green
     qsci->setIndicatorForegroundColor(readColor(colors, "error-indicator", QColor(255, 0, 0, 100)), errorIndicatorNumber); //red
     qsci->setIndicatorOutlineColor(readColor(colors, "error-indicator-outline", QColor(255, 0, 0, 100)), errorIndicatorNumber); //red
     qsci->setIndicatorForegroundColor(readColor(colors, "find-indicator", QColor(255, 255, 0, 100)), findIndicatorNumber); //yellow
@@ -589,6 +620,24 @@ void ScintillaEditor::noColor()
   qsci->setCaretForegroundColor(Qt::black);
   qsci->setMarkerBackgroundColor(QColor(255, 0, 0, 100), errMarkerNumber);
   qsci->setMarkerBackgroundColor(QColor(150, 200, 255, 100), bmMarkerNumber); // light blue
+  qsci->setMarkerBackgroundColor(QColor(11, 156, 49, 100), selectionMarkerLevelNumber);
+  qsci->setMarkerBackgroundColor(QColor(11, 156, 49, 50), selectionMarkerLevelNumber + 1);
+  qsci->setMarkerBackgroundColor(QColor(11, 156, 49, 50), selectionMarkerLevelNumber + 2);
+  qsci->setMarkerBackgroundColor(QColor(11, 156, 49, 50), selectionMarkerLevelNumber + 3);
+  qsci->setMarkerBackgroundColor(QColor(11, 156, 49, 50), selectionMarkerLevelNumber + 4);
+  qsci->setMarkerBackgroundColor(QColor(11, 156, 49, 50), selectionMarkerLevelNumber + 5);
+  qsci->setMarkerBackgroundColor(QColor(150, 200, 255, 100), bmMarkerNumber); // light blue
+  qsci->setIndicatorForegroundColor(QColor(11, 156, 49, 100), selectionIndicatorIsActiveNumber);
+  qsci->setIndicatorOutlineColor(QColor(0, 0, 0, 255), selectionIndicatorIsActiveNumber);
+  qsci->setIndicatorForegroundColor(QColor(11, 156, 49, 50), selectionIndicatorIsActiveNumber + 1);
+  qsci->setIndicatorOutlineColor(QColor(0, 0, 0, 255), selectionIndicatorIsActiveNumber + 1 );
+  qsci->setIndicatorForegroundColor(QColor(255, 128, 128, 100), selectionIndicatorIsImpactedNumber);
+  qsci->setIndicatorOutlineColor(QColor(0, 0, 0, 255), selectionIndicatorIsImpactedNumber);
+  qsci->setIndicatorForegroundColor(QColor(255, 128, 128, 80), selectionIndicatorIsImpactedNumber + 1);
+  qsci->setIndicatorOutlineColor(QColor(0, 0, 0, 255), selectionIndicatorIsImpactedNumber + 1);
+  qsci->setIndicatorForegroundColor(QColor(255, 128, 128, 60), selectionIndicatorIsImpactedNumber + 2 );
+  qsci->setIndicatorOutlineColor(QColor(0, 0, 0, 255), selectionIndicatorIsImpactedNumber + 2 );
+
   qsci->setIndicatorForegroundColor(QColor(255, 0, 0, 128), errorIndicatorNumber); //red
   qsci->setIndicatorOutlineColor(QColor(0, 0, 0, 255), errorIndicatorNumber); // only alpha part is used
   qsci->setIndicatorForegroundColor(QColor(255, 255, 0, 128), findIndicatorNumber); //yellow
@@ -1391,10 +1440,13 @@ void ScintillaEditor::setCursorPosition(int line, int col)
 
 void ScintillaEditor::updateSymbolMarginVisibility()
 {
-  if (qsci->markerFindNext(0, 1 << bmMarkerNumber | 1 << errMarkerNumber) < 0) {
+    if (qsci->markerFindNext(0, 1 << bmMarkerNumber | 1 << errMarkerNumber | 1 << selectionMarkerLevelNumber |
+                             1 << (selectionMarkerLevelNumber + 1) | 1 << (selectionMarkerLevelNumber + 2) |
+                             1 << (selectionMarkerLevelNumber + 3) | 1 << (selectionMarkerLevelNumber + 4) |
+                             1 << (selectionMarkerLevelNumber + 5)) < 0) {
     qsci->setMarginWidth(symbolMargin, 0);
   } else {
-    qsci->setMarginWidth(symbolMargin, "00");
+    qsci->setMarginWidth(symbolMargin, "0");
   }
 }
 
@@ -1452,4 +1504,76 @@ void ScintillaEditor::setFocus()
 {
   qsci->setFocus();
   qsci->SendScintilla(QsciScintilla::SCI_SETFOCUS, true);
+}
+
+/**
+ * @brief Highlights a part of the text according to the limits described in the parameters
+ */
+void ScintillaEditor::setSelectionIndicatorStatus(EditorSelectionIndicatorStatus status, int level, int lineFrom, int colFrom, int lineTo, int colTo)
+{
+  // replace all the indicators at given lines/column with the new one
+  clearSelectionIndicators(lineFrom, colFrom, lineTo, colTo);
+
+  int indicator_base_index = 0;
+  int indicator_level=0;
+  int mark_level=0;
+  if(status == EditorSelectionIndicatorStatus::SELECTED)
+  {
+      indicator_base_index = selectionIndicatorIsActiveNumber;
+      mark_level = (level>5)?5:level;
+      indicator_level = (level>1)?1:level;
+  }else{
+      indicator_base_index = selectionIndicatorIsImpactedNumber;
+      indicator_level = (level>2)?2:level;
+  }
+
+  clearSelectionIndicators(lineFrom, colFrom, lineTo, colTo);
+  qsci->fillIndicatorRange(lineFrom, colFrom, lineTo, colTo,  indicator_base_index + indicator_level);
+
+  if(status == EditorSelectionIndicatorStatus::SELECTED)
+  {
+      qsci->ensureLineVisible(std::max(lineFrom - setCursorPositionVisibleLines, 0));
+      qsci->ensureLineVisible(std::min(lineFrom + setCursorPositionVisibleLines, qsci->lines() - 1));
+
+      // replace the marker at provide line with a new one.
+      qsci->markerDelete(lineFrom);
+
+      qsci->markerAdd(lineFrom, selectionMarkerLevelNumber + mark_level);
+      updateSymbolMarginVisibility();
+  }
+}
+
+/**
+ * @brief Unhighlight all the selection indicators.
+ */
+void ScintillaEditor::clearAllSelectionIndicators()
+{
+  // remove all the indicator in the document.
+  int line, column;
+  qsci->lineIndexFromPosition(qsci->length(), &line, &column);
+  clearSelectionIndicators(0, 0, line, column);
+
+  // remove all the markers
+  qsci->markerDeleteAll(selectionMarkerLevelNumber);
+  qsci->markerDeleteAll(selectionMarkerLevelNumber + 1);
+  qsci->markerDeleteAll(selectionMarkerLevelNumber + 2);
+  qsci->markerDeleteAll(selectionMarkerLevelNumber + 3);
+  qsci->markerDeleteAll(selectionMarkerLevelNumber + 4);
+  qsci->markerDeleteAll(selectionMarkerLevelNumber + 5);
+
+  // if there is no more marker... hide the dedicated area in the editor
+  updateSymbolMarginVisibility();
+}
+
+/**
+* @brief Unhighlight all the texts for DM
+*/
+void ScintillaEditor::clearSelectionIndicators(int lineFrom, int colFrom, int lineTo, int colTo)
+{
+  qsci->clearIndicatorRange(lineFrom, colFrom, lineTo, colTo, selectionIndicatorIsImpactedNumber);
+  qsci->clearIndicatorRange(lineFrom, colFrom, lineTo, colTo, selectionIndicatorIsImpactedNumber + 1);
+  qsci->clearIndicatorRange(lineFrom, colFrom, lineTo, colTo, selectionIndicatorIsImpactedNumber + 2);
+
+  qsci->clearIndicatorRange(lineFrom, colFrom, lineTo, colTo, selectionIndicatorIsActiveNumber);
+  qsci->clearIndicatorRange(lineFrom, colFrom, lineTo, colTo, selectionIndicatorIsActiveNumber + 1);
 }

--- a/src/gui/ScintillaEditor.cc
+++ b/src/gui/ScintillaEditor.cc
@@ -630,13 +630,13 @@ void ScintillaEditor::noColor()
   qsci->setIndicatorForegroundColor(QColor(11, 156, 49, 100), selectionIndicatorIsActiveNumber);
   qsci->setIndicatorOutlineColor(QColor(0, 0, 0, 255), selectionIndicatorIsActiveNumber);
   qsci->setIndicatorForegroundColor(QColor(11, 156, 49, 50), selectionIndicatorIsActiveNumber + 1);
-  qsci->setIndicatorOutlineColor(QColor(0, 0, 0, 255), selectionIndicatorIsActiveNumber + 1 );
+  qsci->setIndicatorOutlineColor(QColor(0, 0, 0, 255), selectionIndicatorIsActiveNumber + 1);
   qsci->setIndicatorForegroundColor(QColor(255, 128, 128, 100), selectionIndicatorIsImpactedNumber);
   qsci->setIndicatorOutlineColor(QColor(0, 0, 0, 255), selectionIndicatorIsImpactedNumber);
   qsci->setIndicatorForegroundColor(QColor(255, 128, 128, 80), selectionIndicatorIsImpactedNumber + 1);
   qsci->setIndicatorOutlineColor(QColor(0, 0, 0, 255), selectionIndicatorIsImpactedNumber + 1);
-  qsci->setIndicatorForegroundColor(QColor(255, 128, 128, 60), selectionIndicatorIsImpactedNumber + 2 );
-  qsci->setIndicatorOutlineColor(QColor(0, 0, 0, 255), selectionIndicatorIsImpactedNumber + 2 );
+  qsci->setIndicatorForegroundColor(QColor(255, 128, 128, 60), selectionIndicatorIsImpactedNumber + 2);
+  qsci->setIndicatorOutlineColor(QColor(0, 0, 0, 255), selectionIndicatorIsImpactedNumber + 2);
 
   qsci->setIndicatorForegroundColor(QColor(255, 0, 0, 128), errorIndicatorNumber); //red
   qsci->setIndicatorOutlineColor(QColor(0, 0, 0, 255), errorIndicatorNumber); // only alpha part is used
@@ -964,9 +964,9 @@ bool ScintillaEditor::eventFilter(QObject *obj, QEvent *e)
   if (e->type() == QEvent::KeyPress) {
     auto keyEvent = static_cast<QKeyEvent *>(e);
     if (keyEvent->key() == Qt::Key_Escape) {
-      emit escapePressed();	    
+      emit escapePressed();
     }
-  }    
+  }
   if (QGuiApplication::keyboardModifiers().testFlag(Qt::ControlModifier) || QGuiApplication::keyboardModifiers().testFlag(Qt::AltModifier)) {
     if (!this->indicatorsActive) {
       this->indicatorsActive = true;
@@ -1440,10 +1440,10 @@ void ScintillaEditor::setCursorPosition(int line, int col)
 
 void ScintillaEditor::updateSymbolMarginVisibility()
 {
-    if (qsci->markerFindNext(0, 1 << bmMarkerNumber | 1 << errMarkerNumber | 1 << selectionMarkerLevelNumber |
-                             1 << (selectionMarkerLevelNumber + 1) | 1 << (selectionMarkerLevelNumber + 2) |
-                             1 << (selectionMarkerLevelNumber + 3) | 1 << (selectionMarkerLevelNumber + 4) |
-                             1 << (selectionMarkerLevelNumber + 5)) < 0) {
+  if (qsci->markerFindNext(0, 1 << bmMarkerNumber | 1 << errMarkerNumber | 1 << selectionMarkerLevelNumber |
+                           1 << (selectionMarkerLevelNumber + 1) | 1 << (selectionMarkerLevelNumber + 2) |
+                           1 << (selectionMarkerLevelNumber + 3) | 1 << (selectionMarkerLevelNumber + 4) |
+                           1 << (selectionMarkerLevelNumber + 5)) < 0) {
     qsci->setMarginWidth(symbolMargin, 0);
   } else {
     qsci->setMarginWidth(symbolMargin, "0");
@@ -1515,31 +1515,29 @@ void ScintillaEditor::setSelectionIndicatorStatus(EditorSelectionIndicatorStatus
   clearSelectionIndicators(lineFrom, colFrom, lineTo, colTo);
 
   int indicator_base_index = 0;
-  int indicator_level=0;
-  int mark_level=0;
-  if(status == EditorSelectionIndicatorStatus::SELECTED)
-  {
-      indicator_base_index = selectionIndicatorIsActiveNumber;
-      mark_level = (level>5)?5:level;
-      indicator_level = (level>1)?1:level;
-  }else{
-      indicator_base_index = selectionIndicatorIsImpactedNumber;
-      indicator_level = (level>2)?2:level;
+  int indicator_level = 0;
+  int mark_level = 0;
+  if (status == EditorSelectionIndicatorStatus::SELECTED) {
+    indicator_base_index = selectionIndicatorIsActiveNumber;
+    mark_level = (level > 5)?5:level;
+    indicator_level = (level > 1)?1:level;
+  } else {
+    indicator_base_index = selectionIndicatorIsImpactedNumber;
+    indicator_level = (level > 2)?2:level;
   }
 
   clearSelectionIndicators(lineFrom, colFrom, lineTo, colTo);
   qsci->fillIndicatorRange(lineFrom, colFrom, lineTo, colTo,  indicator_base_index + indicator_level);
 
-  if(status == EditorSelectionIndicatorStatus::SELECTED)
-  {
-      qsci->ensureLineVisible(std::max(lineFrom - setCursorPositionVisibleLines, 0));
-      qsci->ensureLineVisible(std::min(lineFrom + setCursorPositionVisibleLines, qsci->lines() - 1));
+  if (status == EditorSelectionIndicatorStatus::SELECTED) {
+    qsci->ensureLineVisible(std::max(lineFrom - setCursorPositionVisibleLines, 0));
+    qsci->ensureLineVisible(std::min(lineFrom + setCursorPositionVisibleLines, qsci->lines() - 1));
 
-      // replace the marker at provide line with a new one.
-      qsci->markerDelete(lineFrom);
+    // replace the marker at provide line with a new one.
+    qsci->markerDelete(lineFrom);
 
-      qsci->markerAdd(lineFrom, selectionMarkerLevelNumber + mark_level);
-      updateSymbolMarginVisibility();
+    qsci->markerAdd(lineFrom, selectionMarkerLevelNumber + mark_level);
+    updateSymbolMarginVisibility();
   }
 }
 
@@ -1566,8 +1564,8 @@ void ScintillaEditor::clearAllSelectionIndicators()
 }
 
 /**
-* @brief Unhighlight all the texts for DM
-*/
+ * @brief Unhighlight all the texts for DM
+ */
 void ScintillaEditor::clearSelectionIndicators(int lineFrom, int colFrom, int lineTo, int colTo)
 {
   qsci->clearIndicatorRange(lineFrom, colFrom, lineTo, colTo, selectionIndicatorIsImpactedNumber);

--- a/src/gui/ScintillaEditor.h
+++ b/src/gui/ScintillaEditor.h
@@ -70,6 +70,10 @@ public:
   QPoint mapToGlobal(const QPoint&) override;
 
   void setCursorPosition(int line, int col) override;
+  void setSelectionIndicatorStatus(EditorSelectionIndicatorStatus satuts, int level, int lineFrom, int colFrom, int lineTo, int colTo) override;
+  void clearAllSelectionIndicators() override;
+  void clearSelectionIndicators(int lineFrom, int colFrom, int lineTo, int colTo);
+
   void setFocus() override;
   void setupAutoComplete(const bool forceOff = false);
 
@@ -162,6 +166,9 @@ private:
   static const int hyperlinkIndicatorOffset = 100;
   static const int errMarkerNumber = 2;
   static const int bmMarkerNumber = 3;
+  static const int selectionMarkerLevelNumber = 20; //20 - 25, there is at max 5 level of depth
+  static const int selectionIndicatorIsActiveNumber = 11; //Represents the active selected area text 11 - 12
+  static const int selectionIndicatorIsImpactedNumber = 14; //Represents the impacted selected area text 14-15-16
 
   bool indicatorsActive = false;
 

--- a/src/gui/ScintillaEditor.h
+++ b/src/gui/ScintillaEditor.h
@@ -151,7 +151,7 @@ private slots:
   void onIndicatorClicked(int line, int col, Qt::KeyboardModifiers state);
   void onIndicatorReleased(int line, int col, Qt::KeyboardModifiers state);
 signals:
-   void escapePressed(void);	
+  void escapePressed(void);
 
 public:
   void public_applySettings();


### PR DESCRIPTION
Hi all, 

With @lakfel we would like to implement parts of the work presented in this paper https://thomaspietrzak.com/bibliography/gonzalez23.pdf by [Johann Felipe Gonzalez](https://cil.csit.carleton.ca/staff-members/johann-felipe-gonzalez-avila/) et Al . 

The present PR is the first part containing interactive visual feedback in the text editor when user is selecting different object in the 3D view. The second part will consist in interactive visual feedback as overlay in the 3D view.

A small video of the first part: 
[![Video showing the feature](https://img.youtube.com/vi/4_XNRgZO_MY/0.jpg)](https://youtu.be/4_XNRgZO_MY)

In this video we can see how the active selection impact the text editor content. In green are represented the selected objects and the call stack depth (with the small markers in the left side number from 1 to 5 ). In pink is represented the "impacted" objects. These are the objects that would be changed if the active object is editted. 

I'm now working on the second part of the (the 3d view visual feedback) takes more time as I was stuck with somes issues (https://github.com/openscad/openscad/issues/5237, https://github.com/openscad/openscad/issues/5274, https://github.com/openscad/openscad/issues/4595, https://github.com/openscad/openscad/pull/5272).    