### PR TITLE
In implementation compilation unit: move corresponding header to top.

### DIFF
--- a/src/Feature.cc
+++ b/src/Feature.cc
@@ -1,3 +1,5 @@
+#include "Feature.h"
+
 #include <cstdio>
 #include <iostream>
 #include <sstream>
@@ -7,7 +9,6 @@
 #include <boost/range/adaptor/transformed.hpp>
 #include <utility>
 
-#include "Feature.h"
 #include "utils/printutils.h"
 
 /**

--- a/src/FontCache.cc
+++ b/src/FontCache.cc
@@ -24,6 +24,8 @@
  *
  */
 
+#include "FontCache.h"
+
 #include <cstdint>
 #include <iostream>
 #include <vector>
@@ -33,7 +35,6 @@
 #include <string>
 #include <utility>
 
-#include "FontCache.h"
 #include "platform/PlatformUtils.h"
 #include "utils/printutils.h"
 #include "utils/version_helper.h"

--- a/src/RenderStatistic.cc
+++ b/src/RenderStatistic.cc
@@ -24,6 +24,8 @@
  */
 
 
+#include "RenderStatistic.h"
+
 #include <iostream>
 #include <memory>
 #include <fstream>
@@ -46,7 +48,6 @@
 #include "geometry/manifold/manifoldutils.h"
 #endif // ENABLE_MANIFOLD
 
-#include "RenderStatistic.h"
 
 class GeometryList;
 

--- a/src/core/Arguments.cc
+++ b/src/core/Arguments.cc
@@ -24,9 +24,10 @@
  *
  */
 
+#include "core/Arguments.h"
+
 #include <ostream>
 #include <memory>
-#include "core/Arguments.h"
 #include "core/Expression.h"
 
 Arguments::Arguments(const AssignmentList& argument_expressions, const std::shared_ptr<const Context>& context) :

--- a/src/core/BuiltinContext.cc
+++ b/src/core/BuiltinContext.cc
@@ -1,7 +1,8 @@
+#include "core/BuiltinContext.h"
+
 #include <cmath>
 
 #include "core/Builtins.h"
-#include "core/BuiltinContext.h"
 #include "core/Expression.h"
 #include "core/function.h"
 #include "utils/printutils.h"

--- a/src/core/Builtins.cc
+++ b/src/core/Builtins.cc
@@ -1,8 +1,9 @@
+#include "core/Builtins.h"
+
 #include <memory>
 #include <string>
 #include <vector>
 
-#include "core/Builtins.h"
 #include "core/function.h"
 #include "core/module.h"
 #include "core/Expression.h"

--- a/src/core/Children.cc
+++ b/src/core/Children.cc
@@ -24,11 +24,12 @@
  *
  */
 
+#include "core/Children.h"
+
 #include <memory>
 #include <cstddef>
 #include <vector>
 
-#include "core/Children.h"
 #include "core/ScopeContext.h"
 
 std::shared_ptr<AbstractNode> Children::instantiate(const std::shared_ptr<AbstractNode> &target) const

--- a/src/core/Context.cc
+++ b/src/core/Context.cc
@@ -24,13 +24,14 @@
  *
  */
 
+#include "core/Context.h"
+
 #include <utility>
 #include <memory>
 #include <cstddef>
 #include <string>
 #include <vector>
 
-#include "core/Context.h"
 #include "core/function.h"
 #include "utils/printutils.h"
 

--- a/src/core/ContextFrame.cc
+++ b/src/core/ContextFrame.cc
@@ -24,12 +24,13 @@
  *
  */
 
+#include "core/ContextFrame.h"
+
 #include <utility>
 #include <cstddef>
 #include <string>
 #include <vector>
 
-#include "core/ContextFrame.h"
 
 ContextFrame::ContextFrame(EvaluationSession *session) :
   evaluation_session(session)

--- a/src/core/ContextMemoryManager.cc
+++ b/src/core/ContextMemoryManager.cc
@@ -24,6 +24,8 @@
  *
  */
 
+#include "core/ContextMemoryManager.h"
+
 #include <utility>
 #include <memory>
 #include <deque>
@@ -32,7 +34,6 @@
 #include <vector>
 
 #include "core/Context.h"
-#include "core/ContextMemoryManager.h"
 #include "core/Value.h"
 
 /*

--- a/src/core/DrawingCallback.cc
+++ b/src/core/DrawingCallback.cc
@@ -23,6 +23,8 @@
  *  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
  *
  */
+#include "core/DrawingCallback.h"
+
 #include <memory>
 #include <algorithm>
 #include <cmath>
@@ -30,7 +32,6 @@
 #include <vector>
 
 #include "geometry/Polygon2d.h"
