### PR TITLE
Add .clang-format configuration file.

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,37 @@
+# Some set of config values, then refined below
+BasedOnStyle: Google
+
+ColumnLimit: 105
+ContinuationIndentWidth: 2
+ConstructorInitializerIndentWidth: 2
+
+# public:, private: in classes: no indent
+AccessModifierOffset: -2
+
+# case on same level as switch
+IndentCaseLabels: false
+AllowShortCaseLabelsOnASingleLine: true
+AlignConsecutiveShortCaseStatements:
+  Enabled: true
+  AcrossEmptyLines: true
+  AcrossComments: true
+  AlignCaseColons: false
+
+# Always align pointer * and reference & to the right.
+DerivePointerAlignment: false
+PointerAlignment: Right
+ReferenceAlignment: Left
+
+# To be enabled later:
+#  *  once all misc-include-cleaner are addressed an no accidental inclusion
+#     order needed.
+#  * Some CGAL inclusion order has been figuured out.
+SortIncludes: false
+
+# Braces on newline in functions, classes and namespaces.
+BreakBeforeBraces: Custom
+BraceWrapping:
+  AfterClass: true
+  AfterFunction: true
+
+AllowShortIfStatementsOnASingleLine: AllIfsAndElse


### PR DESCRIPTION
Configured, so that it is similar to what uncrustify would produce, but applyig it will still be a massive change, so there needs to be a large scale submit once. The output looks (to my eyes) strictly better than uncrustify, which sometimes does qeustionable

Started in a comment-thread in another PR
https://github.com/openscad/openscad/pull/5306#issuecomment-2363622267

How to apply:
```bash
clang-format -i $(find src -name "*.cc" -o -name "*.h" | grep -v src/ext/)
```

Some comments
  * I did not attempt to fully recreated the uncrustify configuration (is there an automatic tool ?), but mostly looked at the style 'manually' and applied  configuration options that mostly match it.
  * there are numerous options to tweak https://releases.llvm.org/18.1.6/tools/clang/docs/ClangFormatStyleOptions.html
  * While the typical line length is 80 in many projects, here it looked a bit more so I determined a value  determining the 98% percentile of all line length currently found
  `awk '{print length($0)}' $(find src -name "*.cc" -o -name "*.h" | grep -v src/ext/) | datamash perc:98 1`
which resulted in 106. Chosen value 105
  * I was surprised to see that pointers and references are handled differently: References are left-hugging, pointers are right hugging 'const Foo&' vs. `const Foo *`. (Personally, I'd prefer always right-hugging).
  * I don't like braces on a new line for functions, it unnecessarily eats up vertical space, but added the configuration, as it seems to be largely used.
  * Since output differs from uncrustify and `clang-format`, if this is to be added, this PR or a follow-up PR should probably also remove `.uncrustify.cfg` and update `scripts/beautify.sh` to use `clang-format` 

As Draft pull  request for now as there will probably be discussions.
Yes it will create a large change when applied (and it could be rolled-out in stages, e.g. first with often touched files), but using the more modern tool that is more commonly used will make contribution and readability much easier afterwards.