### PR TITLE
Fix includes for stream-related symbols

### DIFF
--- a/src/LibraryInfo.cc
+++ b/src/LibraryInfo.cc
@@ -1,4 +1,5 @@
 #include "LibraryInfo.h"
+#include <sstream>
 #include <glib.h>
 #include <string>
 #include <vector>

--- a/src/RenderStatistic.cc
+++ b/src/RenderStatistic.cc
@@ -24,6 +24,7 @@
  */
 
 
+#include <iostream>
 #include <memory>
 #include <fstream>
 #include "json/json.hpp"

--- a/src/core/AST.cc
+++ b/src/core/AST.cc
@@ -1,4 +1,5 @@
 #include "core/AST.h"
+#include <ostream>
 #include <memory>
 #include <sstream>
 #include <string>

--- a/src/core/AST.h
+++ b/src/core/AST.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <ostream>
 #include <string>
 #include <memory>
 #include <boost/filesystem.hpp>

--- a/src/core/Arguments.cc
+++ b/src/core/Arguments.cc
@@ -24,6 +24,7 @@
  *
  */
 
+#include <ostream>
 #include <memory>
 #include "core/Arguments.h"
 #include "core/Expression.h"

--- a/src/core/Assignment.cc
+++ b/src/core/Assignment.cc
@@ -27,6 +27,7 @@
 #include "core/Assignment.h"
 #include "core/customizer/Annotation.h"
 #include "core/Expression.h"
+#include <ostream>
 #include <sstream>
 #include <string>
 

--- a/src/core/Expression.cc
+++ b/src/core/Expression.cc
@@ -26,6 +26,7 @@
 #include "utils/compiler_specific.h"
 #include "core/Expression.h"
 #include "core/Value.h"
+#include <ostream>
 #include <cstdint>
 #include <cmath>
 #include <cassert>

--- a/src/core/Expression.h
+++ b/src/core/Expression.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <ostream>
 #include <utility>
 #include <cstddef>
 #include <functional>

--- a/src/core/FunctionType.cc
+++ b/src/core/FunctionType.cc
@@ -1,3 +1,4 @@
+#include <ostream>
 #include "core/Value.h"
 #include "core/Expression.h"
 #include "core/FunctionType.h"

--- a/src/core/ImportNode.cc
+++ b/src/core/ImportNode.cc
@@ -43,6 +43,7 @@
 #include "Feature.h"
 #include "handle_dep.h"
 #include "utils/boost-utils.h"
+#include <ios>
 #include <utility>
 #include <memory>
 #include <sys/types.h>

--- a/src/core/LocalScope.cc
+++ b/src/core/LocalScope.cc
@@ -1,3 +1,4 @@
+#include <ostream>
 #include <memory>
 #include <cstddef>
 #include <string>

--- a/src/core/LocalScope.h
+++ b/src/core/LocalScope.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "core/Assignment.h"
+#include <ostream>
 #include <cstddef>
 #include <unordered_map>
 #include <memory>

--- a/src/core/ModuleInstantiation.cc
+++ b/src/core/ModuleInstantiation.cc
@@ -1,3 +1,4 @@
+#include <ostream>
 #include <memory>
 #include <cstddef>
 #include <string>

--- a/src/core/ModuleInstantiation.h
+++ b/src/core/ModuleInstantiation.h
@@ -2,6 +2,7 @@
 
 #include "core/AST.h"
 #include "core/LocalScope.h"
+#include <ostream>
 #include <memory>
 #include <string>
 #include <utility>

--- a/src/core/NodeDumper.cc
+++ b/src/core/NodeDumper.cc
@@ -1,6 +1,7 @@
 #include "core/NodeDumper.h"
 #include "core/State.h"
 #include "core/ModuleInstantiation.h"
+#include <ostream>
 #include <string>
 #include <sstream>
 #include <boost/regex.hpp>

--- a/src/core/NodeDumper.h
+++ b/src/core/NodeDumper.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <sstream>
 #include <memory>
 #include <string>
 #include <unordered_map>

--- a/src/core/OffsetNode.cc
+++ b/src/core/OffsetNode.cc
@@ -32,6 +32,7 @@
 #include "core/Parameters.h"
 #include "core/Builtins.h"
 
+#include <ios>
 #include <utility>
 #include <memory>
 #include <sstream>

--- a/src/core/Parameters.cc
+++ b/src/core/Parameters.cc
@@ -24,6 +24,7 @@
  *
  */
 
