### PR TITLE
Insert missing <cstdint> header for all files using sized ints.

### DIFF
--- a/src/FontCache.cc
+++ b/src/FontCache.cc
@@ -24,6 +24,7 @@
  *
  */
 
+#include <cstdint>
 #include <iostream>
 #include <vector>
 

--- a/src/FontCache.h
+++ b/src/FontCache.h
@@ -25,6 +25,7 @@
  */
 #pragma once
 
+#include <cstdint>
 #include <map>
 #include <string>
 #include <iostream>

--- a/src/core/FreetypeRenderer.cc
+++ b/src/core/FreetypeRenderer.cc
@@ -23,6 +23,7 @@
  *  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
  *
  */
+#include <cstdint>
 #include <memory>
 #include <cmath>
 #include <cstdio>

--- a/src/core/SurfaceNode.h
+++ b/src/core/SurfaceNode.h
@@ -24,6 +24,7 @@
  *
  */
 
+#include <cstdint>
 #include <memory>
 #include <cstddef>
 #include <string>

--- a/src/core/Value.cc
+++ b/src/core/Value.cc
@@ -24,6 +24,7 @@
  *
  */
 
+#include <cstdint>
 #include <cassert>
 #include <cstddef>
 #include <memory>

--- a/src/core/builtin_functions.cc
+++ b/src/core/builtin_functions.cc
@@ -36,6 +36,7 @@
 #include "io/import.h"
 #include "io/fileutils.h"
 
+#include <cstdint>
 #include <memory>
 #include <cmath>
 #include <sstream>

--- a/src/core/str_utf8_wrapper.h
+++ b/src/core/str_utf8_wrapper.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <cstdint>
 #include <cstddef>
 #include <memory>
 #include <string>

--- a/src/geometry/PolySet.h
+++ b/src/geometry/PolySet.h
@@ -6,6 +6,7 @@
 #include "geometry/Polygon2d.h"
 #include "utils/boost-utils.h"
 
+#include <cstdint>
 #include <memory>
 #include <cstddef>
 #include <string>

--- a/src/geometry/PolySetBuilder.cc
+++ b/src/geometry/PolySetBuilder.cc
@@ -37,6 +37,7 @@
 #include "geometry/manifold/ManifoldGeometry.h"
 #endif
 
+#include <cstdint>
 #include <memory>
 #include <vector>
 

--- a/src/geometry/PolySetBuilder.h
+++ b/src/geometry/PolySetBuilder.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <cstdint>
 #include <memory>
 #include <vector>
 

--- a/src/geometry/PolySetUtils.cc
+++ b/src/geometry/PolySetUtils.cc
@@ -1,5 +1,6 @@
 #include "geometry/PolySetUtils.h"
 
+#include <cstdint>
 #include <memory>
 #include <cstddef>
 #include <sstream>

--- a/src/geometry/linalg.cc
+++ b/src/geometry/linalg.cc
@@ -1,4 +1,5 @@
 #include "geometry/linalg.h"
+#include <cstdint>
 #include <cmath>
 
 // FIXME: We can achieve better pruning by either:

--- a/src/geometry/manifold/ManifoldGeometry.cc
+++ b/src/geometry/manifold/ManifoldGeometry.cc
@@ -1,6 +1,7 @@
 // Portions of this file are Copyright 2023 Google LLC, and licensed under GPL2+. See COPYING.
 #include "geometry/manifold/ManifoldGeometry.h"
 #include "geometry/Polygon2d.h"
+#include <cstdint>
 #include <manifold/cross_section.h>
 #include <manifold/manifold.h>
 #include "geometry/PolySet.h"

--- a/src/geometry/manifold/ManifoldGeometry.h
+++ b/src/geometry/manifold/ManifoldGeometry.h
@@ -2,6 +2,7 @@
 #pragma once
 
 #include "geometry/Geometry.h"
+#include <cstdint>
 #include <memory>
 #include <glm/glm.hpp>
 #include "geometry/linalg.h"

--- a/src/geometry/manifold/manifoldutils.cc
+++ b/src/geometry/manifold/manifoldutils.cc
@@ -7,6 +7,7 @@
 #ifdef ENABLE_CGAL
 #include "geometry/cgal/cgalutils.h"
 #include "geometry/cgal/CGALHybridPolyhedron.h"
