### PR TITLE
Insert include <utility> missing in files using std::move

### DIFF
--- a/src/core/CSGNode.h
+++ b/src/core/CSGNode.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <utility>
 #include <cstddef>
 #include <string>
 #include <vector>

--- a/src/core/CgalAdvNode.cc
+++ b/src/core/CgalAdvNode.cc
@@ -30,6 +30,7 @@
 #include "core/Builtins.h"
 #include "core/Children.h"
 #include "core/Parameters.h"
+#include <utility>
 #include <memory>
 #include <sstream>
 #include <cassert>

--- a/src/core/ColorNode.cc
+++ b/src/core/ColorNode.cc
@@ -31,6 +31,7 @@
 #include "core/Children.h"
 #include "core/Parameters.h"
 #include "utils/printutils.h"
+#include <utility>
 #include <memory>
 #include <cctype>
 #include <cstddef>

--- a/src/core/Context.cc
+++ b/src/core/Context.cc
@@ -24,6 +24,7 @@
  *
  */
 
+#include <utility>
 #include <memory>
 #include <cstddef>
 #include <string>

--- a/src/core/ContextFrame.cc
+++ b/src/core/ContextFrame.cc
@@ -24,6 +24,7 @@
  *
  */
 
+#include <utility>
 #include <cstddef>
 #include <string>
 #include <vector>

--- a/src/core/ContextMemoryManager.cc
+++ b/src/core/ContextMemoryManager.cc
@@ -24,6 +24,7 @@
  *
  */
 
+#include <utility>
 #include <memory>
 #include <deque>
 #include <map>

--- a/src/core/CsgOpNode.cc
+++ b/src/core/CsgOpNode.cc
@@ -32,6 +32,7 @@
 #include "core/Children.h"
 #include "core/Parameters.h"
 
+#include <utility>
 #include <memory>
 #include <sstream>
 #include <string>

--- a/src/core/Expression.h
+++ b/src/core/Expression.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <utility>
 #include <cstddef>
 #include <functional>
 #include <string>

--- a/src/core/FunctionType.h
+++ b/src/core/FunctionType.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <utility>
 #include <memory>
 #include <ostream>
 

--- a/src/core/GroupModule.cc
+++ b/src/core/GroupModule.cc
@@ -24,6 +24,7 @@
  *
  */
 
+#include <utility>
 #include <memory>
 #include "core/ModuleInstantiation.h"
 #include "core/node.h"

--- a/src/core/ImportNode.cc
+++ b/src/core/ImportNode.cc
@@ -43,6 +43,7 @@
 #include "Feature.h"
 #include "handle_dep.h"
 #include "utils/boost-utils.h"
+#include <utility>
 #include <memory>
 #include <sys/types.h>
 #include <sstream>

--- a/src/core/LinearExtrudeNode.cc
+++ b/src/core/LinearExtrudeNode.cc
@@ -35,6 +35,7 @@
 #include "core/Builtins.h"
 #include "handle_dep.h"
 
+#include <utility>
 #include <memory>
 #include <cmath>
 #include <sstream>

--- a/src/core/OffsetNode.cc
+++ b/src/core/OffsetNode.cc
@@ -32,6 +32,7 @@
 #include "core/Parameters.h"
 #include "core/Builtins.h"
 
+#include <utility>
 #include <memory>
 #include <sstream>
 #include <boost/assign/std/vector.hpp>

--- a/src/core/ProjectionNode.cc
+++ b/src/core/ProjectionNode.cc
@@ -31,6 +31,7 @@
 #include "core/Parameters.h"
 #include "core/Builtins.h"
 
+#include <utility>
 #include <memory>
 #include <cassert>
 #include <boost/assign/std/vector.hpp>

--- a/src/core/RenderNode.cc
+++ b/src/core/RenderNode.cc
@@ -31,6 +31,7 @@
 #include "core/Children.h"
 #include "core/Parameters.h"
 
+#include <utility>
 #include <memory>
 #include <sstream>
 #include <boost/assign/std/vector.hpp>

--- a/src/core/RoofNode.cc
+++ b/src/core/RoofNode.cc
@@ -1,6 +1,7 @@
 // This file is a part of openscad. Everything implied is implied.
 // Author: Alexey Korepanov <kaikaikai@yandex.ru>
 
+#include <utility>
 #include <memory>
 #include <sstream>
 

--- a/src/core/RotateExtrudeNode.cc
+++ b/src/core/RotateExtrudeNode.cc
@@ -33,6 +33,7 @@
 #include "io/fileutils.h"
 #include "core/Builtins.h"
 #include "handle_dep.h"
+#include <utility>
 #include <memory>
 #include <cmath>
 #include <sstream>

--- a/src/core/ScopeContext.cc
+++ b/src/core/ScopeContext.cc
@@ -5,6 +5,7 @@
 #include "core/SourceFileCache.h"
 #include "core/UserModule.h"
 