-#include "core/DrawingCallback.h"
 
 DrawingCallback::DrawingCallback(unsigned long fn, double size) :
   pen(Vector2d(0, 0)), offset(Vector2d(0, 0)), advance(Vector2d(0, 0)), fn(fn), size(size)

--- a/src/core/EvaluationSession.cc
+++ b/src/core/EvaluationSession.cc
@@ -24,11 +24,12 @@
  *
  */
 
+#include "core/EvaluationSession.h"
+
 #include <cstddef>
 #include <string>
 
 #include "core/ContextFrame.h"
-#include "core/EvaluationSession.h"
 #include "utils/printutils.h"
 
 size_t EvaluationSession::push_frame(ContextFrame *frame)

--- a/src/core/Expression.cc
+++ b/src/core/Expression.cc
@@ -23,8 +23,9 @@
  *  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
  *
  */
-#include "utils/compiler_specific.h"
 #include "core/Expression.h"
+
+#include "utils/compiler_specific.h"
 #include "core/Value.h"
 #include <ostream>
 #include <cstdint>

--- a/src/core/FreetypeRenderer.cc
+++ b/src/core/FreetypeRenderer.cc
@@ -23,6 +23,8 @@
  *  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
  *
  */
+#include "core/FreetypeRenderer.h"
+
 #include <cstdint>
 #include <memory>
 #include <cmath>
@@ -37,7 +39,6 @@
 
 #include "FontCache.h"
 #include "core/DrawingCallback.h"
-#include "core/FreetypeRenderer.h"
 #include "utils/calc.h"
 
 #include FT_OUTLINE_H

--- a/src/core/FunctionType.cc
+++ b/src/core/FunctionType.cc
@@ -1,7 +1,8 @@
+#include "core/FunctionType.h"
+
 #include <ostream>
 #include "core/Value.h"
 #include "core/Expression.h"
