### PR TITLE
Don't #define _USE_MATH_DEFINES in *.cc files but as compile define.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -198,7 +198,11 @@ file(MAKE_DIRECTORY ${OPENSCAD_LIB_OUTPUT_DIR})
 
 target_compile_options(OpenSCAD PRIVATE "$<$<CONFIG:DEBUG>:-DDEBUG>")
 
-target_compile_definitions(OpenSCAD PRIVATE _REENTRANT UNICODE _UNICODE)
+target_compile_definitions(OpenSCAD PRIVATE
+  _REENTRANT
+  UNICODE
+  _UNICODE
+  _USE_MATH_DEFINES)
 
 if("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU")
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -frounding-math")

--- a/src/core/BuiltinContext.cc
+++ b/src/core/BuiltinContext.cc
@@ -1,5 +1,3 @@
-// NOLINTNEXTLINE(bugprone-reserved-identifier)
-#define _USE_MATH_DEFINES
 #include <cmath>
 
 #include "core/Builtins.h"

--- a/src/geometry/roof_vd.cc
+++ b/src/geometry/roof_vd.cc
@@ -4,11 +4,7 @@
 #include <ostream>
 #include <cstdint>
 #include <memory>
-
-// NOLINTNEXTLINE(bugprone-reserved-identifier)
-#define _USE_MATH_DEFINES
 #include <cmath>
-
 #include <cstddef>
 #include <algorithm>
 #include <map>

--- a/src/io/DxfData.cc
+++ b/src/io/DxfData.cc
@@ -25,9 +25,6 @@
  */
 
 #include <memory>
-
-// NOLINTNEXTLINE(bugprone-reserved-identifier)
-#define _USE_MATH_DEFINES
 #include <cmath>
 
 #include "io/DxfData.h"

--- a/src/utils/calc.cc
+++ b/src/utils/calc.cc
@@ -24,8 +24,6 @@
  *
  */
 
-// NOLINTNEXTLINE(bugprone-reserved-identifier)
-#define _USE_MATH_DEFINES
 #include <cmath>
 #include <cassert>
 #include <algorithm>

--- a/src/utils/degree_trig.cc
+++ b/src/utils/degree_trig.cc
@@ -26,8 +26,6 @@
 //
 // Trigonometry function taking degrees, accurate for 30, 45, 60 and 90, etc.
 //
-// NOLINTNEXTLINE(bugprone-reserved-identifier)
-#define _USE_MATH_DEFINES
 #include <cmath>
 #include <limits>
 


### PR DESCRIPTION
Setting the #define in the compilation unit makes it dependent if the same header had been included before; if <cmath> has been included before (and we don't know that, as we don't know what system headers do between each other), the include-guard will prevent our definition to ever been seen.

So the only way to make sure <cmath> sees the _USE_MATH_DEFINES define is to set it on the compile command line, i.e. in the CMakeLists.txt