### PR TITLE
Add #include <memory> in files that use symbols out of it.

### DIFF
--- a/src/RenderStatistic.cc
+++ b/src/RenderStatistic.cc
@@ -24,6 +24,7 @@
  */
 
 
+#include <memory>
 #include <fstream>
 #include "json/json.hpp"
 #include <string>

--- a/src/RenderStatistic.h
+++ b/src/RenderStatistic.h
@@ -25,6 +25,7 @@
 
 #pragma once
 
+#include <memory>
 #include <chrono>
 #include <string>
 #include <vector>

--- a/src/core/AST.cc
+++ b/src/core/AST.cc
@@ -1,4 +1,5 @@
 #include "core/AST.h"
+#include <memory>
 #include <sstream>
 #include <string>
 #include "utils/boost-utils.h"

--- a/src/core/Arguments.cc
+++ b/src/core/Arguments.cc
@@ -24,6 +24,7 @@
  *
  */
 
+#include <memory>
 #include "core/Arguments.h"
 #include "core/Expression.h"
 

--- a/src/core/Arguments.h
+++ b/src/core/Arguments.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <memory>
 #include <ostream>
 #include <string>
 #include <utility>

--- a/src/core/Assignment.h
+++ b/src/core/Assignment.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <memory>
 #include <ostream>
 #include <string>
 #include <utility>

--- a/src/core/Builtins.cc
+++ b/src/core/Builtins.cc
@@ -1,3 +1,4 @@
+#include <memory>
 #include <string>
 #include <vector>
 

--- a/src/core/CSGNode.cc
+++ b/src/core/CSGNode.cc
@@ -28,6 +28,7 @@
 #include "geometry/PolySet.h"
 #include "geometry/linalg.h"
 
+#include <memory>
 #include <cstddef>
 #include <numeric>
 #include <sstream>

--- a/src/core/CSGTreeEvaluator.cc
+++ b/src/core/CSGTreeEvaluator.cc
@@ -12,6 +12,7 @@
 #include "geometry/PolySet.h"
 #include "geometry/PolySetBuilder.h"
 
+#include <memory>
 #include <string>
 #include <map>
 #include <list>

--- a/src/core/CgalAdvNode.cc
+++ b/src/core/CgalAdvNode.cc
@@ -30,6 +30,7 @@
 #include "core/Builtins.h"
 #include "core/Children.h"
 #include "core/Parameters.h"
+#include <memory>
 #include <sstream>
 #include <cassert>
 #include <boost/assign/std/vector.hpp>

--- a/src/core/Children.cc
+++ b/src/core/Children.cc
@@ -24,6 +24,7 @@
  *
  */
 
+#include <memory>
 #include <cstddef>
 #include <vector>
 

--- a/src/core/ColorNode.cc
+++ b/src/core/ColorNode.cc
@@ -31,6 +31,7 @@
 #include "core/Children.h"
 #include "core/Parameters.h"
 #include "utils/printutils.h"
+#include <memory>
 #include <cctype>
 #include <cstddef>
 #include <sstream>

--- a/src/core/Context.cc
+++ b/src/core/Context.cc
@@ -24,6 +24,7 @@
  *
  */
 
+#include <memory>
 #include <cstddef>
 #include <string>
 #include <vector>

--- a/src/core/Context.h
+++ b/src/core/Context.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <memory>
 #include <cstddef>
 #include <string>
 #include <vector>

--- a/src/core/ContextMemoryManager.cc
+++ b/src/core/ContextMemoryManager.cc
@@ -24,6 +24,7 @@
  *
  */
 
+#include <memory>
 #include <deque>
 #include <map>
 #include <unordered_set>

--- a/src/core/CsgOpNode.cc
+++ b/src/core/CsgOpNode.cc
@@ -32,6 +32,7 @@
 #include "core/Children.h"
 #include "core/Parameters.h"
 
+#include <memory>
 #include <sstream>
 #include <string>
 #include <cassert>

--- a/src/core/DrawingCallback.cc
+++ b/src/core/DrawingCallback.cc
@@ -23,6 +23,7 @@
  *  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
  *
  */
+#include <memory>
 #include <algorithm>
 #include <cmath>
 #include <iostream>

--- a/src/core/DrawingCallback.h
+++ b/src/core/DrawingCallback.h
@@ -25,6 +25,7 @@
  */
 #pragma once
 
+#include <memory>
 #include <vector>
 #include <cmath>
 #include <Eigen/Core>

--- a/src/core/FreetypeRenderer.cc
+++ b/src/core/FreetypeRenderer.cc
@@ -23,6 +23,7 @@
  *  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
  *
  */
+#include <memory>
 #include <cmath>
 #include <cstdio>
 #include <vector>

--- a/src/core/FreetypeRenderer.h
+++ b/src/core/FreetypeRenderer.h
@@ -25,6 +25,7 @@
  */
 #pragma once
 
+#include <memory>
 #include <string>
 #include <vector>
 #include <ostream>

--- a/src/core/GroupModule.cc
+++ b/src/core/GroupModule.cc
@@ -24,6 +24,7 @@
  *
  */
 
+#include <memory>
 #include "core/ModuleInstantiation.h"
 #include "core/node.h"
 #include "core/Builtins.h"

--- a/src/core/ImportNode.cc
+++ b/src/core/ImportNode.cc
@@ -43,6 +43,7 @@
 #include "Feature.h"
 #include "handle_dep.h"
 #include "utils/boost-utils.h"
+#include <memory>
 #include <sys/types.h>
 #include <sstream>
 #include <boost/algorithm/string.hpp>

--- a/src/core/ImportNode.h
+++ b/src/core/ImportNode.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <memory>
 #include <string>
 #include <boost/optional.hpp>
 

--- a/src/core/LinearExtrudeNode.cc
+++ b/src/core/LinearExtrudeNode.cc
@@ -35,6 +35,7 @@
 #include "core/Builtins.h"
 #include "handle_dep.h"
 
