### PR TITLE
Fix includes for <limits>, <list>, <functional> and more <utility>

### DIFF
--- a/src/FontCache.h
+++ b/src/FontCache.h
@@ -25,6 +25,7 @@
  */
 #pragma once
 
+#include <utility>
 #include <cstdint>
 #include <map>
 #include <string>

--- a/src/core/Expression.cc
+++ b/src/core/Expression.cc
@@ -27,6 +27,7 @@
 
 #include "utils/compiler_specific.h"
 #include "core/Value.h"
+#include <functional>
 #include <ostream>
 #include <cstdint>
 #include <cmath>

--- a/src/core/FreetypeRenderer.cc
+++ b/src/core/FreetypeRenderer.cc
@@ -25,6 +25,7 @@
  */
 #include "core/FreetypeRenderer.h"
 
+#include <limits>
 #include <cstdint>
 #include <memory>
 #include <cmath>

--- a/src/core/LocalScope.h
+++ b/src/core/LocalScope.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "core/Assignment.h"
+#include <utility>
 #include <ostream>
 #include <cstddef>
 #include <unordered_map>

--- a/src/core/NodeCache.h
+++ b/src/core/NodeCache.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <utility>
 #include <string>
 #include <unordered_map>
 #include <cassert>

--- a/src/core/Parameters.h
+++ b/src/core/Parameters.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <limits>
 #include <memory>
 #include <string>
 #include <vector>

--- a/src/core/RangeType.h
+++ b/src/core/RangeType.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <utility>
 #include <cstdint>
 #include <ostream>
 #include <cmath>

--- a/src/core/RangeType.h
+++ b/src/core/RangeType.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <limits>
 #include <utility>
 #include <cstdint>
 #include <ostream>

--- a/src/core/Value.cc
+++ b/src/core/Value.cc
@@ -26,6 +26,7 @@
 
 #include "core/Value.h"
 
+#include <limits>
 #include <ostream>
 #include <utility>
 #include <cstdint>

--- a/src/geometry/Geometry.h
+++ b/src/geometry/Geometry.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <utility>
 #include <cstddef>
 #include <string>
 #include <list>

--- a/src/geometry/GeometryEvaluator.cc
+++ b/src/geometry/GeometryEvaluator.cc
@@ -26,6 +26,7 @@
 #include "utils/calc.h"
 #include "io/DxfData.h"
 #include "utils/degree_trig.h"
+#include <list>
 #include <utility>
 #include <memory>
 #include <ciso646> // C alternative tokens (xor)

--- a/src/geometry/GeometryUtils.cc
+++ b/src/geometry/GeometryUtils.cc
@@ -1,5 +1,6 @@
 #include "geometry/GeometryUtils.h"
 
+#include <utility>
 #include <boost/functional/hash.hpp>
 #include <cstddef>
 #include <cmath>

--- a/src/geometry/GeometryUtils.cc
+++ b/src/geometry/GeometryUtils.cc
@@ -1,5 +1,6 @@
 #include "geometry/GeometryUtils.h"
 
+#include <list>
 #include <utility>
 #include <boost/functional/hash.hpp>
 #include <cstddef>

--- a/src/geometry/boolean_utils.cc
+++ b/src/geometry/boolean_utils.cc
@@ -1,5 +1,6 @@
 #include "geometry/boolean_utils.h"
 
+#include <list>
 #include <utility>
 #include <memory>
 #include <cstddef>

--- a/src/geometry/cgal/CGALHybridPolyhedron.cc
+++ b/src/geometry/cgal/CGALHybridPolyhedron.cc
@@ -3,6 +3,7 @@
 
 #include "geometry/cgal/cgalutils.h"
 #include "Feature.h"
+#include <functional>
 #include <memory>
 #include <CGAL/Surface_mesh.h>
 #include <CGAL/boost/graph/helpers.h>

--- a/src/geometry/cgal/CGALHybridPolyhedron.h
+++ b/src/geometry/cgal/CGALHybridPolyhedron.h
@@ -1,6 +1,7 @@
 // Portions of this file are Copyright 2021 Google LLC, and licensed under GPL2+. See COPYING.
 #pragma once
 
+#include <functional>
 #include <memory>
 #include <cstddef>
 #include <string>

--- a/src/geometry/cgal/cgalutils-applyops-hybrid-minkowski.cc
+++ b/src/geometry/cgal/cgalutils-applyops-hybrid-minkowski.cc
@@ -10,6 +10,7 @@
 #include "geometry/cgal/CGALHybridPolyhedron.h"
 #include "core/node.h"
 
