### PR TITLE
Fix includes for `<array>`, `<map>`, `<set>`, `<unordered_map>`, `<unordered_set>`

### DIFF
--- a/src/RenderStatistic.cc
+++ b/src/RenderStatistic.cc
@@ -26,6 +26,7 @@
 
 #include "RenderStatistic.h"
 
+#include <array>
 #include <iostream>
 #include <memory>
 #include <fstream>

--- a/src/core/Assignment.h
+++ b/src/core/Assignment.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <unordered_map>
 #include <memory>
 #include <ostream>
 #include <string>

--- a/src/core/Builtins.cc
+++ b/src/core/Builtins.cc
@@ -1,5 +1,6 @@
 #include "core/Builtins.h"
 
+#include <unordered_map>
 #include <memory>
 #include <string>
 #include <vector>

--- a/src/core/Expression.cc
+++ b/src/core/Expression.cc
@@ -27,6 +27,7 @@
 
 #include "utils/compiler_specific.h"
 #include "core/Value.h"
+#include <set>
 #include <functional>
 #include <ostream>
 #include <cstdint>

--- a/src/core/Value.h
+++ b/src/core/Value.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <unordered_map>
 #include <utility>
 #include <vector>
 #include <string>

--- a/src/core/customizer/ParameterObject.cc
+++ b/src/core/customizer/ParameterObject.cc
@@ -5,6 +5,7 @@
 #include "core/Expression.h"
 #include "core/SourceFile.h"
 
+#include <map>
 #include <utility>
 #include <memory>
 #include <cstddef>

--- a/src/geometry/GeometryUtils.cc
+++ b/src/geometry/GeometryUtils.cc
@@ -1,5 +1,6 @@
 #include "geometry/GeometryUtils.h"
 
+#include <unordered_map>
 #include <list>
 #include <utility>
 #include <boost/functional/hash.hpp>

--- a/src/geometry/cgal/CGALHybridPolyhedron.cc
+++ b/src/geometry/cgal/CGALHybridPolyhedron.cc
@@ -3,6 +3,7 @@
 
 #include "geometry/cgal/cgalutils.h"
 #include "Feature.h"
+#include <map>
 #include <unordered_set>
 #include <functional>
 #include <memory>

--- a/src/geometry/cgal/CGALHybridPolyhedron.cc
+++ b/src/geometry/cgal/CGALHybridPolyhedron.cc
@@ -3,6 +3,7 @@
 
 #include "geometry/cgal/cgalutils.h"
 #include "Feature.h"
+#include <unordered_set>
 #include <functional>
 #include <memory>
 #include <CGAL/Surface_mesh.h>

--- a/src/geometry/cgal/cgalutils-corefinement-visitor.h
+++ b/src/geometry/cgal/cgalutils-corefinement-visitor.h
@@ -1,6 +1,7 @@
 // Portions of this file are Copyright 2021 Google LLC, and licensed under GPL2+. See COPYING.
 #pragma once
 
+#include <unordered_set>
 #include <memory>
 #include <CGAL/Polygon_mesh_processing/corefinement.h>
 #include "geometry/cgal/cgalutils-coplanar-faces-remesher.h"

--- a/src/geometry/cgal/cgalutils-corefinement-visitor.h
+++ b/src/geometry/cgal/cgalutils-corefinement-visitor.h
@@ -1,6 +1,7 @@
 // Portions of this file are Copyright 2021 Google LLC, and licensed under GPL2+. See COPYING.
 #pragma once
 
+#include <unordered_map>
 #include <unordered_set>
 #include <memory>
 #include <CGAL/Polygon_mesh_processing/corefinement.h>

--- a/src/geometry/cgal/cgalutils-mesh.cc
+++ b/src/geometry/cgal/cgalutils-mesh.cc
@@ -3,6 +3,7 @@
 #include "geometry/linalg.h"
 #include "utils/hash.h"
 
+#include <unordered_map>
 #include <memory>
 #include <CGAL/boost/graph/convert_nef_polyhedron_to_polygon_mesh.h>
 #include <CGAL/boost/graph/graph_traits_Surface_mesh.h>

--- a/src/geometry/cgal/cgalutils.cc
+++ b/src/geometry/cgal/cgalutils.cc
@@ -13,6 +13,7 @@
 #include "core/node.h"
 #include "utils/degree_trig.h"
 
