### PR TITLE
Make invocation of bash scripts posix compatible.

### DIFF
--- a/scripts/beautify.sh
+++ b/scripts/beautify.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Reformat C++ code using uncrustify
 

--- a/scripts/coverity.sh
+++ b/scripts/coverity.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 UPLOAD_DIR=coverity
 UPLOAD_HOST=openscad@files.openscad.org

--- a/scripts/generate-potfiles.sh
+++ b/scripts/generate-potfiles.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Generate list of files for translation. The output is saved to po/POTFILES
 # which is needed for the xgettext call.

--- a/scripts/generate-svg-icons.sh
+++ b/scripts/generate-svg-icons.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 ICONDIR=resources/icons/svg-default
 ICONSCAD="$ICONDIR"/icons.scad

--- a/scripts/git_merge_fix_false_deletions.sh
+++ b/scripts/git_merge_fix_false_deletions.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # This script is meant to help with updating old PRs.
 # Mainly any OpenSCAD branch which has not been updated since 2022-02-06

--- a/scripts/github-ci-linux-get-dependencies.sh
+++ b/scripts/github-ci-linux-get-dependencies.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 QT="$1"
 

--- a/scripts/github-ci.sh
+++ b/scripts/github-ci.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -e
 

--- a/scripts/github-release.sh
+++ b/scripts/github-release.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Usage (in github root folder): ./scripts/github-release.sh <version>
 #

--- a/scripts/installer-linux.sh
+++ b/scripts/installer-linux.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # change to the install source directory
 cd "$( dirname "$( type -p $0 )" )"

--- a/scripts/macosx-build-dependencies.sh
+++ b/scripts/macosx-build-dependencies.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # This script builds all library dependencies of OpenSCAD for Mac OS X.
 # The libraries will be build in 64-bit mode and backwards compatible

--- a/scripts/macosx-build-homebrew.sh
+++ b/scripts/macosx-build-homebrew.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # This script builds library dependencies of OpenSCAD for Mac OS X using Homebrew.
 #

--- a/scripts/msys2-install-dependencies.sh
+++ b/scripts/msys2-install-dependencies.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 QT="$1"
 

--- a/scripts/release-common.sh
+++ b/scripts/release-common.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # This script creates a binary release of OpenSCAD. This should work
 # under Mac OS X, Linux 32bit, Linux 64bit, and Linux->Win32 MXE cross-build.

--- a/scripts/sort_cmake_filelist.sh
+++ b/scripts/sort_cmake_filelist.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Sorts the CMake-style file list(s) given as arguments by most recently
 # modified first.

--- a/scripts/update-snapshots.sh
+++ b/scripts/update-snapshots.sh
@@ -1,4 +1,4 @@
-#!/bin/bash -e
+#!/usr/bin/env -S bash -e
 
 NAME=( "OpenSCAD-*-x86_64.AppImage" "OpenSCAD-*-aarch64.AppImage" "OpenSCAD-*-WebAssembly.zip" "OpenSCAD-*.dmg"     "OpenSCAD-*-x86-32.zip" "OpenSCAD-*-x86-32-Installer.exe" "OpenSCAD-*-x86-64.zip" "OpenSCAD-*-x86-64-Installer.exe" )
 KEY=(  "LIN64_SNAPSHOT"             "LIN_AARCH64_SNAPSHOT"        "WASM_SNAPSHOT"              "MAC_SNAPSHOT"       "WIN32_SNAPSHOT_ZIP"    "WIN32_SNAPSHOT_INSTALLER"        "WIN64_SNAPSHOT_ZIP"    "WIN64_SNAPSHOT_INSTALLER"        )

--- a/scripts/update-web.sh
+++ b/scripts/update-web.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Works with Mac OS X and Linux cross-compiling for windows using
 # mingw-cross-env (use like: OS=LINXWIN update-web.sh file1.zip file2.exe).

--- a/tests/data/modulecache-tests/cascade.sh
+++ b/tests/data/modulecache-tests/cascade.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 rm -f cascade*.scad
 echo "include <cascade-A.scad> include <cascade-B.scad> use <cascade-C.scad> use <cascade-D.scad> A(); translate([11,0,0]) B(); translate([22,0,0]) C(); translate([33,0,0]) D();" > cascadetest.scad

--- a/tests/data/modulecache-tests/cascade2.sh
+++ b/tests/data/modulecache-tests/cascade2.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 rm -f cascade-*.scad
 echo "include <cascade-A.scad> include <cascade-B.scad> use <cascade-C.scad> use <cascade-D.scad> A(); translate([11,0,0]) B(); translate([22,0,0]) C(); translate([33,0,0]) D();" > cascadetest.scad


### PR DESCRIPTION
The baked-in assumption that bash resides in /bin/bash is not always true, so invoke with /usr/bin/env to be more compatible.