+#include <sstream>
 #include <memory>
 #include <cstddef>
 #include <set>

--- a/src/core/RotateExtrudeNode.cc
+++ b/src/core/RotateExtrudeNode.cc
@@ -33,6 +33,7 @@
 #include "io/fileutils.h"
 #include "core/Builtins.h"
 #include "handle_dep.h"
+#include <ios>
 #include <utility>
 #include <memory>
 #include <cmath>

--- a/src/core/SourceFile.cc
+++ b/src/core/SourceFile.cc
@@ -32,6 +32,7 @@
 #include "core/ScopeContext.h"
 #include "core/parsersettings.h"
 #include "core/StatCache.h"
+#include <ostream>
 #include <memory>
 #include <boost/algorithm/string.hpp>
 #include <boost/filesystem.hpp>

--- a/src/core/SourceFile.h
+++ b/src/core/SourceFile.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <ostream>
 #include <memory>
 #include <string>
 #include <unordered_map>

--- a/src/core/UserModule.cc
+++ b/src/core/UserModule.cc
@@ -24,6 +24,7 @@
  *
  */
 
+#include <ostream>
 #include <memory>
 #include <vector>
 

--- a/src/core/UserModule.h
+++ b/src/core/UserModule.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <ostream>
 #include <memory>
 #include <string>
 #include <vector>

--- a/src/core/Value.cc
+++ b/src/core/Value.cc
@@ -24,6 +24,7 @@
  *
  */
 
+#include <ostream>
 #include <utility>
 #include <cstdint>
 #include <cassert>

--- a/src/core/customizer/Annotation.cc
+++ b/src/core/customizer/Annotation.cc
@@ -27,6 +27,7 @@
 
 #include "core/customizer/Annotation.h"
 
+#include <ostream>
 #include <memory>
 #include <string>
 #include <utility>

--- a/src/core/customizer/Annotation.h
+++ b/src/core/customizer/Annotation.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <ostream>
 #include <memory>
 #include <string>
 #include <vector>

--- a/src/core/function.cc
+++ b/src/core/function.cc
@@ -28,6 +28,7 @@
 #include "core/Expression.h"
 #include "core/function.h"
 
+#include <ostream>
 #include <memory>
 #include <cstddef>
 #include <utility>

--- a/src/core/function.h
+++ b/src/core/function.h
@@ -5,6 +5,7 @@
 #include "Feature.h"
 #include "core/Value.h"
 
+#include <ostream>
 #include <memory>
 #include <functional>
 #include <string>

--- a/src/core/node.h
+++ b/src/core/node.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <ostream>
 #include <memory>
 #include <cstddef>
 #include <utility>

--- a/src/geometry/Geometry.cc
+++ b/src/geometry/Geometry.cc
@@ -1,5 +1,6 @@
 #include "geometry/Geometry.h"
 #include "utils/printutils.h"
+#include <sstream>
 #include <memory>
 #include <boost/foreach.hpp>
 #include <cstddef>

--- a/src/geometry/PolySet.cc
+++ b/src/geometry/PolySet.cc
@@ -29,6 +29,7 @@
 #include "geometry/linalg.h"
 #include "utils/printutils.h"
 #include "geometry/Grid.h"
+#include <sstream>
 #include <memory>
 #include <Eigen/LU>
 #include <cstddef>

--- a/src/geometry/Polygon2d.cc
+++ b/src/geometry/Polygon2d.cc
@@ -1,5 +1,6 @@
 #include "geometry/Polygon2d.h"
 
+#include <sstream>
 #include <utility>
 #include <cstddef>
 #include <string>

--- a/src/geometry/cgal/cgalutils-coplanar-faces-remesher.h
+++ b/src/geometry/cgal/cgalutils-coplanar-faces-remesher.h
@@ -1,6 +1,7 @@
 // Portions of this file are Copyright 2021 Google LLC, and licensed under GPL2+. See COPYING.
 #pragma once
 
+#include <iostream>
 #include <CGAL/Surface_mesh.h>
 #include <cstddef>
 #include <unordered_map>

--- a/src/geometry/cgal/cgalutils-polyhedron.cc
+++ b/src/geometry/cgal/cgalutils-polyhedron.cc
@@ -6,6 +6,7 @@
 #include "utils/printutils.h"
 #include "geometry/Grid.h"
 