+#include <cstdint>
 #include <memory>
 #include <CGAL/convex_hull_3.h>
 #include <CGAL/Surface_mesh.h>

--- a/src/geometry/roof_vd.cc
+++ b/src/geometry/roof_vd.cc
@@ -1,6 +1,7 @@
 // This file is a part of openscad. Everything implied is implied.
 // Author: Alexey Korepanov <kaikaikai@yandex.ru>
 
+#include <cstdint>
 #include <memory>
 
 // NOLINTNEXTLINE(bugprone-reserved-identifier)

--- a/src/glview/NULLGL.cc
+++ b/src/glview/NULLGL.cc
@@ -1,5 +1,6 @@
 #include "glview/GLView.h"
 
+#include <cstdint>
 #include <memory>
 #include <cstddef>
 #include <string>

--- a/src/glview/OffscreenContext.h
+++ b/src/glview/OffscreenContext.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <cstdint>
 #include "glview/OpenGLContext.h"
 
 class OffscreenContext : public OpenGLContext {

--- a/src/glview/OffscreenContextFactory.h
+++ b/src/glview/OffscreenContextFactory.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <cstdint>
 #include <memory>
 #include <string>
 

--- a/src/glview/OffscreenView.cc
+++ b/src/glview/OffscreenView.cc
@@ -1,5 +1,6 @@
 #include "glview/OffscreenView.h"
 #include "glview/system-gl.h"
+#include <cstdint>
 #include <cmath>
 #include <cstdio>
 #include <string>

--- a/src/glview/OffscreenView.h
+++ b/src/glview/OffscreenView.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <cstdint>
 #include <memory>
 #include <string>
 #include <ostream>

--- a/src/glview/OpenGLContext.cc
+++ b/src/glview/OpenGLContext.cc
@@ -1,5 +1,6 @@
 #include "glview/OpenGLContext.h"
 
+#include <cstdint>
 #include <cstddef>
 #include <vector>
 

--- a/src/glview/offscreen-old/OffscreenContextEGL.cc
+++ b/src/glview/offscreen-old/OffscreenContextEGL.cc
@@ -25,6 +25,7 @@
  */
 #include "glview/offscreen-old/OffscreenContextEGL.h"
 
+#include <cstdint>
 #include <memory>
 #include <EGL/egl.h>
 #define EGL_EGLEXT_PROTOTYPES

--- a/src/glview/offscreen-old/OffscreenContextEGL.h
+++ b/src/glview/offscreen-old/OffscreenContextEGL.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <cstdint>
 #include <memory>
 #include <string>
 

--- a/src/glview/offscreen-old/OffscreenContextGLX.cc
+++ b/src/glview/offscreen-old/OffscreenContextGLX.cc
@@ -38,6 +38,7 @@
 
 
 #include "glview/system-gl.h"
+#include <cstdint>
 #include <memory>
 #include <GL/gl.h>
 #include <GL/glx.h>

--- a/src/glview/offscreen-old/OffscreenContextGLX.h
+++ b/src/glview/offscreen-old/OffscreenContextGLX.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <cstdint>
 #include <memory>
 
 #include "glview/OffscreenContext.h"

--- a/src/glview/offscreen-old/OffscreenContextNSOpenGL.h
+++ b/src/glview/offscreen-old/OffscreenContextNSOpenGL.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <cstdint>
 #include <memory>
 
 #include "glview/OffscreenContext.h"

--- a/src/glview/offscreen-old/OffscreenContextWGL.cc
+++ b/src/glview/offscreen-old/OffscreenContextWGL.cc
@@ -13,6 +13,7 @@
 #include "glview/offscreen-old/OffscreenContextWGL.h"
 
 #undef NOGDI
+#include <cstdint>
 #include <memory>
 #include <windows.h>
 

--- a/src/glview/offscreen-old/OffscreenContextWGL.h
+++ b/src/glview/offscreen-old/OffscreenContextWGL.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <cstdint>
 #include <memory>
 
 #include "glview/OffscreenContext.h"

--- a/src/gui/FontList.cc
+++ b/src/gui/FontList.cc
@@ -1,3 +1,4 @@
+#include <cstdint>
 #include <qitemselectionmodel.h>
 #include <string>
 #include <iostream>

--- a/src/gui/FontList.h
+++ b/src/gui/FontList.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <cstdint>
 #include <vector>
 
 #include <QWidget>

--- a/src/gui/MouseSelector.cc
+++ b/src/gui/MouseSelector.cc
@@ -1,6 +1,7 @@
 #include "glview/system-gl.h"
 #include "gui/MouseSelector.h"
 
+#include <cstdint>
 #include <QOpenGLFramebufferObject>
 #include <string>
 #include <memory>

--- a/src/gui/input/HidApiInputDriver.cc
+++ b/src/gui/input/HidApiInputDriver.cc
@@ -29,6 +29,7 @@
  *  Public Domain.
  */
 
+#include <cstdint>
 #include <bitset>
 #include <boost/format.hpp>
 #include <chrono>

--- a/src/io/export.cc
+++ b/src/io/export.cc
@@ -29,6 +29,7 @@
 #include "utils/printutils.h"
 #include "geometry/Geometry.h"
 
+#include <cstdint>
 #include <memory>
 #include <cstddef>
 #include <fstream>

--- a/src/io/export_3mf_v1.cc
+++ b/src/io/export_3mf_v1.cc
@@ -36,6 +36,7 @@
 #include "geometry/manifold/ManifoldGeometry.h"
 #endif
 
+#include <cstdint>
 #include <memory>
 #include <string>
 

--- a/src/io/export_3mf_v2.cc
+++ b/src/io/export_3mf_v2.cc
@@ -36,6 +36,7 @@
 #include "geometry/manifold/ManifoldGeometry.h"
 #endif
 
+#include <cstdint>
 #include <memory>
 #include <string>
 

--- a/src/io/export_stl.cc
+++ b/src/io/export_stl.cc
@@ -27,6 +27,7 @@
 #include "io/export.h"
 #include "geometry/PolySet.h"
 #include "geometry/PolySetUtils.h"
+#include <cstdint>
 #include <memory>
 #include <double-conversion/double-conversion.h>
 #ifdef ENABLE_MANIFOLD

--- a/src/io/import_off.cc
+++ b/src/io/import_off.cc
@@ -3,6 +3,7 @@
 #include "geometry/PolySet.h"
 #include "utils/printutils.h"
 #include "core/AST.h"
+#include <cstdint>
 #include <memory>
 #include <charconv>
 #include <cstddef>

--- a/src/io/import_stl.cc
+++ b/src/io/import_stl.cc
@@ -4,6 +4,7 @@
 #include "utils/printutils.h"
 #include "core/AST.h"
 
+#include <cstdint>
 #include <memory>
 #include <cstddef>
 #include <fstream>

--- a/src/platform/PlatformUtils.cc
+++ b/src/platform/PlatformUtils.cc
@@ -1,3 +1,4 @@
+#include <cstdint>
 #include <cstdlib>
 #include <iomanip>
 #include <string>

--- a/src/platform/PlatformUtils.h
+++ b/src/platform/PlatformUtils.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <cstdint>
 #include <cstddef>
 #include <string>
 

--- a/src/utils/hash.cc
+++ b/src/utils/hash.cc
@@ -1,4 +1,5 @@
 #include "utils/hash.h"
+#include <cstdint>
 #include <boost/functional/hash.hpp>
 
 #include <cstddef>

--- a/src/utils/hash.h
+++ b/src/utils/hash.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "geometry/linalg.h"
+#include <cstdint>
 #include <cstddef>
 
 using Vector3l = Eigen::Matrix<int64_t, 3, 1>;


### PR DESCRIPTION
Add to all files that uses any of u?int(8|16|32|64)_t and were not including <cstdint> yet.

## Automatically generated

```
scripts/run-clang-tidy-cached.cc
../dev-tools/insert-header.cc '<cstdint>' $(grep "no header providing.*misc-include-cleaner" OpenSCAD_clang-tidy.out | awk -F: '/^src\/.*(u?int(8|16|32|64)_t)/ {print $1}' | sort -u)
```

(w/ insert-header.cc from this [script collection](https://github.com/hzeller/dev-tools))