+#include <memory>
 #include <cmath>
 #include <sstream>
 #include <boost/assign/std/vector.hpp>

--- a/src/core/LocalScope.cc
+++ b/src/core/LocalScope.cc
@@ -1,3 +1,4 @@
+#include <memory>
 #include <cstddef>
 #include <string>
 #include <vector>

--- a/src/core/ModuleInstantiation.cc
+++ b/src/core/ModuleInstantiation.cc
@@ -1,3 +1,4 @@
+#include <memory>
 #include <cstddef>
 #include <string>
 

--- a/src/core/ModuleInstantiation.h
+++ b/src/core/ModuleInstantiation.h
@@ -2,6 +2,7 @@
 
 #include "core/AST.h"
 #include "core/LocalScope.h"
+#include <memory>
 #include <string>
 #include <utility>
 #include <vector>

--- a/src/core/NodeDumper.h
+++ b/src/core/NodeDumper.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <memory>
 #include <string>
 #include <unordered_map>
 #include <list>

--- a/src/core/OffsetNode.cc
+++ b/src/core/OffsetNode.cc
@@ -32,6 +32,7 @@
 #include "core/Parameters.h"
 #include "core/Builtins.h"
 
+#include <memory>
 #include <sstream>
 #include <boost/assign/std/vector.hpp>
 using namespace boost::assign; // bring 'operator+=()' into scope

--- a/src/core/Parameters.cc
+++ b/src/core/Parameters.cc
@@ -24,6 +24,7 @@
  *
  */
 
+#include <memory>
 #include <cstddef>
 #include <set>
 #include <string>

--- a/src/core/Parameters.h
+++ b/src/core/Parameters.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <memory>
 #include <string>
 #include <vector>
 

--- a/src/core/ProjectionNode.cc
+++ b/src/core/ProjectionNode.cc
@@ -31,6 +31,7 @@
 #include "core/Parameters.h"
 #include "core/Builtins.h"
 
+#include <memory>
 #include <cassert>
 #include <boost/assign/std/vector.hpp>
 using namespace boost::assign; // bring 'operator+=()' into scope

--- a/src/core/RenderNode.cc
+++ b/src/core/RenderNode.cc
@@ -31,6 +31,7 @@
 #include "core/Children.h"
 #include "core/Parameters.h"
 
+#include <memory>
 #include <sstream>
 #include <boost/assign/std/vector.hpp>
 using namespace boost::assign; // bring 'operator+=()' into scope

--- a/src/core/RoofNode.cc
+++ b/src/core/RoofNode.cc
@@ -1,6 +1,7 @@
 // This file is a part of openscad. Everything implied is implied.
 // Author: Alexey Korepanov <kaikaikai@yandex.ru>
 
+#include <memory>
 #include <sstream>
 
 #include "core/module.h"

--- a/src/core/RotateExtrudeNode.cc
+++ b/src/core/RotateExtrudeNode.cc
@@ -33,6 +33,7 @@
 #include "io/fileutils.h"
 #include "core/Builtins.h"
 #include "handle_dep.h"
+#include <memory>
 #include <cmath>
 #include <sstream>
 #include <boost/assign/std/vector.hpp>

--- a/src/core/ScopeContext.cc
+++ b/src/core/ScopeContext.cc
@@ -5,6 +5,7 @@
 #include "core/SourceFileCache.h"
 #include "core/UserModule.h"
 
+#include <memory>
 #include <cmath>
 #include <vector>
 

--- a/src/core/SourceFile.cc
+++ b/src/core/SourceFile.cc
@@ -32,6 +32,7 @@
 #include "core/ScopeContext.h"
 #include "core/parsersettings.h"
 #include "core/StatCache.h"
+#include <memory>
 #include <boost/algorithm/string.hpp>
 #include <boost/filesystem.hpp>
 #include <string>

--- a/src/core/SourceFile.h
+++ b/src/core/SourceFile.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <memory>
 #include <string>
 #include <unordered_map>
 #include <unordered_set>

--- a/src/core/SurfaceNode.cc
+++ b/src/core/SurfaceNode.cc
@@ -38,6 +38,7 @@
 #include "lodepng/lodepng.h"
 #include "core/SurfaceNode.h"
 
+#include <memory>
 #include <cstdint>
 #include <cstddef>
 #include <sstream>

--- a/src/core/SurfaceNode.h
+++ b/src/core/SurfaceNode.h
@@ -24,6 +24,7 @@
  *
  */
 
+#include <memory>
 #include <cstddef>
 #include <string>
 #include <vector>

--- a/src/core/TextNode.cc
+++ b/src/core/TextNode.cc
@@ -24,6 +24,7 @@
  *
  */
 
+#include <memory>
 #include <vector>
 
 #include "core/Children.h"

--- a/src/core/TextNode.h
+++ b/src/core/TextNode.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <memory>
 #include <string>
 #include <vector>
 

--- a/src/core/TransformNode.cc
+++ b/src/core/TransformNode.cc
@@ -32,6 +32,7 @@
 #include "core/Parameters.h"
 #include "utils/printutils.h"
 #include "utils/degree_trig.h"
+#include <memory>
 #include <cstddef>
 #include <sstream>
 #include <utility>

--- a/src/core/Tree.cc
+++ b/src/core/Tree.cc
@@ -1,6 +1,7 @@
 #include "core/Tree.h"
 #include "core/NodeDumper.h"
 
+#include <memory>
 #include <cassert>
 #include <algorithm>
 #include <sstream>

--- a/src/core/Tree.h
+++ b/src/core/Tree.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "core/NodeCache.h"
+#include <memory>
 #include <map>
 #include <string>
 #include <utility>

--- a/src/core/UserModule.cc
+++ b/src/core/UserModule.cc
@@ -24,6 +24,7 @@
  *
  */
 
+#include <memory>
 #include <vector>
 
 #include "core/UserModule.h"

