### PR TITLE
force manifold evaluation before worker exit

### DIFF
--- a/src/gui/CGALWorker.cc
+++ b/src/gui/CGALWorker.cc
@@ -3,6 +3,7 @@
 #include <memory>
 #include <QThread>
 
+#include "ManifoldGeometry.h"
 #include "core/Tree.h"
 #include "geometry/GeometryEvaluator.h"
 #include "core/progress.h"
@@ -36,6 +37,11 @@ void CGALWorker::work()
   try {
     GeometryEvaluator evaluator(*this->tree);
     root_geom = evaluator.evaluateGeometry(*this->tree->root(), true);
+
+    if (auto manifold = std::dynamic_pointer_cast<const ManifoldGeometry>(root_geom)) {
+      if (manifold->getManifold().Status() != manifold::Manifold::Error::NoError)
+        LOG(message_group::Error, "Rendering cancelled due to unknown manifold error.");
+    }
   } catch (const ProgressCancelException& e) {
     LOG("Rendering cancelled.");
   } catch (const HardWarningException& e) {

--- a/src/gui/CGALWorker.cc
+++ b/src/gui/CGALWorker.cc
@@ -39,6 +39,9 @@ void CGALWorker::work()
     root_geom = evaluator.evaluateGeometry(*this->tree->root(), true);
 
     if (auto manifold = std::dynamic_pointer_cast<const ManifoldGeometry>(root_geom)) {
+      // calling status forces evaluation
+      // we should complete evaluation within the worker thread, so computation
+      // will not block the GUI.
       if (manifold->getManifold().Status() != manifold::Manifold::Error::NoError)
         LOG(message_group::Error, "Rendering cancelled due to unknown manifold error.");
     }


### PR DESCRIPTION
The worker may return an unevaluated manifold geometry, which will be evaluated when the renderer attempts to get the underlying mesh, and freeze the GUI thread. This also throws the render time off.