+#include <ostream>
 #include <memory>
 #include <CGAL/Exact_predicates_inexact_constructions_kernel.h>
 

--- a/src/geometry/manifold/ManifoldGeometry.cc
+++ b/src/geometry/manifold/ManifoldGeometry.cc
@@ -1,6 +1,7 @@
 // Portions of this file are Copyright 2023 Google LLC, and licensed under GPL2+. See COPYING.
 #include "geometry/manifold/ManifoldGeometry.h"
 #include "geometry/Polygon2d.h"
+#include <sstream>
 #include <utility>
 #include <cstdint>
 #include <manifold/cross_section.h>

--- a/src/geometry/roof_vd.cc
+++ b/src/geometry/roof_vd.cc
@@ -1,6 +1,7 @@
 // This file is a part of openscad. Everything implied is implied.
 // Author: Alexey Korepanov <kaikaikai@yandex.ru>
 
+#include <ostream>
 #include <cstdint>
 #include <memory>
 

--- a/src/glview/OffscreenContextCGL.cc
+++ b/src/glview/OffscreenContextCGL.cc
@@ -1,5 +1,6 @@
 #include "glview/OffscreenContextCGL.h"
 
+#include <sstream>
 #include <memory>
 #include <cstddef>
 #include <string>

--- a/src/glview/OffscreenView.cc
+++ b/src/glview/OffscreenView.cc
@@ -1,5 +1,6 @@
 #include "glview/OffscreenView.h"
 #include "glview/system-gl.h"
+#include <iostream>
 #include <cstdint>
 #include <cmath>
 #include <cstdio>

--- a/src/glview/Renderer.cc
+++ b/src/glview/Renderer.cc
@@ -6,6 +6,7 @@
 #include "platform/PlatformUtils.h"
 #include "glview/system-gl.h"
 
+#include <sstream>
 #include <Eigen/LU>
 #include <fstream>
 #include <string>

--- a/src/glview/offscreen-old/OffscreenContextEGL.cc
+++ b/src/glview/offscreen-old/OffscreenContextEGL.cc
@@ -25,6 +25,7 @@
  */
 #include "glview/offscreen-old/OffscreenContextEGL.h"
 
+#include <iostream>
 #include <cstdint>
 #include <memory>
 #include <EGL/egl.h>

--- a/src/glview/offscreen-old/OffscreenContextGLX.cc
+++ b/src/glview/offscreen-old/OffscreenContextGLX.cc
@@ -38,6 +38,7 @@
 
 
 #include "glview/system-gl.h"
+#include <iostream>
 #include <cstdint>
 #include <memory>
 #include <GL/gl.h>

--- a/src/glview/offscreen-old/OffscreenContextWGL.cc
+++ b/src/glview/offscreen-old/OffscreenContextWGL.cc
@@ -13,6 +13,7 @@
 #include "glview/offscreen-old/OffscreenContextWGL.h"
 
 #undef NOGDI
+#include <iostream>
 #include <cstdint>
 #include <memory>
 #include <windows.h>

--- a/src/gui/Animate.cc
+++ b/src/gui/Animate.cc
@@ -1,6 +1,7 @@
 #include "gui/Animate.h"
 #include "utils/printutils.h"
 #include "gui/MainWindow.h"
+#include <iostream>
 #include <boost/filesystem.hpp>
 #include <QFormLayout>
 

--- a/src/gui/MainWindow.cc
+++ b/src/gui/MainWindow.cc
@@ -23,6 +23,7 @@
  *  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
  *
  */
+#include <sstream>
 #include <iostream>
 #include <memory>
 #include <string>

--- a/src/gui/Measurement.cc
+++ b/src/gui/Measurement.cc
@@ -26,6 +26,7 @@
 
 #include "gui/Measurement.h"
 
+#include <sstream>
 #include <string>
 
 Measurement::Measurement()

--- a/src/gui/QGLView.cc
+++ b/src/gui/QGLView.cc
@@ -33,6 +33,7 @@
 #include "glview/glew-utils.h"
 #endif
 
+#include <iostream>
 #include <QApplication>
 #include <QWheelEvent>
 #include <QCheckBox>

--- a/src/gui/ViewportControl.cc
+++ b/src/gui/ViewportControl.cc
@@ -2,6 +2,7 @@
 #include "utils/printutils.h"
 #include "gui/MainWindow.h"
 #include "gui/QGLView.h"
