### PR TITLE
Fix a bunch of  `[misc-include-cleaner]` clang-tidy findings

### DIFF
--- a/src/Cache.h
+++ b/src/Cache.h
@@ -44,6 +44,7 @@
 
 #pragma once
 
+#include <cstddef>
 #include <unordered_map>
 #include "printutils.h"
 

--- a/src/FontCache.cc
+++ b/src/FontCache.cc
@@ -29,6 +29,7 @@
 
 #include <boost/filesystem.hpp>
 #include <boost/algorithm/string.hpp>
+#include <string>
 #include <utility>
 
 #include "FontCache.h"

--- a/src/FontCache.cc
+++ b/src/FontCache.cc
@@ -25,6 +25,7 @@
  */
 
 #include <iostream>
+#include <vector>
 
 #include <boost/filesystem.hpp>
 #include <boost/algorithm/string.hpp>

--- a/src/LibraryInfo.cc
+++ b/src/LibraryInfo.cc
@@ -1,5 +1,6 @@
 #include "LibraryInfo.h"
 #include <glib.h>
+#include <string>
 #include <vector>
 
 #include "version_check.h"

--- a/src/RenderStatistic.cc
+++ b/src/RenderStatistic.cc
@@ -26,6 +26,7 @@
 
 #include <fstream>
 #include <json.hpp>
+#include <vector>
 
 #include "printutils.h"
 #include "GeometryCache.h"
@@ -289,7 +290,7 @@ void LogVisitor::visit(const ManifoldGeometry& mani_geom)
 {
   LOG("   Top level object is a 3D object (manifold):");
   auto &mani = mani_geom.getManifold();
-  
+
   LOG("   Status:     %1$s", ManifoldUtils::statusToString(mani.Status()));
   LOG("   Genus:      %1$d", mani.Genus());
   LOG("   Vertices:   %1$6d", mani.NumVert());

--- a/src/RenderStatistic.cc
+++ b/src/RenderStatistic.cc
@@ -26,6 +26,7 @@
 
 #include <fstream>
 #include <json.hpp>
+#include <string>
 #include <vector>
 
 #include "printutils.h"

--- a/src/RenderStatistic.h
+++ b/src/RenderStatistic.h
@@ -26,6 +26,8 @@
 #pragma once
 
 #include <chrono>
+#include <vector>
+
 #include "Camera.h"
 #include "Geometry.h"
 

--- a/src/RenderStatistic.h
+++ b/src/RenderStatistic.h
@@ -26,6 +26,7 @@
 #pragma once
 
 #include <chrono>
+#include <string>
 #include <vector>
 
 #include "Camera.h"

--- a/src/core/AST.cc
+++ b/src/core/AST.cc
@@ -1,5 +1,6 @@
 #include "AST.h"
 #include <sstream>
+#include <string>
 #include "boost-utils.h"
 
 const Location Location::NONE(0, 0, 0, 0, std::make_shared<fs::path>(fs::path{}));

--- a/src/core/Arguments.h
+++ b/src/core/Arguments.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <ostream>
+#include <string>
 #include <utility>
 #include <vector>
 #include <boost/optional.hpp>

--- a/src/core/Assignment.cc
+++ b/src/core/Assignment.cc
@@ -28,6 +28,7 @@
 #include "Annotation.h"
 #include "Expression.h"
 #include <sstream>
+#include <string>
 
 void Assignment::addAnnotations(AnnotationList *annotations)
 {

--- a/src/core/Builtins.cc
+++ b/src/core/Builtins.cc
@@ -1,3 +1,5 @@
+#include <vector>
+
 #include "Builtins.h"
 #include "function.h"
 #include "module.h"

--- a/src/core/Builtins.cc
+++ b/src/core/Builtins.cc
@@ -1,3 +1,4 @@
+#include <string>
 #include <vector>
 
 #include "Builtins.h"

--- a/src/core/Builtins.h
+++ b/src/core/Builtins.h
@@ -2,6 +2,7 @@
 
 #include <string>
 #include <unordered_map>
+#include <vector>
 #include "module.h"
 #include "Assignment.h"
 

--- a/src/core/CSGNode.cc
+++ b/src/core/CSGNode.cc
@@ -28,6 +28,7 @@
 #include "PolySet.h"
 #include "linalg.h"
 
+#include <cstddef>
 #include <numeric>
 #include <sstream>
 #include <stack>

--- a/src/core/CSGNode.h
+++ b/src/core/CSGNode.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <cstddef>
 #include <string>
 #include <vector>
 #include <memory>

--- a/src/core/CgalAdvNode.h
+++ b/src/core/CgalAdvNode.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <string>
+
 #include "node.h"
 #include "linalg.h"
 

--- a/src/core/Children.cc
+++ b/src/core/Children.cc
@@ -25,6 +25,7 @@
  */
 
 #include <cstddef>
+#include <vector>
 
 #include "Children.h"
 #include "ScopeContext.h"

--- a/src/core/Children.cc
+++ b/src/core/Children.cc
@@ -24,6 +24,8 @@
  *
  */
 
+#include <cstddef>
+
 #include "Children.h"
 #include "ScopeContext.h"
 

--- a/src/core/Children.h
+++ b/src/core/Children.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <cstddef>
 #include <utility>
 #include <memory>
 

--- a/src/core/Children.h
+++ b/src/core/Children.h
@@ -3,6 +3,7 @@
 #include <cstddef>
 #include <utility>
 #include <memory>
+#include <vector>
 
 #include "Context.h"
 #include "LocalScope.h"

--- a/src/core/ColorNode.cc
+++ b/src/core/ColorNode.cc
@@ -34,6 +34,7 @@
 #include <cctype>
 #include <cstddef>
 #include <sstream>
+#include <string>
 #include <iterator>
 #include <unordered_map>
 #include <boost/algorithm/string/case_conv.hpp>

--- a/src/core/ColorNode.cc
+++ b/src/core/ColorNode.cc
@@ -32,6 +32,7 @@
 #include "Parameters.h"
 #include "printutils.h"
 #include <cctype>
+#include <cstddef>
 #include <sstream>
 #include <iterator>
 #include <unordered_map>

--- a/src/core/ColorNode.h
+++ b/src/core/ColorNode.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <string>
+
 #include "node.h"
 #include "linalg.h"
 

--- a/src/core/Context.cc
+++ b/src/core/Context.cc
@@ -25,6 +25,7 @@
  */
 
 #include <cstddef>
+#include <string>
 #include <vector>
 
 #include "Context.h"

--- a/src/core/Context.cc
+++ b/src/core/Context.cc
@@ -24,6 +24,8 @@
  *
  */
 
+#include <cstddef>
+
 #include "Context.h"
 #include "function.h"
 #include "printutils.h"

--- a/src/core/Context.cc
+++ b/src/core/Context.cc
@@ -25,6 +25,7 @@
  */
 
 #include <cstddef>
+#include <vector>
 
 #include "Context.h"
 #include "function.h"

--- a/src/core/Context.h
+++ b/src/core/Context.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <cstddef>
+#include <vector>
 
 #include "ContextFrame.h"
 #include "ContextMemoryManager.h"

--- a/src/core/Context.h
+++ b/src/core/Context.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <cstddef>
+
 #include "ContextFrame.h"
 #include "ContextMemoryManager.h"
 

--- a/src/core/Context.h
+++ b/src/core/Context.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <cstddef>
+#include <string>
 #include <vector>
 
 #include "ContextFrame.h"

--- a/src/core/ContextFrame.cc
+++ b/src/core/ContextFrame.cc
@@ -24,6 +24,8 @@
  *
  */
 
+#include <cstddef>
+
 #include "ContextFrame.h"
 
 ContextFrame::ContextFrame(EvaluationSession *session) :

--- a/src/core/ContextFrame.cc
+++ b/src/core/ContextFrame.cc
@@ -25,6 +25,7 @@
  */
 
 #include <cstddef>
+#include <string>
 #include <vector>
 
 #include "ContextFrame.h"

--- a/src/core/ContextFrame.cc
+++ b/src/core/ContextFrame.cc
@@ -25,6 +25,7 @@
  */
 
 #include <cstddef>
+#include <vector>
 
 #include "ContextFrame.h"
 

--- a/src/core/ContextFrame.h
+++ b/src/core/ContextFrame.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <cstddef>
+#include <vector>
 
 #include "EvaluationSession.h"
 #include "ValueMap.h"

--- a/src/core/ContextFrame.h
+++ b/src/core/ContextFrame.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <cstddef>
+
 #include "EvaluationSession.h"
 #include "ValueMap.h"
 

--- a/src/core/ContextFrame.h
+++ b/src/core/ContextFrame.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <cstddef>
+#include <string>
 #include <vector>
 
 #include "EvaluationSession.h"

--- a/src/core/ContextMemoryManager.cc
+++ b/src/core/ContextMemoryManager.cc
@@ -27,6 +27,7 @@
 #include <deque>
 #include <map>
 #include <unordered_set>
+#include <vector>
 
 #include "Context.h"
 #include "ContextMemoryManager.h"

--- a/src/core/ContextMemoryManager.h
+++ b/src/core/ContextMemoryManager.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <cstddef>
 #include <memory>
 #include <vector>
 

--- a/src/core/CsgOpNode.cc
+++ b/src/core/CsgOpNode.cc
@@ -31,7 +31,9 @@
 #include "Builtins.h"
 #include "Children.h"
 #include "Parameters.h"
+
 #include <sstream>
+#include <string>
 #include <cassert>
 
 static std::shared_ptr<AbstractNode> builtin_union(const ModuleInstantiation *inst, Arguments arguments, const Children& children)
@@ -92,4 +94,3 @@ void register_builtin_csgops()
     "intersection()",
   });
 }
-

--- a/src/core/CsgOpNode.h
+++ b/src/core/CsgOpNode.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <string>
+
 #include "node.h"
 #include "enums.h"
 

--- a/src/core/DrawingCallback.cc
+++ b/src/core/DrawingCallback.cc
@@ -23,10 +23,10 @@
  *  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
  *
  */
-#include <cmath>
-
-#include <iostream>
 #include <algorithm>
+#include <cmath>
+#include <iostream>
+#include <vector>
 
 #include "Polygon2d.h"
 #include "DrawingCallback.h"
@@ -43,7 +43,7 @@ DrawingCallback::~DrawingCallback()
 void DrawingCallback::start_glyph()
 {
   this->polygon = std::make_shared<Polygon2d>();
-  // FIXME: Why do we think that a glyph is sanitized? 
+  // FIXME: Why do we think that a glyph is sanitized?
   this->polygon->setSanitized(true);
 }
 

--- a/src/core/EvaluationSession.cc
+++ b/src/core/EvaluationSession.cc
@@ -25,6 +25,8 @@
  */
 
 #include <cstddef>
+#include <string>
+
 #include "ContextFrame.h"
 #include "EvaluationSession.h"
 #include "printutils.h"

--- a/src/core/EvaluationSession.cc
+++ b/src/core/EvaluationSession.cc
@@ -24,6 +24,7 @@
  *
  */
 
+#include <cstddef>
 #include "ContextFrame.h"
 #include "EvaluationSession.h"
 #include "printutils.h"

--- a/src/core/EvaluationSession.h
+++ b/src/core/EvaluationSession.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <cstddef>
 #include <string>
 #include <utility>
 #include <vector>

--- a/src/core/Expression.cc
+++ b/src/core/Expression.cc
@@ -29,6 +29,7 @@
 #include <cstdint>
 #include <cmath>
 #include <cassert>
+#include <cstddef>
 #include <memory>
 #include <sstream>
 #include <algorithm>

--- a/src/core/Expression.h
+++ b/src/core/Expression.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <cstddef>
 #include <functional>
 #include <string>
 #include <variant>

--- a/src/core/FreetypeRenderer.cc
+++ b/src/core/FreetypeRenderer.cc
@@ -25,6 +25,7 @@
  */
 #include <cmath>
 #include <cstdio>
+#include <vector>
 
 #include <iostream>
 

--- a/src/core/ImportNode.h
+++ b/src/core/ImportNode.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <string>
 #include <boost/optional.hpp>
 
 #include "node.h"

--- a/src/core/LinearExtrudeNode.h
+++ b/src/core/LinearExtrudeNode.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <string>
+
 #include "node.h"
 #include "Value.h"
 #include "linalg.h"

--- a/src/core/LocalScope.cc
+++ b/src/core/LocalScope.cc
@@ -1,4 +1,5 @@
 #include <cstddef>
+#include <vector>
 
 #include "Assignment.h"
 #include "LocalScope.h"

--- a/src/core/LocalScope.cc
+++ b/src/core/LocalScope.cc
@@ -1,4 +1,5 @@
 #include <cstddef>
+#include <string>
 #include <vector>
 
 #include "Assignment.h"

--- a/src/core/LocalScope.cc
+++ b/src/core/LocalScope.cc
@@ -1,3 +1,5 @@
+#include <cstddef>
+
 #include "Assignment.h"
 #include "LocalScope.h"
 #include "ModuleInstantiation.h"

--- a/src/core/LocalScope.h
+++ b/src/core/LocalScope.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "Assignment.h"
+#include <cstddef>
 #include <unordered_map>
 #include <memory>
 

--- a/src/core/LocalScope.h
+++ b/src/core/LocalScope.h
@@ -4,6 +4,7 @@
 #include <cstddef>
 #include <unordered_map>
 #include <memory>
+#include <vector>
 
 class AbstractNode;
 class Context;

--- a/src/core/LocalScope.h
+++ b/src/core/LocalScope.h
@@ -4,6 +4,7 @@
 #include <cstddef>
 #include <unordered_map>
 #include <memory>
+#include <string>
 #include <vector>
 
 class AbstractNode;

--- a/src/core/ModuleInstantiation.cc
+++ b/src/core/ModuleInstantiation.cc
@@ -1,4 +1,5 @@
 #include <cstddef>
+#include <string>
 
 #include "compiler_specific.h"
 #include "Context.h"

--- a/src/core/ModuleInstantiation.cc
+++ b/src/core/ModuleInstantiation.cc
@@ -1,3 +1,5 @@
+#include <cstddef>
+
 #include "compiler_specific.h"
 #include "Context.h"
 #include "ModuleInstantiation.h"

--- a/src/core/ModuleInstantiation.h
+++ b/src/core/ModuleInstantiation.h
@@ -2,7 +2,7 @@
 
 #include "AST.h"
 #include "LocalScope.h"
-#include <utility>
+#include <string>
 #include <utility>
 #include <vector>
 

--- a/src/core/NodeCache.h
+++ b/src/core/NodeCache.h
@@ -3,6 +3,8 @@
 #include <string>
 #include <unordered_map>
 #include <cassert>
+#include <cstddef>
+
 #include "node.h"
 #include "printutils.h"
 

--- a/src/core/OffsetNode.h
+++ b/src/core/OffsetNode.h
@@ -3,6 +3,8 @@
 #include "node.h"
 #include "ext/polyclipping/clipper.hpp"
 
+#include <string>
+
 class OffsetNode : public AbstractPolyNode
 {
 public:

--- a/src/core/Parameters.cc
+++ b/src/core/Parameters.cc
@@ -27,6 +27,7 @@
 #include <cstddef>
 #include <set>
 #include <utility>
+#include <vector>
 
 #include "Expression.h"
 #include "Parameters.h"

--- a/src/core/Parameters.cc
+++ b/src/core/Parameters.cc
@@ -26,6 +26,7 @@
 
 #include <cstddef>
 #include <set>
+#include <string>
 #include <utility>
 #include <vector>
 

--- a/src/core/Parameters.cc
+++ b/src/core/Parameters.cc
@@ -24,6 +24,7 @@
  *
  */
 
+#include <cstddef>
 #include <set>
 #include <utility>
 

--- a/src/core/RangeType.h
+++ b/src/core/RangeType.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <cstdint>
 #include <ostream>
 #include <cmath>
 

--- a/src/core/RotateExtrudeNode.h
+++ b/src/core/RotateExtrudeNode.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <string>
+
 #include "node.h"
 #include "Value.h"
 

--- a/src/core/ScopeContext.cc
+++ b/src/core/ScopeContext.cc
@@ -4,7 +4,9 @@
 #include "printutils.h"
 #include "SourceFileCache.h"
 #include "UserModule.h"
+
 #include <cmath>
+#include <vector>
 
 // Experimental code. See issue #399
 #if 0

--- a/src/core/ScopeContext.h
+++ b/src/core/ScopeContext.h
@@ -1,6 +1,8 @@
 #pragma once
 
 #include <memory>
+#include <vector>
+
 #include "Arguments.h"
 #include "Children.h"
 #include "Context.h"

--- a/src/core/ScopeContext.h
+++ b/src/core/ScopeContext.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <memory>
+#include <string>
 #include <vector>
 
 #include "Arguments.h"

--- a/src/core/SourceFile.cc
+++ b/src/core/SourceFile.cc
@@ -35,6 +35,8 @@
 #include <boost/algorithm/string.hpp>
 #include <boost/filesystem.hpp>
 #include <utility>
+#include <vector>
+
 namespace fs = boost::filesystem;
 #include "FontCache.h"
 #include <sys/stat.h>

--- a/src/core/SourceFile.cc
+++ b/src/core/SourceFile.cc
@@ -34,6 +34,7 @@
 #include "StatCache.h"
 #include <boost/algorithm/string.hpp>
 #include <boost/filesystem.hpp>
+#include <string>
 #include <utility>
 #include <vector>
 

--- a/src/core/SourceFile.h
+++ b/src/core/SourceFile.h
@@ -4,6 +4,7 @@
 #include <unordered_map>
 #include <unordered_set>
 #include <ctime>
+#include <vector>
 
 #include "module.h"
 #include "LocalScope.h"

--- a/src/core/SourceFileCache.cc
+++ b/src/core/SourceFileCache.cc
@@ -7,6 +7,7 @@
 
 #include <cstdio>
 #include <fstream>
+#include <string>
 #include <sys/stat.h>
 #include <algorithm>
 

--- a/src/core/SurfaceNode.cc
+++ b/src/core/SurfaceNode.cc
@@ -42,7 +42,9 @@
 #include <cstddef>
 #include <sstream>
 #include <fstream>
+#include <vector>
 #include <unordered_map>
+
 #include <boost/functional/hash.hpp>
 #include <boost/tokenizer.hpp>
 #include <boost/lexical_cast.hpp>

--- a/src/core/SurfaceNode.cc
+++ b/src/core/SurfaceNode.cc
@@ -39,6 +39,7 @@
 #include "SurfaceNode.h"
 
 #include <cstdint>
+#include <cstddef>
 #include <sstream>
 #include <fstream>
 #include <unordered_map>

--- a/src/core/SurfaceNode.h
+++ b/src/core/SurfaceNode.h
@@ -24,6 +24,7 @@
  *
  */
 
+#include <cstddef>
 #include "node.h"
 
 struct img_data_t
@@ -72,4 +73,3 @@ private:
   img_data_t read_dat(std::string filename) const;
   img_data_t read_png_or_dat(std::string filename) const;
 };