+#include <list>
 #include <exception>
 #include <utility>
 #include <CGAL/Exact_predicates_inexact_constructions_kernel.h>

--- a/src/geometry/cgal/cgalutils-applyops-hybrid.cc
+++ b/src/geometry/cgal/cgalutils-applyops-hybrid.cc
@@ -3,6 +3,7 @@
 
 #ifdef ENABLE_CGAL
 
+#include <utility>
 #include <memory>
 #include <cstddef>
 #include <vector>

--- a/src/geometry/cgal/cgalutils-applyops.cc
+++ b/src/geometry/cgal/cgalutils-applyops.cc
@@ -16,6 +16,7 @@
 #endif
 #include "core/node.h"
 
+#include <utility>
 #include <exception>
 #include <CGAL/Exact_predicates_inexact_constructions_kernel.h>
 #include <CGAL/normal_vector_newell_3.h>

--- a/src/geometry/cgal/cgalutils-tess.cc
+++ b/src/geometry/cgal/cgalutils-tess.cc
@@ -1,5 +1,6 @@
 #include "geometry/cgal/cgalutils.h"
 #include "utils/printutils.h"
+#include <list>
 #include <cstddef>
 //#include "geometry/cgal/cgal.h"
 //#include "libtess2/Source/tess.h"

--- a/src/geometry/cgal/cgalutils-triangulate.cc
+++ b/src/geometry/cgal/cgalutils-triangulate.cc
@@ -2,6 +2,7 @@
 #include "geometry/PolySetBuilder.h"
 #include "geometry/cgal/cgalutils.h"
 
+#include <list>
 #include <memory>
 #include <utility>
 

--- a/src/geometry/cgal/cgalutils.cc
+++ b/src/geometry/cgal/cgalutils.cc
@@ -13,6 +13,7 @@
 #include "core/node.h"
 #include "utils/degree_trig.h"
 
+#include <utility>
 #include <memory>
 #include <CGAL/Aff_transformation_3.h>
 #include <CGAL/normal_vector_newell_3.h>

--- a/src/geometry/manifold/ManifoldGeometry.cc
+++ b/src/geometry/manifold/ManifoldGeometry.cc
@@ -1,6 +1,7 @@
 // Portions of this file are Copyright 2023 Google LLC, and licensed under GPL2+. See COPYING.
 #include "geometry/manifold/ManifoldGeometry.h"
 #include "geometry/Polygon2d.h"
+#include <functional>
 #include <exception>
 #include <sstream>
 #include <utility>

--- a/src/geometry/manifold/ManifoldGeometry.h
+++ b/src/geometry/manifold/ManifoldGeometry.h
@@ -2,6 +2,7 @@
 #pragma once
 
 #include "geometry/Geometry.h"
+#include <functional>
 #include <cstdint>
 #include <memory>
 #include <glm/glm.hpp>

--- a/src/geometry/manifold/manifold-applyops-minkowski.cc
+++ b/src/geometry/manifold/manifold-applyops-minkowski.cc
@@ -1,19 +1,19 @@
 // Portions of this file are Copyright 2023 Google LLC, and licensed under GPL2+. See COPYING.
 #ifdef ENABLE_MANIFOLD
 
-#include "geometry/cgal/cgal.h"
-#include "geometry/cgal/cgalutils.h"
 #include <exception>
 #include <memory>
+#include <utility>
+#include <vector>
 #include <CGAL/convex_hull_3.h>
 
+#include "geometry/cgal/cgal.h"
+#include "geometry/cgal/cgalutils.h"
 #include "geometry/PolySet.h"
 #include "utils/printutils.h"
 #include "geometry/manifold/manifoldutils.h"
 #include "geometry/manifold/ManifoldGeometry.h"
 #include "utils/parallel.h"