+#include <set>
 #include <utility>
 #include <memory>
 #include <CGAL/Aff_transformation_3.h>

--- a/src/geometry/manifold/ManifoldGeometry.cc
+++ b/src/geometry/manifold/ManifoldGeometry.cc
@@ -1,6 +1,7 @@
 // Portions of this file are Copyright 2023 Google LLC, and licensed under GPL2+. See COPYING.
 #include "geometry/manifold/ManifoldGeometry.h"
 #include "geometry/Polygon2d.h"
+#include <map>
 #include <set>
 #include <functional>
 #include <exception>

--- a/src/geometry/manifold/ManifoldGeometry.cc
+++ b/src/geometry/manifold/ManifoldGeometry.cc
@@ -1,6 +1,7 @@
 // Portions of this file are Copyright 2023 Google LLC, and licensed under GPL2+. See COPYING.
 #include "geometry/manifold/ManifoldGeometry.h"
 #include "geometry/Polygon2d.h"
+#include <set>
 #include <functional>
 #include <exception>
 #include <sstream>

--- a/src/geometry/manifold/manifoldutils.cc
+++ b/src/geometry/manifold/manifoldutils.cc
@@ -7,6 +7,7 @@
 #ifdef ENABLE_CGAL
 #include "geometry/cgal/cgalutils.h"
 #include "geometry/cgal/CGALHybridPolyhedron.h"
+#include <set>
 #include <exception>
 #include <utility>
 #include <cstdint>

--- a/src/geometry/manifold/manifoldutils.cc
+++ b/src/geometry/manifold/manifoldutils.cc
@@ -7,6 +7,7 @@
 #ifdef ENABLE_CGAL
 #include "geometry/cgal/cgalutils.h"
 #include "geometry/cgal/CGALHybridPolyhedron.h"
+#include <map>
 #include <set>
 #include <exception>
 #include <utility>

--- a/src/glview/ColorMap.cc
+++ b/src/glview/ColorMap.cc
@@ -2,6 +2,7 @@
 #include "utils/printutils.h"
 #include "platform/PlatformUtils.h"
 
+#include <set>
 #include <list>
 #include <utility>
 #include <exception>

--- a/src/glview/Renderer.h
+++ b/src/glview/Renderer.h
@@ -7,6 +7,7 @@
 #include "core/Selection.h"
 
 #ifdef _MSC_VER // NULL
+#include <map>
 #include <cstdlib>
 #endif
 

--- a/src/glview/VBORenderer.cc
+++ b/src/glview/VBORenderer.cc
@@ -30,6 +30,7 @@
 #include "utils/printutils.h"
 #include "utils/hash.h" // IWYU pragma: keep
 
+#include <array>
 #include <unordered_map>
 #include <utility>
 #include <memory>

--- a/src/glview/VBORenderer.cc
+++ b/src/glview/VBORenderer.cc
@@ -30,6 +30,7 @@
 #include "utils/printutils.h"
 #include "utils/hash.h" // IWYU pragma: keep
 
+#include <unordered_map>
 #include <utility>
 #include <memory>
 #include <cstddef>

--- a/src/glview/VBORenderer.h
+++ b/src/glview/VBORenderer.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <array>
 #include <utility>
 #include <memory>
 #include <cstddef>

--- a/src/glview/VertexArray.cc
+++ b/src/glview/VertexArray.cc
@@ -1,3 +1,4 @@
+#include <array>
 #include <utility>
 #include <iostream>
 #include <iomanip>

--- a/src/glview/VertexArray.h
+++ b/src/glview/VertexArray.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <array>
 #include <functional>
 #include <memory>
 #include <cstddef>

--- a/src/gui/FontList.cc
+++ b/src/gui/FontList.cc
@@ -1,5 +1,6 @@
 #include "gui/FontList.h"
 
+#include <array>
 #include <cstdint>
 #include <qitemselectionmodel.h>
 #include <string>

--- a/src/gui/MainWindow.cc
+++ b/src/gui/MainWindow.cc
@@ -25,6 +25,7 @@
  */
 #include "gui/MainWindow.h"
 