+#include <iostream>
 #include <boost/filesystem.hpp>
 #include <cfloat>
 #include <QDoubleSpinBox>

--- a/src/gui/input/HidApiInputDriver.cc
+++ b/src/gui/input/HidApiInputDriver.cc
@@ -29,6 +29,7 @@
  *  Public Domain.
  */
 
+#include <sstream>
 #include <cstdint>
 #include <bitset>
 #include <boost/format.hpp>

--- a/src/gui/input/HidApiInputDriver.cc
+++ b/src/gui/input/HidApiInputDriver.cc
@@ -29,6 +29,7 @@
  *  Public Domain.
  */
 
+#include <ios>
 #include <sstream>
 #include <cstdint>
 #include <bitset>

--- a/src/gui/input/InputDriverManager.cc
+++ b/src/gui/input/InputDriverManager.cc
@@ -26,6 +26,7 @@
 #include "gui/input/InputDriverEvent.h"
 #include "gui/input/InputDriverManager.h"
 #include "gui/MainWindow.h"
+#include <sstream>
 #include <QAction>
 #include <QMenu>
 #include <QApplication>

--- a/src/handle_dep.cc
+++ b/src/handle_dep.cc
@@ -1,5 +1,6 @@
 #include "handle_dep.h"
 #include "utils/printutils.h"
+#include <iostream>
 #include <string>
 #include <sstream>
 #include <cstdlib> // for system()

--- a/src/io/export.cc
+++ b/src/io/export.cc
@@ -29,6 +29,7 @@
 #include "utils/printutils.h"
 #include "geometry/Geometry.h"
 
+#include <iostream>
 #include <cstdint>
 #include <memory>
 #include <cstddef>

--- a/src/io/export_3mf_v1.cc
+++ b/src/io/export_3mf_v1.cc
@@ -36,6 +36,7 @@
 #include "geometry/manifold/ManifoldGeometry.h"
 #endif
 
+#include <ostream>
 #include <cstdint>
 #include <memory>
 #include <string>

--- a/src/io/export_3mf_v2.cc
+++ b/src/io/export_3mf_v2.cc
@@ -36,6 +36,7 @@
 #include "geometry/manifold/ManifoldGeometry.h"
 #endif
 
+#include <ostream>
 #include <utility>
 #include <cstdint>
 #include <memory>

--- a/src/io/export_amf.cc
+++ b/src/io/export_amf.cc
@@ -34,6 +34,7 @@
 #include "geometry/cgal/CGAL_Nef_polyhedron.h"
 #endif
 
+#include <ostream>
 #include <memory>
 #include <cstddef>
 #include <string>

--- a/src/io/export_dxf.cc
+++ b/src/io/export_dxf.cc
@@ -24,6 +24,7 @@
  *
  */
 
+#include <ostream>
 #include <memory>
 #include "io/export.h"
 #include "geometry/PolySet.h"

--- a/src/io/export_nef.cc
+++ b/src/io/export_nef.cc
@@ -32,6 +32,7 @@
 #include "geometry/cgal/CGAL_Nef_polyhedron.h"
 #include "geometry/cgal/cgal.h"
 #include "geometry/cgal/cgalutils.h"
+#include <ostream>
 #include <memory>
 #include <CGAL/IO/Nef_polyhedron_iostream_3.h> // for dumping .nef3
 

--- a/src/io/export_obj.cc
+++ b/src/io/export_obj.cc
@@ -25,6 +25,7 @@
  *
  */
 
+#include <ostream>
 #include <memory>
 #include "io/export.h"
 

--- a/src/io/export_off.cc
+++ b/src/io/export_off.cc
@@ -32,6 +32,7 @@
 #include "geometry/PolySet.h"
 #include "geometry/PolySetUtils.h"
 
+#include <ostream>
 #include <memory>
 #include <cstddef>
 #include <cstdint>

--- a/src/io/export_pdf.cc
+++ b/src/io/export_pdf.cc
@@ -5,6 +5,7 @@
 // #include "version.h"
 #include "utils/version_helper.h"
 
+#include <ostream>
 #include <memory>
 #include <string>
 #include <cmath>

--- a/src/io/export_png.cc
+++ b/src/io/export_png.cc
@@ -2,6 +2,7 @@
 #include "utils/printutils.h"
 #include "glview/OffscreenView.h"
 #include "glview/CsgInfo.h"
+#include <ostream>
 #include <cstdio>
 #include <memory>
 #include "glview/RenderSettings.h"