-

--- a/src/core/SurfaceNode.h
+++ b/src/core/SurfaceNode.h
@@ -25,6 +25,7 @@
  */
 
 #include <cstddef>
+#include <string>
 #include <vector>
 
 #include "node.h"

--- a/src/core/SurfaceNode.h
+++ b/src/core/SurfaceNode.h
@@ -25,6 +25,8 @@
  */
 
 #include <cstddef>
+#include <vector>
+
 #include "node.h"
 
 struct img_data_t

--- a/src/core/TextNode.cc
+++ b/src/core/TextNode.cc
@@ -24,6 +24,8 @@
  *
  */
 
+#include <vector>
+
 #include "Children.h"
 #include "module.h"
 #include "ModuleInstantiation.h"

--- a/src/core/TextNode.h
+++ b/src/core/TextNode.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <vector>
+
 #include "node.h"
 #include "FreetypeRenderer.h"
 

--- a/src/core/TextNode.h
+++ b/src/core/TextNode.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <string>
 #include <vector>
 
 #include "node.h"

--- a/src/core/TransformNode.cc
+++ b/src/core/TransformNode.cc
@@ -32,6 +32,7 @@
 #include "Parameters.h"
 #include "printutils.h"
 #include "degree_trig.h"
+#include <cstddef>
 #include <sstream>
 #include <utility>
 #include <vector>

--- a/src/core/TransformNode.h
+++ b/src/core/TransformNode.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <string>
+
 #include "node.h"
 #include "linalg.h"
 

--- a/src/core/Tree.cc
+++ b/src/core/Tree.cc
@@ -4,6 +4,7 @@
 #include <cassert>
 #include <algorithm>
 #include <sstream>
+#include <string>
 #include <tuple>
 
 Tree::~Tree()

--- a/src/core/Tree.h
+++ b/src/core/Tree.h
@@ -2,6 +2,7 @@
 
 #include "NodeCache.h"
 #include <map>
+#include <string>
 #include <utility>
 
 /*!

--- a/src/core/UndefType.h
+++ b/src/core/UndefType.h
@@ -3,6 +3,7 @@
 #include <memory>
 #include <ostream>
 #include <sstream>
+#include <string>
 #include <vector>
 
 class Value;

--- a/src/core/UndefType.h
+++ b/src/core/UndefType.h
@@ -1,7 +1,9 @@
 #pragma once
 
+#include <memory>
 #include <ostream>
 #include <sstream>
+#include <vector>
 
 class Value;
 

--- a/src/core/UserModule.cc
+++ b/src/core/UserModule.cc
@@ -37,6 +37,7 @@
 #include "compiler_specific.h"
 #include <cstddef>
 #include <sstream>
+#include <string>
 
 std::vector<std::string> StaticModuleNameStack::stack;
 

--- a/src/core/UserModule.cc
+++ b/src/core/UserModule.cc
@@ -33,6 +33,7 @@
 #include "Expression.h"
 #include "printutils.h"
 #include "compiler_specific.h"
+#include <cstddef>
 #include <sstream>
 
 std::vector<std::string> StaticModuleNameStack::stack;

--- a/src/core/UserModule.cc
+++ b/src/core/UserModule.cc
@@ -24,6 +24,8 @@
  *
  */
 
+#include <vector>
+
 #include "UserModule.h"
 #include "ModuleInstantiation.h"
 #include "core/node.h"

--- a/src/core/Value.cc
+++ b/src/core/Value.cc
@@ -25,6 +25,7 @@
  */
 
 #include <cassert>
+#include <cstddef>
 #include <memory>
 #include <numeric>
 #include <sstream>

--- a/src/core/Value.cc
+++ b/src/core/Value.cc
@@ -29,6 +29,7 @@
 #include <memory>
 #include <numeric>
 #include <sstream>
+#include <string>
 #include <vector>
 #include <boost/lexical_cast.hpp>
 

--- a/src/core/Value.cc
+++ b/src/core/Value.cc
@@ -29,6 +29,7 @@
 #include <memory>
 #include <numeric>
 #include <sstream>
+#include <vector>
 #include <boost/lexical_cast.hpp>
 
 #include "Value.h"

--- a/src/core/Value.h
+++ b/src/core/Value.h
@@ -5,6 +5,7 @@
 #include <string>
 #include <algorithm>
 #include <cstdint>
+#include <cstddef>
 #include <limits>
 #include <ostream>
 #include <memory>

--- a/src/core/ValueMap.h
+++ b/src/core/ValueMap.h
@@ -1,5 +1,7 @@
 #pragma once
 #include "Value.h"
+
+#include <cstddef>
 #include <utility>
 #include <unordered_map>
 

--- a/src/core/ValueMap.h
+++ b/src/core/ValueMap.h
@@ -2,6 +2,7 @@
 #include "Value.h"
 
 #include <cstddef>
+#include <string>
 #include <utility>
 #include <unordered_map>
 

--- a/src/core/builtin_functions.cc
+++ b/src/core/builtin_functions.cc
@@ -42,6 +42,7 @@
 #include <limits>
 #include <algorithm>
 #include <random>
+#include <vector>
 
 #include "boost-utils.h"
 // hash double

--- a/src/core/control.cc
+++ b/src/core/control.cc
@@ -25,6 +25,8 @@
  */
 
 #include <cstddef>
+#include <vector>
+
 #include "module.h"
 #include "ModuleInstantiation.h"
 #include "core/node.h"

--- a/src/core/control.cc
+++ b/src/core/control.cc
@@ -24,6 +24,7 @@
  *
  */
 
+#include <cstddef>
 #include "module.h"
 #include "ModuleInstantiation.h"
 #include "core/node.h"

--- a/src/core/customizer/Annotation.cc
+++ b/src/core/customizer/Annotation.cc
@@ -27,7 +27,9 @@
 
 #include "Annotation.h"
 
+#include <string>
 #include <utility>
+
 #include "Expression.h"
 
 Annotation::Annotation(std::string name, std::shared_ptr<Expression> expr)

--- a/src/core/customizer/CommentParser.cc
+++ b/src/core/customizer/CommentParser.cc
@@ -1,3 +1,5 @@
+#include <cstddef>
+
 #include "CommentParser.h"
 #include "Expression.h"
 #include "Annotation.h"

--- a/src/core/customizer/CommentParser.h
+++ b/src/core/customizer/CommentParser.h
@@ -1,6 +1,8 @@
 #pragma once
 
 #include <memory>