-#include "core/FunctionType.h"
 
 Value FunctionType::operator==(const FunctionType& other) const {
   return this == &other;

--- a/src/core/ImportNode.cc
+++ b/src/core/ImportNode.cc
@@ -24,8 +24,9 @@
  *
  */
 
-#include "io/import.h"
 #include "core/ImportNode.h"
+
+#include "io/import.h"
 
 #include "core/module.h"
 #include "core/ModuleInstantiation.h"

--- a/src/core/LocalScope.cc
+++ b/src/core/LocalScope.cc
@@ -1,3 +1,5 @@
+#include "core/LocalScope.h"
+
 #include <ostream>
 #include <memory>
 #include <cstddef>
@@ -5,7 +7,6 @@
 #include <vector>
 
 #include "core/Assignment.h"
-#include "core/LocalScope.h"
 #include "core/ModuleInstantiation.h"
 #include "core/UserModule.h"
 #include "core/function.h"

--- a/src/core/ModuleInstantiation.cc
+++ b/src/core/ModuleInstantiation.cc
@@ -1,3 +1,5 @@
+#include "core/ModuleInstantiation.h"
+
 #include <ostream>
 #include <memory>
 #include <cstddef>
@@ -5,7 +7,6 @@
 
 #include "utils/compiler_specific.h"
 #include "core/Context.h"
-#include "core/ModuleInstantiation.h"
 #include "core/Expression.h"
 #include "utils/exceptions.h"
 #include "utils/printutils.h"

--- a/src/core/Parameters.cc
+++ b/src/core/Parameters.cc
@@ -24,6 +24,8 @@
  *
  */
 
+#include "core/Parameters.h"
+
 #include <sstream>
 #include <memory>
 #include <cstddef>
@@ -33,7 +35,6 @@
 #include <vector>
 
 #include "core/Expression.h"
-#include "core/Parameters.h"
 
 Parameters::Parameters(ContextFrame&& frame, Location loc) :
   loc(std::move(loc)),

--- a/src/core/RoofNode.cc
+++ b/src/core/RoofNode.cc
@@ -1,6 +1,8 @@
 // This file is a part of openscad. Everything implied is implied.
 // Author: Alexey Korepanov <kaikaikai@yandex.ru>
 
+#include "core/RoofNode.h"
+
 #include <utility>
 #include <memory>
 #include <sstream>
@@ -10,7 +12,6 @@
 #include "core/Builtins.h"
 #include "core/Parameters.h"
 #include "core/Children.h"
-#include "core/RoofNode.h"
 
 static std::shared_ptr<AbstractNode> builtin_roof(const ModuleInstantiation *inst, Arguments arguments, const Children& children)
 {

--- a/src/core/SurfaceNode.cc
+++ b/src/core/SurfaceNode.cc
@@ -24,6 +24,8 @@
  *
  */
 
+#include "core/SurfaceNode.h"
+
 #include "core/module.h"
 #include "core/ModuleInstantiation.h"
 #include "core/node.h"
@@ -36,7 +38,6 @@
 #include "io/fileutils.h"
 #include "handle_dep.h"
 #include "lodepng/lodepng.h"
-#include "core/SurfaceNode.h"
 
 #include <utility>
 #include <memory>

--- a/src/core/SurfaceNode.h
+++ b/src/core/SurfaceNode.h
@@ -31,6 +31,7 @@
 #include <vector>
 
 #include "core/node.h"
+#include "core/Value.h"
 
 struct img_data_t
 {

--- a/src/core/TextNode.cc
+++ b/src/core/TextNode.cc
@@ -24,6 +24,8 @@
  *
  */
 
+#include "core/TextNode.h"
+
 #include <utility>
 #include <memory>
 #include <vector>
@@ -35,7 +37,6 @@
 #include "utils/printutils.h"
 #include "core/Builtins.h"
 
-#include "core/TextNode.h"
 #include "core/FreetypeRenderer.h"
 
 #include <boost/assign/std/vector.hpp>

--- a/src/core/UserModule.cc
+++ b/src/core/UserModule.cc
@@ -24,11 +24,12 @@
  *
  */
 
+#include "core/UserModule.h"
+
 #include <ostream>
 #include <memory>
 #include <vector>
 
-#include "core/UserModule.h"
 #include "core/ModuleInstantiation.h"
 #include "core/node.h"
 #include "utils/exceptions.h"

--- a/src/core/Value.cc
+++ b/src/core/Value.cc
@@ -24,6 +24,8 @@
  *
  */
 
+#include "core/Value.h"
+
 #include <ostream>
 #include <utility>
 #include <cstdint>
@@ -36,7 +38,6 @@
 #include <vector>
 #include <boost/lexical_cast.hpp>
 
-#include "core/Value.h"
 #include "core/EvaluationSession.h"
 #include "utils/printutils.h"
 #include "utils/StackCheck.h"

--- a/src/core/customizer/CommentParser.cc
+++ b/src/core/customizer/CommentParser.cc
@@ -1,7 +1,8 @@
+#include "core/customizer/CommentParser.h"
+
 #include <memory>
 #include <cstddef>
 
-#include "core/customizer/CommentParser.h"
 #include "core/Expression.h"
 #include "core/customizer/Annotation.h"
 #include <string>

--- a/src/core/customizer/ParameterObject.cc
+++ b/src/core/customizer/ParameterObject.cc
@@ -1,8 +1,9 @@
+#include "core/customizer/ParameterObject.h"
+
 #include "core/customizer/Annotation.h"
 #include "core/Assignment.h"
 #include "core/Expression.h"
 #include "core/SourceFile.h"
-#include "core/customizer/ParameterObject.h"
 
 #include <utility>
 #include <memory>

--- a/src/core/function.cc
+++ b/src/core/function.cc
@@ -24,9 +24,10 @@
  *
  */
 
+#include "core/function.h"
+
 #include "core/Arguments.h"
 #include "core/Expression.h"
-#include "core/function.h"
 
 #include <ostream>
 #include <memory>

--- a/src/core/module.cc
+++ b/src/core/module.cc
@@ -24,11 +24,12 @@
  *
  */
 
+#include "core/module.h"
+
 #include <memory>
 #include "core/Arguments.h"
 #include "core/Children.h"
 #include "core/Context.h"
-#include "core/module.h"
 #include "core/ModuleInstantiation.h"
 
 BuiltinModule::BuiltinModule(std::shared_ptr<AbstractNode>(*instantiate)(const ModuleInstantiation *, const std::shared_ptr<const Context>&), const Feature *feature) :

--- a/src/core/parsersettings.cc
+++ b/src/core/parsersettings.cc
@@ -1,7 +1,8 @@
+#include "core/parsersettings.h"
+
 #include <string>
 #include <vector>
 
-#include "core/parsersettings.h"
 #include <boost/filesystem.hpp>
 #include <boost/algorithm/string.hpp>
 #include "platform/PlatformUtils.h"

--- a/src/core/progress.cc
+++ b/src/core/progress.cc
@@ -1,5 +1,6 @@
-#include <memory>
 #include "core/progress.h"
+
+#include <memory>
 #include "core/node.h"
 
 int progress_report_count;

--- a/src/geometry/cgal/CGALCache.cc
+++ b/src/geometry/cgal/CGALCache.cc
@@ -1,8 +1,9 @@
+#include "geometry/cgal/CGALCache.h"
+
 #include <memory>
 #include <cstddef>
 #include <string>
 
-#include "geometry/cgal/CGALCache.h"
 #include "utils/printutils.h"
 #include "geometry/cgal/CGAL_Nef_polyhedron.h"
 #include "geometry/cgal/CGALHybridPolyhedron.h"

--- a/src/geometry/cgal/CGAL_Nef_polyhedron.cc
+++ b/src/geometry/cgal/CGAL_Nef_polyhedron.cc
@@ -1,9 +1,10 @@
+#include "geometry/cgal/CGAL_Nef_polyhedron.h"
+
 #include <memory>
 #include <cstddef>
 #include <string>
 
 #include "geometry/cgal/cgal.h"
-#include "geometry/cgal/CGAL_Nef_polyhedron.h"
 #include "geometry/cgal/cgalutils.h"
 #include "utils/printutils.h"
 #include "utils/svg.h"

--- a/src/geometry/cgal/cgalutils.cc
+++ b/src/geometry/cgal/cgalutils.cc
@@ -3,8 +3,9 @@
 
 #ifdef ENABLE_CGAL
 
-#include "geometry/cgal/cgal.h"
 #include "geometry/cgal/cgalutils.h"
+
+#include "geometry/cgal/cgal.h"
 #include "geometry/PolySet.h"
 #include "utils/printutils.h"
 #include "geometry/Polygon2d.h"

--- a/src/geometry/roof_ss.cc
+++ b/src/geometry/roof_ss.cc
@@ -1,6 +1,8 @@
 // This file is a part of openscad. Everything implied is implied.
 // Author: Alexey Korepanov <kaikaikai@yandex.ru>
 
+#include "geometry/roof_ss.h"
+
 #include <memory>
 #include <boost/shared_ptr.hpp>
 
@@ -17,7 +19,6 @@
 #include "geometry/GeometryUtils.h"
 #include "geometry/ClipperUtils.h"
 #include "core/RoofNode.h"
-#include "geometry/roof_ss.h"
 #include "geometry/PolySetBuilder.h"
 
 #define RAISE_ROOF_EXCEPTION(message) \

--- a/src/geometry/roof_vd.cc
+++ b/src/geometry/roof_vd.cc
@@ -1,6 +1,8 @@
 // This file is a part of openscad. Everything implied is implied.
 // Author: Alexey Korepanov <kaikaikai@yandex.ru>
 
+#include "geometry/roof_vd.h"
+
 #include <ostream>
 #include <cstdint>
 #include <memory>
@@ -15,7 +17,6 @@
 #include "geometry/GeometryUtils.h"
 #include "geometry/ClipperUtils.h"
 #include "core/RoofNode.h"
-#include "geometry/roof_vd.h"
 
 #define RAISE_ROOF_EXCEPTION(message) \
         throw RoofNode::roof_exception((boost::format("%s line %d: %s") % __FILE__ % __LINE__ % (message)).str());

--- a/src/gui/Console.cc
+++ b/src/gui/Console.cc
@@ -24,13 +24,14 @@
  *
  */
 
+#include "gui/Console.h"
+
 #include <QMenu>
 #include <QFileInfo>
 #include <QFileDialog>
 #include <QTextStream>
 #include <QRegularExpression>
 #include <QString>
-#include "gui/Console.h"
 #include "gui/MainWindow.h"
 #include "utils/printutils.h"
 #include "gui/Preferences.h"

--- a/src/gui/Dock.cc
+++ b/src/gui/Dock.cc
@@ -1,7 +1,8 @@
+#include "gui/Dock.h"
+
 #include <iostream>
 #include "gui/QSettingsCached.h"
 
-#include "gui/Dock.h"
 
 Dock::Dock(QWidget *parent) : QDockWidget(parent)
 {

--- a/src/gui/ExportPdfDialog.cc
+++ b/src/gui/ExportPdfDialog.cc
@@ -24,8 +24,9 @@
  *
  */
 
-#include <QString>
 #include "gui/ExportPdfDialog.h"
+
+#include <QString>
 
 ExportPdfDialog::ExportPdfDialog()
 {

--- a/src/gui/FontList.cc
+++ b/src/gui/FontList.cc
@@ -1,3 +1,5 @@
+#include "gui/FontList.h"
+
 #include <cstdint>
 #include <qitemselectionmodel.h>
 #include <string>
@@ -18,7 +20,6 @@
 #include <QSpinBox>
 #include <QLineEdit>
 
-#include "gui/FontList.h"
 #include "FontCache.h"
 #include "utils/printutils.h"
 

--- a/src/gui/FontListDialog.cc
+++ b/src/gui/FontListDialog.cc
@@ -24,10 +24,11 @@
  *
  */
 
+#include "gui/FontListDialog.h"
+
 #include <QClipboard>
 #include <QSortFilterProxyModel>
 
-#include "gui/FontListDialog.h"
 #include "FontCache.h"
 
 FontListDialog::FontListDialog()

--- a/src/gui/FontListTableView.cc
+++ b/src/gui/FontListTableView.cc
@@ -23,12 +23,13 @@
  *  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
  *
  */
+#include "gui/FontListTableView.h"
+
 #include <QDrag>
 #include <QPixmap>
 #include <QPainter>
 #include <QMimeData>
 #include <QTableView>
-#include "gui/FontListTableView.h"
 
 FontListTableView::FontListTableView(QWidget *parent) : QTableView(parent)
 {

--- a/src/gui/InitConfigurator.cc
+++ b/src/gui/InitConfigurator.cc
@@ -1,7 +1,8 @@
 
+#include "gui/InitConfigurator.h"
+
 #include <QSettings>
 #include "gui/Settings.h"
-#include "gui/InitConfigurator.h"
 
 #include <string>
 

--- a/src/gui/LaunchingScreen.cc
+++ b/src/gui/LaunchingScreen.cc
@@ -1,8 +1,9 @@
+#include "gui/LaunchingScreen.h"
+
 #include <QFileInfo>
 #include <QListWidgetItem>
 
 #include "version.h"
-#include "gui/LaunchingScreen.h"
 #include "ui_LaunchingScreen.h"
 #include "gui/QSettingsCached.h"
 

--- a/src/gui/MainWindow.cc
+++ b/src/gui/MainWindow.cc
@@ -23,6 +23,8 @@
  *  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
  *
  */
+#include "gui/MainWindow.h"
+
 #include <sstream>
 #include <iostream>
 #include <memory>
@@ -37,7 +39,6 @@
 #include "openscad.h"
 #include "geometry/GeometryCache.h"
 #include "core/SourceFileCache.h"
-#include "gui/MainWindow.h"
 #include "gui/OpenSCADApp.h"
 #include "core/parsersettings.h"
 #include "glview/RenderSettings.h"

--- a/src/gui/MouseSelector.cc
+++ b/src/gui/MouseSelector.cc
@@ -1,5 +1,6 @@
-#include "glview/system-gl.h"
 #include "gui/MouseSelector.h"
+
+#include "glview/system-gl.h"
 
 #include <cstdint>
 #include <QOpenGLFramebufferObject>

--- a/src/gui/OctoPrint.cc
+++ b/src/gui/OctoPrint.cc
@@ -24,8 +24,9 @@
  *
  */
 
-#include "gui/Settings.h"
 #include "gui/OctoPrint.h"
+
+#include "gui/Settings.h"
 
 #include <string>
 #include <utility>

--- a/src/gui/PrintInitDialog.cc
+++ b/src/gui/PrintInitDialog.cc
@@ -24,11 +24,12 @@
  *
  */
 
+#include "gui/PrintInitDialog.h"
+
 #include <QString>
 
 #include "gui/Settings.h"
 #include "gui/PrintService.h"
-#include "gui/PrintInitDialog.h"
 #include "gui/QSettingsCached.h"
 
 PrintInitDialog::PrintInitDialog()

--- a/src/gui/PrintService.cc
+++ b/src/gui/PrintService.cc
@@ -24,8 +24,9 @@
  *
  */
 
-#include "utils/printutils.h"
 #include "gui/PrintService.h"
+
+#include "utils/printutils.h"
 
 std::mutex PrintService::printServiceMutex;
 

--- a/src/gui/QGLView.cc
+++ b/src/gui/QGLView.cc
@@ -24,8 +24,9 @@
  *
  */
 
-#include "gui/qtgettext.h"
 #include "gui/QGLView.h"
+
+#include "gui/qtgettext.h"
 #include "gui/Preferences.h"
 #include "glview/Renderer.h"
 #include "utils/degree_trig.h"

--- a/src/gui/QSettingsCached.cc
+++ b/src/gui/QSettingsCached.cc
@@ -1,5 +1,6 @@
-#include <memory>
 #include "gui/QSettingsCached.h"
+
+#include <memory>
 
 std::unique_ptr<QSettings> QSettingsCached::qsettingsPointer;
 std::mutex QSettingsCached::ctor_mutex;

--- a/src/gui/ScadApi.cc
+++ b/src/gui/ScadApi.cc
@@ -1,8 +1,9 @@
+#include "gui/ScadApi.h"
+
 #include <QDir>
 #include <QFileInfo>
 #include <QRegularExpression>
 
-#include "gui/ScadApi.h"
 #include "core/Builtins.h"
 #include "gui/ScintillaEditor.h"
 #include "core/parsersettings.h"

--- a/src/gui/ScadLexer.cc
+++ b/src/gui/ScadLexer.cc
@@ -1,10 +1,11 @@
+#include "gui/ScadLexer.h"
+
 #include <string>
 #include <vector>
 
 #include <boost/algorithm/string.hpp>
 #include <boost/algorithm/string/split.hpp>
 
-#include "gui/ScadLexer.h"
 
 #if !ENABLE_LEXERTL
 

--- a/src/gui/ScintillaEditor.cc
+++ b/src/gui/ScintillaEditor.cc
@@ -1,3 +1,5 @@
+#include "gui/ScintillaEditor.h"
+
 #include <memory>
 #include <ciso646> // C alternative tokens (xor)
 #include <cstdlib>
@@ -13,7 +15,6 @@
 #include <QShortcut>
 #include <Qsci/qscicommandset.h>
 
-#include "gui/ScintillaEditor.h"
 #include "gui/Preferences.h"
 #include "platform/PlatformUtils.h"
 #include "gui/Settings.h"

--- a/src/gui/TabManager.cc
+++ b/src/gui/TabManager.cc
@@ -1,3 +1,5 @@
+#include "gui/TabManager.h"
+
 #include <QFileInfo>
 #include <QFile>
 #include <QDir>
@@ -12,7 +14,6 @@
 #include <Qsci/qscicommandset.h>
 
 #include "gui/Editor.h"
-#include "gui/TabManager.h"
 #include "gui/TabWidget.h"
 #include "gui/ScintillaEditor.h"
 #include "gui/Preferences.h"

--- a/src/gui/TabWidget.cc
+++ b/src/gui/TabWidget.cc
@@ -1,9 +1,10 @@
+#include "gui/TabWidget.h"
+
 #include <QTabBar>
 #include <QStackedWidget>
 #include <QMouseEvent>
 #include <QList>
 
-#include "gui/TabWidget.h"
 
 TabWidget::TabWidget(QWidget *parent) : QTabBar(parent)
 {

--- a/src/gui/UIUtils.cc
+++ b/src/gui/UIUtils.cc
@@ -24,6 +24,8 @@
  *
  */
 
+#include "gui/UIUtils.h"
+
 #include <QDir>
 #include <QFileInfo>
 #include <QUrl>
@@ -31,7 +33,6 @@
 #include <QDesktopServices>
 
 #include "version.h"
-#include "gui/UIUtils.h"
 #include "platform/PlatformUtils.h"
 #include "gui/QSettingsCached.h"
 

--- a/src/gui/input/AxisConfigWidget.cc
+++ b/src/gui/input/AxisConfigWidget.cc
@@ -24,11 +24,12 @@
  *
  */
 
+#include "gui/input/AxisConfigWidget.h"
+
 #include <QWidget>
 #include <cstddef>
 #include <string>
 
-#include "gui/input/AxisConfigWidget.h"
 
 #include "gui/Settings.h"
 #include "gui/input/InputDriverManager.h"

--- a/src/gui/input/ButtonConfigWidget.cc
+++ b/src/gui/input/ButtonConfigWidget.cc
@@ -24,9 +24,10 @@
  *
  */
 
+#include "gui/input/ButtonConfigWidget.h"
+
 #include <QWidget>
 #include <cstddef>
-#include "gui/input/ButtonConfigWidget.h"
 #include "gui/Settings.h"
 #include "gui/input/InputDriverManager.h"
 #include "gui/SettingsWriter.h"

--- a/src/gui/input/HidApiInputDriver.cc
+++ b/src/gui/input/HidApiInputDriver.cc
@@ -29,6 +29,8 @@
  *  Public Domain.
  */
 
+#include "gui/input/HidApiInputDriver.h"
+
 #include <ios>
 #include <sstream>
 #include <cstdint>
@@ -44,7 +46,6 @@
 
 #include "gui/Settings.h"
 #include "platform/PlatformUtils.h"
-#include "gui/input/HidApiInputDriver.h"
 #include "gui/input/InputDriverEvent.h"
 #include "gui/input/InputDriverManager.h"
 #include "utils/printutils.h"

--- a/src/gui/input/InputDriverManager.cc
+++ b/src/gui/input/InputDriverManager.cc
@@ -23,8 +23,9 @@
  *  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
  *
  */
-#include "gui/input/InputDriverEvent.h"
 #include "gui/input/InputDriverManager.h"
+
+#include "gui/input/InputDriverEvent.h"
 #include "gui/MainWindow.h"
 #include <sstream>
 #include <QAction>

--- a/src/gui/input/JoystickInputDriver.cc
+++ b/src/gui/input/JoystickInputDriver.cc
@@ -23,6 +23,8 @@
  *  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
  *
  */
+#include "gui/input/JoystickInputDriver.h"
+
 #include <string>
 #include <fcntl.h>
 #include <sys/types.h>
@@ -31,7 +33,6 @@
 #include <utility>
 
 #include "gui/input/InputDriverManager.h"
-#include "gui/input/JoystickInputDriver.h"
 #include "utils/printutils.h"
 
 #include <unistd.h>

--- a/src/gui/input/QGamepadInputDriver.cc
+++ b/src/gui/input/QGamepadInputDriver.cc
@@ -24,8 +24,9 @@
  *
  */
 
-#include "gui/input/InputDriverManager.h"
 #include "gui/input/QGamepadInputDriver.h"
+
+#include "gui/input/InputDriverManager.h"
 
 #include <string>
 

--- a/src/gui/parameter/ParameterVector.cc
+++ b/src/gui/parameter/ParameterVector.cc
@@ -1,5 +1,6 @@
-#include <cstddef>
 #include "gui/parameter/ParameterVector.h"
+
+#include <cstddef>
 #include "gui/IgnoreWheelWhenNotFocused.h"
 
 ParameterVector::ParameterVector(QWidget *parent, VectorParameter *parameter, DescriptionStyle descriptionStyle) :

--- a/src/gui/parameter/ParameterWidget.cc
+++ b/src/gui/parameter/ParameterWidget.cc
@@ -23,10 +23,11 @@
  *  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
  *
  */
+#include "gui/parameter/ParameterWidget.h"
+
 #include <memory>
 #include <QWidget>
 
-#include "gui/parameter/ParameterWidget.h"
 
 #include "gui/parameter/GroupWidget.h"
 #include "gui/parameter/ParameterSpinBox.h"

--- a/src/io/DxfData.cc
+++ b/src/io/DxfData.cc
@@ -24,10 +24,11 @@
  *
  */
 
+#include "io/DxfData.h"
+
 #include <memory>
 #include <cmath>
 
-#include "io/DxfData.h"
 #include "geometry/Grid.h"
 #include "utils/printutils.h"
 #include "utils/calc.h"

--- a/src/io/fileutils.cc
+++ b/src/io/fileutils.cc
@@ -1,6 +1,7 @@
+#include "io/fileutils.h"
+
 #include <string>
 
-#include "io/fileutils.h"
 #include "utils/printutils.h"
 
 #include <boost/filesystem.hpp>

--- a/src/libsvg/ellipse.cc
+++ b/src/libsvg/ellipse.cc
@@ -22,12 +22,13 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+#include "libsvg/ellipse.h"
+
 #include <sstream>
 #include <cstdlib>
 #include <string>
 #include <iostream>
 
-#include "libsvg/ellipse.h"
 #include "libsvg/util.h"
 
 namespace libsvg {

--- a/src/libsvg/group.cc
+++ b/src/libsvg/group.cc
@@ -22,12 +22,13 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+#include "libsvg/group.h"
+
 #include <sstream>
 #include <cstdlib>
 #include <string>
 #include <iostream>
 
-#include "libsvg/group.h"
 
 namespace libsvg {
 

--- a/src/libsvg/libsvg.cc
+++ b/src/libsvg/libsvg.cc
@@ -22,6 +22,8 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+#include "libsvg/libsvg.h"
+
 #include <iostream>
 #include <memory>
 #include <map>
@@ -33,7 +35,6 @@
 #include <boost/format.hpp>
 #include <libxml/xmlreader.h>
 
-#include "libsvg/libsvg.h"
 
 #include "libsvg/shape.h"
 #include "libsvg/use.h"

--- a/src/libsvg/line.cc
+++ b/src/libsvg/line.cc
@@ -22,9 +22,10 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+#include "libsvg/line.h"
+
 #include <sstream>
 #include <string>
-#include "libsvg/line.h"
 #include "libsvg/util.h"
 
 namespace libsvg {

--- a/src/libsvg/path.cc
+++ b/src/libsvg/path.cc
@@ -22,6 +22,8 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+#include "libsvg/path.h"
+
 #include <sstream>
 #include <cstdlib>
 #include <vector>
@@ -37,7 +39,6 @@
 #include <boost/tokenizer.hpp>
 #include <boost/algorithm/string.hpp>
 
-#include "libsvg/path.h"
 #include "utils/degree_trig.h"
 #include "utils/calc.h"
 #include "libsvg/util.h"

--- a/src/libsvg/polygon.cc
+++ b/src/libsvg/polygon.cc
@@ -22,9 +22,10 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+#include "libsvg/polygon.h"
+
 #include <boost/tokenizer.hpp>
 
-#include "libsvg/polygon.h"
 #include "libsvg/util.h"
 
 #include <string>

--- a/src/libsvg/polyline.cc
+++ b/src/libsvg/polyline.cc
@@ -22,10 +22,11 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+#include "libsvg/polyline.h"
+
 #include <boost/tokenizer.hpp>
 
 #include <string>
-#include "libsvg/polyline.h"
 #include "libsvg/util.h"
 
 namespace libsvg {

--- a/src/libsvg/rect.cc
+++ b/src/libsvg/rect.cc
@@ -22,6 +22,8 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+#include "libsvg/rect.h"
+
 #include <sstream>
 #include <cstdlib>
 #include <iostream>
@@ -30,7 +32,6 @@
 
 #include <boost/format.hpp>
 
-#include "libsvg/rect.h"
 #include "libsvg/util.h"
 
 namespace libsvg {

--- a/src/libsvg/shape.cc
+++ b/src/libsvg/shape.cc
@@ -22,6 +22,8 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+#include "libsvg/shape.h"
+
 #include <iostream>
 #include <memory>
 #include <cstdio>
@@ -33,7 +35,6 @@
 #include <boost/algorithm/string.hpp>
 #include <boost/spirit/include/qi.hpp>
 
-#include "libsvg/shape.h"
 #include "libsvg/circle.h"
 #include "libsvg/ellipse.h"
 #include "libsvg/line.h"

--- a/src/libsvg/svgpage.cc
+++ b/src/libsvg/svgpage.cc
@@ -22,12 +22,13 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+#include "libsvg/svgpage.h"
+
 #include <sstream>
 #include <cstdlib>
 #include <string>
 #include <iostream>
 
-#include "libsvg/svgpage.h"
 
 namespace libsvg {
 

--- a/src/libsvg/text.cc
+++ b/src/libsvg/text.cc
@@ -22,9 +22,10 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+#include "libsvg/text.h"
+
 #include <sstream>
 #include <string>
-#include "libsvg/text.h"
 #include "libsvg/util.h"
 
 namespace libsvg {

--- a/src/libsvg/transformation.cc
+++ b/src/libsvg/transformation.cc
@@ -22,13 +22,14 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+#include "libsvg/transformation.h"
+
 #include <sstream>
 #include <string>
 #include <vector>
 #include <iostream>
 
 #include "libsvg/util.h"
-#include "libsvg/transformation.h"
 #include "utils/degree_trig.h"
 
 namespace libsvg {

--- a/src/libsvg/tspan.cc
+++ b/src/libsvg/tspan.cc
@@ -22,10 +22,11 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+#include "libsvg/tspan.h"
+
 #include <sstream>
 #include <string>
 
-#include "libsvg/tspan.h"
 #include "libsvg/util.h"
 
 namespace libsvg {

--- a/src/libsvg/use.cc
+++ b/src/libsvg/use.cc
@@ -22,6 +22,8 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+#include "libsvg/use.h"
+
 #include <sstream>
 #include <memory>
 #include <cstdlib>
@@ -29,7 +31,6 @@
 #include <string>
 #include <vector>
 
-#include "libsvg/use.h"
 #include "libsvg/util.h"
 
 namespace libsvg {

--- a/src/libsvg/util.cc
+++ b/src/libsvg/util.cc
@@ -22,6 +22,8 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+#include "libsvg/util.h"
+
 #include <ostream>
 #include <boost/spirit/include/qi.hpp>
 
@@ -32,7 +34,6 @@
 #include <boost/fusion/adapted/struct/adapt_struct.hpp>
 #include <boost/fusion/include/adapt_struct.hpp>
 
-#include "libsvg/util.h"
 
 BOOST_FUSION_ADAPT_STRUCT(libsvg::length_struct, (double, number)(std::string, unit))
 

--- a/src/platform/PlatformUtils.cc
+++ b/src/platform/PlatformUtils.cc
@@ -1,10 +1,11 @@
+#include "platform/PlatformUtils.h"
+
 #include <cstdint>
 #include <cstdlib>
 #include <iomanip>
 #include <string>
 #include <vector>
 
-#include "platform/PlatformUtils.h"
 #include "utils/printutils.h"
 
 #ifdef OPENSCAD_SUFFIX

--- a/src/utils/calc.cc
+++ b/src/utils/calc.cc
@@ -23,11 +23,12 @@
  *  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
  *
  */
+#include "utils/calc.h"
 
 #include <cmath>
+
 #include <cassert>
 #include <algorithm>
-#include "utils/calc.h"
 #include "geometry/Grid.h"
 #include "utils/degree_trig.h"
 

--- a/src/utils/degree_trig.cc
+++ b/src/utils/degree_trig.cc
@@ -23,13 +23,14 @@
  *  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
  *
  */
+#include "utils/degree_trig.h"
+
 //
 // Trigonometry function taking degrees, accurate for 30, 45, 60 and 90, etc.
 //
 #include <cmath>
 #include <limits>
 
-#include "utils/degree_trig.h"
 
 static inline double rad2deg(double x)
 {


### PR DESCRIPTION
Move header foo.h within implementation foo.cc to the top. That ensures that the header at least is self-contained.

This revealed, that the core/SurfaceNode.h header was missing an include of core/Value.h.

This PR leaves out changing src/glview, as there are too many header dependencies that break, and should be addressed separately.