### PR TITLE
Thrust is no longer used

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -919,8 +919,6 @@ if(EXPERIMENTAL AND ENABLE_TBB)
   # ("exact" CGAL numerics are not thread-safe)
   target_compile_options(OpenSCAD PRIVATE 
     -DENABLE_TBB
-    -DTHRUST_HOST_SYSTEM=THRUST_HOST_SYSTEM_TBB
-    -DTHRUST_DEVICE_SYSTEM=THRUST_DEVICE_SYSTEM_TBB
   )
   find_package(TBB QUIET)
   if (NOT TBB_FOUND AND PKG_CONFIG_FOUND)

--- a/scripts/github-ci-linux-get-dependencies.sh
+++ b/scripts/github-ci-linux-get-dependencies.sh
@@ -9,7 +9,7 @@ PACKAGES2="libboost-all-dev libeigen3-dev libzip-dev libcrypto++-dev"
 PACKAGES3="libxi-dev libxmu-dev qtbase5-dev qtmultimedia5-dev libqt5opengl5-dev libqt5svg5-dev libqscintilla2-qt5-dev"
 PACKAGES4="libcairo2-dev libcgal-dev libglew-dev libgmp-dev libmpfr-dev libegl-dev libegl1-mesa-dev"
 PACKAGES5="libdouble-conversion-dev libfontconfig-dev libharfbuzz-dev libopencsg-dev lib3mf-dev libtbb-dev"
-PACKAGES6="libthrust-dev libglm-dev libxml2-dev"
+PACKAGES6="libglm-dev libxml2-dev"
 
 if [[ "$DIST" == "focal" ]]; then
 


### PR DESCRIPTION
Since:
4b645fc30 ("updated manifold to latest version with double precision floating point (#5282)", 2024-09-20)