+#include <utility>
 #include <memory>
 #include <cmath>
 #include <vector>

--- a/src/core/SurfaceNode.cc
+++ b/src/core/SurfaceNode.cc
@@ -38,6 +38,7 @@
 #include "lodepng/lodepng.h"
 #include "core/SurfaceNode.h"
 
+#include <utility>
 #include <memory>
 #include <cstdint>
 #include <cstddef>

--- a/src/core/TextNode.cc
+++ b/src/core/TextNode.cc
@@ -24,6 +24,7 @@
  *
  */
 
+#include <utility>
 #include <memory>
 #include <vector>
 

--- a/src/core/Value.cc
+++ b/src/core/Value.cc
@@ -24,6 +24,7 @@
  *
  */
 
+#include <utility>
 #include <cstdint>
 #include <cassert>
 #include <cstddef>

--- a/src/core/builtin_functions.cc
+++ b/src/core/builtin_functions.cc
@@ -36,6 +36,7 @@
 #include "io/import.h"
 #include "io/fileutils.h"
 
+#include <utility>
 #include <cstdint>
 #include <memory>
 #include <cmath>

--- a/src/core/control.cc
+++ b/src/core/control.cc
@@ -24,6 +24,7 @@
  *
  */
 
+#include <utility>
 #include <memory>
 #include <cstddef>
 #include <vector>

--- a/src/core/customizer/ParameterObject.cc
+++ b/src/core/customizer/ParameterObject.cc
@@ -4,6 +4,7 @@
 #include "core/SourceFile.h"
 #include "core/customizer/ParameterObject.h"
 
+#include <utility>
 #include <memory>
 #include <cstddef>
 #include <sstream>

--- a/src/core/primitives.cc
+++ b/src/core/primitives.cc
@@ -36,6 +36,7 @@
 #include "utils/degree_trig.h"
 #include "core/module.h"
 #include "utils/printutils.h"
+#include <utility>
 #include <boost/assign/std/vector.hpp>
 #include <cassert>
 #include <cstddef>

--- a/src/core/str_utf8_wrapper.h
+++ b/src/core/str_utf8_wrapper.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <utility>
 #include <cstdint>
 #include <cstddef>
 #include <memory>

--- a/src/geometry/ClipperUtils.cc
+++ b/src/geometry/ClipperUtils.cc
@@ -1,6 +1,7 @@
 #include "geometry/ClipperUtils.h"
 #include "utils/printutils.h"
 
+#include <utility>
 #include <memory>
 #include <cstddef>
 #include <vector>

--- a/src/geometry/GeometryEvaluator.cc
+++ b/src/geometry/GeometryEvaluator.cc
@@ -26,6 +26,7 @@
 #include "utils/calc.h"
 #include "io/DxfData.h"
 #include "utils/degree_trig.h"
+#include <utility>
 #include <memory>
 #include <ciso646> // C alternative tokens (xor)
 #include <algorithm>

--- a/src/geometry/PolySetBuilder.cc
+++ b/src/geometry/PolySetBuilder.cc
@@ -37,6 +37,7 @@
 #include "geometry/manifold/ManifoldGeometry.h"
 #endif
 
+#include <utility>
 #include <cstdint>
 #include <memory>
 #include <vector>

--- a/src/geometry/Polygon2d.cc
+++ b/src/geometry/Polygon2d.cc
@@ -1,5 +1,6 @@
 #include "geometry/Polygon2d.h"
 
+#include <utility>
 #include <cstddef>
 #include <string>
 #include <memory>

--- a/src/geometry/Polygon2d.h
+++ b/src/geometry/Polygon2d.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <utility>
 #include <memory>
 #include <cstddef>
 #include <string>

--- a/src/geometry/boolean_utils.cc
+++ b/src/geometry/boolean_utils.cc
@@ -1,5 +1,6 @@
 #include "geometry/boolean_utils.h"
 
+#include <utility>
 #include <memory>
 #include <cstddef>
 #include <vector>

--- a/src/geometry/cgal/cgalutils-applyops-hybrid-minkowski.cc
+++ b/src/geometry/cgal/cgalutils-applyops-hybrid-minkowski.cc
@@ -10,6 +10,7 @@
 #include "geometry/cgal/CGALHybridPolyhedron.h"
 #include "core/node.h"
 
+#include <utility>
 #include <CGAL/Exact_predicates_inexact_constructions_kernel.h>
 #include <CGAL/normal_vector_newell_3.h>
 #include <CGAL/Handle_hash_function.h>

--- a/src/geometry/linear_extrude.cc
+++ b/src/geometry/linear_extrude.cc
@@ -1,5 +1,6 @@
 #include "geometry/linear_extrude.h"
 
+#include <utility>
 #include <memory>
 #include <cstddef>
 #include <queue>

