### PR TITLE
Use manifold headers relative to path manifold/...

### DIFF
--- a/src/RenderStatistic.cc
+++ b/src/RenderStatistic.cc
@@ -39,7 +39,7 @@
 
 #ifdef ENABLE_MANIFOLD
 #include "ManifoldGeometry.h"
-#include "manifold.h"
+#include "manifold/manifold.h"
 #include "manifoldutils.h"
 #endif // ENABLE_MANIFOLD
 

--- a/src/geometry/manifold/ManifoldGeometry.cc
+++ b/src/geometry/manifold/ManifoldGeometry.cc
@@ -1,7 +1,7 @@
 // Portions of this file are Copyright 2023 Google LLC, and licensed under GPL2+. See COPYING.
 #include "ManifoldGeometry.h"
 #include "Polygon2d.h"
-#include "manifold.h"
+#include "manifold/manifold.h"
 #include "PolySet.h"
 #include "Feature.h"
 #include "PolySetBuilder.h"

--- a/src/geometry/manifold/ManifoldGeometry.h
+++ b/src/geometry/manifold/ManifoldGeometry.h
@@ -4,7 +4,7 @@
 #include "Geometry.h"
 #include <glm/glm.hpp>
 #include "linalg.h"
-#include "manifold.h"
+#include "manifold/manifold.h"
 #include <map>
 #include <set>
 

--- a/src/geometry/manifold/manifoldutils.cc
+++ b/src/geometry/manifold/manifoldutils.cc
@@ -3,7 +3,7 @@
 #include "ManifoldGeometry.h"
 #include "PolySetBuilder.h"
 #include "Feature.h"
-#include "manifold.h"
+#include "manifold/manifold.h"
 #include "printutils.h"
 #ifdef ENABLE_CGAL
 #include "cgalutils.h"
@@ -13,7 +13,7 @@
 #endif
 #include "PolySetUtils.h"
 #include "PolySet.h"
-#include "polygon.h"
+#include "manifold/polygon.h"
 
 using Error = manifold::Manifold::Error;
 

--- a/src/geometry/manifold/manifoldutils.h
+++ b/src/geometry/manifold/manifoldutils.h
@@ -3,7 +3,7 @@
 #include "Geometry.h"
 #include "enums.h"
 #include "ManifoldGeometry.h"
-#include "manifold.h"
+#include "manifold/manifold.h"
 
 namespace ManifoldUtils {
 

--- a/src/io/libsvg/polygon.cc
+++ b/src/io/libsvg/polygon.cc
@@ -24,7 +24,7 @@
  */
 #include <boost/tokenizer.hpp>
 
-#include "polygon.h"
+#include "io/libsvg/polygon.h"
 #include "util.h"
 
 namespace libsvg {

--- a/src/io/libsvg/shape.cc
+++ b/src/io/libsvg/shape.cc
@@ -38,7 +38,7 @@
 #include "text.h"
 #include "tspan.h"
 #include "data.h"
-#include "polygon.h"
+#include "io/libsvg/polygon.h"
 #include "polyline.h"
 #include "rect.h"
 #include "svgpage.h"


### PR DESCRIPTION
That way, it is easier to see where the header is coming from (in particular it helps to disambiguate from the svg polygon header).

Also getting ready for whatever https://github.com/elalish/manifold/issues/701 will bring.