--- a/src/io/export_stl.cc
+++ b/src/io/export_stl.cc
@@ -27,6 +27,7 @@
 #include "io/export.h"
 #include "geometry/PolySet.h"
 #include "geometry/PolySetUtils.h"
+#include <ostream>
 #include <cstdint>
 #include <memory>
 #include <double-conversion/double-conversion.h>

--- a/src/io/export_stl.cc
+++ b/src/io/export_stl.cc
@@ -27,6 +27,7 @@
 #include "io/export.h"
 #include "geometry/PolySet.h"
 #include "geometry/PolySetUtils.h"
+#include <ios>
 #include <ostream>
 #include <cstdint>
 #include <memory>

--- a/src/io/export_svg.cc
+++ b/src/io/export_svg.cc
@@ -24,6 +24,7 @@
  *
  */
 
+#include <ostream>
 #include <memory>
 #include "io/export.h"
 #include "geometry/PolySet.h"

--- a/src/io/export_wrl.cc
+++ b/src/io/export_wrl.cc
@@ -28,6 +28,7 @@
 #include "geometry/PolySet.h"
 #include "geometry/PolySetUtils.h"
 
+#include <ostream>
 #include <memory>
 #include <cstddef>
 

--- a/src/io/imageutils-lodepng.cc
+++ b/src/io/imageutils-lodepng.cc
@@ -1,5 +1,6 @@
 #include "io/imageutils.h"
 #include "lodepng/lodepng.h"
+#include <iostream>
 #include <cstdio>
 #include <cstdlib>
 #include <vector>

--- a/src/io/imageutils.cc
+++ b/src/io/imageutils.cc
@@ -1,4 +1,5 @@
 #include "io/imageutils.h"
+#include <iostream>
 #include <cassert>
 #include <cstring>
 #include <fstream>

--- a/src/io/import_nef.cc
+++ b/src/io/import_nef.cc
@@ -1,5 +1,6 @@
 #include "io/import.h"
 
+#include <ios>
 #include <memory>
 #include <string>
 #include "utils/printutils.h"

--- a/src/io/import_obj.cc
+++ b/src/io/import_obj.cc
@@ -1,6 +1,7 @@
 #include "io/import.h"
 #include "geometry/PolySet.h"
 #include "geometry/PolySetBuilder.h"
+#include <ios>
 #include <memory>
 #include <fstream>
 #include <string>

--- a/src/io/import_off.cc
+++ b/src/io/import_off.cc
@@ -3,6 +3,7 @@
 #include "geometry/PolySet.h"
 #include "utils/printutils.h"
 #include "core/AST.h"
+#include <ios>
 #include <cstdint>
 #include <memory>
 #include <charconv>

--- a/src/io/import_stl.cc
+++ b/src/io/import_stl.cc
@@ -4,6 +4,7 @@
 #include "utils/printutils.h"
 #include "core/AST.h"
 
+#include <ios>
 #include <cstdint>
 #include <memory>
 #include <cstddef>

--- a/src/io/libsvg/circle.cc
+++ b/src/io/libsvg/circle.cc
@@ -25,6 +25,7 @@
 #include "libsvg/circle.h"
 #include "libsvg/util.h"
 