--- a/src/geometry/manifold/ManifoldGeometry.cc
+++ b/src/geometry/manifold/ManifoldGeometry.cc
@@ -1,6 +1,7 @@
 // Portions of this file are Copyright 2023 Google LLC, and licensed under GPL2+. See COPYING.
 #include "geometry/manifold/ManifoldGeometry.h"
 #include "geometry/Polygon2d.h"
+#include <utility>
 #include <cstdint>
 #include <manifold/cross_section.h>
 #include <manifold/manifold.h>

--- a/src/geometry/manifold/manifoldutils.cc
+++ b/src/geometry/manifold/manifoldutils.cc
@@ -7,6 +7,7 @@
 #ifdef ENABLE_CGAL
 #include "geometry/cgal/cgalutils.h"
 #include "geometry/cgal/CGALHybridPolyhedron.h"
+#include <utility>
 #include <cstdint>
 #include <memory>
 #include <CGAL/convex_hull_3.h>

--- a/src/glview/VBORenderer.cc
+++ b/src/glview/VBORenderer.cc
@@ -30,6 +30,7 @@
 #include "utils/printutils.h"
 #include "utils/hash.h" // IWYU pragma: keep
 
+#include <utility>
 #include <memory>
 #include <cstddef>
 #include <iomanip>

--- a/src/glview/cgal/CGALRenderer.cc
+++ b/src/glview/cgal/CGALRenderer.cc
@@ -24,6 +24,7 @@
  *
  */
 
+#include <utility>
 #include <memory>
 
 #ifdef _MSC_VER

--- a/src/glview/cgal/CGAL_OGL_VBO_helper.h
+++ b/src/glview/cgal/CGAL_OGL_VBO_helper.h
@@ -30,6 +30,7 @@
 #include "glview/VertexArray.h"
 #include "CGAL/OGL_helper.h"
 
+#include <utility>
 #include <memory>
 #include <cstdlib>
 #include <vector>

--- a/src/glview/preview/OpenCSGRenderer.h
+++ b/src/glview/preview/OpenCSGRenderer.h
@@ -2,6 +2,7 @@
 
 #include "glview/Renderer.h"
 #include "glview/system-gl.h"
+#include <utility>
 #include <memory>
 #ifdef ENABLE_OPENCSG
 #include <opencsg.h>

--- a/src/gui/ScadApi.h
+++ b/src/gui/ScadApi.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <utility>
 #include <QObject>
 #include <QString>
 #include <QStringList>

--- a/src/gui/input/InputDriverEvent.h
+++ b/src/gui/input/InputDriverEvent.h
@@ -25,6 +25,7 @@
  */
 #pragma once
 
+#include <utility>
 #include <QEvent>
 #include <string>
 

--- a/src/io/dxfdim.cc
+++ b/src/io/dxfdim.cc
@@ -35,6 +35,7 @@
 #include "handle_dep.h"
 #include "utils/degree_trig.h"
 
+#include <utility>
 #include <cstddef>
 #include <cmath>
 #include <sstream>

--- a/src/io/export_3mf_v2.cc
+++ b/src/io/export_3mf_v2.cc
@@ -36,6 +36,7 @@
 #include "geometry/manifold/ManifoldGeometry.h"
 #endif
 
+#include <utility>
 #include <cstdint>
 #include <memory>
 #include <string>

--- a/src/io/import_3mf_v2.cc
+++ b/src/io/import_3mf_v2.cc
@@ -33,6 +33,7 @@
 #include "core/AST.h"
 #include "lib3mf_implicit.hpp"
 
+#include <utility>
 #include <memory>
 #include <vector>
 

--- a/src/io/import_amf.cc
+++ b/src/io/import_amf.cc
@@ -34,6 +34,7 @@
 #include "geometry/cgal/cgalutils.h"
 #endif
 
+#include <utility>
 #include <memory>
 #include <sys/types.h>
 #include <cstddef>

--- a/src/io/import_json.cc
+++ b/src/io/import_json.cc
@@ -24,6 +24,7 @@
  *
  */
 
+#include <utility>
 #include <fstream>
 #include <string>
 #include "json/json.hpp"

--- a/src/io/libsvg/transformation.h
+++ b/src/io/libsvg/transformation.h
@@ -24,6 +24,7 @@
  */
 #pragma once
 
+#include <utility>
 #include <string>
 #include <vector>
 


### PR DESCRIPTION
** Note: stacked on top of #5322 so merge this PR after that is merged **

## Automatically generated

```
scripts/run-clang-tidy-cached.cc
../dev-tools/insert-header.cc '<utility>' $(grep "no header providing.*misc-include-cleaner" OpenSCAD_clang-tidy.out | awk -F: '/^src\/.*(std::move)/ {print $1}' | sort -u)
```

(w/ insert-header.cc from this [script collection](https://github.com/hzeller/dev-tools))