+#include <string>
+
 #include "SourceFile.h"
 
 namespace CommentParser {

--- a/src/core/customizer/ParameterObject.cc
+++ b/src/core/customizer/ParameterObject.cc
@@ -6,6 +6,7 @@
 
 #include <cstddef>
 #include <sstream>
+#include <string>
 #include <vector>
 #include <boost/algorithm/string.hpp>
 

--- a/src/core/customizer/ParameterObject.cc
+++ b/src/core/customizer/ParameterObject.cc
@@ -6,6 +6,7 @@
 
 #include <cstddef>
 #include <sstream>
+#include <vector>
 #include <boost/algorithm/string.hpp>
 
 namespace {

--- a/src/core/customizer/ParameterObject.cc
+++ b/src/core/customizer/ParameterObject.cc
@@ -4,6 +4,7 @@
 #include "SourceFile.h"
 #include "ParameterObject.h"
 
+#include <cstddef>
 #include <sstream>
 #include <boost/algorithm/string.hpp>
 

--- a/src/core/customizer/ParameterObject.h
+++ b/src/core/customizer/ParameterObject.h
@@ -4,6 +4,7 @@
 #include <json.hpp>
 #include <utility>
 #include <variant>
+#include <vector>
 
 #include "ParameterSet.h"
 using json = nlohmann::json;

--- a/src/core/customizer/ParameterObject.h
+++ b/src/core/customizer/ParameterObject.h
@@ -2,6 +2,7 @@
 
 #include <cstddef>
 #include <json.hpp>
+#include <string>
 #include <utility>
 #include <variant>
 #include <vector>

--- a/src/core/customizer/ParameterObject.h
+++ b/src/core/customizer/ParameterObject.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <cstddef>
 #include <json.hpp>
 #include <utility>
 #include <variant>

--- a/src/core/customizer/ParameterSet.cc
+++ b/src/core/customizer/ParameterSet.cc
@@ -2,6 +2,8 @@
 #include "printutils.h"
 #include <boost/property_tree/json_parser.hpp>
 
+#include <string>
+
 static std::string parameterSetsKey("parameterSets");
 static std::string fileFormatVersionKey("fileFormatVersion");
 static std::string fileFormatVersionValue("1");

--- a/src/core/customizer/ParameterSet.h
+++ b/src/core/customizer/ParameterSet.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <map>
+#include <string>
 #include <vector>
 #include <boost/property_tree/ptree.hpp>
 

--- a/src/core/function.cc
+++ b/src/core/function.cc
@@ -28,6 +28,7 @@
 #include "Expression.h"
 #include "function.h"
 
+#include <cstddef>
 #include <utility>
 
 BuiltinFunction::BuiltinFunction(Value(*f)(const std::shared_ptr<const Context>&, const FunctionCall *), const Feature *feature) :

--- a/src/core/node.cc
+++ b/src/core/node.cc
@@ -32,6 +32,7 @@
 #include <functional>
 #include <iostream>
 #include <algorithm>
+#include <string>
 
 size_t AbstractNode::idx_counter;
 

--- a/src/core/node.cc
+++ b/src/core/node.cc
@@ -27,6 +27,8 @@
 #include "core/node.h"
 #include "ModuleInstantiation.h"
 #include "progress.h"
+
+#include <cstddef>
 #include <functional>
 #include <iostream>
 #include <algorithm>

--- a/src/core/node.h
+++ b/src/core/node.h
@@ -1,10 +1,12 @@
 #pragma once
 
+#include <cstddef>
 #include <utility>
 #include <utility>
 #include <vector>
 #include <string>
 #include <deque>
+
 #include "BaseVisitable.h"
 #include "AST.h"
 #include "ModuleInstantiation.h"

--- a/src/core/parsersettings.cc
+++ b/src/core/parsersettings.cc
@@ -1,3 +1,4 @@
+#include <string>
 #include <vector>
 
 #include "parsersettings.h"

--- a/src/core/parsersettings.cc
+++ b/src/core/parsersettings.cc
@@ -1,3 +1,5 @@
+#include <vector>
+
 #include "parsersettings.h"
 #include <boost/filesystem.hpp>
 #include <boost/algorithm/string.hpp>

--- a/src/core/primitives.cc
+++ b/src/core/primitives.cc
@@ -43,6 +43,7 @@
 #include <iterator>
 #include <memory>
 #include <sstream>
+#include <string>
 #include <vector>
 
 using namespace boost::assign; // bring 'operator+=()' into scope

--- a/src/core/primitives.cc
+++ b/src/core/primitives.cc
@@ -43,6 +43,8 @@
 #include <iterator>
 #include <memory>
 #include <sstream>
+#include <vector>
+
 using namespace boost::assign; // bring 'operator+=()' into scope
 
 #define F_MINIMUM 0.01
@@ -280,7 +282,7 @@ std::unique_ptr<const Geometry> CylinderNode::createGeometry() const
 
   bool cone = (r2 == 0.0);
   bool inverted_cone = (r1 == 0.0);
-  
+
   auto polyset = std::make_unique<PolySet>(3, /*convex*/true);
   polyset->vertices.reserve((cone || inverted_cone) ? num_fragments + 1 : 2 * num_fragments);
 

--- a/src/core/primitives.cc
+++ b/src/core/primitives.cc
@@ -38,6 +38,7 @@
 #include "printutils.h"
 #include <boost/assign/std/vector.hpp>
 #include <cassert>
+#include <cstddef>
 #include <cmath>
 #include <iterator>
 #include <memory>

--- a/src/core/primitives.h
+++ b/src/core/primitives.h
@@ -30,7 +30,7 @@
 
 #include <cstddef>
 #include <sstream>
-
+#include <vector>
 
 class CubeNode : public LeafNode
 {

--- a/src/core/primitives.h
+++ b/src/core/primitives.h
@@ -30,6 +30,7 @@
 
 #include <cstddef>
 #include <sstream>
+#include <string>
 #include <vector>
 
 class CubeNode : public LeafNode

--- a/src/core/primitives.h
+++ b/src/core/primitives.h
@@ -27,6 +27,8 @@
 #include "GeometryUtils.h"
 #include "linalg.h"
 #include "node.h"
+
+#include <cstddef>
 #include <sstream>
 
 
@@ -172,4 +174,3 @@ public:
   std::vector<std::vector<size_t>> paths;
   int convexity = 1;
 };
-

--- a/src/core/str_utf8_wrapper.h
+++ b/src/core/str_utf8_wrapper.h
@@ -1,6 +1,8 @@
 #pragma once
 
+#include <cstddef>
 #include <memory>
+#include <string>
 
 #include <glib.h>
 

--- a/src/geometry/ClipperUtils.cc
+++ b/src/geometry/ClipperUtils.cc
@@ -1,5 +1,6 @@
 #include "ClipperUtils.h"
 #include "printutils.h"
+#include <cstddef>
 
 namespace ClipperUtils {
 

--- a/src/geometry/ClipperUtils.cc
+++ b/src/geometry/ClipperUtils.cc
@@ -1,6 +1,8 @@
 #include "ClipperUtils.h"
 #include "printutils.h"
+
 #include <cstddef>
+#include <vector>
 
 namespace ClipperUtils {
 

--- a/src/geometry/ClipperUtils.h
+++ b/src/geometry/ClipperUtils.h
@@ -3,6 +3,8 @@
 #include "ext/polyclipping/clipper.hpp"
 #include "Polygon2d.h"
 
+#include <vector>
+
 namespace ClipperUtils {
 
 template <typename T>

--- a/src/geometry/Geometry.cc
+++ b/src/geometry/Geometry.cc
@@ -1,6 +1,7 @@
 #include "Geometry.h"
 #include "printutils.h"
 #include <boost/foreach.hpp>
+#include <cstddef>
 #include <utility>
 
 GeometryList::GeometryList(Geometry::Geometries geometries) : children(std::move(geometries))

--- a/src/geometry/Geometry.cc
+++ b/src/geometry/Geometry.cc
@@ -2,6 +2,7 @@
 #include "printutils.h"
 #include <boost/foreach.hpp>
 #include <cstddef>
+#include <string>
 #include <utility>
 
 GeometryList::GeometryList(Geometry::Geometries geometries) : children(std::move(geometries))

--- a/src/geometry/GeometryCache.cc
+++ b/src/geometry/GeometryCache.cc
@@ -1,7 +1,9 @@
 #include "GeometryCache.h"
 #include "printutils.h"
 #include "Geometry.h"
+
 #include <cstddef>
+#include <string>
 
 #ifdef ENABLE_CGAL
 #include "CGAL_Nef_polyhedron.h"

--- a/src/geometry/GeometryCache.cc
+++ b/src/geometry/GeometryCache.cc
@@ -1,6 +1,7 @@
 #include "GeometryCache.h"
 #include "printutils.h"
 #include "Geometry.h"
+#include <cstddef>
 
 #ifdef ENABLE_CGAL
 #include "CGAL_Nef_polyhedron.h"

--- a/src/geometry/GeometryCache.h
+++ b/src/geometry/GeometryCache.h
@@ -3,6 +3,7 @@
 #include "Cache.h"
 #include <memory>
 #include "Geometry.h"
+#include <cstddef>
 
 class GeometryCache
 {

--- a/src/geometry/GeometryCache.h
+++ b/src/geometry/GeometryCache.h
@@ -1,9 +1,11 @@
 #pragma once
 
-#include "Cache.h"
-#include <memory>
-#include "Geometry.h"
 #include <cstddef>
+#include <memory>
+#include <string>
+
+#include "Cache.h"
+#include "Geometry.h"
 
 class GeometryCache
 {

--- a/src/geometry/GeometryEvaluator.cc
+++ b/src/geometry/GeometryEvaluator.cc
@@ -42,6 +42,8 @@
 #endif
 #include "linear_extrude.h"
 
+#include <cstddef>
+
 class Geometry;
 class Polygon2d;
 class Tree;

--- a/src/geometry/GeometryEvaluator.cc
+++ b/src/geometry/GeometryEvaluator.cc
@@ -43,6 +43,7 @@
 #include "linear_extrude.h"
 
 #include <cstddef>
+#include <vector>
 
 class Geometry;
 class Polygon2d;
@@ -898,7 +899,7 @@ static std::unique_ptr<Geometry> rotatePolygon(const RotateExtrudeNode& node, co
                 rings[j % 2][(i + 1) % o.vertices.size()],
                 rings[(j + 1) % 2][(i + 1) % o.vertices.size()],
                 rings[j % 2][i]
-        });                
+        });
 
         builder.appendPolygon({
                 rings[(j + 1) % 2][(i + 1) % o.vertices.size()],

--- a/src/geometry/GeometryUtils.cc
+++ b/src/geometry/GeometryUtils.cc
@@ -1,9 +1,10 @@
 #include "GeometryUtils.h"
 
-#include <string>
+#include <boost/functional/hash.hpp>
+#include <cstddef>
 #include <cmath>
 #include <memory>
-#include <boost/functional/hash.hpp>
+#include <string>
 
 #include "ext/libtess2/Include/tesselator.h"
 #include "printutils.h"

--- a/src/geometry/GeometryUtils.cc
+++ b/src/geometry/GeometryUtils.cc
@@ -5,6 +5,7 @@
 #include <cmath>
 #include <memory>
 #include <string>
+#include <vector>
 
 #include "ext/libtess2/Include/tesselator.h"
 #include "printutils.h"

--- a/src/geometry/PolySet.cc
+++ b/src/geometry/PolySet.cc
@@ -31,6 +31,7 @@
 #include "Grid.h"
 #include <Eigen/LU>
 #include <cstddef>
+#include <string>
 #include <utility>
 #include <vector>
 

--- a/src/geometry/PolySet.cc
+++ b/src/geometry/PolySet.cc
@@ -32,6 +32,7 @@
 #include <Eigen/LU>
 #include <cstddef>
 #include <utility>
+#include <vector>
 
 /*! /class PolySet
 
@@ -97,7 +98,7 @@ void PolySet::transform(const Transform3d& mat)
   // If mirroring transform, flip faces to avoid the object to end up being inside-out
   bool mirrored = mat.matrix().determinant() < 0;
 
-  for (auto& v : this->vertices) 
+  for (auto& v : this->vertices)
       v = mat * v;
 
   if(mirrored)

--- a/src/geometry/PolySet.cc
+++ b/src/geometry/PolySet.cc
@@ -30,6 +30,7 @@
 #include "printutils.h"
 #include "Grid.h"
 #include <Eigen/LU>
+#include <cstddef>
 #include <utility>
 
 /*! /class PolySet

--- a/src/geometry/PolySet.h
+++ b/src/geometry/PolySet.h
@@ -6,8 +6,10 @@
 #include "Polygon2d.h"
 #include "boost-utils.h"
 
-#include <vector>
+#include <cstddef>
 #include <string>
+#include <vector>
+
 class PolySetBuilder;
 
 class PolySet : public Geometry

--- a/src/geometry/PolySetBuilder.cc
+++ b/src/geometry/PolySetBuilder.cc
@@ -37,6 +37,8 @@
 #include "ManifoldGeometry.h"
 #endif
 
+#include <vector>
+
 PolySetBuilder::PolySetBuilder(int vertices_count, int indices_count, int dim, boost::tribool convex)
   : convex_(convex), dim_(dim)
 {
@@ -119,7 +121,7 @@ void PolySetBuilder::beginPolygon(int nvertices) {
 void PolySetBuilder::addVertex(int ind)
 {
   // Ignore consecutive duplicate indices
-  if (current_polygon_.empty() || 
+  if (current_polygon_.empty() ||
       ind != current_polygon_.back() && ind != current_polygon_.front()) {
     current_polygon_.push_back(ind);
   }

--- a/src/geometry/PolySetBuilder.h
+++ b/src/geometry/PolySetBuilder.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <memory>
+#include <vector>
 
 #include <Reindexer.h>
 #include "Polygon2d.h"

--- a/src/geometry/PolySetUtils.cc
+++ b/src/geometry/PolySetUtils.cc
@@ -1,5 +1,6 @@
 #include "PolySetUtils.h"
 
+#include <cstddef>
 #include <sstream>
 #include <boost/range/adaptor/reversed.hpp>
 

--- a/src/geometry/PolySetUtils.cc
+++ b/src/geometry/PolySetUtils.cc
@@ -2,6 +2,8 @@
 
 #include <cstddef>
 #include <sstream>
+#include <vector>
+
 #include <boost/range/adaptor/reversed.hpp>
 
 #include "PolySet.h"
@@ -29,7 +31,7 @@ std::unique_ptr<Polygon2d> project(const PolySet& ps) {
   for (const auto& p : ps.indices) {
     Outline2d outline;
     for (const auto& v : p) {
-      pt=ps.vertices[v];	    
+      pt=ps.vertices[v];
       outline.vertices.emplace_back(pt[0], pt[1]);
     }
     poly->addOutline(outline);

--- a/src/geometry/PolySetUtils.h
+++ b/src/geometry/PolySetUtils.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <string>
 #include <memory>
 
 #include "Geometry.h"

--- a/src/geometry/Polygon2d.cc
+++ b/src/geometry/Polygon2d.cc
@@ -1,6 +1,8 @@
 #include "Polygon2d.h"
 
+#include <cstddef>
 #include <memory>
+
 #include "printutils.h"
 #ifdef ENABLE_MANIFOLD
 #include "manifoldutils.h"

--- a/src/geometry/Polygon2d.cc
+++ b/src/geometry/Polygon2d.cc
@@ -1,6 +1,7 @@
 #include "Polygon2d.h"
 
 #include <cstddef>
+#include <string>
 #include <memory>
 
 #include "printutils.h"
@@ -166,9 +167,9 @@ double Polygon2d::area() const
    * Rendering (both preview and render mode)
    * Polygon area calculation
    *
-   * One use-case is special: For geometry construction in Manifold mode, we require this function to 
+   * One use-case is special: For geometry construction in Manifold mode, we require this function to
    * guarantee that vertices and their order are untouched (apart from adding a zero 3rd dimension)
-   * 
+   *
  */
 std::unique_ptr<PolySet> Polygon2d::tessellate() const
 {

--- a/src/geometry/Polygon2d.h
+++ b/src/geometry/Polygon2d.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <cstddef>
 #include <vector>
 #include "Geometry.h"
 #include "linalg.h"

--- a/src/geometry/Polygon2d.h
+++ b/src/geometry/Polygon2d.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <cstddef>
+#include <string>
 #include <vector>
 #include "Geometry.h"
 #include "linalg.h"

--- a/src/geometry/Reindexer.h
+++ b/src/geometry/Reindexer.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <cstddef>
 #include <unordered_map>
 #include <functional>
 #include <vector>

--- a/src/geometry/boolean_utils.cc
+++ b/src/geometry/boolean_utils.cc
@@ -1,6 +1,7 @@
 #include "boolean_utils.h"
 
 #include <cstddef>
+#include <vector>
 
 #ifdef ENABLE_CGAL
 #include "cgal.h"

--- a/src/geometry/boolean_utils.cc
+++ b/src/geometry/boolean_utils.cc
@@ -1,5 +1,7 @@
 #include "boolean_utils.h"
 
+#include <cstddef>
+
 #ifdef ENABLE_CGAL
 #include "cgal.h"
 #include "CGALHybridPolyhedron.h"

--- a/src/geometry/cgal/CGALCache.cc
+++ b/src/geometry/cgal/CGALCache.cc
@@ -1,3 +1,5 @@
+#include <cstddef>
+
 #include "CGALCache.h"
 #include "printutils.h"
 #include "CGAL_Nef_polyhedron.h"

--- a/src/geometry/cgal/CGALCache.cc
+++ b/src/geometry/cgal/CGALCache.cc
@@ -1,4 +1,5 @@
 #include <cstddef>
+#include <string>
 
 #include "CGALCache.h"
 #include "printutils.h"

--- a/src/geometry/cgal/CGALCache.h
+++ b/src/geometry/cgal/CGALCache.h
@@ -3,6 +3,7 @@
 #include "Cache.h"
 #include <cstddef>
 #include <memory>
+#include <string>
 #include "Geometry.h"
 
 class CGALCache

--- a/src/geometry/cgal/CGALCache.h
+++ b/src/geometry/cgal/CGALCache.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "Cache.h"
+#include <cstddef>
 #include <memory>
 #include "Geometry.h"
 

--- a/src/geometry/cgal/CGALHybridPolyhedron.h
+++ b/src/geometry/cgal/CGALHybridPolyhedron.h
@@ -2,6 +2,7 @@
 #pragma once
 
 #include <cstddef>
+#include <string>
 #include <variant>
 
 #include "cgal.h"

--- a/src/geometry/cgal/CGALHybridPolyhedron.h
+++ b/src/geometry/cgal/CGALHybridPolyhedron.h
@@ -1,6 +1,7 @@
 // Portions of this file are Copyright 2021 Google LLC, and licensed under GPL2+. See COPYING.
 #pragma once
 
+#include <cstddef>
 #include <variant>
 
 #include "cgal.h"

--- a/src/geometry/cgal/CGAL_Nef_polyhedron.cc
+++ b/src/geometry/cgal/CGAL_Nef_polyhedron.cc
@@ -1,4 +1,6 @@
 #include <cstddef>
+#include <string>
+
 #include "cgal.h"
 #include "CGAL_Nef_polyhedron.h"
 #include "cgalutils.h"

--- a/src/geometry/cgal/CGAL_Nef_polyhedron.cc
+++ b/src/geometry/cgal/CGAL_Nef_polyhedron.cc
@@ -1,3 +1,4 @@
+#include <cstddef>
 #include "cgal.h"
 #include "CGAL_Nef_polyhedron.h"
 #include "cgalutils.h"

--- a/src/geometry/cgal/CGAL_Nef_polyhedron.h
+++ b/src/geometry/cgal/CGAL_Nef_polyhedron.h
@@ -2,6 +2,7 @@
 
 #include "cgal.h"
 #include "Geometry.h"
+#include <cstddef>
 #include <memory>
 #include <string>
 #include <utility>

--- a/src/geometry/cgal/cgal.h
+++ b/src/geometry/cgal/cgal.h
@@ -15,6 +15,7 @@
    //*/
 
 #include "ext/CGAL/CGAL_workaround_Mark_bounded_volumes.h" // This file must be included prior to CGAL/Nef_polyhedron_3.h
+#include <vector>
 #include <CGAL/Gmpq.h>
 #include <CGAL/Extended_cartesian.h>
 #include <CGAL/Nef_polyhedron_2.h>

--- a/src/geometry/cgal/cgalutils-applyops-hybrid-minkowski.cc
+++ b/src/geometry/cgal/cgalutils-applyops-hybrid-minkowski.cc
@@ -20,6 +20,7 @@
 
 #include <CGAL/convex_hull_3.h>
 
+#include <cstddef>
 #include <memory>
 #include <map>
 #include <queue>
@@ -241,11 +242,3 @@ std::shared_ptr<const Geometry> applyMinkowskiHybrid(const Geometry::Geometries&
 
 
 #endif // ENABLE_CGAL
-
-
-
-
-
-
-
-

--- a/src/geometry/cgal/cgalutils-applyops-hybrid-minkowski.cc
+++ b/src/geometry/cgal/cgalutils-applyops-hybrid-minkowski.cc
@@ -25,6 +25,7 @@
 #include <map>
 #include <queue>
 #include <unordered_set>
+#include <vector>
 
 namespace CGALUtils {
 

--- a/src/geometry/cgal/cgalutils-applyops-hybrid.cc
+++ b/src/geometry/cgal/cgalutils-applyops-hybrid.cc
@@ -4,6 +4,8 @@
 #ifdef ENABLE_CGAL
 
 #include <cstddef>
+#include <vector>
+
 #include "cgalutils.h"
 #include "CGALHybridPolyhedron.h"
 #include "node.h"

--- a/src/geometry/cgal/cgalutils-applyops-hybrid.cc
+++ b/src/geometry/cgal/cgalutils-applyops-hybrid.cc
@@ -3,6 +3,7 @@
 
 #ifdef ENABLE_CGAL
 
+#include <cstddef>
 #include "cgalutils.h"
 #include "CGALHybridPolyhedron.h"
 #include "node.h"

--- a/src/geometry/cgal/cgalutils-applyops.cc
+++ b/src/geometry/cgal/cgalutils-applyops.cc
@@ -28,6 +28,7 @@
 #include "Reindexer.h"
 #include "GeometryUtils.h"
 
+#include <cstddef>
 #include <memory>
 #include <map>
 #include <queue>
@@ -156,11 +157,3 @@ std::shared_ptr<const Geometry> applyOperator3D(const Geometry::Geometries& chil
 
 
 #endif // ENABLE_CGAL
-
-
-
-
-
-
-
-

--- a/src/geometry/cgal/cgalutils-applyops.cc
+++ b/src/geometry/cgal/cgalutils-applyops.cc
@@ -33,6 +33,7 @@
 #include <map>
 #include <queue>
 #include <unordered_set>
+#include <vector>
 
 namespace CGALUtils {
 

--- a/src/geometry/cgal/cgalutils-coplanar-faces-remesher.h
+++ b/src/geometry/cgal/cgalutils-coplanar-faces-remesher.h
@@ -2,6 +2,7 @@
 #pragma once
 
 #include <CGAL/Surface_mesh.h>
+#include <cstddef>
 #include <unordered_map>
 #include <unordered_set>
 #include <vector>

--- a/src/geometry/cgal/cgalutils-corefinement-visitor.h
+++ b/src/geometry/cgal/cgalutils-corefinement-visitor.h
@@ -5,6 +5,7 @@
 #include "cgalutils-coplanar-faces-remesher.h"
 
 #include <cstddef>
+#include <vector>
 
 namespace CGALUtils {
 

--- a/src/geometry/cgal/cgalutils-corefinement-visitor.h
+++ b/src/geometry/cgal/cgalutils-corefinement-visitor.h
@@ -4,6 +4,8 @@
 #include <CGAL/Polygon_mesh_processing/corefinement.h>
 #include "cgalutils-coplanar-faces-remesher.h"
 
+#include <cstddef>
+
 namespace CGALUtils {
 
 namespace internal {

--- a/src/geometry/cgal/cgalutils-hybrid.cc
+++ b/src/geometry/cgal/cgalutils-hybrid.cc
@@ -8,6 +8,7 @@
 #include <CGAL/Polygon_mesh_processing/triangulate_faces.h>
 #include <CGAL/Surface_mesh.h>
 #include <CGAL/convex_hull_3.h>
+#include <cstddef>
 
 #include "CGAL_Nef_polyhedron.h"
 #include "PolySetUtils.h"
@@ -148,4 +149,3 @@ std::shared_ptr<CGAL_Nef_polyhedron> createNefPolyhedronFromHybrid(const CGALHyb
 }
 
 } // namespace CGALUtils
-

--- a/src/geometry/cgal/cgalutils-hybrid.cc
+++ b/src/geometry/cgal/cgalutils-hybrid.cc
@@ -16,6 +16,8 @@
 #include "ManifoldGeometry.h"
 #endif
 
+#include <vector>
+
 namespace CGALUtils {
 
 template <typename K>

--- a/src/geometry/cgal/cgalutils-mesh-edits.h
+++ b/src/geometry/cgal/cgalutils-mesh-edits.h
@@ -1,10 +1,15 @@
 // Portions of this file are Copyright 2021 Google LLC, and licensed under GPL2+. See COPYING.
 #pragma once
 
-#include <CGAL/Surface_mesh.h>
 #include <CGAL/Polygon_mesh_processing/triangulate_faces.h>
+#include <CGAL/Surface_mesh.h>
+#include <cstddef>
+#include <functional>
+#include <unordered_map>
 #include <unordered_set>
 #include <vector>
+
+#include "printutils.h"
 
 namespace CGALUtils {
 

--- a/src/geometry/cgal/cgalutils-mesh.cc
+++ b/src/geometry/cgal/cgalutils-mesh.cc
@@ -9,6 +9,9 @@
 #include "PolySetBuilder.h"
 #include <CGAL/Polygon_mesh_processing/polygon_soup_to_polygon_mesh.h>
 #include <CGAL/Polygon_mesh_processing/repair_polygon_soup.h>
+
+#include <cstddef>
+
 namespace CGALUtils {
 
 namespace PMP = CGAL::Polygon_mesh_processing;
@@ -136,4 +139,3 @@ void cleanupMesh(CGAL_HybridMesh& mesh, bool is_corefinement_result)
 }
 
 } // namespace CGALUtils
-

--- a/src/geometry/cgal/cgalutils-mesh.cc
+++ b/src/geometry/cgal/cgalutils-mesh.cc
@@ -11,6 +11,7 @@
 #include <CGAL/Polygon_mesh_processing/repair_polygon_soup.h>
 
 #include <cstddef>
+#include <vector>
 
 namespace CGALUtils {
 

--- a/src/geometry/cgal/cgalutils-polyhedron.cc
+++ b/src/geometry/cgal/cgalutils-polyhedron.cc
@@ -10,6 +10,8 @@
 
 #include <boost/range/adaptor/reversed.hpp>
 
+#include <cstddef>
+
 #undef GEN_SURFACE_DEBUG
 namespace /* anonymous */ {
 
@@ -354,4 +356,3 @@ public:
 }  // namespace CGALUtils
 
 #endif /* ENABLE_CGAL */
-

--- a/src/geometry/cgal/cgalutils-polyhedron.cc
+++ b/src/geometry/cgal/cgalutils-polyhedron.cc
@@ -11,6 +11,7 @@
 #include <boost/range/adaptor/reversed.hpp>
 
 #include <cstddef>
+#include <vector>
 
 #undef GEN_SURFACE_DEBUG
 namespace /* anonymous */ {

--- a/src/geometry/cgal/cgalutils-project.cc
+++ b/src/geometry/cgal/cgalutils-project.cc
@@ -23,6 +23,7 @@
 
 #include <map>
 #include <queue>
+#include <vector>
 
 static void add_outline_to_poly(CGAL_Nef_polyhedron2::Explorer& explorer,
                                 CGAL_Nef_polyhedron2::Explorer::Halfedge_around_face_const_circulator circ,

--- a/src/geometry/cgal/cgalutils-tess.cc
+++ b/src/geometry/cgal/cgalutils-tess.cc
@@ -1,5 +1,6 @@
 #include "cgalutils.h"
 #include "printutils.h"
+#include <cstddef>
 //#include "cgal.h"
 //#include "tess.h"
 
@@ -190,4 +191,3 @@ bool tessellatePolygon(const PolygonK& polygon,
 }
 
 }  // namespace CGALUtils
-

--- a/src/geometry/cgal/cgalutils.cc
+++ b/src/geometry/cgal/cgalutils.cc
@@ -32,7 +32,7 @@
 #include <cstddef>
 #include <map>
 #include <queue>
-
+#include <vector>
 
 namespace CGALUtils {
 

--- a/src/geometry/cgal/cgalutils.cc
+++ b/src/geometry/cgal/cgalutils.cc
@@ -29,6 +29,7 @@
 #include "ManifoldGeometry.h"
 #endif
 
+#include <cstddef>
 #include <map>
 #include <queue>
 
@@ -513,10 +514,3 @@ std::shared_ptr<const PolySet> getGeometryAsPolySet(const std::shared_ptr<const 
 }  // namespace CGALUtils
 
 #endif /* ENABLE_CGAL */
-
-
-
-
-
-
-

--- a/src/geometry/cgal/cgalutils.h
+++ b/src/geometry/cgal/cgalutils.h
@@ -4,6 +4,7 @@
 #include "PolySet.h"
 #include "CGAL_Nef_polyhedron.h"
 #include "enums.h"
+#include <cstddef>
 
 #include <CGAL/Exact_predicates_inexact_constructions_kernel.h>
 

--- a/src/geometry/cgal/cgalutils.h
+++ b/src/geometry/cgal/cgalutils.h
@@ -4,7 +4,9 @@
 #include "PolySet.h"
 #include "CGAL_Nef_polyhedron.h"
 #include "enums.h"
+
 #include <cstddef>
+#include <vector>
 
 #include <CGAL/Exact_predicates_inexact_constructions_kernel.h>
 

--- a/src/geometry/linear_extrude.cc
+++ b/src/geometry/linear_extrude.cc
@@ -2,6 +2,8 @@
 
 #include <cstddef>
 #include <queue>
+#include <vector>
+
 #include <boost/logic/tribool.hpp>
 
 #include "GeometryUtils.h"
@@ -14,7 +16,7 @@
 #include "Feature.h"
 
 namespace {
-  
+
 /*
   Compare Euclidean length of vectors
   Return:
@@ -218,7 +220,7 @@ std::unique_ptr<PolySet> assemblePolySetForManifold(
 
   // LOG(PolySetUtils::polySetToPolyhedronSource(*final_polyset));
 
-  return final_polyset; 
+  return final_polyset;
 }
 
 std::unique_ptr<PolySet> assemblePolySetForCGAL(const Polygon2d& polyref,
@@ -308,7 +310,7 @@ void add_slice_indices(PolygonIndices &indices, int slice_idx, int slice_stride,
       Vector2d curr2 = trans2 * o.vertices[i % o.vertices.size()];
       int curr_idx = curr_outline + (i % o.vertices.size());
       int prev_idx = curr_outline + i - 1;
-      
+
       int diff_sign = sgn_vdiff(prev1 - curr2, curr1 - prev2);
       bool splitfirst = diff_sign == -1 || (diff_sign == 0 && !flip);
 
@@ -477,7 +479,7 @@ std::unique_ptr<Geometry> extrudePolygon(const LinearExtrudeNode& node, const Po
   auto full_height = (h2 - h1);
   for (unsigned int slice_idx = 0; slice_idx <= num_slices; slice_idx++) {
     Eigen::Affine2d trans(
-      Eigen::Scaling(Vector2d(1,1) - full_scale * slice_idx / num_slices) * 
+      Eigen::Scaling(Vector2d(1,1) - full_scale * slice_idx / num_slices) *
       Eigen::Affine2d(rotate_degrees(full_rot * slice_idx / num_slices)));
 
     for (const auto& o : polyref.outlines()) {
@@ -513,7 +515,7 @@ std::unique_ptr<Geometry> extrudePolygon(const LinearExtrudeNode& node, const Po
   else
 #endif
   return assemblePolySetForCGAL(polyref, vertices, indices,
-                                node.convexity, isConvex, 
+                                node.convexity, isConvex,
                                 node.scale_x, node.scale_y,
                                 h1, h2, node.twist);
 }

--- a/src/geometry/linear_extrude.cc
+++ b/src/geometry/linear_extrude.cc
@@ -1,5 +1,6 @@
 #include "linear_extrude.h"
 
+#include <cstddef>
 #include <queue>
 #include <boost/logic/tribool.hpp>
 

--- a/src/geometry/manifold/ManifoldGeometry.cc
+++ b/src/geometry/manifold/ManifoldGeometry.cc
@@ -10,6 +10,7 @@
 #include "ColorMap.h"
 #include "src/glview/RenderSettings.h"
 #include <cstddef>
+#include <string>
 #include <memory>
 #ifdef ENABLE_CGAL
 #include "cgalutils.h"
@@ -151,7 +152,7 @@ std::shared_ptr<PolySet> ManifoldGeometry::toPolySet() const {
       return getFaceFrontColorIndex();
     }
     const auto & color = colorIt->second;
-    
+
     auto pair = colorToIndex.insert({color, ps->colors.size()});
     if (pair.second) {
       ps->colors.push_back(color);
@@ -197,7 +198,7 @@ public:
 
   void operator()(HDS& hds) override {
     CGAL_Polybuilder B(hds, true);
-  
+
     B.begin_surface(meshgl.NumVert(), meshgl.NumTri());
     for (size_t vertid = 0; vertid < meshgl.NumVert(); vertid++)
       B.add_vertex(CGALUtils::vector_convert<CGALPoint>(meshgl.GetVertPos(vertid)));
@@ -235,7 +236,7 @@ ManifoldGeometry ManifoldGeometry::binOp(const ManifoldGeometry& lhs, const Mani
   auto mani = lhs.manifold_.Boolean(rhs.manifold_, opType);
   auto originalIDToColor = lhs.originalIDToColor_;
   auto subtractedIDs = lhs.subtractedIDs_;
-  
+
   auto originalIDs = lhs.originalIDs_;
   originalIDs.insert(rhs.originalIDs_.begin(), rhs.originalIDs_.end());
 
@@ -318,7 +319,7 @@ void ManifoldGeometry::transform(const Transform3d& mat) {
     mat(0, 1), mat(1, 1), mat(2, 1),
     mat(0, 2), mat(1, 2), mat(2, 2),
     mat(0, 3), mat(1, 3), mat(2, 3)
-  );                            
+  );
   manifold_ = getManifold().Transform(glMat);
 }
 

--- a/src/geometry/manifold/ManifoldGeometry.cc
+++ b/src/geometry/manifold/ManifoldGeometry.cc
@@ -9,6 +9,7 @@
 #include "manifoldutils.h"
 #include "ColorMap.h"
 #include "src/glview/RenderSettings.h"
+#include <cstddef>
 #include <memory>
 #ifdef ENABLE_CGAL
 #include "cgalutils.h"

--- a/src/geometry/manifold/ManifoldGeometry.h
+++ b/src/geometry/manifold/ManifoldGeometry.h
@@ -8,6 +8,7 @@
 #include <cstddef>
 #include <map>
 #include <set>
+#include <string>
 
 namespace manifold {
   class Manifold;

--- a/src/geometry/manifold/ManifoldGeometry.h
+++ b/src/geometry/manifold/ManifoldGeometry.h
@@ -5,6 +5,7 @@
 #include <glm/glm.hpp>
 #include "linalg.h"
 #include "manifold/manifold.h"
+#include <cstddef>
 #include <map>
 #include <set>
 

--- a/src/geometry/manifold/manifold-applyops-minkowski.cc
+++ b/src/geometry/manifold/manifold-applyops-minkowski.cc
@@ -11,6 +11,8 @@
 #include "ManifoldGeometry.h"
 #include "parallel.h"
 
+#include <vector>
+
 namespace ManifoldUtils {
 
 /*!
@@ -41,7 +43,7 @@ std::shared_ptr<const Geometry> applyMinkowskiManifold(const Geometry::Geometrie
     }
     throw 0;
   };
-  
+
   assert(children.size() >= 2);
   auto it = children.begin();
   CGAL::Timer t_tot;
@@ -104,7 +106,7 @@ std::shared_ptr<const Geometry> applyMinkowskiManifold(const Geometry::Geometrie
       });
 
       std::vector<Hull_kernel::Point_3> minkowski_points;
-      
+
       auto combineParts = [&](const Hull_Points &points0, const Hull_Points &points1) -> std::shared_ptr<const ManifoldGeometry> {
         CGAL::Timer t;
 
@@ -196,7 +198,7 @@ std::shared_ptr<const Geometry> applyMinkowskiManifold(const Geometry::Geometrie
                                                 part));
       }
       auto N = ManifoldUtils::applyOperator3DManifold(fake_children, OpenSCADOperator::UNION);
-        
+
       // FIXME: This should really never throw.
       // Assert once we figured out what went wrong with issue #1069?
       if (!N) throw 0;

--- a/src/geometry/manifold/manifoldutils.cc
+++ b/src/geometry/manifold/manifoldutils.cc
@@ -15,6 +15,7 @@
 #include "manifold/polygon.h"
 
 #include <cstddef>
+#include <vector>
 
 using Error = manifold::Manifold::Error;
 
@@ -71,7 +72,7 @@ std::shared_ptr<ManifoldGeometry> createManifoldFromSurfaceMesh(const TriangleMe
   auto mani = manifold::Manifold(meshgl).AsOriginal();
   if (mani.Status() != Error::NoError) {
     LOG(message_group::Error,
-        "[manifold] Surface_mesh -> Manifold conversion failed: %1$s", 
+        "[manifold] Surface_mesh -> Manifold conversion failed: %1$s",
         ManifoldUtils::statusToString(mani.Status()));
     return nullptr;
   }
@@ -118,7 +119,7 @@ std::shared_ptr<ManifoldGeometry> createManifoldFromTriangularPolySet(const Poly
   }
   auto next_id = manifold::Manifold::ReserveIDs(colorToFaceIndices.size());
   for (const auto& [color, faceIndices] : colorToFaceIndices) {
-    
+
     auto id = next_id++;
     if (color.has_value()) {
       originalIDToColor[id] = color.value();
@@ -127,7 +128,7 @@ std::shared_ptr<ManifoldGeometry> createManifoldFromTriangularPolySet(const Poly
     mesh.runIndex.push_back(mesh.triVerts.size());
     mesh.runOriginalID.push_back(id);
     originalIDs.insert(id);
-    
+
     for (size_t faceIndex : faceIndices) {
       auto & face = ps.indices[faceIndex];
       assert(face.size() == 3);
@@ -148,7 +149,7 @@ std::shared_ptr<ManifoldGeometry> createManifoldFromPolySet(const PolySet& ps)
   // (through using manifold::Mesh).
   // We need to make sure our PolySet is triangulated before doing that.
   // Note: We currently don't have a way of directly checking if a PolySet is manifold,
-  // so we just try converting to a Manifold object and check its status. 
+  // so we just try converting to a Manifold object and check its status.
   std::unique_ptr<const PolySet> triangulated;
   if (!ps.isTriangular()) {
     triangulated = PolySetUtils::tessellate_faces(ps);
@@ -164,7 +165,7 @@ std::shared_ptr<ManifoldGeometry> createManifoldFromPolySet(const PolySet& ps)
   // causes of a non-manifold topology:
   // Polygon soup of manifold topology with co-incident vertices having identical vertex positions
   //
-  // Note: This causes us to lose the ability to represent manifold topologies with duplicate 
+  // Note: This causes us to lose the ability to represent manifold topologies with duplicate
   // vertex positions (touching cubes, donut with vertex in the center etc.)
   PolySetBuilder builder(ps.vertices.size(), ps.indices.size(),
                          ps.getDimension(), ps.convexValue());
@@ -188,7 +189,7 @@ std::shared_ptr<ManifoldGeometry> createManifoldFromPolySet(const PolySet& ps)
     std::vector<Vector3d> points3d;
     psq.quantizeVertices(&points3d);
     auto ps_tri = PolySetUtils::tessellate_faces(psq);
-    
+
     CGAL_DoubleMesh m;
 
     if (ps_tri->isConvex()) {

--- a/src/geometry/manifold/manifoldutils.cc
+++ b/src/geometry/manifold/manifoldutils.cc
@@ -14,6 +14,8 @@
 #include "PolySet.h"
 #include "manifold/polygon.h"
 
+#include <cstddef>
+
 using Error = manifold::Manifold::Error;
 
 namespace ManifoldUtils {

--- a/src/geometry/roof_ss.cc
+++ b/src/geometry/roof_ss.cc
@@ -11,6 +11,7 @@
 
 #include <algorithm>
 #include <map>
+#include <vector>
 
 #include "GeometryUtils.h"
 #include "ClipperUtils.h"

--- a/src/geometry/roof_vd.cc
+++ b/src/geometry/roof_vd.cc
@@ -5,6 +5,7 @@
 #define _USE_MATH_DEFINES
 #include <cmath>
 
+#include <cstddef>
 #include <algorithm>
 #include <map>
 #include <boost/polygon/voronoi.hpp>

--- a/src/geometry/roof_vd.cc
+++ b/src/geometry/roof_vd.cc
@@ -9,6 +9,7 @@
 #include <algorithm>
 #include <map>
 #include <boost/polygon/voronoi.hpp>
+#include <vector>
 #include <PolySetBuilder.h>
 
 #include "GeometryUtils.h"

--- a/src/glview/Camera.cc
+++ b/src/glview/Camera.cc
@@ -3,6 +3,8 @@
 #include "printutils.h"
 #include "degree_trig.h"
 
+#include <vector>
+
 static const double DEFAULT_DISTANCE = 140.0;
 static const double DEFAULT_FOV = 22.5;
 

--- a/src/glview/Camera.h
+++ b/src/glview/Camera.h
@@ -18,6 +18,7 @@
 
 #include "linalg.h"
 #include "ScopeContext.h"
+#include <string>
 #include <vector>
 #include <Eigen/Geometry>
 

--- a/src/glview/CsgInfo.h
+++ b/src/glview/CsgInfo.h
@@ -8,6 +8,8 @@
 #include "RenderSettings.h"
 #include "printutils.h"
 
+#include <vector>
+
 /*
    Small helper class for compiling and normalizing node trees into CSG products
  */

--- a/src/glview/GLView.cc
+++ b/src/glview/GLView.cc
@@ -9,6 +9,7 @@
 
 #include <cmath>
 #include <cstdio>
+#include <string>
 
 #ifdef ENABLE_OPENCSG
 #include <opencsg.h>
@@ -402,7 +403,7 @@ void GLView::showObject(const SelectedObject &obj, const Vector3d &eyedir)
     case SelectionType::SELECTION_POINT:
     {
       double n=1/sqrt(3);
-      // create an octaeder	   
+      // create an octaeder
       //x- x+ y- y+ z- z+
       int sequence[]={ 2, 0, 4, 1, 2, 4, 0, 3, 4, 3, 1, 4, 0, 2, 5, 2, 1, 5, 3, 0, 5, 1, 3, 5 };
       glBegin(GL_TRIANGLES);
@@ -417,12 +418,12 @@ void GLView::showObject(const SelectedObject &obj, const Vector3d &eyedir)
 		case 3: glVertex3d(obj.p1[0],obj.p1[1]+vd,obj.p1[2]); break;
 		case 4: glVertex3d(obj.p1[0],obj.p1[1],obj.p1[2]-vd); break;
 		case 5: glVertex3d(obj.p1[0],obj.p1[1],obj.p1[2]+vd); break;
-          }		
-	}	
-      }	
+          }
+	}
+      }
       glEnd();
      }
-     break;	
+     break;
    case SelectionType::SELECTION_LINE:
      {
 	Vector3d diff=obj.p2-obj.p1;
@@ -433,8 +434,8 @@ void GLView::showObject(const SelectedObject &obj, const Vector3d &eyedir)
         glVertex3d(obj.p2[0]+wdir[0],obj.p2[1]+wdir[1],obj.p2[2]+wdir[2]);
         glVertex3d(obj.p1[0]+wdir[0],obj.p1[1]+wdir[1],obj.p1[2]+wdir[2]);
         glEnd();
-      }	
-      break;	
+      }
+      break;
   }
 }
 

--- a/src/glview/GLView.h
+++ b/src/glview/GLView.h
@@ -21,6 +21,7 @@
 #include <Eigen/Geometry>
 #include <string>
 #include <iostream>
+#include <vector>
 #include "Camera.h"
 #include "ColorMap.h"
 #include "system-gl.h"

--- a/src/glview/LegacyRendererUtils.cc
+++ b/src/glview/LegacyRendererUtils.cc
@@ -7,6 +7,7 @@
 #include "system-gl.h"
 
 #include <Eigen/LU>
+#include <cstddef>
 #include <fstream>
 
 #ifdef ENABLE_OPENCSG

--- a/src/glview/NULLGL.cc
+++ b/src/glview/NULLGL.cc
@@ -1,5 +1,7 @@
 #include "GLView.h"
 
+#include <cstddef>
+
 GLView::GLView() {}
 void GLView::setRenderer(std::shared_ptr<Renderer>) {}
 void GLView::initializeGL() {}

--- a/src/glview/NULLGL.cc
+++ b/src/glview/NULLGL.cc
@@ -1,6 +1,7 @@
 #include "GLView.h"
 
 #include <cstddef>
+#include <string>
 #include <vector>
 
 GLView::GLView() {}

--- a/src/glview/NULLGL.cc
+++ b/src/glview/NULLGL.cc
@@ -1,6 +1,7 @@
 #include "GLView.h"
 
 #include <cstddef>
+#include <vector>
 
 GLView::GLView() {}
 void GLView::setRenderer(std::shared_ptr<Renderer>) {}

--- a/src/glview/OffscreenContextCGL.cc
+++ b/src/glview/OffscreenContextCGL.cc
@@ -1,5 +1,6 @@
 #include "OffscreenContextCGL.h"
 
+#include <cstddef>
 #include <iostream>
 
 #include "system-gl.h"

--- a/src/glview/OffscreenContextCGL.cc
+++ b/src/glview/OffscreenContextCGL.cc
@@ -1,6 +1,7 @@
 #include "OffscreenContextCGL.h"
 
 #include <cstddef>
+#include <string>
 #include <iostream>
 
 #include "system-gl.h"

--- a/src/glview/OffscreenContextCGL.h
+++ b/src/glview/OffscreenContextCGL.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <cstddef>
 #include <memory>
 
 #include "OffscreenContext.h"

--- a/src/glview/OffscreenContextEGL.cc
+++ b/src/glview/OffscreenContextEGL.cc
@@ -3,8 +3,9 @@
 #include <fcntl.h>
 #include <cstddef>
 #include <iostream>
-#include <sstream>
 #include <set>
+#include <sstream>
+#include <string>
 #include <vector>
 
 #include "printutils.h"
@@ -121,7 +122,7 @@ std::shared_ptr<OffscreenContext> CreateOffscreenContextEGL(size_t width, size_t
   }
   PRINTDB("GLAD: Loaded EGL %d.%d on first load",
 	  GLAD_VERSION_MAJOR(initialEglVersion) % GLAD_VERSION_MINOR(initialEglVersion));
-  
+
   EGLint conformant;
   if (!gles) conformant = EGL_OPENGL_BIT;
   else if (majorGLVersion >= 3) conformant = EGL_OPENGL_ES3_BIT;

--- a/src/glview/OffscreenContextEGL.cc
+++ b/src/glview/OffscreenContextEGL.cc
@@ -1,6 +1,7 @@
 #include "OffscreenContextEGL.h"
 
 #include <fcntl.h>
+#include <cstddef>
 #include <iostream>
 #include <sstream>
 #include <set>

--- a/src/glview/OffscreenContextEGL.h
+++ b/src/glview/OffscreenContextEGL.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <cstddef>
 #include <memory>
 #include <string>
 

--- a/src/glview/OffscreenContextFactory.cc
+++ b/src/glview/OffscreenContextFactory.cc
@@ -1,5 +1,7 @@
 #include "OffscreenContextFactory.h"
 
+#include <string>
+
 #include "printutils.h"
 
 #ifdef __APPLE__
@@ -81,10 +83,10 @@ std::shared_ptr<OpenGLContext> create(const std::string& provider, const Offscre
 #endif
 #ifdef ENABLE_GLX
   if (provider == "glx-old") {
-   return offscreen_old::CreateOffscreenContextGLX(attrib.width, attrib.height, attrib.majorGLVersion, attrib.minorGLVersion, 
+   return offscreen_old::CreateOffscreenContextGLX(attrib.width, attrib.height, attrib.majorGLVersion, attrib.minorGLVersion,
                                     attrib.gles, attrib.compatibilityProfile);
   } else if (provider == "glx") {
-   return CreateOffscreenContextGLX(attrib.width, attrib.height, attrib.majorGLVersion, attrib.minorGLVersion, 
+   return CreateOffscreenContextGLX(attrib.width, attrib.height, attrib.majorGLVersion, attrib.minorGLVersion,
                                     attrib.gles, attrib.compatibilityProfile);
   }
 #endif
@@ -105,4 +107,3 @@ std::shared_ptr<OpenGLContext> create(const std::string& provider, const Offscre
 }
 
 }  // namespace OffscreenContextFactory
-

--- a/src/glview/OffscreenContextGLX.cc
+++ b/src/glview/OffscreenContextGLX.cc
@@ -3,6 +3,7 @@
 #define GLAD_GLX_IMPLEMENTATION
 #include <glad/glx.h>
 
+#include <cstddef>
 #include <iostream>
 #include <sstream>
 

--- a/src/glview/OffscreenContextGLX.cc
+++ b/src/glview/OffscreenContextGLX.cc
@@ -6,6 +6,7 @@
 #include <cstddef>
 #include <iostream>
 #include <sstream>
+#include <string>
 
 #include "scope_guard.hpp"
 #include "printutils.h"
@@ -98,12 +99,12 @@ public:
     const auto root = DefaultRootWindow(this->display);
     XSetWindowAttributes windowAttributes = {
       .event_mask = StructureNotifyMask | ExposureMask | KeyPressMask,
-      .colormap = XCreateColormap(this->display, root, visinfo->visual, AllocNone), 
+      .colormap = XCreateColormap(this->display, root, visinfo->visual, AllocNone),
     };
     unsigned long mask = CWBackPixel | CWBorderPixel | CWColormap | CWEventMask;
 
-    this->xWindow = 
-      XCreateWindow(this->display, root, 0, 0, this->width(), this->height(), 0, 
+    this->xWindow =
+      XCreateWindow(this->display, root, 0, 0, this->width(), this->height(), 0,
                     visinfo->depth, InputOutput, visinfo->visual, mask, &windowAttributes);
     XSync(this->display, false);
     if (xlibLastError != Success) {
@@ -171,14 +172,14 @@ std::shared_ptr<OffscreenContext> CreateOffscreenContextGLX(size_t width, size_t
   PRINTDB("GLAD: Loaded GLX %d.%d", glxMajor % glxMinor);
 
   // We require GLX >= 1.3.
-  // However, glxQueryVersion sometimes returns an earlier version than is actually available, so 
+  // However, glxQueryVersion sometimes returns an earlier version than is actually available, so
   // we also accept GLX < 1.3 as long as glXGetVisualFromFBConfig() exists.
   // FIXME: Figure out if this is still relevant with GLAD, as we may want to check functions anyway?
   if (glxMajor == 1 && glxMinor <= 2 && glXGetVisualFromFBConfig == nullptr) {
     LOG("Error: GLX version 1.3 functions missing. Your GLX version: %1$d.%2$d", glxMajor, glxMinor);
     return nullptr;
   }
-  
+
   if (!ctx->createGLXContext(majorGLVersion, minorGLVersion, compatibilityProfile)) {
     return nullptr;
   }

--- a/src/glview/OffscreenContextGLX.h
+++ b/src/glview/OffscreenContextGLX.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <cstddef>
 #include <memory>
 
 #include "OffscreenContext.h"

--- a/src/glview/OpenGLContext.cc
+++ b/src/glview/OpenGLContext.cc
@@ -1,6 +1,7 @@
 #include "OpenGLContext.h"
 
 #include <cstddef>
+#include <vector>
 
 #include "system-gl.h"
 

--- a/src/glview/OpenGLContext.cc
+++ b/src/glview/OpenGLContext.cc
@@ -1,5 +1,7 @@
 #include "OpenGLContext.h"
 
+#include <cstddef>
+
 #include "system-gl.h"
 
 std::vector<uint8_t> OpenGLContext::getFramebuffer() const

--- a/src/glview/Renderer.cc
+++ b/src/glview/Renderer.cc
@@ -8,6 +8,7 @@
 
 #include <Eigen/LU>
 #include <fstream>
+#include <vector>
 
 #ifndef NULLGL
 

--- a/src/glview/Renderer.cc
+++ b/src/glview/Renderer.cc
@@ -8,6 +8,7 @@
 
 #include <Eigen/LU>
 #include <fstream>
+#include <string>
 #include <vector>
 
 #ifndef NULLGL

--- a/src/glview/Renderer.h
+++ b/src/glview/Renderer.h
@@ -10,6 +10,8 @@
 #include <cstdlib>
 #endif
 
+#include <vector>
+
 class Renderer
 {
 public:

--- a/src/glview/Renderer.h
+++ b/src/glview/Renderer.h
@@ -10,6 +10,7 @@
 #include <cstdlib>
 #endif
 
+#include <string>
 #include <vector>
 
 class Renderer

--- a/src/glview/VBORenderer.h
+++ b/src/glview/VBORenderer.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <cstddef>
 #include "Renderer.h"
 #include "system-gl.h"
 #ifdef ENABLE_OPENCSG

--- a/src/glview/VertexArray.h
+++ b/src/glview/VertexArray.h
@@ -4,6 +4,7 @@
 #include <unordered_map>
 #include <boost/functional/hash.hpp>
 #include <utility>
+#include <vector>
 
 #include "system-gl.h"
 #include "printutils.h"

--- a/src/glview/VertexArray.h
+++ b/src/glview/VertexArray.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <cstddef>
 #include <unordered_map>
 #include <boost/functional/hash.hpp>
 #include <utility>

--- a/src/glview/VertexState.h
+++ b/src/glview/VertexState.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <cstddef>
 #include <functional>
 #include <vector>
 

--- a/src/glview/cgal/CGALRenderer.cc
+++ b/src/glview/cgal/CGALRenderer.cc
@@ -45,6 +45,7 @@
 #endif
 
 #include <cstddef>
+#include <vector>
 
 // #include "Preferences.h"
 

--- a/src/glview/cgal/CGALRenderer.cc
+++ b/src/glview/cgal/CGALRenderer.cc
@@ -44,6 +44,8 @@
 #include "ManifoldGeometry.h"
 #endif
 
+#include <cstddef>
+
 // #include "Preferences.h"
 
 CGALRenderer::CGALRenderer(const std::shared_ptr<const class Geometry> &geom) {

--- a/src/glview/cgal/CGALRenderer.h
+++ b/src/glview/cgal/CGALRenderer.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <memory>
+#include <vector>
 
 #include "VBORenderer.h"
 #ifdef ENABLE_CGAL

--- a/src/glview/cgal/CGAL_OGL_VBO_helper.h
+++ b/src/glview/cgal/CGAL_OGL_VBO_helper.h
@@ -29,7 +29,9 @@
 #include "system-gl.h"
 #include "VertexArray.h"
 #include "ext/CGAL/OGL_helper.h"
+
 #include <cstdlib>
+#include <vector>
 
 using namespace CGAL::OGL;
 
@@ -294,7 +296,7 @@ public:
     if (Feature::ExperimentalVxORenderersIndexing.is_enabled()) {
       glGenBuffers(1, &halffacets_elements_vbo);
     }
-    
+
     // FIXME: We don't know the size of this VertexArray in advanced, so we have to deal with some fallback mechanism for filling in the data. This complicates code quite a bit
     VertexArray halffacets_array(std::make_unique<VertexStateFactory>(), halffacets_states, halffacets_vertices_vbo, halffacets_elements_vbo);
     halffacets_array.addSurfaceData();

--- a/src/glview/cgal/LegacyCGALRenderer.cc
+++ b/src/glview/cgal/LegacyCGALRenderer.cc
@@ -44,6 +44,8 @@
 #include "ManifoldGeometry.h"
 #endif
 
+#include <vector>
+
 //#include "Preferences.h"
 
 LegacyCGALRenderer::LegacyCGALRenderer(const std::shared_ptr<const class Geometry>& geom)
@@ -163,7 +165,7 @@ void LegacyCGALRenderer::draw(bool showfaces, bool showedges, const shaderinfo_t
         glVertex3d(v[0], v[1], 0);
       }
       glEnd();
-    }    
+    }
     glEnable(GL_LIGHTING);
 
     glEnable(GL_DEPTH_TEST);

--- a/src/glview/preview/CSGTreeNormalizer.h
+++ b/src/glview/preview/CSGTreeNormalizer.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <cstddef>
 #include <memory>
 
 class CSGTreeNormalizer

--- a/src/glview/preview/LegacyOpenCSGRenderer.cc
+++ b/src/glview/preview/LegacyOpenCSGRenderer.cc
@@ -33,6 +33,8 @@
 #include <utility>
 #include "PolySet.h"
 
+#include <vector>
+
 #ifdef ENABLE_OPENCSG
 
 class OpenCSGPrim : public OpenCSG::Primitive
@@ -60,7 +62,7 @@ private:
 
 // Primitive for depth rendering using OpenCSG
 std::unique_ptr<OpenCSGPrim> createCSGPrimitive(const CSGChainObject& csgobj, OpenCSG::Operation operation,
-                                bool highlight_mode, bool background_mode, OpenSCADOperator type, 
+                                bool highlight_mode, bool background_mode, OpenSCADOperator type,
                                 const LegacyOpenCSGRenderer &renderer) {
   auto prim = std::make_unique<OpenCSGPrim>(operation, csgobj.leaf->polyset->getConvexity(), renderer);
   prim->polyset = csgobj.leaf->polyset;

--- a/src/glview/preview/OpenCSGRenderer.cc
+++ b/src/glview/preview/OpenCSGRenderer.cc
@@ -33,6 +33,7 @@
 #include <memory.h>
 #include <cstddef>
 #include <utility>
+#include <vector>
 
 #ifdef ENABLE_OPENCSG
 

--- a/src/glview/preview/OpenCSGRenderer.cc
+++ b/src/glview/preview/OpenCSGRenderer.cc
@@ -31,6 +31,7 @@
 #include "Feature.h"
 #include "PolySet.h"
 #include <memory.h>
+#include <cstddef>
 #include <utility>
 
 #ifdef ENABLE_OPENCSG

--- a/src/glview/preview/OpenCSGRenderer.h
+++ b/src/glview/preview/OpenCSGRenderer.h
@@ -10,6 +10,7 @@
 #include "VBORenderer.h"
 
 #include <cstddef>
+#include <vector>
 
 class CSGChainObject;
 class CSGProducts;

--- a/src/glview/preview/OpenCSGRenderer.h
+++ b/src/glview/preview/OpenCSGRenderer.h
@@ -9,6 +9,8 @@
 
 #include "VBORenderer.h"
 
+#include <cstddef>
+
 class CSGChainObject;
 class CSGProducts;
 class OpenCSGPrim;

--- a/src/glview/preview/ThrownTogetherRenderer.cc
+++ b/src/glview/preview/ThrownTogetherRenderer.cc
@@ -26,6 +26,7 @@
 
 #include "ThrownTogetherRenderer.h"
 
+#include <cstddef>
 #include <utility>
 #include "Feature.h"
 #include "PolySet.h"

--- a/src/glview/preview/ThrownTogetherRenderer.h
+++ b/src/glview/preview/ThrownTogetherRenderer.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <cstddef>
+
 #include "Renderer.h"
 #include "CSGNode.h"
 

--- a/src/glview/preview/ThrownTogetherRenderer.h
+++ b/src/glview/preview/ThrownTogetherRenderer.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <cstddef>
+#include <vector>
 
 #include "Renderer.h"
 #include "CSGNode.h"

--- a/src/gui/Animate.h
+++ b/src/gui/Animate.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <string>
+
 #include "qtgettext.h"
 #include "ui_Animate.h"
 #include <QIcon>

--- a/src/gui/Editor.h
+++ b/src/gui/Editor.h
@@ -9,6 +9,7 @@
 #include "IndicatorData.h"
 #include "parameter/ParameterWidget.h"
 
+#include <string>
 #include <vector>
 
 enum class EditorSelectionIndicatorStatus

--- a/src/gui/Editor.h
+++ b/src/gui/Editor.h
@@ -9,6 +9,8 @@
 #include "IndicatorData.h"
 #include "parameter/ParameterWidget.h"
 
+#include <vector>
+
 enum class EditorSelectionIndicatorStatus
 {
   SELECTED,

--- a/src/gui/FontList.cc
+++ b/src/gui/FontList.cc
@@ -1,6 +1,7 @@
 #include <qitemselectionmodel.h>
 #include <string>
 #include <iostream>
+#include <vector>
 
 #include <QClipboard>
 #include <QRegularExpression>

--- a/src/gui/InitConfigurator.cc
+++ b/src/gui/InitConfigurator.cc
@@ -2,6 +2,8 @@
 #include <QSettings>
 #include "Settings.h"
 
+#include <string>
+
 void InitConfigurator::initUpdateCheckBox(const BlockSignals<QCheckBox *>& checkBox, const Settings::SettingsEntryBool& entry)
 {
   checkBox->setChecked(entry.value());

--- a/src/gui/InitConfigurator.h
+++ b/src/gui/InitConfigurator.h
@@ -6,6 +6,8 @@
 #include <QSpinBox>
 #include <QCheckBox>
 
+#include <string>
+
 template <class WidgetPtr>
 class BlockSignals
 {

--- a/src/gui/MainWindow.cc
+++ b/src/gui/MainWindow.cc
@@ -25,6 +25,7 @@
  */
 #include <iostream>
 #include <memory>
+#include <string>
 #include <vector>
 
 #include "boost-utils.h"

--- a/src/gui/MainWindow.cc
+++ b/src/gui/MainWindow.cc
@@ -25,6 +25,7 @@
  */
 #include <iostream>
 #include <memory>
+#include <vector>
 
 #include "boost-utils.h"
 #include "Builtins.h"

--- a/src/gui/Measurement.cc
+++ b/src/gui/Measurement.cc
@@ -26,6 +26,8 @@
 
 #include "Measurement.h"
 
+#include <string>
+
 Measurement::Measurement()
 {
 }
@@ -48,7 +50,7 @@ void Measurement::startMeasureAngle(void)
   this->qglview->update();
   this->qglview->measure_state=MEASURE_ANG1;
 }
-QString Measurement::statemachine(QPoint mouse) 
+QString Measurement::statemachine(QPoint mouse)
 {
   if(qglview->measure_state == MEASURE_IDLE) return "";
   qglview->selectPoint(mouse.x(),mouse.y());

--- a/src/gui/MouseSelector.cc
+++ b/src/gui/MouseSelector.cc
@@ -2,6 +2,7 @@
 #include "MouseSelector.h"
 
 #include <QOpenGLFramebufferObject>
+#include <string>
 #include <memory>
 /**
  * The selection is making use of a special shader, that renders each object in a color

--- a/src/gui/Network.h
+++ b/src/gui/Network.h
@@ -29,7 +29,9 @@
 #include <QObject>
 #include <QString>
 #include <QtNetwork>
+
 #include <utility>
+#include <string>
 #include <vector>
 
 #include "printutils.h"

--- a/src/gui/Network.h
+++ b/src/gui/Network.h
@@ -30,7 +30,7 @@
 #include <QString>
 #include <QtNetwork>
 #include <utility>
-#include <utility>
+#include <vector>
 
 #include "printutils.h"
 #include "PlatformUtils.h"

--- a/src/gui/OctoPrint.cc
+++ b/src/gui/OctoPrint.cc
@@ -28,6 +28,8 @@
 #include "OctoPrint.h"
 
 #include <utility>
+#include <vector>
+
 #include "printutils.h"
 #include "PlatformUtils.h"
 

--- a/src/gui/OctoPrint.cc
+++ b/src/gui/OctoPrint.cc
@@ -27,6 +27,7 @@
 #include "Settings.h"
 #include "OctoPrint.h"
 
+#include <string>
 #include <utility>
 #include <vector>
 

--- a/src/gui/OctoPrint.h
+++ b/src/gui/OctoPrint.h
@@ -27,6 +27,7 @@
 #pragma once
 
 #include <tuple>
+#include <string>
 #include <vector>
 
 #include <QFile>

--- a/src/gui/OctoPrint.h
+++ b/src/gui/OctoPrint.h
@@ -27,6 +27,7 @@
 #pragma once
 
 #include <tuple>
+#include <vector>
 
 #include <QFile>
 #include <QString>

--- a/src/gui/Preferences.cc
+++ b/src/gui/Preferences.cc
@@ -49,6 +49,8 @@
 #include "OctoPrint.h"
 #include "IgnoreWheelWhenNotFocused.h"
 
+#include <string>
+
 Preferences *Preferences::instance = nullptr;
 
 const char *Preferences::featurePropertyName = "FeatureProperty";

--- a/src/gui/QGLView.cc
+++ b/src/gui/QGLView.cc
@@ -51,6 +51,7 @@
 
 #include <cstdio>
 #include <sstream>
+#include <string>
 #include <vector>
 
 #ifdef ENABLE_OPENCSG

--- a/src/gui/QGLView.cc
+++ b/src/gui/QGLView.cc
@@ -51,6 +51,7 @@
 
 #include <cstdio>
 #include <sstream>
+#include <vector>
 
 #ifdef ENABLE_OPENCSG
 #  include <opencsg.h>
@@ -349,11 +350,11 @@ void QGLView::mouseReleaseEvent(QMouseEvent *event)
     if(event->button() == button_right) {
       QPoint point = event->pos();
       emit doRightClick(point);
-    }  
+    }
     if(event->button() == button_left) {
       QPoint point = event->pos();
       emit doLeftClick(point);
-    }  
+    }
   }
   mouse_drag_moved = false;
 }
@@ -552,5 +553,5 @@ void QGLView::selectPoint(int mouse_x, int mouse_y)
   if(obj.size() == 1) {
     this->selected_obj.push_back(obj[0]);
     update();
-  }	  
+  }
 }

--- a/src/gui/QGLView.h
+++ b/src/gui/QGLView.h
@@ -4,6 +4,7 @@
 #include <QtGlobal>
 #include <QOpenGLWidget>
 #include <QLabel>
+#include <vector>
 
 #include <Eigen/Core>
 #include <Eigen/Geometry>

--- a/src/gui/QGLView.h
+++ b/src/gui/QGLView.h
@@ -4,6 +4,7 @@
 #include <QtGlobal>
 #include <QOpenGLWidget>
 #include <QLabel>
+#include <string>
 #include <vector>
 
 #include <Eigen/Core>

--- a/src/gui/ScadLexer.cc
+++ b/src/gui/ScadLexer.cc
@@ -1,7 +1,8 @@
 #include <string>
+#include <vector>
+
 #include <boost/algorithm/string.hpp>
 #include <boost/algorithm/string/split.hpp>
-
 
 #include "ScadLexer.h"
 

--- a/src/gui/ScintillaEditor.cc
+++ b/src/gui/ScintillaEditor.cc
@@ -1,5 +1,6 @@
 #include <ciso646> // C alternative tokens (xor)
 #include <cstdlib>
+#include <vector>
 #include <algorithm>
 #include <boost/filesystem.hpp>
 #include <boost/property_tree/ptree.hpp>

--- a/src/gui/ScintillaEditor.cc
+++ b/src/gui/ScintillaEditor.cc
@@ -1,5 +1,6 @@
 #include <ciso646> // C alternative tokens (xor)
 #include <cstdlib>
+#include <string>
 #include <vector>
 #include <algorithm>
 #include <boost/filesystem.hpp>

--- a/src/gui/ScintillaEditor.h
+++ b/src/gui/ScintillaEditor.h
@@ -2,6 +2,7 @@
 
 #include <functional>
 #include <memory>
+#include <vector>
 
 #include <boost/property_tree/ptree.hpp>
 #include <boost/property_tree/json_parser.hpp>

--- a/src/gui/ScintillaEditor.h
+++ b/src/gui/ScintillaEditor.h
@@ -2,6 +2,7 @@
 
 #include <functional>
 #include <memory>
+#include <string>
 #include <vector>
 
 #include <boost/property_tree/ptree.hpp>

--- a/src/gui/Settings.cc
+++ b/src/gui/Settings.cc
@@ -5,6 +5,7 @@
 #include <boost/lexical_cast.hpp>
 #include <cstddef>
 #include <utility>
+#include <vector>
 
 namespace Settings {
 

--- a/src/gui/Settings.cc
+++ b/src/gui/Settings.cc
@@ -3,6 +3,7 @@
 #include "input/InputEventMapper.h"
 #include <boost/algorithm/string.hpp>
 #include <boost/lexical_cast.hpp>
+#include <cstddef>
 #include <utility>
 
 namespace Settings {

--- a/src/gui/Settings.cc
+++ b/src/gui/Settings.cc
@@ -4,6 +4,7 @@
 #include <boost/algorithm/string.hpp>
 #include <boost/lexical_cast.hpp>
 #include <cstddef>
+#include <string>
 #include <utility>
 #include <vector>
 

--- a/src/gui/Settings.h
+++ b/src/gui/Settings.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <cstddef>
 #include <map>
 #include <list>
 #include <string>

--- a/src/gui/SettingsWriter.cc
+++ b/src/gui/SettingsWriter.cc
@@ -26,6 +26,8 @@
 #include "SettingsWriter.h"
 #include "QSettingsCached.h"
 
+#include <string>
+
 void SettingsWriter::handle(Settings::SettingsEntry& entry) const {
   QSettingsCached settings;
   std::string key = entry.category() + "/" + entry.name();

--- a/src/gui/TabManager.cc
+++ b/src/gui/TabManager.cc
@@ -18,6 +18,8 @@
 #include "Preferences.h"
 #include "MainWindow.h"
 
+#include <cstddef>
+
 TabManager::TabManager(MainWindow *o, const QString& filename)
 {
   par = o;

--- a/src/gui/TabManager.h
+++ b/src/gui/TabManager.h
@@ -2,6 +2,7 @@
 
 #include <cstddef>
 #include <functional>
+#include <string>
 #include <QObject>
 #include <QSet>
 #include "Editor.h"

--- a/src/gui/TabManager.h
+++ b/src/gui/TabManager.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <cstddef>
 #include <functional>
 #include <QObject>
 #include <QSet>

--- a/src/gui/UIUtils.cc
+++ b/src/gui/UIUtils.cc
@@ -38,6 +38,8 @@
 #include <boost/property_tree/ptree.hpp>
 #include <boost/property_tree/json_parser.hpp>
 
+#include <string>
+
 QFileInfo UIUtils::openFile(QWidget *parent)
 {
   QSettingsCached settings;

--- a/src/gui/input/AxisConfigWidget.cc
+++ b/src/gui/input/AxisConfigWidget.cc
@@ -25,6 +25,8 @@
  */
 
 #include <QWidget>
+#include <cstddef>
+
 #include "AxisConfigWidget.h"
 
 #include "Settings.h"

--- a/src/gui/input/AxisConfigWidget.cc
+++ b/src/gui/input/AxisConfigWidget.cc
@@ -26,6 +26,7 @@
 
 #include <QWidget>
 #include <cstddef>
+#include <string>
 
 #include "AxisConfigWidget.h"
 

--- a/src/gui/input/ButtonConfigWidget.cc
+++ b/src/gui/input/ButtonConfigWidget.cc
@@ -25,6 +25,7 @@
  */
 
 #include <QWidget>
+#include <cstddef>
 #include "ButtonConfigWidget.h"
 #include "Settings.h"
 #include "input/InputDriverManager.h"

--- a/src/gui/input/DBusInputDriver.h
+++ b/src/gui/input/DBusInputDriver.h
@@ -27,6 +27,7 @@
 
 #include <QStringList>
 #include "InputDriver.h"
+#include <string>
 
 class DBusInputDriver : public InputDriver
 {

--- a/src/gui/input/HidApiInputDriver.cc
+++ b/src/gui/input/HidApiInputDriver.cc
@@ -29,14 +29,15 @@
  *  Public Domain.
  */
 
-#include <chrono>
-#include <iomanip>
 #include <bitset>
-#include <fstream>
-#include <ostream>
-#include <codecvt>
-#include <cmath>
 #include <boost/format.hpp>
+#include <chrono>
+#include <cmath>
+#include <codecvt>
+#include <fstream>
+#include <iomanip>
+#include <ostream>
+#include <string>
 
 #include "Settings.h"
 #include "PlatformUtils.h"

--- a/src/gui/input/HidApiInputDriver.h
+++ b/src/gui/input/HidApiInputDriver.h
@@ -26,6 +26,7 @@
 
 #pragma once
 
+#include <cstddef>
 #include <utility>
 #include <hidapi.h>
 

--- a/src/gui/input/HidApiInputDriver.h
+++ b/src/gui/input/HidApiInputDriver.h
@@ -27,6 +27,7 @@
 #pragma once
 
 #include <cstddef>
+#include <string>
 #include <utility>
 #include <hidapi.h>
 

--- a/src/gui/input/InputDriver.h
+++ b/src/gui/input/InputDriver.h
@@ -27,6 +27,7 @@
 
 #include <QThread>
 #include <cstddef>
+#include <string>
 
 class InputDriver : public QThread
 {

--- a/src/gui/input/InputDriver.h
+++ b/src/gui/input/InputDriver.h
@@ -26,6 +26,7 @@
 #pragma once
 
 #include <QThread>
+#include <cstddef>
 
 class InputDriver : public QThread
 {

--- a/src/gui/input/InputDriverEvent.h
+++ b/src/gui/input/InputDriverEvent.h
@@ -26,6 +26,7 @@
 #pragma once
 
 #include <QEvent>
+#include <string>
 
 class InputEventHandler
 {

--- a/src/gui/input/InputDriverManager.cc
+++ b/src/gui/input/InputDriverManager.cc
@@ -31,6 +31,7 @@
 #include <QApplication>
 #include <QCoreApplication>
 #include <cstddef>
+#include <string>
 
 InputDriverManager *InputDriverManager::self = nullptr;
 

--- a/src/gui/input/InputDriverManager.cc
+++ b/src/gui/input/InputDriverManager.cc
@@ -30,6 +30,7 @@
 #include <QMenu>
 #include <QApplication>
 #include <QCoreApplication>
+#include <cstddef>
 
 InputDriverManager *InputDriverManager::self = nullptr;
 

--- a/src/gui/input/InputDriverManager.h
+++ b/src/gui/input/InputDriverManager.h
@@ -30,6 +30,7 @@
 #include <QTimer>
 #include <QIcon>
 
+#include <cstddef>
 #include "InputDriver.h"
 #include "InputEventMapper.h"
 

--- a/src/gui/input/InputDriverManager.h
+++ b/src/gui/input/InputDriverManager.h
@@ -31,6 +31,8 @@
 #include <QIcon>
 
 #include <cstddef>
+#include <string>
+
 #include "InputDriver.h"
 #include "InputEventMapper.h"
 

--- a/src/gui/input/InputEventMapper.cc
+++ b/src/gui/input/InputEventMapper.cc
@@ -31,6 +31,7 @@
 #include "ButtonConfigWidget.h"
 #include <ciso646> // C alternative tokens
 #include <cstddef>
+#include <string>
 #include <cmath>
 #include <QSettings>
 

--- a/src/gui/input/InputEventMapper.cc
+++ b/src/gui/input/InputEventMapper.cc
@@ -30,6 +30,7 @@
 #include "AxisConfigWidget.h"
 #include "ButtonConfigWidget.h"
 #include <ciso646> // C alternative tokens
+#include <cstddef>
 #include <cmath>
 #include <QSettings>
 

--- a/src/gui/input/InputEventMapper.h
+++ b/src/gui/input/InputEventMapper.h
@@ -28,6 +28,7 @@
 #include <QTimer>
 #include <QObject>
 
+#include <cstddef>
 #include "InputDriver.h"
 #include "InputDriverEvent.h"
 

--- a/src/gui/input/InputEventMapper.h
+++ b/src/gui/input/InputEventMapper.h
@@ -29,6 +29,7 @@
 #include <QObject>
 
 #include <cstddef>
+#include <string>
 #include "InputDriver.h"
 #include "InputDriverEvent.h"
 

--- a/src/gui/input/JoystickInputDriver.h
+++ b/src/gui/input/JoystickInputDriver.h
@@ -28,6 +28,7 @@
 #include "InputDriver.h"
 
 #include <cstddef>
+#include <string>
 
 class JoystickInputDriver : public InputDriver
 {

--- a/src/gui/input/JoystickInputDriver.h
+++ b/src/gui/input/JoystickInputDriver.h
@@ -27,6 +27,8 @@
 
 #include "InputDriver.h"
 
+#include <cstddef>
+
 class JoystickInputDriver : public InputDriver
 {
 public:

--- a/src/gui/input/QGamepadInputDriver.cc
+++ b/src/gui/input/QGamepadInputDriver.cc
@@ -27,6 +27,8 @@
 #include "InputDriverManager.h"
 #include "QGamepadInputDriver.h"
 
+#include <string>
+
 void QGamepadInputDriver::run()
 {
 }

--- a/src/gui/input/QGamepadInputDriver.h
+++ b/src/gui/input/QGamepadInputDriver.h
@@ -29,6 +29,7 @@
 
 #include <cstddef>
 #include <memory>
+#include <string>
 #include <QtGamepad/QGamepad>
 
 class QGamepadInputDriver : public InputDriver

--- a/src/gui/input/QGamepadInputDriver.h
+++ b/src/gui/input/QGamepadInputDriver.h
@@ -27,6 +27,7 @@
 
 #include "InputDriver.h"
 
+#include <cstddef>
 #include <memory>
 #include <QtGamepad/QGamepad>
 

--- a/src/gui/input/SpaceNavInputDriver.cc
+++ b/src/gui/input/SpaceNavInputDriver.cc
@@ -35,6 +35,7 @@
 
 #include <spnav.h>
 #include <unistd.h>
+#include <string>
 
 void SpaceNavInputDriver::run()
 {

--- a/src/gui/input/SpaceNavInputDriver.h
+++ b/src/gui/input/SpaceNavInputDriver.h
@@ -27,6 +27,7 @@
 #pragma once
 
 #include <cstddef>
+#include <string>
 #include "input/InputDriver.h"
 
 class SpaceNavInputDriver : public InputDriver

--- a/src/gui/input/SpaceNavInputDriver.h
+++ b/src/gui/input/SpaceNavInputDriver.h
@@ -26,6 +26,7 @@
 
 #pragma once
 
+#include <cstddef>
 #include "input/InputDriver.h"
 
 class SpaceNavInputDriver : public InputDriver

--- a/src/gui/parameter/ParameterText.cc
+++ b/src/gui/parameter/ParameterText.cc
@@ -1,5 +1,7 @@
 #include "ParameterText.h"
 
+#include <string>
+
 ParameterText::ParameterText(QWidget *parent, StringParameter *parameter, DescriptionStyle descriptionStyle) :
   ParameterVirtualWidget(parent, parameter),
   parameter(parameter)

--- a/src/gui/parameter/ParameterText.h
+++ b/src/gui/parameter/ParameterText.h
@@ -3,6 +3,8 @@
 #include "ParameterVirtualWidget.h"
 #include "ui_ParameterText.h"
 
+#include <string>
+
 class ParameterText : public ParameterVirtualWidget, Ui::ParameterText
 {
   Q_OBJECT

--- a/src/gui/parameter/ParameterVector.cc
+++ b/src/gui/parameter/ParameterVector.cc
@@ -1,3 +1,4 @@
+#include <cstddef>
 #include "ParameterVector.h"
 #include "IgnoreWheelWhenNotFocused.h"
 

--- a/src/gui/parameter/ParameterVector.h
+++ b/src/gui/parameter/ParameterVector.h
@@ -3,6 +3,8 @@
 #include "ParameterVirtualWidget.h"
 #include "ui_ParameterVector.h"
 
+#include <vector>
+
 class ParameterVector : public ParameterVirtualWidget, Ui::ParameterVector
 {
   Q_OBJECT

--- a/src/gui/parameter/ParameterVirtualWidget.cc
+++ b/src/gui/parameter/ParameterVirtualWidget.cc
@@ -1,6 +1,7 @@
 #include "ParameterVirtualWidget.h"
 
 #include <QRegularExpression>
+#include <vector>
 
 ParameterDescriptionWidget::ParameterDescriptionWidget(QWidget *parent) :
   QWidget(parent)

--- a/src/gui/parameter/ParameterVirtualWidget.h
+++ b/src/gui/parameter/ParameterVirtualWidget.h
@@ -1,6 +1,8 @@
 #pragma once
 
 #include <boost/optional.hpp>
+#include <vector>
+
 #include "qtgettext.h"
 #include "ui_ParameterDescriptionWidget.h"
 #include "ParameterObject.h"

--- a/src/gui/parameter/ParameterWidget.cc
+++ b/src/gui/parameter/ParameterWidget.cc
@@ -42,6 +42,7 @@
 #include <QMessageBox>
 #include <cstddef>
 #include <utility>
+#include <vector>
 
 ParameterWidget::ParameterWidget(QWidget *parent) : QWidget(parent)
 {

--- a/src/gui/parameter/ParameterWidget.cc
+++ b/src/gui/parameter/ParameterWidget.cc
@@ -40,6 +40,7 @@
 
 #include <QInputDialog>
 #include <QMessageBox>
+#include <cstddef>
 #include <utility>
 
 ParameterWidget::ParameterWidget(QWidget *parent) : QWidget(parent)

--- a/src/gui/parameter/ParameterWidget.cc
+++ b/src/gui/parameter/ParameterWidget.cc
@@ -41,6 +41,7 @@
 #include <QInputDialog>
 #include <QMessageBox>
 #include <cstddef>
+#include <string>
 #include <utility>
 #include <vector>
 

--- a/src/gui/parameter/ParameterWidget.h
+++ b/src/gui/parameter/ParameterWidget.h
@@ -28,6 +28,7 @@
 #include <QTimer>
 #include <cstddef>
 #include <map>
+#include <vector>
 
 #include "qtgettext.h" // IWYU pragma: keep
 #include "ui_ParameterWidget.h"

--- a/src/gui/parameter/ParameterWidget.h
+++ b/src/gui/parameter/ParameterWidget.h
@@ -26,6 +26,7 @@
 #pragma once
 
 #include <QTimer>
+#include <cstddef>
 #include <map>
 
 #include "qtgettext.h" // IWYU pragma: keep

--- a/src/gui/parameter/ParameterWidget.h
+++ b/src/gui/parameter/ParameterWidget.h
@@ -28,6 +28,7 @@
 #include <QTimer>
 #include <cstddef>
 #include <map>
+#include <string>
 #include <vector>
 
 #include "qtgettext.h" // IWYU pragma: keep

--- a/src/io/DxfData.cc
+++ b/src/io/DxfData.cc
@@ -43,6 +43,7 @@
 #include <boost/filesystem.hpp>
 #include <algorithm>
 #include <sstream>
+#include <string>
 #include <map>
 
 #include "Value.h"

--- a/src/io/DxfData.cc
+++ b/src/io/DxfData.cc
@@ -27,16 +27,17 @@
 // NOLINTNEXTLINE(bugprone-reserved-identifier)
 #define _USE_MATH_DEFINES
 #include <cmath>
-#include <cstddef>
 
 #include "DxfData.h"
 #include "Grid.h"
 #include "printutils.h"
 #include "calc.h"
 
-#include <fstream>
 #include <cassert>
+#include <cstddef>
+#include <fstream>
 #include <unordered_map>
+#include <vector>
 #include <boost/lexical_cast.hpp>
 #include <boost/algorithm/string.hpp>
 #include <boost/filesystem.hpp>

--- a/src/io/DxfData.cc
+++ b/src/io/DxfData.cc
@@ -27,6 +27,7 @@
 // NOLINTNEXTLINE(bugprone-reserved-identifier)
 #define _USE_MATH_DEFINES
 #include <cmath>
+#include <cstddef>
 
 #include "DxfData.h"
 #include "Grid.h"

--- a/src/io/DxfData.h
+++ b/src/io/DxfData.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <memory>
+#include <string>
 #include <vector>
 #include "linalg.h"
 

--- a/src/io/dxfdim.cc
+++ b/src/io/dxfdim.cc
@@ -35,6 +35,7 @@
 #include "handle_dep.h"
 #include "degree_trig.h"
 
+#include <cstddef>
 #include <cmath>
 #include <sstream>
 #include <cstdint>

--- a/src/io/dxfdim.cc
+++ b/src/io/dxfdim.cc
@@ -39,6 +39,7 @@
 #include <cmath>
 #include <sstream>
 #include <cstdint>
+#include <vector>
 
 #include <boost/filesystem.hpp>
 std::unordered_map<std::string, double> dxf_dim_cache;

--- a/src/io/dxfdim.cc
+++ b/src/io/dxfdim.cc
@@ -39,6 +39,7 @@
 #include <cmath>
 #include <sstream>
 #include <cstdint>
+#include <string>
 #include <vector>
 
 #include <boost/filesystem.hpp>

--- a/src/io/export.cc
+++ b/src/io/export.cc
@@ -29,6 +29,7 @@
 #include "printutils.h"
 #include "Geometry.h"
 
+#include <cstddef>
 #include <fstream>
 
 #ifdef _WIN32

--- a/src/io/export.cc
+++ b/src/io/export.cc
@@ -31,6 +31,7 @@
 
 #include <cstddef>
 #include <fstream>
+#include <vector>
 
 #ifdef _WIN32
 #include <io.h>
@@ -169,8 +170,8 @@ double remove_negative_zero(double x) {
 
 Vector3d remove_negative_zero(const Vector3d& pt) {
   return {
-    remove_negative_zero(pt[0]), 
-    remove_negative_zero(pt[1]), 
+    remove_negative_zero(pt[0]),
+    remove_negative_zero(pt[1]),
     remove_negative_zero(pt[2]),
   };
 }
@@ -192,7 +193,7 @@ struct LexographicLess {
 };
 #endif
 
-} // namespace 
+} // namespace
 
 std::unique_ptr<PolySet> createSortedPolySet(const PolySet& ps)
 {

--- a/src/io/export.h
+++ b/src/io/export.h
@@ -4,6 +4,7 @@
 #include <functional>
 #include <array>
 #include <memory>
+#include <string>
 #include <vector>
 
 #include <boost/range/algorithm.hpp>

--- a/src/io/export.h
+++ b/src/io/export.h
@@ -4,6 +4,7 @@
 #include <functional>
 #include <array>
 #include <memory>
+#include <vector>
 
 #include <boost/range/algorithm.hpp>
 #include <boost/range/adaptor/map.hpp>
@@ -44,7 +45,7 @@ enum class paperSizes {
 // for gui, but declared here to keep it aligned with the enum.
 // can't use Qt mechanism in the IO code.
 // needs to match number of sizes
-const std::array<std::string,5> paperSizeStrings{  
+const std::array<std::string,5> paperSizeStrings{
 "A4","A3","Letter","Legal","Tabloid"
 };
 
@@ -58,7 +59,7 @@ const int paperDimensions[5][2]={
 {612,792},
 {612,1008},
 {792,1224}
-}; 
+};
 
 enum class paperOrientations {
 PORTRAIT,LANDSCAPE,AUTO
@@ -67,7 +68,7 @@ PORTRAIT,LANDSCAPE,AUTO
 // for gui, but declared here to keep it aligned with the enum.
 // can't use Qt mechanism in the IO code.
 // needs to match number of orientations
-const std::array<std::string,3> paperOrientationsStrings{  
+const std::array<std::string,3> paperOrientationsStrings{
 "Portrait","Landscape","Auto"
 };
 
@@ -78,7 +79,7 @@ struct ExportPdfOptions {
     bool showScaleMsg=TRUE;
     bool showGrid=FALSE;
     double gridSize=10.; // New
-    bool showDsgnFN=TRUE; 
+    bool showDsgnFN=TRUE;
     paperOrientations Orientation=paperOrientations::PORTRAIT;
     paperSizes paperSize=paperSizes::A4;
 };

--- a/src/io/export_3mf_v1.cc
+++ b/src/io/export_3mf_v1.cc
@@ -36,6 +36,7 @@
 #include "ManifoldGeometry.h"
 #endif
 
+#include <string>
 
 static uint32_t lib3mf_write_callback(const char *data, uint32_t bytes, std::ostream *stream)
 {

--- a/src/io/export_3mf_v2.cc
+++ b/src/io/export_3mf_v2.cc
@@ -36,6 +36,7 @@
 #include "ManifoldGeometry.h"
 #endif
 
+#include <string>
 
 static uint32_t lib3mf_write_callback(const char *data, uint32_t bytes, std::ostream *stream)
 {

--- a/src/io/export_amf.cc
+++ b/src/io/export_amf.cc
@@ -35,6 +35,7 @@
 #endif
 
 #include <cstddef>
+#include <string>
 #include <vector>
 
 #define QUOTE(x__) # x__

--- a/src/io/export_amf.cc
+++ b/src/io/export_amf.cc
@@ -35,6 +35,7 @@
 #endif
 
 #include <cstddef>
+#include <vector>
 
 #define QUOTE(x__) # x__
 #define QUOTED(x__) QUOTE(x__)

--- a/src/io/export_amf.cc
+++ b/src/io/export_amf.cc
@@ -34,6 +34,8 @@
 #include "CGAL_Nef_polyhedron.h"
 #endif
 
+#include <cstddef>
+
 #define QUOTE(x__) # x__
 #define QUOTED(x__) QUOTE(x__)
 

--- a/src/io/export_off.cc
+++ b/src/io/export_off.cc
@@ -32,6 +32,9 @@
 #include "PolySet.h"
 #include "PolySetUtils.h"
 
+#include <cstddef>
+#include <cstdint>
+
 uint8_t clamp_color_channel(float value)
 {
   if (value < 0) return 0;

--- a/src/io/export_param.cc
+++ b/src/io/export_param.cc
@@ -25,6 +25,7 @@
  */
 
 #include <iostream>
+#include <string>
 #include <json.hpp>
 #include <boost/property_tree/json_parser.hpp>
 

--- a/src/io/export_stl.cc
+++ b/src/io/export_stl.cc
@@ -40,6 +40,7 @@
 #endif
 
 #include <cstddef>
+#include <vector>
 
 namespace {
 /* Define values for double-conversion library. */
@@ -74,7 +75,7 @@ std::string toString(const Vector3f& v)
 }
 
 int32_t flipEndianness(int32_t x) {
-  return 
+  return
     ((x << 24) & 0xff000000) | ((x >> 24) & 0xff) |
     ((x << 8) & 0xff0000) | ((x >> 8) & 0xff00);
 }
@@ -118,7 +119,7 @@ uint64_t append_stl(std::shared_ptr<const PolySet> polyset, std::ostream& output
   if (!binary) {
     vertexStrings.resize(ps->vertices.size());
     std::transform(ps->vertices.begin(), ps->vertices.end(), vertexStrings.begin(),
-      [](const auto& p) 
+      [](const auto& p)
      { return toString({static_cast<float>(p.x()), static_cast<float>(p.y()) , static_cast<float>(p.z()) }); });
   }
 
@@ -157,11 +158,11 @@ uint64_t append_stl(std::shared_ptr<const PolySet> polyset, std::ostream& output
       const auto &s1 = vertexStrings[t[1]];
       const auto &s2 = vertexStrings[t[2]];
 
-      // Since the points are different, the precision we use to 
-      // format them to string should guarantee the strings are 
+      // Since the points are different, the precision we use to
+      // format them to string should guarantee the strings are
       // different too.
       assert(s0 != s1 && s0 != s2 && s1 != s2);
-      
+
       output << "  facet normal ";
       output << toString(
         {static_cast<float>(normal.x()), static_cast<float>(normal.y()), static_cast<float>(normal.z()) }) << "\n";

--- a/src/io/export_stl.cc
+++ b/src/io/export_stl.cc
@@ -39,6 +39,8 @@
 #include "cgalutils.h"
 #endif
 
+#include <cstddef>
+
 namespace {
 /* Define values for double-conversion library. */
 #define DC_BUFFER_SIZE (128)

--- a/src/io/export_stl.cc
+++ b/src/io/export_stl.cc
@@ -40,6 +40,7 @@
 #endif
 
 #include <cstddef>
+#include <string>
 #include <vector>
 
 namespace {

--- a/src/io/export_wrl.cc
+++ b/src/io/export_wrl.cc
@@ -28,6 +28,8 @@
 #include "PolySet.h"
 #include "PolySetUtils.h"
 
+#include <cstddef>
+
 void export_wrl(const std::shared_ptr<const Geometry>& geom, std::ostream& output)
 {
   // FIXME: In lazy union mode, should we export multiple IndexedFaceSets?

--- a/src/io/fileutils.cc
+++ b/src/io/fileutils.cc
@@ -1,3 +1,5 @@
+#include <string>
+
 #include "fileutils.h"
 #include "printutils.h"
 

--- a/src/io/imageutils-macosx.cc
+++ b/src/io/imageutils-macosx.cc
@@ -2,6 +2,7 @@
 #include <iostream>
 #include "imageutils.h"
 #include <cassert>
+#include <cstddef>
 
 CGDataConsumerCallbacks dc_callbacks;
 
@@ -101,6 +102,3 @@ bool write_png(std::ostream& output, unsigned char *pixels, int width, int heigh
   CGColorSpaceRelease(colorSpace);
   return true;
 }
-
-
-

--- a/src/io/import_3mf_v1.cc
+++ b/src/io/import_3mf_v1.cc
@@ -32,6 +32,8 @@
 #include "version_helper.h"
 #include "AST.h"
 
+#include <string>
+
 #include <Model/COM/NMR_DLLInterfaces.h>
 #undef BOOL
 using namespace NMR;

--- a/src/io/import_3mf_v2.cc
+++ b/src/io/import_3mf_v2.cc
@@ -33,12 +33,13 @@
 #include "AST.h"
 #include "lib3mf_implicit.hpp"
 
+#include <vector>
 
 namespace {
   std::unique_ptr<PolySet> getAsPolySet(const Lib3MF::PMeshObject& object) {
     try {
       if (!object) return nullptr;
-    
+
       Lib3MF_uint64 vertex_count = object->GetVertexCount();
       Lib3MF_uint64 triangle_count = object->GetTriangleCount();
       if (!vertex_count || !triangle_count) return nullptr;

--- a/src/io/import_amf.cc
+++ b/src/io/import_amf.cc
@@ -35,6 +35,7 @@
 #endif
 
 #include <sys/types.h>
+#include <cstddef>
 #include <map>
 #include <fstream>
 #include <cassert>

--- a/src/io/import_amf.cc
+++ b/src/io/import_amf.cc
@@ -39,6 +39,7 @@
 #include <map>
 #include <fstream>
 #include <cassert>
+#include <vector>
 #include <libxml/xmlreader.h>
 #include <boost/filesystem.hpp>
 #include <boost/lexical_cast.hpp>

--- a/src/io/import_amf.cc
+++ b/src/io/import_amf.cc
@@ -39,6 +39,7 @@
 #include <map>
 #include <fstream>
 #include <cassert>
+#include <string>
 #include <vector>
 #include <libxml/xmlreader.h>
 #include <boost/filesystem.hpp>

--- a/src/io/import_json.cc
+++ b/src/io/import_json.cc
@@ -25,6 +25,7 @@
  */
 
 #include <fstream>
+#include <string>
 #include <json.hpp>
 
 #include "Value.h"

--- a/src/io/import_nef.cc
+++ b/src/io/import_nef.cc
@@ -1,6 +1,7 @@
 #include "import.h"
 
 #include <memory>
+#include <string>
 #include "printutils.h"
 #include "AST.h"
 

--- a/src/io/import_obj.cc
+++ b/src/io/import_obj.cc
@@ -2,6 +2,7 @@
 #include "PolySet.h"
 #include "PolySetBuilder.h"
 #include <fstream>
+#include <string>
 #include <vector>
 #include <boost/regex.hpp>
 #include <boost/lexical_cast.hpp>
@@ -50,7 +51,7 @@ std::unique_ptr<PolySet> import_obj(const std::string& filename, const Location&
       try {
         Vector3d v;
         for (int i = 0; i < 3; i++) {
-          v[i]= boost::lexical_cast<double>(results[i + 1]); 
+          v[i]= boost::lexical_cast<double>(results[i + 1]);
         }
         vertex_map.push_back(builder.vertexIndex(v));
       } catch (const boost::bad_lexical_cast& blc) {
@@ -71,10 +72,10 @@ std::unique_ptr<PolySet> import_obj(const std::string& filename, const Location&
           int ind=boost::lexical_cast<int>(wordindex[0]);
           if(ind >= 1 && ind  <= vertex_map.size()) {
             builder.addVertex(vertex_map[ind-1]);
-          } else {  
+          } else {
             LOG(message_group::Warning, "Index %1$d out of range in Line %2$d", filename, lineno);
           }
-        } 
+        }
       }
 
     } else if (boost::regex_search(line, results, ex_vt)) { // ignore texture coords

--- a/src/io/import_off.cc
+++ b/src/io/import_off.cc
@@ -7,6 +7,7 @@
 #include <cstddef>
 #include <fstream>
 #include <sstream>
+#include <string>
 #include <locale>
 #include <vector>
 #include <boost/regex.hpp>

--- a/src/io/import_off.cc
+++ b/src/io/import_off.cc
@@ -8,6 +8,7 @@
 #include <fstream>
 #include <sstream>
 #include <locale>
+#include <vector>
 #include <boost/regex.hpp>
 #include <boost/lexical_cast.hpp>
 #include <boost/algorithm/string.hpp>
@@ -263,7 +264,7 @@ std::unique_ptr<PolySet> import_off(const std::string& filename, const Location&
         int b=getcolor(words[i++]);
         int a=i < words.size() ? getcolor(words[i++]) : 255;
         Color4f color(r, g, b, a);
-        
+
         auto iter_pair = color_indices.insert_or_assign(color, ps->colors.size());
         if (iter_pair.second) ps->colors.push_back(color); // inserted
         ps->color_indices.resize(face_idx, -1);

--- a/src/io/import_off.cc
+++ b/src/io/import_off.cc
@@ -4,6 +4,7 @@
 #include "printutils.h"
 #include "AST.h"
 #include <charconv>
+#include <cstddef>
 #include <fstream>
 #include <sstream>
 #include <locale>

--- a/src/io/import_stl.cc
+++ b/src/io/import_stl.cc
@@ -6,6 +6,7 @@
 
 #include <cstddef>
 #include <fstream>
+#include <string>
 #include <boost/predef.h>
 #include <boost/regex.hpp>
 #include <boost/lexical_cast.hpp>

--- a/src/io/import_stl.cc
+++ b/src/io/import_stl.cc
@@ -4,6 +4,7 @@
 #include "printutils.h"
 #include "AST.h"
 
+#include <cstddef>
 #include <fstream>
 #include <boost/predef.h>
 #include <boost/regex.hpp>

--- a/src/io/import_svg.cc
+++ b/src/io/import_svg.cc
@@ -27,6 +27,7 @@
 #include <Eigen/Core>
 #include <Eigen/Geometry>
 
+#include <vector>
 #include "import.h"
 #include "Polygon2d.h"
 #include "printutils.h"

--- a/src/io/import_svg.cc
+++ b/src/io/import_svg.cc
@@ -27,6 +27,7 @@
 #include <Eigen/Core>
 #include <Eigen/Geometry>
 
+#include <string>
 #include <vector>
 #include "import.h"
 #include "Polygon2d.h"

--- a/src/io/libsvg/circle.cc
+++ b/src/io/libsvg/circle.cc
@@ -25,6 +25,8 @@
 #include "circle.h"
 #include "util.h"
 
+#include <string>
+
 namespace libsvg {
 
 const std::string circle::name("circle");

--- a/src/io/libsvg/circle.h
+++ b/src/io/libsvg/circle.h
@@ -24,6 +24,8 @@
  */
 #pragma once
 
+#include <string>
+
 #include "shape.h"
 
 namespace libsvg {

--- a/src/io/libsvg/data.cc
+++ b/src/io/libsvg/data.cc
@@ -24,6 +24,8 @@
  */
 #include "data.h"
 
+#include <string>
+
 namespace libsvg {
 
 const std::string data::name("data");

--- a/src/io/libsvg/data.h
+++ b/src/io/libsvg/data.h
@@ -24,6 +24,8 @@
  */
 #pragma once
 
+#include <string>
+
 #include "shape.h"
 
 namespace libsvg {
@@ -48,5 +50,3 @@ public:
 };
 
 }
-
-

--- a/src/io/libsvg/ellipse.cc
+++ b/src/io/libsvg/ellipse.cc
@@ -23,6 +23,7 @@
  * THE SOFTWARE.
  */
 #include <cstdlib>
+#include <string>
 #include <iostream>
 
 #include "ellipse.h"

--- a/src/io/libsvg/ellipse.h
+++ b/src/io/libsvg/ellipse.h
@@ -24,6 +24,8 @@
  */
 #pragma once
 
+#include <string>
+
 #include "shape.h"
 
 namespace libsvg {

--- a/src/io/libsvg/group.cc
+++ b/src/io/libsvg/group.cc
@@ -23,6 +23,7 @@
  * THE SOFTWARE.
  */
 #include <cstdlib>
+#include <string>
 #include <iostream>
 
 #include "group.h"

--- a/src/io/libsvg/group.h
+++ b/src/io/libsvg/group.h
@@ -24,6 +24,8 @@
  */
 #pragma once
 
+#include <string>
+
 #include "shape.h"
 
 namespace libsvg {

--- a/src/io/libsvg/libsvg.cc
+++ b/src/io/libsvg/libsvg.cc
@@ -24,6 +24,7 @@
  */
 #include <map>
 #include <stack>
+#include <string>
 #include <vector>
 #include <Eigen/Core>
 #include <Eigen/Geometry>

--- a/src/io/libsvg/libsvg.h
+++ b/src/io/libsvg/libsvg.h
@@ -26,6 +26,7 @@
 
 #include <utility>
 #include <memory>
+#include <vector>
 
 #include "shape.h"
 

--- a/src/io/libsvg/libsvg.h
+++ b/src/io/libsvg/libsvg.h
@@ -26,6 +26,7 @@
 
 #include <utility>
 #include <memory>
+#include <string>
 #include <vector>
 
 #include "shape.h"

--- a/src/io/libsvg/line.cc
+++ b/src/io/libsvg/line.cc
@@ -22,6 +22,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+#include <string>
 #include "line.h"
 #include "util.h"
 

--- a/src/io/libsvg/line.h
+++ b/src/io/libsvg/line.h
@@ -24,6 +24,7 @@
  */
 #pragma once
 
+#include <string>
 #include "shape.h"
 
 namespace libsvg {

--- a/src/io/libsvg/path.cc
+++ b/src/io/libsvg/path.cc
@@ -23,7 +23,7 @@
  * THE SOFTWARE.
  */
 #include <cstdlib>
-
+#include <vector>
 #include <string>
 #include <iostream>
 #include <cmath>

--- a/src/io/libsvg/path.cc
+++ b/src/io/libsvg/path.cc
@@ -28,6 +28,7 @@
 #include <iostream>
 #include <cmath>
 #include <cctype>
+#include <string>
 
 #include <Eigen/Core>
 #include <Eigen/Geometry>

--- a/src/io/libsvg/polygon.cc
+++ b/src/io/libsvg/polygon.cc
@@ -27,6 +27,8 @@
 #include "polygon.h"
 #include "util.h"
 
+#include <string>
+
 namespace libsvg {
 
 const std::string polygon::name("polygon");

--- a/src/io/libsvg/polygon.h
+++ b/src/io/libsvg/polygon.h
@@ -24,6 +24,7 @@
  */
 #pragma once
 
+#include <string>
 #include "shape.h"
 
 namespace libsvg {

--- a/src/io/libsvg/polyline.cc
+++ b/src/io/libsvg/polyline.cc
@@ -24,6 +24,7 @@
  */
 #include <boost/tokenizer.hpp>
 
+#include <string>
 #include "polyline.h"
 #include "util.h"
 

--- a/src/io/libsvg/polyline.h
+++ b/src/io/libsvg/polyline.h
@@ -24,6 +24,7 @@
  */
 #pragma once
 
+#include <string>
 #include "shape.h"
 
 namespace libsvg {

--- a/src/io/libsvg/rect.cc
+++ b/src/io/libsvg/rect.cc
@@ -25,6 +25,7 @@
 #include <cstdlib>
 #include <iostream>
 #include <cmath>
+#include <string>
 
 #include <boost/format.hpp>
 

--- a/src/io/libsvg/rect.h
+++ b/src/io/libsvg/rect.h
@@ -24,6 +24,7 @@
  */
 #pragma once
 
+#include <string>
 #include "path.h"
 
 namespace libsvg {

--- a/src/io/libsvg/svgpage.cc
+++ b/src/io/libsvg/svgpage.cc
@@ -23,6 +23,7 @@
  * THE SOFTWARE.
  */
 #include <cstdlib>
+#include <string>
 #include <iostream>
 
 #include "svgpage.h"

--- a/src/io/libsvg/svgpage.h
+++ b/src/io/libsvg/svgpage.h
@@ -24,6 +24,7 @@
  */
 #pragma once
 
+#include <string>
 #include "shape.h"
 #include "util.h"
 

--- a/src/io/libsvg/text.cc
+++ b/src/io/libsvg/text.cc
@@ -22,6 +22,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+#include <string>
 #include "text.h"
 #include "util.h"
 

--- a/src/io/libsvg/text.h
+++ b/src/io/libsvg/text.h
@@ -24,6 +24,7 @@
  */
 #pragma once
 
+#include <string>
 #include "shape.h"
 
 namespace libsvg {
@@ -60,5 +61,3 @@ public:
 };
 
 } // namespace libsvg
-
-

--- a/src/io/libsvg/tspan.cc
+++ b/src/io/libsvg/tspan.cc
@@ -22,6 +22,8 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+#include <string>
+
 #include "tspan.h"
 #include "util.h"
 

--- a/src/io/libsvg/tspan.h
+++ b/src/io/libsvg/tspan.h
@@ -24,6 +24,7 @@
  */
 #pragma once
 
+#include <string>
 #include "shape.h"
 
 namespace libsvg {
@@ -60,5 +61,3 @@ public:
 };
 
 } // namespace libsvg
-
-

--- a/src/io/libsvg/use.cc
+++ b/src/io/libsvg/use.cc
@@ -24,6 +24,7 @@
  */
 #include <cstdlib>
 #include <iostream>
+#include <string>
 #include <vector>
 
 #include "use.h"

--- a/src/io/libsvg/use.cc
+++ b/src/io/libsvg/use.cc
@@ -24,6 +24,7 @@
  */
 #include <cstdlib>
 #include <iostream>
+#include <vector>
 
 #include "use.h"
 #include "util.h"

--- a/src/io/libsvg/use.h
+++ b/src/io/libsvg/use.h
@@ -25,6 +25,7 @@
 #pragma once
 
 #include <vector>
+#include <string>
 #include <memory>
 #include "shape.h"
 

--- a/src/io/libsvg/util.cc
+++ b/src/io/libsvg/util.cc
@@ -24,6 +24,7 @@
  */
 #include <boost/spirit/include/qi.hpp>
 
+#include <string>
 #include <vector>
 
 // include fusion headers for Ubuntu trusty, everything later seems happy without

--- a/src/io/libsvg/util.cc
+++ b/src/io/libsvg/util.cc
@@ -24,6 +24,8 @@
  */
 #include <boost/spirit/include/qi.hpp>
 
+#include <vector>
+
 // include fusion headers for Ubuntu trusty, everything later seems happy without
 #include <boost/fusion/adapted/struct/adapt_struct.hpp>
 #include <boost/fusion/include/adapt_struct.hpp>

--- a/src/openscad_mimalloc.h
+++ b/src/openscad_mimalloc.h
@@ -11,6 +11,7 @@
 #endif
 
 #if defined(ENABLE_CGAL)
+#include <cstddef>
 // gmp requires function signature with extra oldsize parameters for some reason.
 inline void *gmp_realloc(void *ptr, size_t /*oldsize*/, size_t newsize) { return mi_realloc(ptr, newsize); }
 inline void gmp_free(void *ptr, size_t /*oldsize*/) { mi_free(ptr); }

--- a/src/platform/PlatformUtils-win.cc
+++ b/src/platform/PlatformUtils-win.cc
@@ -1,6 +1,7 @@
 #include "PlatformUtils.h"
 
 #include <map>
+#include <string>
 
 #include "printutils.h"
 #include "findversion.h"
@@ -242,4 +243,3 @@ void PlatformUtils::ensureStdIO(void)
   mi_register_output(&mi_output, NULL);
 #endif
 }
-

--- a/src/platform/PlatformUtils.cc
+++ b/src/platform/PlatformUtils.cc
@@ -1,5 +1,6 @@
 #include <cstdlib>
 #include <iomanip>
+#include <string>
 #include <vector>
 
 #include "PlatformUtils.h"

--- a/src/platform/PlatformUtils.cc
+++ b/src/platform/PlatformUtils.cc
@@ -1,5 +1,7 @@
 #include <cstdlib>
 #include <iomanip>
+#include <vector>
+
 #include "PlatformUtils.h"
 #include "printutils.h"
 

--- a/src/platform/PlatformUtils.h
+++ b/src/platform/PlatformUtils.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <cstddef>
 #include <string>
 
 #include <boost/filesystem.hpp>

--- a/src/utils/boost-utils.cc
+++ b/src/utils/boost-utils.cc
@@ -1,5 +1,6 @@
 #include "boost-utils.h"
 #include <cstdio>
+#include <string>
 #include <iostream>
 
 namespace fs = boost::filesystem;

--- a/src/utils/exceptions.h
+++ b/src/utils/exceptions.h
@@ -3,6 +3,7 @@
 #include <stdexcept>
 #include <sstream>
 #include <utility>
+#include <string>
 #include "AST.h"
 #include "printutils.h"
 

--- a/src/utils/hash.cc
+++ b/src/utils/hash.cc
@@ -1,6 +1,8 @@
 #include "hash.h"
 #include <boost/functional/hash.hpp>
 
+#include <cstddef>
+
 namespace std {
 std::size_t hash<Vector3f>::operator()(const Vector3f& s) const {
   return Eigen::hash_value(s);

--- a/src/utils/hash.h
+++ b/src/utils/hash.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "linalg.h"
+#include <cstddef>
 
 using Vector3l = Eigen::Matrix<int64_t, 3, 1>;
 

--- a/src/utils/parallel.h
+++ b/src/utils/parallel.h
@@ -1,6 +1,8 @@
 #pragma once
 #include <algorithm>
 #include <cstddef>
+#include <vector>
+
 #if ENABLE_TBB
 #include <tbb/parallel_for.h>
 #include <tbb/parallel_for_each.h>

--- a/src/utils/parallel.h
+++ b/src/utils/parallel.h
@@ -1,5 +1,6 @@
 #pragma once
 #include <algorithm>
+#include <cstddef>
 #if ENABLE_TBB
 #include <tbb/parallel_for.h>
 #include <tbb/parallel_for_each.h>

--- a/src/utils/printutils.cc
+++ b/src/utils/printutils.cc
@@ -1,5 +1,6 @@
 #include "printutils.h"
 #include <sstream>
+#include <string>
 #include <cstdio>
 #include <boost/algorithm/string.hpp>
 #include <boost/algorithm/string/predicate.hpp>

--- a/src/utils/printutils.h
+++ b/src/utils/printutils.h
@@ -1,12 +1,15 @@
 #pragma once
 
-#include <string>
-#include <list>
-#include <iostream>
-#include <boost/format.hpp>
 #include <boost/algorithm/string.hpp>
-#include <utility>
+#include <boost/format.hpp>
+#include <cstddef>
+#include <initializer_list>
+#include <iostream>
+#include <list>
 #include <sstream>
+#include <string>
+#include <tuple>
+#include <utility>
 
 #include <libintl.h>
 // Undefine some defines from libintl.h to presolve

--- a/src/utils/svg.cc
+++ b/src/utils/svg.cc
@@ -4,6 +4,7 @@
 #include <boost/algorithm/string.hpp>
 #include <boost/lexical_cast.hpp>
 #include <map>
+#include <string>
 #include <vector>
 
 namespace OpenSCAD {

--- a/src/utils/svg.cc
+++ b/src/utils/svg.cc
@@ -4,6 +4,7 @@
 #include <boost/algorithm/string.hpp>
 #include <boost/lexical_cast.hpp>
 #include <map>
+#include <vector>
 
 namespace OpenSCAD {
 

--- a/src/utils/svg.h
+++ b/src/utils/svg.h
@@ -2,6 +2,7 @@
 
 #include "cgal.h"
 #include <boost/algorithm/string.hpp>
+#include <string>
 #include <map>
 
 namespace OpenSCAD {

--- a/src/utils/version_helper.h
+++ b/src/utils/version_helper.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <sstream>
+#include <string>
 
 namespace OpenSCAD {
 

--- a/src/version.cc
+++ b/src/version.cc
@@ -26,6 +26,8 @@
 
 #include "version.h"
 
+#include <string>
+
 #define QUOTE(x__) # x__
 #define QUOTED(x__) QUOTE(x__)
 


### PR DESCRIPTION
Using the clang-tidy runner ( #5304 ), found some missing includes and fixed them half-automated.

This PR adds includes needed for `size_t` (include `<cstddef>`), `std::vector` and `std::string` (including `<vector>` and `<string>`). Separated out as three different commits to not mix things too much.

This reduces `[misc-include-cleaner]` warnings by about 400, about 10%.
  * before: 3985
  * after: 3567

I found that the places how headers are ordered was not necessarily following a common style (e.g. c headers before c++ before project headers), so I put them where things fit 'best'. Longer term, adopting a style there is probably a good idea, but I didn't want to mess _too_ much with that in the first round.

There are a few places where some trailing whitespaces had been found and removed - this is because I've configured my editor to do that by default; they are so few that they hopefully don't mess with ongoing pull requests.

My plan is to chip away on the include cleaner and other clang-tidy findings (if the main contributors welcome these improvements). Rough plan is to first add all the missing includes (because we know then that everything needed is there), so that the superfluous includes can be removed afterwards (as they might be needed right now to accidentally help out other files to work).