--- a/src/core/UserModule.h
+++ b/src/core/UserModule.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <memory>
 #include <string>
 #include <vector>
 

--- a/src/core/builtin_functions.cc
+++ b/src/core/builtin_functions.cc
@@ -36,6 +36,7 @@
 #include "io/import.h"
 #include "io/fileutils.h"
 
+#include <memory>
 #include <cmath>
 #include <sstream>
 #include <ctime>

--- a/src/core/control.cc
+++ b/src/core/control.cc
@@ -24,6 +24,7 @@
  *
  */
 
+#include <memory>
 #include <cstddef>
 #include <vector>
 

--- a/src/core/customizer/Annotation.cc
+++ b/src/core/customizer/Annotation.cc
@@ -27,6 +27,7 @@
 
 #include "core/customizer/Annotation.h"
 
+#include <memory>
 #include <string>
 #include <utility>
 

--- a/src/core/customizer/CommentParser.cc
+++ b/src/core/customizer/CommentParser.cc
@@ -1,3 +1,4 @@
+#include <memory>
 #include <cstddef>
 
 #include "core/customizer/CommentParser.h"

--- a/src/core/customizer/ParameterObject.cc
+++ b/src/core/customizer/ParameterObject.cc
@@ -4,6 +4,7 @@
 #include "core/SourceFile.h"
 #include "core/customizer/ParameterObject.h"
 
+#include <memory>
 #include <cstddef>
 #include <sstream>
 #include <string>

--- a/src/core/customizer/ParameterObject.h
+++ b/src/core/customizer/ParameterObject.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <memory>
 #include <cstddef>
 #include "json/json.hpp"
 #include <string>

--- a/src/core/function.cc
+++ b/src/core/function.cc
@@ -28,6 +28,7 @@
 #include "core/Expression.h"
 #include "core/function.h"
 
+#include <memory>
 #include <cstddef>
 #include <utility>
 

--- a/src/core/function.h
+++ b/src/core/function.h
@@ -5,6 +5,7 @@
 #include "Feature.h"
 #include "core/Value.h"
 
+#include <memory>
 #include <functional>
 #include <string>
 #include <variant>

--- a/src/core/module.cc
+++ b/src/core/module.cc
@@ -24,6 +24,7 @@
  *
  */
 
+#include <memory>
 #include "core/Arguments.h"
 #include "core/Children.h"
 #include "core/Context.h"

--- a/src/core/module.h
+++ b/src/core/module.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <memory>
 #include <functional>
 #include <string>
 #include "Feature.h"

--- a/src/core/node.cc
+++ b/src/core/node.cc
@@ -28,6 +28,7 @@
 #include "core/ModuleInstantiation.h"
 #include "core/progress.h"
 
+#include <memory>
 #include <cstddef>
 #include <functional>
 #include <iostream>

--- a/src/core/node.h
+++ b/src/core/node.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <memory>
 #include <cstddef>
 #include <utility>
 #include <utility>

--- a/src/core/primitives.h
+++ b/src/core/primitives.h
@@ -28,6 +28,7 @@
 #include "geometry/linalg.h"
 #include "core/node.h"
 
+#include <memory>
 #include <cstddef>
 #include <sstream>
 #include <string>

--- a/src/core/progress.cc
+++ b/src/core/progress.cc
@@ -1,3 +1,4 @@
+#include <memory>
 #include "core/progress.h"
 #include "core/node.h"
 

--- a/src/geometry/ClipperUtils.cc
+++ b/src/geometry/ClipperUtils.cc
@@ -1,6 +1,7 @@
 #include "geometry/ClipperUtils.h"
 #include "utils/printutils.h"
 
+#include <memory>
 #include <cstddef>
 #include <vector>
 

--- a/src/geometry/ClipperUtils.h
+++ b/src/geometry/ClipperUtils.h
@@ -3,6 +3,7 @@
 #include "polyclipping/clipper.hpp"
 #include "geometry/Polygon2d.h"
 