+#include <sstream>
 #include <string>
 
 namespace libsvg {

--- a/src/io/libsvg/data.cc
+++ b/src/io/libsvg/data.cc
@@ -24,6 +24,7 @@
  */
 #include "libsvg/data.h"
 
+#include <sstream>
 #include <string>
 
 namespace libsvg {

--- a/src/io/libsvg/ellipse.cc
+++ b/src/io/libsvg/ellipse.cc
@@ -22,6 +22,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+#include <sstream>
 #include <cstdlib>
 #include <string>
 #include <iostream>

--- a/src/io/libsvg/group.cc
+++ b/src/io/libsvg/group.cc
@@ -22,6 +22,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+#include <sstream>
 #include <cstdlib>
 #include <string>
 #include <iostream>

--- a/src/io/libsvg/libsvg.cc
+++ b/src/io/libsvg/libsvg.cc
@@ -22,6 +22,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+#include <iostream>
 #include <memory>
 #include <map>
 #include <stack>

--- a/src/io/libsvg/line.cc
+++ b/src/io/libsvg/line.cc
@@ -22,6 +22,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+#include <sstream>
 #include <string>
 #include "libsvg/line.h"
 #include "libsvg/util.h"

--- a/src/io/libsvg/path.cc
+++ b/src/io/libsvg/path.cc
@@ -22,6 +22,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+#include <sstream>
 #include <cstdlib>
 #include <vector>
 #include <string>

--- a/src/io/libsvg/rect.cc
+++ b/src/io/libsvg/rect.cc
@@ -22,6 +22,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+#include <sstream>
 #include <cstdlib>
 #include <iostream>
 #include <cmath>

--- a/src/io/libsvg/shape.cc
+++ b/src/io/libsvg/shape.cc
@@ -22,6 +22,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+#include <iostream>
 #include <memory>
 #include <cstdio>
 #include <cmath>

--- a/src/io/libsvg/svgpage.cc
+++ b/src/io/libsvg/svgpage.cc
@@ -22,6 +22,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+#include <sstream>
 #include <cstdlib>
 #include <string>
 #include <iostream>

--- a/src/io/libsvg/text.cc
+++ b/src/io/libsvg/text.cc
@@ -22,6 +22,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+#include <sstream>
 #include <string>
 #include "libsvg/text.h"
 #include "libsvg/util.h"

--- a/src/io/libsvg/transformation.cc
+++ b/src/io/libsvg/transformation.cc
@@ -22,6 +22,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+#include <sstream>
 #include <string>
 #include <vector>
 #include <iostream>

--- a/src/io/libsvg/tspan.cc
+++ b/src/io/libsvg/tspan.cc
@@ -22,6 +22,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+#include <sstream>
 #include <string>
 
 #include "libsvg/tspan.h"

--- a/src/io/libsvg/use.cc
+++ b/src/io/libsvg/use.cc
@@ -22,6 +22,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+#include <sstream>
 #include <memory>
 #include <cstdlib>
 #include <iostream>

--- a/src/io/libsvg/util.cc
+++ b/src/io/libsvg/util.cc
@@ -22,6 +22,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+#include <ostream>
 #include <boost/spirit/include/qi.hpp>
 
 #include <string>

--- a/src/io/libsvg/util.h
+++ b/src/io/libsvg/util.h
@@ -24,6 +24,7 @@
  */
 #pragma once
 
+#include <ostream>
 #include <string>
 
 namespace libsvg {

--- a/src/openscad.cc
+++ b/src/openscad.cc
@@ -48,6 +48,7 @@
 #include "core/customizer/ParameterObject.h"
 #include "core/customizer/ParameterSet.h"
 #include "openscad_mimalloc.h"
+#include <sstream>
 #include <iostream>
 #include <memory>
 #include <string>

--- a/src/openscad.cc
+++ b/src/openscad.cc
@@ -48,6 +48,7 @@
 #include "core/customizer/ParameterObject.h"
 #include "core/customizer/ParameterSet.h"
 #include "openscad_mimalloc.h"
+#include <iostream>
 #include <memory>
 #include <string>
 #include <vector>

--- a/src/platform/PlatformUtils-posix.cc
+++ b/src/platform/PlatformUtils-posix.cc
@@ -1,3 +1,4 @@
+#include <ios>
 #include <mutex>
 #include <string>
 #include <fstream>

--- a/src/platform/PlatformUtils-win.cc
+++ b/src/platform/PlatformUtils-win.cc
@@ -1,5 +1,6 @@
 #include "platform/PlatformUtils.h"
 
+#include <ios>
 #include <map>
 #include <string>
 

--- a/src/utils/printutils.cc
+++ b/src/utils/printutils.cc
@@ -1,4 +1,5 @@
 #include "utils/printutils.h"
+#include <iostream>
 #include <sstream>
 #include <string>
 #include <cstdio>

--- a/src/utils/svg.cc
+++ b/src/utils/svg.cc
@@ -1,6 +1,7 @@
 #ifdef ENABLE_CGAL
 #include "utils/svg.h"
 #include "geometry/cgal/cgalutils.h"
+#include <sstream>
 #include <boost/algorithm/string.hpp>
 #include <boost/lexical_cast.hpp>
 #include <map>


### PR DESCRIPTION
Four separate commits for each header `<iostream>`, `<ostream>`, `<sstream>`, and `<ios>`

Done in a similar way like #5321, #5322, #5323: extracting missing includes from clang-tidy output and applying them there.

Put together in one PR to avoid merge conflict issues as observed in the stacked PR #5323