+#include <array>
 #include <functional>
 #include <exception>
 #include <sstream>

--- a/src/gui/MainWindow.h
+++ b/src/gui/MainWindow.h
@@ -12,6 +12,7 @@
 #include "gui/qtgettext.h" // IWYU pragma: keep
 #include "ui_MainWindow.h"
 
+#include <unordered_map>
 #include <memory>
 #include <string>
 #include <vector>

--- a/src/gui/Settings.cc
+++ b/src/gui/Settings.cc
@@ -2,6 +2,7 @@
 #include "glview/RenderSettings.h"
 #include "utils/printutils.h"
 #include "gui/input/InputEventMapper.h"
+#include <array>
 #include <boost/algorithm/string.hpp>
 #include <boost/lexical_cast.hpp>
 #include <cstddef>

--- a/src/gui/parameter/ParameterWidget.cc
+++ b/src/gui/parameter/ParameterWidget.cc
@@ -25,6 +25,7 @@
  */
 #include "gui/parameter/ParameterWidget.h"
 
+#include <map>
 #include <set>
 #include <memory>
 #include <QWidget>

--- a/src/gui/parameter/ParameterWidget.cc
+++ b/src/gui/parameter/ParameterWidget.cc
@@ -25,6 +25,7 @@
  */
 #include "gui/parameter/ParameterWidget.h"
 
+#include <set>
 #include <memory>
 #include <QWidget>
 

--- a/src/io/dxfdim.cc
+++ b/src/io/dxfdim.cc
@@ -35,6 +35,7 @@
 #include "handle_dep.h"
 #include "utils/degree_trig.h"
 
+#include <unordered_map>
 #include <utility>
 #include <cstddef>
 #include <cmath>

--- a/src/io/export.cc
+++ b/src/io/export.cc
@@ -29,6 +29,7 @@
 #include "utils/printutils.h"
 #include "geometry/Geometry.h"
 
+#include <map>
 #include <iostream>
 #include <cstdint>
 #include <memory>

--- a/src/io/export.h
+++ b/src/io/export.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <map>
 #include <iostream>
 #include <functional>
 #include <array>

--- a/src/io/export_stl.cc
+++ b/src/io/export_stl.cc
@@ -27,6 +27,7 @@
 #include "io/export.h"
 #include "geometry/PolySet.h"
 #include "geometry/PolySetUtils.h"
+#include <array>
 #include <ios>
 #include <ostream>
 #include <cstdint>

--- a/src/io/import_off.cc
+++ b/src/io/import_off.cc
@@ -3,6 +3,7 @@
 #include "geometry/PolySet.h"
 #include "utils/printutils.h"
 #include "core/AST.h"
+#include <map>
 #include <ios>
 #include <cstdint>
 #include <memory>

--- a/src/io/import_stl.cc
+++ b/src/io/import_stl.cc
@@ -4,6 +4,7 @@
 #include "utils/printutils.h"
 #include "core/AST.h"
 
+#include <array>
 #include <ios>
 #include <cstdint>
 #include <memory>

--- a/src/openscad.cc
+++ b/src/openscad.cc
@@ -48,6 +48,7 @@
 #include "core/customizer/ParameterObject.h"
 #include "core/customizer/ParameterSet.h"
 #include "openscad_mimalloc.h"
+#include <set>
 #include <utility>
 #include <exception>
 #include <sstream>

--- a/src/openscad.cc
+++ b/src/openscad.cc
@@ -48,6 +48,7 @@
 #include "core/customizer/ParameterObject.h"
 #include "core/customizer/ParameterSet.h"
 #include "openscad_mimalloc.h"
+#include <map>
 #include <set>
 #include <utility>
 #include <exception>

--- a/src/utils/printutils.cc
+++ b/src/utils/printutils.cc
@@ -1,4 +1,5 @@
 #include "utils/printutils.h"
+#include <set>
 #include <list>
 #include <iostream>
 #include <sstream>


### PR DESCRIPTION
Fix missing includes, container edition

Multiple commits, one per include:

  *  `<array>`  for `std::array`
  *  `<map>` for `std::map`
  *  `<set>` for `std::set`
  *  `<unordered_map>` for `std::unordered_map`
  *  `<unordered_set>` for `std::unordered_set`