-
-#include <vector>
 
 namespace ManifoldUtils {
 

--- a/src/geometry/manifold/manifold-applyops-minkowski.cc
+++ b/src/geometry/manifold/manifold-applyops-minkowski.cc
@@ -1,6 +1,7 @@
 // Portions of this file are Copyright 2023 Google LLC, and licensed under GPL2+. See COPYING.
 #ifdef ENABLE_MANIFOLD
 
+#include <list>
 #include <exception>
 #include <memory>
 #include <utility>

--- a/src/geometry/roof_ss.cc
+++ b/src/geometry/roof_ss.cc
@@ -3,6 +3,7 @@
 
 #include "geometry/roof_ss.h"
 
+#include <functional>
 #include <memory>
 #include <boost/shared_ptr.hpp>
 

--- a/src/glview/ColorMap.cc
+++ b/src/glview/ColorMap.cc
@@ -2,6 +2,7 @@
 #include "utils/printutils.h"
 #include "platform/PlatformUtils.h"
 
+#include <list>
 #include <utility>
 #include <exception>
 #include <memory>

--- a/src/glview/ColorMap.cc
+++ b/src/glview/ColorMap.cc
@@ -2,6 +2,7 @@
 #include "utils/printutils.h"
 #include "platform/PlatformUtils.h"
 
+#include <utility>
 #include <exception>
 #include <memory>
 #include <boost/property_tree/json_parser.hpp>

--- a/src/glview/GLView.cc
+++ b/src/glview/GLView.cc
@@ -7,6 +7,7 @@
 #include "utils/degree_trig.h"
 #include "glview/hershey.h"
 
+#include <functional>
 #include <memory>
 #include <cmath>
 #include <cstdio>

--- a/src/glview/VBORenderer.h
+++ b/src/glview/VBORenderer.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <utility>
 #include <memory>
 #include <cstddef>
 #include "glview/Renderer.h"

--- a/src/glview/VertexArray.cc
+++ b/src/glview/VertexArray.cc
@@ -1,3 +1,4 @@
+#include <utility>
 #include <iostream>
 #include <iomanip>
 #include <sstream>

--- a/src/glview/VertexArray.h
+++ b/src/glview/VertexArray.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <functional>
 #include <memory>
 #include <cstddef>
 #include <unordered_map>

--- a/src/glview/cgal/CGALRenderer.cc
+++ b/src/glview/cgal/CGALRenderer.cc
@@ -24,6 +24,7 @@
  *
  */
 
+#include <limits>
 #include <utility>
 #include <memory>
 

--- a/src/glview/cgal/CGALRenderer.h
+++ b/src/glview/cgal/CGALRenderer.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <utility>
 #include <memory>
 #include <vector>
 

--- a/src/glview/cgal/LegacyCGALRenderer.cc
+++ b/src/glview/cgal/LegacyCGALRenderer.cc
@@ -24,6 +24,7 @@
  *
  */
 
+#include <limits>
 #include <memory>
 
 #ifdef _MSC_VER

--- a/src/glview/cgal/LegacyCGALRenderer.h
+++ b/src/glview/cgal/LegacyCGALRenderer.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <utility>
 #include <memory>
 #include <vector>
 

--- a/src/glview/preview/CSGTreeNormalizer.cc
+++ b/src/glview/preview/CSGTreeNormalizer.cc
@@ -1,3 +1,4 @@
+#include <utility>
 #include <memory>
 #include <stack>
 

--- a/src/glview/preview/LegacyThrownTogetherRenderer.h
+++ b/src/glview/preview/LegacyThrownTogetherRenderer.h
@@ -2,6 +2,7 @@
 
 #include "glview/Renderer.h"
 #include "core/CSGNode.h"
+#include <utility>
 #include <memory>
 #include <boost/functional/hash.hpp>
 #include <unordered_map>

--- a/src/gui/ErrorLog.cc
+++ b/src/gui/ErrorLog.cc
@@ -1,5 +1,6 @@
 #include "gui/ErrorLog.h"
 #include "utils/printutils.h"
+#include <utility>
 #include <boost/filesystem.hpp>
 
 ErrorLog::ErrorLog(QWidget *parent) : QWidget(parent)

--- a/src/gui/ErrorLog.h
+++ b/src/gui/ErrorLog.h
@@ -3,6 +3,7 @@
 #include "gui/qtgettext.h"
 #include "ui_ErrorLog.h"
 #include "utils/printutils.h"
+#include <list>
 #include <QStandardItemModel>
 
 enum errorLog_column {

--- a/src/gui/MainWindow.cc
+++ b/src/gui/MainWindow.cc
@@ -25,6 +25,7 @@
  */
 #include "gui/MainWindow.h"
 
+#include <functional>
 #include <exception>
 #include <sstream>
 #include <iostream>

--- a/src/gui/Network.h
+++ b/src/gui/Network.h
@@ -26,6 +26,7 @@
 
 #pragma once
 
+#include <functional>
 #include <exception>
 #include <QObject>
 #include <QString>

--- a/src/gui/OctoPrint.h
+++ b/src/gui/OctoPrint.h
@@ -26,6 +26,7 @@
 
 #pragma once
 
+#include <utility>
 #include <tuple>
 #include <string>
 #include <vector>

--- a/src/gui/Preferences.cc
+++ b/src/gui/Preferences.cc
@@ -26,6 +26,7 @@
 
 #include "gui/Preferences.h"
 
+#include <list>
 #include <QActionGroup>
 #include <QMessageBox>
 #include <QFontDatabase>

--- a/src/gui/ScintillaEditor.cc
+++ b/src/gui/ScintillaEditor.cc
@@ -1,5 +1,6 @@
 #include "gui/ScintillaEditor.h"
 
+#include <functional>
 #include <exception>
 #include <memory>
 #include <ciso646> // C alternative tokens (xor)

--- a/src/gui/TabManager.cc
+++ b/src/gui/TabManager.cc
@@ -1,5 +1,6 @@
 #include "gui/TabManager.h"
 
+#include <functional>
 #include <exception>
 #include <QFileInfo>
 #include <QFile>

--- a/src/gui/input/InputDriverManager.cc
+++ b/src/gui/input/InputDriverManager.cc
@@ -27,6 +27,7 @@
 
 #include "gui/input/InputDriverEvent.h"
 #include "gui/MainWindow.h"
+#include <list>
 #include <sstream>
 #include <QAction>
 #include <QMenu>

--- a/src/gui/input/InputDriverManager.h
+++ b/src/gui/input/InputDriverManager.h
@@ -25,6 +25,7 @@
  */
 #pragma once
 
+#include <list>
 #include <QWidget>
 #include <QThread>
 #include <QTimer>

--- a/src/gui/parameter/ParameterSlider.cc
+++ b/src/gui/parameter/ParameterSlider.cc
@@ -1,4 +1,5 @@
 #include "gui/parameter/ParameterSlider.h"
+#include <limits>
 #include "gui/IgnoreWheelWhenNotFocused.h"
 
 ParameterSlider::ParameterSlider(QWidget *parent, NumberParameter *parameter, DescriptionStyle descriptionStyle) :

--- a/src/gui/parameter/ParameterSpinBox.cc
+++ b/src/gui/parameter/ParameterSpinBox.cc
@@ -1,4 +1,5 @@
 #include "gui/parameter/ParameterSpinBox.h"
+#include <limits>
 #include "gui/IgnoreWheelWhenNotFocused.h"
 
 ParameterSpinBox::ParameterSpinBox(QWidget *parent, NumberParameter *parameter, DescriptionStyle descriptionStyle) :

--- a/src/gui/parameter/ParameterVector.cc
+++ b/src/gui/parameter/ParameterVector.cc
@@ -1,5 +1,6 @@
 #include "gui/parameter/ParameterVector.h"
 
+#include <limits>
 #include <cstddef>
 #include "gui/IgnoreWheelWhenNotFocused.h"
 

--- a/src/io/export_dxf.cc
+++ b/src/io/export_dxf.cc
@@ -24,6 +24,7 @@
  *
  */
 
+#include <limits>
 #include <ostream>
 #include <memory>
 #include "io/export.h"

--- a/src/libsvg/libsvg.cc
+++ b/src/libsvg/libsvg.cc
@@ -24,6 +24,7 @@
  */
 #include "libsvg/libsvg.h"
 
+#include <utility>
 #include <iostream>
 #include <memory>
 #include <map>

--- a/src/openscad.cc
+++ b/src/openscad.cc
@@ -48,6 +48,7 @@
 #include "core/customizer/ParameterObject.h"
 #include "core/customizer/ParameterSet.h"
 #include "openscad_mimalloc.h"
+#include <utility>
 #include <exception>
 #include <sstream>
 #include <iostream>

--- a/src/openscad.h
+++ b/src/openscad.h
@@ -26,6 +26,7 @@
 
 #pragma once
 
+#include <utility>
 #include <boost/filesystem.hpp>
 
 class SourceFile;

--- a/src/utils/boost-utils.h
+++ b/src/utils/boost-utils.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <limits>
 #include <boost/filesystem.hpp>
 #include "utils/printutils.h"
 namespace fs = boost::filesystem;

--- a/src/utils/printutils.cc
+++ b/src/utils/printutils.cc
@@ -1,4 +1,5 @@
 #include "utils/printutils.h"
+#include <list>
 #include <iostream>
 #include <sstream>
 #include <string>


### PR DESCRIPTION
Similar approach to previous fixes. One submit per header

  * `<utility>` for `std::pair`, `std::swap`, `std::forward`, `std::tuple`, `std::make_pair`
  * `<list>` for `std::list`
  * `<functional>` for `std::function`
  * `<limits>` for `std::numeric_limtis`

This drops the ` [misc-include-cleaner]` warnings unter 3000 (still ways to go).