### PR TITLE
CGAL 6.0 build fix

### DIFF
--- a/src/geometry/roof_ss.cc
+++ b/src/geometry/roof_ss.cc
@@ -5,17 +5,18 @@
 
 #include <functional>
 #include <memory>
-#include <boost/shared_ptr.hpp>
 
 #include <CGAL/Exact_predicates_inexact_constructions_kernel.h>
 #include <CGAL/Polygon_with_holes_2.h>
 #include <CGAL/create_straight_skeleton_from_polygon_with_holes_2.h>
 #include <CGAL/partition_2.h>
 #include <CGAL/Partition_traits_2.h>
+#if CGAL_VERSION_NR < CGAL_VERSION_NUMBER(6, 0, 0)
+#include <boost/shared_ptr.hpp>
+#endif
 
 #include <algorithm>
 #include <map>
-#include <vector>
 
 #include "geometry/GeometryUtils.h"
 #include "geometry/ClipperUtils.h"
@@ -38,7 +39,11 @@ using CGAL_Ss = CGAL::Straight_skeleton_2<CGAL_KERNEL>;
 
 using CGAL_PT = CGAL::Partition_traits_2<CGAL_KERNEL>;
 
+#if CGAL_VERSION_NR < CGAL_VERSION_NUMBER(6, 0, 0)
 using CGAL_SsPtr = boost::shared_ptr<CGAL_Ss>;
+#else
+using CGAL_SsPtr = std::shared_ptr<CGAL_Ss>;
+#endif
 
 using PolyTree = ClipperLib::PolyTree;
 using PolyNode = ClipperLib::PolyNode;


### PR DESCRIPTION
CGAL changed the return type of `CGAL::create_interior_straight_skeleton_2()` from boost::shared_ptr to std::shared_ptr.