### PR TITLE
Address some long-tail missing std::* includes

### DIFF
--- a/src/core/ContextMemoryManager.cc
+++ b/src/core/ContextMemoryManager.cc
@@ -26,6 +26,7 @@
 
 #include "core/ContextMemoryManager.h"
 
+#include <variant>
 #include <cassert>
 #include <utility>
 #include <memory>

--- a/src/core/SurfaceNode.cc
+++ b/src/core/SurfaceNode.cc
@@ -39,6 +39,7 @@
 #include "handle_dep.h"
 #include "lodepng/lodepng.h"
 
+#include <string>
 #include <utility>
 #include <memory>
 #include <cstdint>

--- a/src/core/SurfaceNode.cc
+++ b/src/core/SurfaceNode.cc
@@ -39,6 +39,7 @@
 #include "handle_dep.h"
 #include "lodepng/lodepng.h"
 
+#include <new>
 #include <string>
 #include <utility>
 #include <memory>

--- a/src/core/Tree.h
+++ b/src/core/Tree.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "core/NodeCache.h"
+#include <tuple>
 #include <memory>
 #include <map>
 #include <string>

--- a/src/core/Value.cc
+++ b/src/core/Value.cc
@@ -26,6 +26,7 @@
 
 #include "core/Value.h"
 
+#include <variant>
 #include <limits>
 #include <ostream>
 #include <utility>

--- a/src/core/customizer/ParameterObject.cc
+++ b/src/core/customizer/ParameterObject.cc
@@ -5,6 +5,7 @@
 #include "core/Expression.h"
 #include "core/SourceFile.h"
 
+#include <variant>
 #include <map>
 #include <utility>
 #include <memory>

--- a/src/geometry/cgal/cgalutils-applyops-hybrid.cc
+++ b/src/geometry/cgal/cgalutils-applyops-hybrid.cc
@@ -3,6 +3,7 @@
 
 #ifdef ENABLE_CGAL
 
+#include <queue>
 #include <cassert>
 #include <utility>
 #include <memory>

--- a/src/geometry/manifold/manifoldutils.cc
+++ b/src/geometry/manifold/manifoldutils.cc
@@ -7,6 +7,7 @@
 #ifdef ENABLE_CGAL
 #include "geometry/cgal/cgalutils.h"
 #include "geometry/cgal/CGALHybridPolyhedron.h"
+#include <optional>
 #include <cassert>
 #include <map>
 #include <set>

--- a/src/glview/ColorMap.cc
+++ b/src/glview/ColorMap.cc
@@ -2,6 +2,7 @@
 #include "utils/printutils.h"
 #include "platform/PlatformUtils.h"
 
+#include <stdexcept>
 #include <set>
 #include <list>
 #include <utility>

--- a/src/glview/OffscreenView.h
+++ b/src/glview/OffscreenView.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <stdexcept>
 #include <cstdint>
 #include <memory>
 #include <string>

--- a/src/glview/RenderSettings.cc
+++ b/src/glview/RenderSettings.cc
@@ -1,4 +1,5 @@
 #include "glview/RenderSettings.h"
+#include <stdexcept>
 #include <string>
 #include "utils/printutils.h"
 

--- a/src/glview/RenderSettings.cc
+++ b/src/glview/RenderSettings.cc
@@ -1,4 +1,5 @@
 #include "glview/RenderSettings.h"
+#include <string>
 #include "utils/printutils.h"
 
 std::string renderBackend3DToString(RenderBackend3D backend) {

--- a/src/gui/Preferences.cc
+++ b/src/gui/Preferences.cc
@@ -26,6 +26,7 @@
 
 #include "gui/Preferences.h"
 
+#include <tuple>
 #include <cassert>
 #include <list>
 #include <QActionGroup>

--- a/src/gui/ScadApi.cc
+++ b/src/gui/ScadApi.cc
@@ -1,5 +1,6 @@
 #include "gui/ScadApi.h"
 
+#include <string>
 #include <QDir>
 #include <QFileInfo>
 #include <QRegularExpression>

--- a/src/gui/parameter/ParameterWidget.cc
+++ b/src/gui/parameter/ParameterWidget.cc
@@ -25,6 +25,7 @@
  */
 #include "gui/parameter/ParameterWidget.h"
 
+#include <stdexcept>
 #include <cassert>
 #include <map>
 #include <set>

--- a/src/io/DxfData.cc
+++ b/src/io/DxfData.cc
@@ -26,6 +26,7 @@
 
 #include "io/DxfData.h"
 
+#include <stdexcept>
 #include <memory>
 #include <cmath>
 

--- a/src/io/import_off.cc
+++ b/src/io/import_off.cc
@@ -3,6 +3,7 @@
 #include "geometry/PolySet.h"
 #include "utils/printutils.h"
 #include "core/AST.h"
+#include <system_error>
 #include <map>
 #include <ios>
 #include <cstdint>

--- a/src/openscad.cc
+++ b/src/openscad.cc
@@ -48,6 +48,7 @@
 #include "core/customizer/ParameterObject.h"
 #include "core/customizer/ParameterSet.h"
 #include "openscad_mimalloc.h"
+#include <stdexcept>
 #include <map>
 #include <set>
 #include <utility>

--- a/src/platform/PlatformUtils.cc
+++ b/src/platform/PlatformUtils.cc
@@ -1,5 +1,6 @@
 #include "platform/PlatformUtils.h"
 
+#include <stdexcept>
 #include <cstdint>
 #include <cstdlib>
 #include <iomanip>

--- a/src/utils/boost-utils.cc
+++ b/src/utils/boost-utils.cc
@@ -1,4 +1,5 @@
 #include "utils/boost-utils.h"
+#include <stdexcept>
 #include <cstdio>
 #include <string>
 #include <iostream>

--- a/src/utils/svg.cc
+++ b/src/utils/svg.cc
@@ -1,6 +1,7 @@
 #ifdef ENABLE_CGAL
 #include "utils/svg.h"
 #include "geometry/cgal/cgalutils.h"
+#include <ostream>
 #include <sstream>
 #include <boost/algorithm/string.hpp>
 #include <boost/lexical_cast.hpp>


### PR DESCRIPTION
One commit per header. Addressing headers needed for

   * `std::bad_alloc`
   * `std::optional`
   * `std::endl`
   * `std::priority_queue`
   * `std::invalid_argument`
   * `std::out_of_range`
   * `std::runtime_error`
   * `std::getline`
   * `std::string`
   * `std::u32string`
   * `std::errc`
   * `std::tie`
   * `std::tuple`
   * `std::get_if`
   * `std::holds_alternative`
   * `std::visit`