+#include <memory>
 #include <vector>
 
 namespace ClipperUtils {

--- a/src/geometry/Geometry.cc
+++ b/src/geometry/Geometry.cc
@@ -1,5 +1,6 @@
 #include "geometry/Geometry.h"
 #include "utils/printutils.h"
+#include <memory>
 #include <boost/foreach.hpp>
 #include <cstddef>
 #include <string>

--- a/src/geometry/GeometryCache.cc
+++ b/src/geometry/GeometryCache.cc
@@ -2,6 +2,7 @@
 #include "utils/printutils.h"
 #include "geometry/Geometry.h"
 
+#include <memory>
 #include <cstddef>
 #include <string>
 

--- a/src/geometry/GeometryEvaluator.cc
+++ b/src/geometry/GeometryEvaluator.cc
@@ -26,6 +26,7 @@
 #include "utils/calc.h"
 #include "io/DxfData.h"
 #include "utils/degree_trig.h"
+#include <memory>
 #include <ciso646> // C alternative tokens (xor)
 #include <algorithm>
 #include "utils/boost-utils.h"

--- a/src/geometry/PolySet.cc
+++ b/src/geometry/PolySet.cc
@@ -29,6 +29,7 @@
 #include "geometry/linalg.h"
 #include "utils/printutils.h"
 #include "geometry/Grid.h"
+#include <memory>
 #include <Eigen/LU>
 #include <cstddef>
 #include <string>

--- a/src/geometry/PolySet.h
+++ b/src/geometry/PolySet.h
@@ -6,6 +6,7 @@
 #include "geometry/Polygon2d.h"
 #include "utils/boost-utils.h"
 
+#include <memory>
 #include <cstddef>
 #include <string>
 #include <vector>

--- a/src/geometry/PolySetBuilder.cc
+++ b/src/geometry/PolySetBuilder.cc
@@ -37,6 +37,7 @@
 #include "geometry/manifold/ManifoldGeometry.h"
 #endif
 
+#include <memory>
 #include <vector>
 
 PolySetBuilder::PolySetBuilder(int vertices_count, int indices_count, int dim, boost::tribool convex)

--- a/src/geometry/PolySetUtils.cc
+++ b/src/geometry/PolySetUtils.cc
@@ -1,5 +1,6 @@
 #include "geometry/PolySetUtils.h"
 
+#include <memory>
 #include <cstddef>
 #include <sstream>
 #include <vector>

--- a/src/geometry/Polygon2d.h
+++ b/src/geometry/Polygon2d.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <memory>
 #include <cstddef>
 #include <string>
 #include <vector>

--- a/src/geometry/boolean_utils.cc
+++ b/src/geometry/boolean_utils.cc
@@ -1,5 +1,6 @@
 #include "geometry/boolean_utils.h"
 
+#include <memory>
 #include <cstddef>
 #include <vector>
 

--- a/src/geometry/boolean_utils.h
+++ b/src/geometry/boolean_utils.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <memory>
 #include "core/enums.h"
 #include "geometry/PolySet.h"
 #include "geometry/Geometry.h"

--- a/src/geometry/cgal/CGALCache.cc
+++ b/src/geometry/cgal/CGALCache.cc
@@ -1,3 +1,4 @@
+#include <memory>
 #include <cstddef>
 #include <string>
 

--- a/src/geometry/cgal/CGALHybridPolyhedron.cc
+++ b/src/geometry/cgal/CGALHybridPolyhedron.cc
@@ -3,6 +3,7 @@
 
 #include "geometry/cgal/cgalutils.h"
 #include "Feature.h"
+#include <memory>
 #include <CGAL/Surface_mesh.h>
 #include <CGAL/boost/graph/helpers.h>
 #include <fstream>

--- a/src/geometry/cgal/CGALHybridPolyhedron.h
+++ b/src/geometry/cgal/CGALHybridPolyhedron.h
@@ -1,6 +1,7 @@
 // Portions of this file are Copyright 2021 Google LLC, and licensed under GPL2+. See COPYING.
 #pragma once
 
+#include <memory>
 #include <cstddef>
 #include <string>
 #include <variant>

--- a/src/geometry/cgal/CGAL_Nef_polyhedron.cc
+++ b/src/geometry/cgal/CGAL_Nef_polyhedron.cc
@@ -1,3 +1,4 @@
+#include <memory>
 #include <cstddef>
 #include <string>
 

--- a/src/geometry/cgal/cgalutils-applyops-hybrid.cc
+++ b/src/geometry/cgal/cgalutils-applyops-hybrid.cc
@@ -3,6 +3,7 @@
 
 #ifdef ENABLE_CGAL
 
+#include <memory>
 #include <cstddef>
 #include <vector>
 

--- a/src/geometry/cgal/cgalutils-corefinement-visitor.h
+++ b/src/geometry/cgal/cgalutils-corefinement-visitor.h
@@ -1,6 +1,7 @@
 // Portions of this file are Copyright 2021 Google LLC, and licensed under GPL2+. See COPYING.
 #pragma once
 
+#include <memory>
 #include <CGAL/Polygon_mesh_processing/corefinement.h>
 #include "geometry/cgal/cgalutils-coplanar-faces-remesher.h"
 

--- a/src/geometry/cgal/cgalutils-hybrid.cc
+++ b/src/geometry/cgal/cgalutils-hybrid.cc
@@ -3,6 +3,7 @@
 #include "geometry/cgal/CGALHybridPolyhedron.h"
 
 
+#include <memory>
 #include <CGAL/boost/graph/helpers.h>
 #include <CGAL/Polygon_mesh_processing/orientation.h>
 #include <CGAL/Polygon_mesh_processing/triangulate_faces.h>

--- a/src/geometry/cgal/cgalutils-mesh.cc
+++ b/src/geometry/cgal/cgalutils-mesh.cc
@@ -3,6 +3,7 @@
 #include "geometry/linalg.h"
 #include "utils/hash.h"
 
+#include <memory>
 #include <CGAL/boost/graph/convert_nef_polyhedron_to_polygon_mesh.h>
 #include <CGAL/boost/graph/graph_traits_Surface_mesh.h>
 #include <CGAL/Surface_mesh.h>

--- a/src/geometry/cgal/cgalutils-polyhedron.cc
+++ b/src/geometry/cgal/cgalutils-polyhedron.cc
@@ -6,6 +6,7 @@
 #include "utils/printutils.h"
 #include "geometry/Grid.h"
 
+#include <memory>
 #include <CGAL/Exact_predicates_inexact_constructions_kernel.h>
 
 #include <boost/range/adaptor/reversed.hpp>

--- a/src/geometry/cgal/cgalutils-project.cc
+++ b/src/geometry/cgal/cgalutils-project.cc
@@ -10,6 +10,7 @@
 #include "geometry/Polygon2d.h"
 #include "geometry/PolySetUtils.h"
 
+#include <memory>
 #include <CGAL/Exact_predicates_inexact_constructions_kernel.h>
 #include <CGAL/normal_vector_newell_3.h>
 #include <CGAL/Handle_hash_function.h>

--- a/src/geometry/cgal/cgalutils-triangulate.cc
+++ b/src/geometry/cgal/cgalutils-triangulate.cc
@@ -2,6 +2,7 @@
 #include "geometry/PolySetBuilder.h"
 #include "geometry/cgal/cgalutils.h"
 
+#include <memory>
 #include <utility>
 
 #include <CGAL/Constrained_Delaunay_triangulation_2.h>

--- a/src/geometry/cgal/cgalutils.cc
+++ b/src/geometry/cgal/cgalutils.cc
@@ -12,6 +12,7 @@
 #include "core/node.h"
 #include "utils/degree_trig.h"
 
+#include <memory>
 #include <CGAL/Aff_transformation_3.h>
 #include <CGAL/normal_vector_newell_3.h>
 #include <CGAL/Handle_hash_function.h>

--- a/src/geometry/cgal/cgalutils.h
+++ b/src/geometry/cgal/cgalutils.h
@@ -5,6 +5,7 @@
 #include "geometry/cgal/CGAL_Nef_polyhedron.h"
 #include "core/enums.h"
 
+#include <memory>
 #include <cstddef>
 #include <vector>
 

--- a/src/geometry/linear_extrude.cc
+++ b/src/geometry/linear_extrude.cc
@@ -1,5 +1,6 @@
 #include "geometry/linear_extrude.h"
 
+#include <memory>
 #include <cstddef>
 #include <queue>
 #include <vector>

--- a/src/geometry/manifold/ManifoldGeometry.h
+++ b/src/geometry/manifold/ManifoldGeometry.h
@@ -2,6 +2,7 @@
 #pragma once
 
 #include "geometry/Geometry.h"
+#include <memory>
 #include <glm/glm.hpp>
 #include "geometry/linalg.h"
 #include <manifold/manifold.h>

--- a/src/geometry/manifold/manifold-applyops-minkowski.cc
+++ b/src/geometry/manifold/manifold-applyops-minkowski.cc
@@ -3,6 +3,7 @@
 
 #include "geometry/cgal/cgal.h"
 #include "geometry/cgal/cgalutils.h"
+#include <memory>
 #include <CGAL/convex_hull_3.h>
 
 #include "geometry/PolySet.h"

--- a/src/geometry/manifold/manifold-applyops.cc
+++ b/src/geometry/manifold/manifold-applyops.cc
@@ -3,6 +3,7 @@
 
 #ifdef ENABLE_MANIFOLD
 
+#include <memory>
 #include "geometry/manifold/manifoldutils.h"
 #include "geometry/manifold/ManifoldGeometry.h"
 #include "core/node.h"

--- a/src/geometry/manifold/manifoldutils.cc
+++ b/src/geometry/manifold/manifoldutils.cc
@@ -7,6 +7,7 @@
 #ifdef ENABLE_CGAL
 #include "geometry/cgal/cgalutils.h"
 #include "geometry/cgal/CGALHybridPolyhedron.h"
+#include <memory>
 #include <CGAL/convex_hull_3.h>
 #include <CGAL/Surface_mesh.h>
 #endif

--- a/src/geometry/manifold/manifoldutils.h
+++ b/src/geometry/manifold/manifoldutils.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <memory>
 #include "geometry/Geometry.h"
 #include "core/enums.h"
 #include "geometry/manifold/ManifoldGeometry.h"

--- a/src/geometry/roof_ss.cc
+++ b/src/geometry/roof_ss.cc
@@ -1,6 +1,7 @@
 // This file is a part of openscad. Everything implied is implied.
 // Author: Alexey Korepanov <kaikaikai@yandex.ru>
 
+#include <memory>
 #include <boost/shared_ptr.hpp>
 
 #include <CGAL/Exact_predicates_inexact_constructions_kernel.h>

--- a/src/geometry/roof_ss.h
+++ b/src/geometry/roof_ss.h
@@ -3,6 +3,7 @@
 
 #pragma once
 
+#include <memory>
 #include "geometry/Polygon2d.h"
 #include "geometry/PolySet.h"
 

--- a/src/geometry/roof_vd.cc
+++ b/src/geometry/roof_vd.cc
@@ -1,6 +1,8 @@
 // This file is a part of openscad. Everything implied is implied.
 // Author: Alexey Korepanov <kaikaikai@yandex.ru>
 
+#include <memory>
+
 // NOLINTNEXTLINE(bugprone-reserved-identifier)
 #define _USE_MATH_DEFINES
 #include <cmath>

--- a/src/geometry/roof_vd.h
+++ b/src/geometry/roof_vd.h
@@ -3,6 +3,7 @@
 
 #pragma once
 
+#include <memory>
 #include "geometry/Polygon2d.h"
 #include "geometry/PolySet.h"
 

--- a/src/glview/Camera.cc
+++ b/src/glview/Camera.cc
@@ -3,6 +3,7 @@
 #include "utils/printutils.h"
 #include "utils/degree_trig.h"
 
+#include <memory>
 #include <vector>
 
 static const double DEFAULT_DISTANCE = 140.0;

--- a/src/glview/Camera.h
+++ b/src/glview/Camera.h
@@ -18,6 +18,7 @@
 
 #include "geometry/linalg.h"
 #include "core/ScopeContext.h"
+#include <memory>
 #include <string>
 #include <vector>
 #include <Eigen/Geometry>

--- a/src/glview/ColorMap.cc
+++ b/src/glview/ColorMap.cc
@@ -2,6 +2,7 @@
 #include "utils/printutils.h"
 #include "platform/PlatformUtils.h"
 
+#include <memory>
 #include <boost/property_tree/json_parser.hpp>
 #include <boost/filesystem.hpp>
 #include <cmath>

--- a/src/glview/ColorMap.h
+++ b/src/glview/ColorMap.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <memory>
 #include <map>
 #include <string>
 #include <list>

--- a/src/glview/CsgInfo.h
+++ b/src/glview/CsgInfo.h
@@ -8,6 +8,7 @@
 #include "glview/RenderSettings.h"
 #include "utils/printutils.h"
 
+#include <memory>
 #include <vector>
 
 /*

--- a/src/glview/GLView.cc
+++ b/src/glview/GLView.cc
@@ -7,6 +7,7 @@
 #include "utils/degree_trig.h"
 #include "glview/hershey.h"
 
+#include <memory>
 #include <cmath>
 #include <cstdio>
 #include <string>

--- a/src/glview/GLView.h
+++ b/src/glview/GLView.h
@@ -17,6 +17,7 @@
 
  */
 
+#include <memory>
 #include <Eigen/Core>
 #include <Eigen/Geometry>
 #include <string>

--- a/src/glview/NULLGL.cc
+++ b/src/glview/NULLGL.cc
@@ -1,5 +1,6 @@
 #include "glview/GLView.h"
 
+#include <memory>
 #include <cstddef>
 #include <string>
 #include <vector>

--- a/src/glview/OffscreenContextCGL.cc
+++ b/src/glview/OffscreenContextCGL.cc
@@ -1,5 +1,6 @@
 #include "glview/OffscreenContextCGL.h"
 
+#include <memory>
 #include <cstddef>
 #include <string>
 #include <iostream>

--- a/src/glview/OffscreenContextEGL.cc
+++ b/src/glview/OffscreenContextEGL.cc
@@ -1,5 +1,6 @@
 #include "glview/OffscreenContextEGL.h"
 
+#include <memory>
 #include <fcntl.h>
 #include <cstddef>
 #include <iostream>

--- a/src/glview/OffscreenContextFactory.cc
+++ b/src/glview/OffscreenContextFactory.cc
@@ -1,5 +1,6 @@
 #include "glview/OffscreenContextFactory.h"
 
+#include <memory>
 #include <string>
 
 #include "utils/printutils.h"

--- a/src/glview/OffscreenContextGLX.cc
+++ b/src/glview/OffscreenContextGLX.cc
@@ -1,5 +1,7 @@
 #include "glview/OffscreenContextGLX.h"
 
+#include <memory>
+
 #define GLAD_GLX_IMPLEMENTATION
 #include <glad/glx.h>
 

--- a/src/glview/OffscreenContextNULL.cc
+++ b/src/glview/OffscreenContextNULL.cc
@@ -4,6 +4,7 @@
  */
 #include "glview/OffscreenContextNULL.h"
 
+#include <memory>
 #include <string>
 
 class OffscreenContextNULL : public OffscreenContext {

--- a/src/glview/VBORenderer.cc
+++ b/src/glview/VBORenderer.cc
@@ -30,6 +30,7 @@
 #include "utils/printutils.h"
 #include "utils/hash.h" // IWYU pragma: keep
 
+#include <memory>
 #include <cstddef>
 #include <iomanip>
 #include <sstream>

--- a/src/glview/VBORenderer.h
+++ b/src/glview/VBORenderer.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <memory>
 #include <cstddef>
 #include "glview/Renderer.h"
 #include "glview/system-gl.h"

--- a/src/glview/VertexArray.h
+++ b/src/glview/VertexArray.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <memory>
 #include <cstddef>
 #include <unordered_map>
 #include <boost/functional/hash.hpp>

--- a/src/glview/VertexState.h
+++ b/src/glview/VertexState.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <memory>
 #include <cstddef>
 #include <functional>
 #include <vector>

--- a/src/glview/cgal/CGALRenderer.cc
+++ b/src/glview/cgal/CGALRenderer.cc
@@ -24,6 +24,8 @@
  *
  */
 
+#include <memory>
+
 #ifdef _MSC_VER
 // Boost conflicts with MPFR under MSVC (google it)
 #include <mpfr.h>

--- a/src/glview/cgal/CGAL_OGL_VBO_helper.h
+++ b/src/glview/cgal/CGAL_OGL_VBO_helper.h
@@ -30,6 +30,7 @@
 #include "glview/VertexArray.h"
 #include "CGAL/OGL_helper.h"
 
+#include <memory>
 #include <cstdlib>
 #include <vector>
 

--- a/src/glview/cgal/LegacyCGALRenderer.cc
+++ b/src/glview/cgal/LegacyCGALRenderer.cc
@@ -24,6 +24,8 @@
  *
  */
 
+#include <memory>
+
 #ifdef _MSC_VER
 // Boost conflicts with MPFR under MSVC (google it)
 #include <mpfr.h>

--- a/src/glview/offscreen-old/OffscreenContextEGL.cc
+++ b/src/glview/offscreen-old/OffscreenContextEGL.cc
@@ -25,6 +25,7 @@
  */
 #include "glview/offscreen-old/OffscreenContextEGL.h"
 
+#include <memory>
 #include <EGL/egl.h>
 #define EGL_EGLEXT_PROTOTYPES
 #include <EGL/eglext.h>

--- a/src/glview/offscreen-old/OffscreenContextGLX.cc
+++ b/src/glview/offscreen-old/OffscreenContextGLX.cc
@@ -38,6 +38,7 @@
 
 
 #include "glview/system-gl.h"
+#include <memory>
 #include <GL/gl.h>
 #include <GL/glx.h>
 

--- a/src/glview/offscreen-old/OffscreenContextWGL.cc
+++ b/src/glview/offscreen-old/OffscreenContextWGL.cc
@@ -13,6 +13,7 @@
 #include "glview/offscreen-old/OffscreenContextWGL.h"
 
 #undef NOGDI
+#include <memory>
 #include <windows.h>
 
 #include <vector>

--- a/src/glview/preview/CSGTreeNormalizer.cc
+++ b/src/glview/preview/CSGTreeNormalizer.cc
@@ -1,3 +1,4 @@
+#include <memory>
 #include <stack>
 
 #include "glview/preview/CSGTreeNormalizer.h"

--- a/src/glview/preview/LegacyOpenCSGRenderer.cc
+++ b/src/glview/preview/LegacyOpenCSGRenderer.cc
@@ -29,6 +29,7 @@
 #include "glview/preview/LegacyOpenCSGRenderer.h"
 #include "glview/LegacyRendererUtils.h"
 
+#include <memory>
 #include <memory.h>
 #include <utility>
 #include "geometry/PolySet.h"

--- a/src/glview/preview/LegacyOpenCSGRenderer.h
+++ b/src/glview/preview/LegacyOpenCSGRenderer.h
@@ -2,6 +2,7 @@
 
 #include "glview/Renderer.h"
 #include "glview/system-gl.h"
+#include <memory>
 #ifdef ENABLE_OPENCSG
 #include <opencsg.h>
 #endif

--- a/src/glview/preview/LegacyThrownTogetherRenderer.cc
+++ b/src/glview/preview/LegacyThrownTogetherRenderer.cc
@@ -26,6 +26,7 @@
 
 #include "glview/preview/LegacyThrownTogetherRenderer.h"
 
+#include <memory>
 #include <utility>
 #include "Feature.h"
 #include "geometry/PolySet.h"

--- a/src/glview/preview/LegacyThrownTogetherRenderer.h
+++ b/src/glview/preview/LegacyThrownTogetherRenderer.h
@@ -2,6 +2,7 @@
 
 #include "glview/Renderer.h"
 #include "core/CSGNode.h"
+#include <memory>
 #include <boost/functional/hash.hpp>
 #include <unordered_map>
 

--- a/src/glview/preview/OpenCSGRenderer.cc
+++ b/src/glview/preview/OpenCSGRenderer.cc
@@ -30,6 +30,7 @@
 
 #include "Feature.h"
 #include "geometry/PolySet.h"
+#include <memory>
 #include <memory.h>
 #include <cstddef>
 #include <utility>

--- a/src/glview/preview/OpenCSGRenderer.h
+++ b/src/glview/preview/OpenCSGRenderer.h
@@ -2,6 +2,7 @@
 
 #include "glview/Renderer.h"
 #include "glview/system-gl.h"
+#include <memory>
 #ifdef ENABLE_OPENCSG
 #include <opencsg.h>
 #endif

--- a/src/glview/preview/ThrownTogetherRenderer.cc
+++ b/src/glview/preview/ThrownTogetherRenderer.cc
@@ -26,6 +26,7 @@
 
 #include "glview/preview/ThrownTogetherRenderer.h"
 
+#include <memory>
 #include <cstddef>
 #include <utility>
 #include "Feature.h"

--- a/src/glview/preview/ThrownTogetherRenderer.h
+++ b/src/glview/preview/ThrownTogetherRenderer.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <memory>
 #include <cstddef>
 #include <vector>
 

--- a/src/gui/CGALWorker.cc
+++ b/src/gui/CGALWorker.cc
@@ -1,4 +1,5 @@
 #include "gui/CGALWorker.h"
+#include <memory>
 #include <QThread>
 
 #include "core/Tree.h"

--- a/src/gui/QSettingsCached.cc
+++ b/src/gui/QSettingsCached.cc
@@ -1,3 +1,4 @@
+#include <memory>
 #include "gui/QSettingsCached.h"
 
 std::unique_ptr<QSettings> QSettingsCached::qsettingsPointer;

--- a/src/gui/ScintillaEditor.cc
+++ b/src/gui/ScintillaEditor.cc
@@ -1,3 +1,4 @@
+#include <memory>
 #include <ciso646> // C alternative tokens (xor)
 #include <cstdlib>
 #include <string>

--- a/src/gui/parameter/ParameterWidget.cc
+++ b/src/gui/parameter/ParameterWidget.cc
@@ -23,6 +23,7 @@
  *  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
  *
  */
+#include <memory>
 #include <QWidget>
 
 #include "gui/parameter/ParameterWidget.h"

--- a/src/io/DxfData.cc
+++ b/src/io/DxfData.cc
@@ -24,6 +24,8 @@
  *
  */
 
+#include <memory>
+
 // NOLINTNEXTLINE(bugprone-reserved-identifier)
 #define _USE_MATH_DEFINES
 #include <cmath>

--- a/src/io/export.cc
+++ b/src/io/export.cc
@@ -29,6 +29,7 @@
 #include "utils/printutils.h"
 #include "geometry/Geometry.h"
 
+#include <memory>
 #include <cstddef>
 #include <fstream>
 #include <vector>

--- a/src/io/export_3mf_v1.cc
+++ b/src/io/export_3mf_v1.cc
@@ -36,6 +36,7 @@
 #include "geometry/manifold/ManifoldGeometry.h"
 #endif
 
+#include <memory>
 #include <string>
 
 static uint32_t lib3mf_write_callback(const char *data, uint32_t bytes, std::ostream *stream)

--- a/src/io/export_3mf_v2.cc
+++ b/src/io/export_3mf_v2.cc
@@ -36,6 +36,7 @@
 #include "geometry/manifold/ManifoldGeometry.h"
 #endif
 
+#include <memory>
 #include <string>
 
 static uint32_t lib3mf_write_callback(const char *data, uint32_t bytes, std::ostream *stream)

--- a/src/io/export_amf.cc
+++ b/src/io/export_amf.cc
@@ -34,6 +34,7 @@
 #include "geometry/cgal/CGAL_Nef_polyhedron.h"
 #endif
 
+#include <memory>
 #include <cstddef>
 #include <string>
 #include <vector>

--- a/src/io/export_dxf.cc
+++ b/src/io/export_dxf.cc
@@ -24,6 +24,7 @@
  *
  */
 
+#include <memory>
 #include "io/export.h"
 #include "geometry/PolySet.h"
 

--- a/src/io/export_nef.cc
+++ b/src/io/export_nef.cc
@@ -32,6 +32,7 @@
 #include "geometry/cgal/CGAL_Nef_polyhedron.h"
 #include "geometry/cgal/cgal.h"
 #include "geometry/cgal/cgalutils.h"
+#include <memory>
 #include <CGAL/IO/Nef_polyhedron_iostream_3.h> // for dumping .nef3
 
 void export_nefdbg(const std::shared_ptr<const Geometry>& geom, std::ostream& output)

--- a/src/io/export_obj.cc
+++ b/src/io/export_obj.cc
@@ -25,6 +25,7 @@
  *
  */
 
+#include <memory>
 #include "io/export.h"
 
 #include "geometry/PolySetUtils.h"

--- a/src/io/export_off.cc
+++ b/src/io/export_off.cc
@@ -32,6 +32,7 @@
 #include "geometry/PolySet.h"
 #include "geometry/PolySetUtils.h"
 
+#include <memory>
 #include <cstddef>
 #include <cstdint>
 

--- a/src/io/export_pdf.cc
+++ b/src/io/export_pdf.cc
@@ -5,6 +5,7 @@
 // #include "version.h"
 #include "utils/version_helper.h"
 
+#include <memory>
 #include <string>
 #include <cmath>
 

--- a/src/io/export_stl.cc
+++ b/src/io/export_stl.cc
@@ -27,6 +27,7 @@
 #include "io/export.h"
 #include "geometry/PolySet.h"
 #include "geometry/PolySetUtils.h"
+#include <memory>
 #include <double-conversion/double-conversion.h>
 #ifdef ENABLE_MANIFOLD
 #include "geometry/manifold/ManifoldGeometry.h"

--- a/src/io/export_svg.cc
+++ b/src/io/export_svg.cc
@@ -24,6 +24,7 @@
  *
  */
 
+#include <memory>
 #include "io/export.h"
 #include "geometry/PolySet.h"
 

--- a/src/io/export_wrl.cc
+++ b/src/io/export_wrl.cc
@@ -28,6 +28,7 @@
 #include "geometry/PolySet.h"
 #include "geometry/PolySetUtils.h"
 
+#include <memory>
 #include <cstddef>
 
 void export_wrl(const std::shared_ptr<const Geometry>& geom, std::ostream& output)

--- a/src/io/import.h
+++ b/src/io/import.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <memory>
 #include <string>
 #include <boost/optional.hpp>
 

--- a/src/io/import_3mf_dummy.cc
+++ b/src/io/import_3mf_dummy.cc
@@ -24,6 +24,7 @@
  *
  */
 
+#include <memory>
 #include <string>
 #include "io/import.h"
 #include "utils/printutils.h"

--- a/src/io/import_3mf_v1.cc
+++ b/src/io/import_3mf_v1.cc
@@ -32,6 +32,7 @@
 #include "utils/version_helper.h"
 #include "core/AST.h"
 
+#include <memory>
 #include <string>
 
 #include <Model/COM/NMR_DLLInterfaces.h>

--- a/src/io/import_3mf_v2.cc
+++ b/src/io/import_3mf_v2.cc
@@ -33,6 +33,7 @@
 #include "core/AST.h"
 #include "lib3mf_implicit.hpp"
 
+#include <memory>
 #include <vector>
 
 namespace {

--- a/src/io/import_amf.cc
+++ b/src/io/import_amf.cc
@@ -34,6 +34,7 @@
 #include "geometry/cgal/cgalutils.h"
 #endif
 
+#include <memory>
 #include <sys/types.h>
 #include <cstddef>
 #include <map>

--- a/src/io/import_obj.cc
+++ b/src/io/import_obj.cc
@@ -1,6 +1,7 @@
 #include "io/import.h"
 #include "geometry/PolySet.h"
 #include "geometry/PolySetBuilder.h"
+#include <memory>
 #include <fstream>
 #include <string>
 #include <vector>

--- a/src/io/import_off.cc
+++ b/src/io/import_off.cc
@@ -3,6 +3,7 @@
 #include "geometry/PolySet.h"
 #include "utils/printutils.h"
 #include "core/AST.h"
+#include <memory>
 #include <charconv>
 #include <cstddef>
 #include <fstream>

--- a/src/io/import_stl.cc
+++ b/src/io/import_stl.cc
@@ -4,6 +4,7 @@
 #include "utils/printutils.h"
 #include "core/AST.h"
 
+#include <memory>
 #include <cstddef>
 #include <fstream>
 #include <string>

--- a/src/io/import_svg.cc
+++ b/src/io/import_svg.cc
@@ -24,6 +24,7 @@
  *
  */
 
+#include <memory>
 #include <Eigen/Core>
 #include <Eigen/Geometry>
 

--- a/src/io/libsvg/libsvg.cc
+++ b/src/io/libsvg/libsvg.cc
@@ -22,6 +22,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+#include <memory>
 #include <map>
 #include <stack>
 #include <string>

--- a/src/io/libsvg/shape.cc
+++ b/src/io/libsvg/shape.cc
@@ -22,6 +22,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+#include <memory>
 #include <cstdio>
 #include <cmath>
 #include <string>

--- a/src/io/libsvg/use.cc
+++ b/src/io/libsvg/use.cc
@@ -22,6 +22,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+#include <memory>
 #include <cstdlib>
 #include <iostream>
 #include <string>

--- a/src/openscad.cc
+++ b/src/openscad.cc
@@ -48,6 +48,7 @@
 #include "core/customizer/ParameterObject.h"
 #include "core/customizer/ParameterSet.h"
 #include "openscad_mimalloc.h"
+#include <memory>
 #include <string>
 #include <vector>
 #include <fstream>


### PR DESCRIPTION
Add the header to all files that use one of

 * std::shared_ptr
 * std::unique_ptr
 * std::make_shared
 * std::make_unique

As found by clang-tidy and reported as [misc-include-cleaner].

Reduces [misc-include-cleaner] warnings 3565 -> 3264

Mostly auto-generated by extracting the relevant files from clang-tidy output, then using a [c++ `script'](https://github.com/hzeller/dev-tools) to insert the missing headers.

```bash
scripts/run-clang-tidy-cached.cc --checks="-*,misc-include-cleaner"  # find relevant issues

# Include <memory> header to all files that need it
../dev-tools/insert-header.cc '<memory>' $(grep "no header providing.*misc-include-cleaner" OpenSCAD_clang-tidy.out | awk -F: '/^src\/.*std::shared_ptr|std::unique_ptr|std::make_shared|std::make_unique/ {print $1}' | grep -v src/ext | sort | uniq)
```

Sicne the headers are all non-sorted and non-grouped, no attempt is made to 'sort' them into any particular block (except for being before angle-bracket include if available). These things can be done automatically once we have all include cleaner issues addressed and can use clang-format to prettify all the includes.