### PR TITLE
Fix missing standard headers

### DIFF
--- a/src/RenderStatistic.cc
+++ b/src/RenderStatistic.cc
@@ -26,6 +26,7 @@
 
 #include "RenderStatistic.h"
 
+#include <chrono>
 #include <cassert>
 #include <array>
 #include <iostream>

--- a/src/RenderStatistic.cc
+++ b/src/RenderStatistic.cc
@@ -26,6 +26,7 @@
 
 #include "RenderStatistic.h"
 
+#include <algorithm>
 #include <chrono>
 #include <cassert>
 #include <array>

--- a/src/core/ColorNode.cc
+++ b/src/core/ColorNode.cc
@@ -31,6 +31,7 @@
 #include "core/Children.h"
 #include "core/Parameters.h"
 #include "utils/printutils.h"
+#include <algorithm>
 #include <utility>
 #include <memory>
 #include <cctype>

--- a/src/core/FreetypeRenderer.cc
+++ b/src/core/FreetypeRenderer.cc
@@ -25,6 +25,7 @@
  */
 #include "core/FreetypeRenderer.h"
 
+#include <algorithm>
 #include <limits>
 #include <cstdint>
 #include <memory>

--- a/src/core/ImportNode.cc
+++ b/src/core/ImportNode.cc
@@ -44,6 +44,7 @@
 #include "Feature.h"
 #include "handle_dep.h"
 #include "utils/boost-utils.h"
+#include <cmath>
 #include <ios>
 #include <utility>
 #include <memory>

--- a/src/core/NodeDumper.cc
+++ b/src/core/NodeDumper.cc
@@ -1,6 +1,7 @@
 #include "core/NodeDumper.h"
 #include "core/State.h"
 #include "core/ModuleInstantiation.h"
+#include <algorithm>
 #include <iterator>
 #include <ostream>
 #include <string>

--- a/src/core/NodeDumper.cc
+++ b/src/core/NodeDumper.cc
@@ -1,6 +1,7 @@
 #include "core/NodeDumper.h"
 #include "core/State.h"
 #include "core/ModuleInstantiation.h"
+#include <iterator>
 #include <ostream>
 #include <string>
 #include <sstream>

--- a/src/core/RangeType.h
+++ b/src/core/RangeType.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <iterator>
 #include <limits>
 #include <utility>
 #include <cstdint>

--- a/src/core/RoofNode.cc
+++ b/src/core/RoofNode.cc
@@ -3,6 +3,7 @@
 
 #include "core/RoofNode.h"
 
+#include <algorithm>
 #include <utility>
 #include <memory>
 #include <sstream>

--- a/src/core/SourceFile.cc
+++ b/src/core/SourceFile.cc
@@ -32,6 +32,7 @@
 #include "core/ScopeContext.h"
 #include "core/parsersettings.h"
 #include "core/StatCache.h"
+#include <algorithm>
 #include <ostream>
 #include <memory>
 #include <boost/algorithm/string.hpp>

--- a/src/core/SourceFileCache.cc
+++ b/src/core/SourceFileCache.cc
@@ -3,6 +3,7 @@
 #include "core/SourceFile.h"
 #include "utils/printutils.h"
 #include "openscad.h"
+#include <ctime>
 #include <boost/format.hpp>
 
 #include <cstdio>

--- a/src/core/SurfaceNode.cc
+++ b/src/core/SurfaceNode.cc
@@ -39,6 +39,7 @@
 #include "handle_dep.h"
 #include "lodepng/lodepng.h"
 
+#include <cstring>
 #include <new>
 #include <string>
 #include <utility>

--- a/src/core/SurfaceNode.cc
+++ b/src/core/SurfaceNode.cc
@@ -39,6 +39,7 @@
 #include "handle_dep.h"
 #include "lodepng/lodepng.h"
 
+#include <algorithm>
 #include <cstring>
 #include <new>
 #include <string>

--- a/src/core/TransformNode.cc
+++ b/src/core/TransformNode.cc
@@ -32,6 +32,7 @@
 #include "core/Parameters.h"
 #include "utils/printutils.h"
 #include "utils/degree_trig.h"
+#include <cmath>
 #include <memory>
 #include <cstddef>
 #include <sstream>

--- a/src/core/TransformNode.cc
+++ b/src/core/TransformNode.cc
@@ -32,6 +32,7 @@
 #include "core/Parameters.h"
 #include "utils/printutils.h"
 #include "utils/degree_trig.h"
+#include <algorithm>
 #include <cmath>
 #include <memory>
 #include <cstddef>

--- a/src/core/UndefType.h
+++ b/src/core/UndefType.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <initializer_list>
 #include <memory>
 #include <ostream>
 #include <sstream>

--- a/src/core/Value.cc
+++ b/src/core/Value.cc
@@ -26,6 +26,7 @@
 
 #include "core/Value.h"
 
+#include <cmath>
 #include <variant>
 #include <limits>
 #include <ostream>

--- a/src/core/Value.h
+++ b/src/core/Value.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <iterator>
 #include <unordered_map>
 #include <utility>
 #include <vector>

--- a/src/core/node.cc
+++ b/src/core/node.cc
@@ -28,6 +28,7 @@
 #include "core/ModuleInstantiation.h"
 #include "core/progress.h"
 
+#include <deque>
 #include <memory>
 #include <cstddef>
 #include <functional>

--- a/src/core/parsersettings.cc
+++ b/src/core/parsersettings.cc
@@ -1,5 +1,6 @@
 #include "core/parsersettings.h"
 
+#include <algorithm>
 #include <iterator>
 #include <cassert>
 #include <string>

--- a/src/core/parsersettings.cc
+++ b/src/core/parsersettings.cc
@@ -1,5 +1,6 @@
 #include "core/parsersettings.h"
 
+#include <iterator>
 #include <cassert>
 #include <string>
 #include <vector>

--- a/src/core/primitives.cc
+++ b/src/core/primitives.cc
@@ -36,6 +36,7 @@
 #include "utils/degree_trig.h"
 #include "core/module.h"
 #include "utils/printutils.h"
+#include <algorithm>
 #include <utility>
 #include <boost/assign/std/vector.hpp>
 #include <cassert>

--- a/src/core/str_utf8_wrapper.h
+++ b/src/core/str_utf8_wrapper.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <iterator>
 #include <utility>
 #include <cstdint>
 #include <cstddef>

--- a/src/geometry/ClipperUtils.cc
+++ b/src/geometry/ClipperUtils.cc
@@ -1,6 +1,7 @@
 #include "geometry/ClipperUtils.h"
 #include "utils/printutils.h"
 
+#include <cmath>
 #include <cassert>
 #include <utility>
 #include <memory>

--- a/src/geometry/ClipperUtils.cc
+++ b/src/geometry/ClipperUtils.cc
@@ -1,6 +1,7 @@
 #include "geometry/ClipperUtils.h"
 #include "utils/printutils.h"
 
+#include <algorithm>
 #include <cmath>
 #include <cassert>
 #include <utility>

--- a/src/geometry/GeometryEvaluator.cc
+++ b/src/geometry/GeometryEvaluator.cc
@@ -27,6 +27,7 @@
 #include "io/DxfData.h"
 #include "glview/RenderSettings.h"
 #include "utils/degree_trig.h"
+#include <cmath>
 #include <iterator>
 #include <cassert>
 #include <list>

--- a/src/geometry/GeometryEvaluator.cc
+++ b/src/geometry/GeometryEvaluator.cc
@@ -27,6 +27,7 @@
 #include "io/DxfData.h"
 #include "glview/RenderSettings.h"
 #include "utils/degree_trig.h"
+#include <iterator>
 #include <cassert>
 #include <list>
 #include <utility>

--- a/src/geometry/GeometryUtils.cc
+++ b/src/geometry/GeometryUtils.cc
@@ -1,5 +1,6 @@
 #include "geometry/GeometryUtils.h"
 
+#include <algorithm>
 #include <cassert>
 #include <unordered_map>
 #include <list>

--- a/src/geometry/PolySet.cc
+++ b/src/geometry/PolySet.cc
@@ -29,6 +29,7 @@
 #include "geometry/linalg.h"
 #include "utils/printutils.h"
 #include "geometry/Grid.h"
+#include <algorithm>
 #include <sstream>
 #include <memory>
 #include <Eigen/LU>

--- a/src/geometry/PolySetBuilder.cc
+++ b/src/geometry/PolySetBuilder.cc
@@ -37,6 +37,7 @@
 #include "geometry/manifold/ManifoldGeometry.h"
 #endif
 
+#include <iterator>
 #include <cassert>
 #include <utility>
 #include <cstdint>

--- a/src/geometry/PolySetBuilder.cc
+++ b/src/geometry/PolySetBuilder.cc
@@ -37,6 +37,7 @@
 #include "geometry/manifold/ManifoldGeometry.h"
 #endif
 
+#include <algorithm>
 #include <iterator>
 #include <cassert>
 #include <utility>

--- a/src/geometry/boolean_utils.cc
+++ b/src/geometry/boolean_utils.cc
@@ -1,5 +1,6 @@
 #include "geometry/boolean_utils.h"
 
+#include <iterator>
 #include <cassert>
 #include <list>
 #include <utility>

--- a/src/geometry/cgal/cgalutils-applyops-hybrid-minkowski.cc
+++ b/src/geometry/cgal/cgalutils-applyops-hybrid-minkowski.cc
@@ -10,6 +10,7 @@
 #include "geometry/cgal/CGALHybridPolyhedron.h"
 #include "core/node.h"
 
+#include <iterator>
 #include <cassert>
 #include <list>
 #include <exception>

--- a/src/geometry/cgal/cgalutils-polyhedron.cc
+++ b/src/geometry/cgal/cgalutils-polyhedron.cc
@@ -6,6 +6,7 @@
 #include "utils/printutils.h"
 #include "geometry/Grid.h"
 
+#include <algorithm>
 #include <iterator>
 #include <ostream>
 #include <memory>

--- a/src/geometry/cgal/cgalutils-polyhedron.cc
+++ b/src/geometry/cgal/cgalutils-polyhedron.cc
@@ -6,6 +6,7 @@
 #include "utils/printutils.h"
 #include "geometry/Grid.h"
 
+#include <iterator>
 #include <ostream>
 #include <memory>
 #include <CGAL/Exact_predicates_inexact_constructions_kernel.h>

--- a/src/geometry/linear_extrude.cc
+++ b/src/geometry/linear_extrude.cc
@@ -1,5 +1,6 @@
 #include "geometry/linear_extrude.h"
 
+#include <algorithm>
 #include <cmath>
 #include <iterator>
 #include <cassert>

--- a/src/geometry/linear_extrude.cc
+++ b/src/geometry/linear_extrude.cc
@@ -1,5 +1,6 @@
 #include "geometry/linear_extrude.h"
 
+#include <iterator>
 #include <cassert>
 #include <utility>
 #include <memory>

--- a/src/geometry/linear_extrude.cc
+++ b/src/geometry/linear_extrude.cc
@@ -1,5 +1,6 @@
 #include "geometry/linear_extrude.h"
 
+#include <cmath>
 #include <iterator>
 #include <cassert>
 #include <utility>

--- a/src/geometry/manifold/manifold-applyops-minkowski.cc
+++ b/src/geometry/manifold/manifold-applyops-minkowski.cc
@@ -1,6 +1,7 @@
 // Portions of this file are Copyright 2023 Google LLC, and licensed under GPL2+. See COPYING.
 #ifdef ENABLE_MANIFOLD
 
+#include <iterator>
 #include <cassert>
 #include <list>
 #include <exception>

--- a/src/geometry/roof_ss.cc
+++ b/src/geometry/roof_ss.cc
@@ -3,6 +3,7 @@
 
 #include "geometry/roof_ss.h"
 
+#include <iterator>
 #include <functional>
 #include <memory>
 

--- a/src/glview/ColorMap.cc
+++ b/src/glview/ColorMap.cc
@@ -2,6 +2,7 @@
 #include "utils/printutils.h"
 #include "platform/PlatformUtils.h"
 
+#include <algorithm>
 #include <iomanip>
 #include <stdexcept>
 #include <set>

--- a/src/glview/ColorMap.cc
+++ b/src/glview/ColorMap.cc
@@ -2,6 +2,7 @@
 #include "utils/printutils.h"
 #include "platform/PlatformUtils.h"
 
+#include <iomanip>
 #include <stdexcept>
 #include <set>
 #include <list>

--- a/src/glview/ColorMap.h
+++ b/src/glview/ColorMap.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <functional>
 #include <memory>
 #include <map>
 #include <string>

--- a/src/glview/VertexArray.cc
+++ b/src/glview/VertexArray.cc
@@ -1,3 +1,4 @@
+#include <cstring>
 #include <cassert>
 #include <array>
 #include <utility>

--- a/src/glview/cgal/CGALRenderUtils.cc
+++ b/src/glview/cgal/CGALRenderUtils.cc
@@ -1,3 +1,4 @@
+#include <algorithm>
 #include "glview/cgal/CGALRenderUtils.h"
 
 

--- a/src/gui/MainWindow.cc
+++ b/src/gui/MainWindow.cc
@@ -25,6 +25,7 @@
  */
 #include "gui/MainWindow.h"
 
+#include <deque>
 #include <cassert>
 #include <array>
 #include <functional>

--- a/src/gui/Measurement.cc
+++ b/src/gui/Measurement.cc
@@ -26,6 +26,7 @@
 
 #include "gui/Measurement.h"
 
+#include <cmath>
 #include <sstream>
 #include <string>
 

--- a/src/gui/Network.h
+++ b/src/gui/Network.h
@@ -26,6 +26,7 @@
 
 #pragma once
 
+#include <algorithm>
 #include <functional>
 #include <exception>
 #include <QObject>

--- a/src/gui/ScadLexer.cc
+++ b/src/gui/ScadLexer.cc
@@ -1,5 +1,6 @@
 #include "gui/ScadLexer.h"
 
+#include <iterator>
 #include <string>
 #include <vector>
 

--- a/src/gui/ScintillaEditor.h
+++ b/src/gui/ScintillaEditor.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <map>
 #include <functional>
 #include <memory>
 #include <string>

--- a/src/gui/input/AxisConfigWidget.cc
+++ b/src/gui/input/AxisConfigWidget.cc
@@ -26,6 +26,7 @@
 
 #include "gui/input/AxisConfigWidget.h"
 
+#include <cmath>
 #include <QWidget>
 #include <cstddef>
 #include <string>

--- a/src/gui/input/InputDriverManager.cc
+++ b/src/gui/input/InputDriverManager.cc
@@ -27,6 +27,7 @@
 
 #include "gui/input/InputDriverEvent.h"
 #include "gui/MainWindow.h"
+#include <algorithm>
 #include <list>
 #include <sstream>
 #include <QAction>

--- a/src/gui/parameter/ParameterSlider.cc
+++ b/src/gui/parameter/ParameterSlider.cc
@@ -1,4 +1,5 @@
 #include "gui/parameter/ParameterSlider.h"
+#include <cmath>
 #include <iterator>
 #include <cassert>
 #include <limits>

--- a/src/gui/parameter/ParameterSlider.cc
+++ b/src/gui/parameter/ParameterSlider.cc
@@ -1,4 +1,5 @@
 #include "gui/parameter/ParameterSlider.h"
+#include <iterator>
 #include <cassert>
 #include <limits>
 #include "gui/IgnoreWheelWhenNotFocused.h"

--- a/src/gui/parameter/ParameterSpinBox.cc
+++ b/src/gui/parameter/ParameterSpinBox.cc
@@ -1,4 +1,5 @@
 #include "gui/parameter/ParameterSpinBox.h"
+#include <algorithm>
 #include <limits>
 #include "gui/IgnoreWheelWhenNotFocused.h"
 

--- a/src/gui/parameter/ParameterVector.cc
+++ b/src/gui/parameter/ParameterVector.cc
@@ -1,5 +1,6 @@
 #include "gui/parameter/ParameterVector.h"
 
+#include <algorithm>
 #include <cassert>
 #include <limits>
 #include <cstddef>

--- a/src/gui/parameter/ParameterVirtualWidget.cc
+++ b/src/gui/parameter/ParameterVirtualWidget.cc
@@ -1,5 +1,6 @@
 #include "gui/parameter/ParameterVirtualWidget.h"
 
+#include <algorithm>
 #include <cmath>
 #include <cassert>
 #include <QRegularExpression>

--- a/src/gui/parameter/ParameterVirtualWidget.cc
+++ b/src/gui/parameter/ParameterVirtualWidget.cc
@@ -1,5 +1,6 @@
 #include "gui/parameter/ParameterVirtualWidget.h"
 
+#include <cmath>
 #include <cassert>
 #include <QRegularExpression>
 #include <vector>

--- a/src/io/export.cc
+++ b/src/io/export.cc
@@ -29,6 +29,7 @@
 #include "utils/printutils.h"
 #include "geometry/Geometry.h"
 
+#include <functional>
 #include <cassert>
 #include <map>
 #include <iostream>

--- a/src/io/export.cc
+++ b/src/io/export.cc
@@ -29,6 +29,7 @@
 #include "utils/printutils.h"
 #include "geometry/Geometry.h"
 
+#include <algorithm>
 #include <functional>
 #include <cassert>
 #include <map>

--- a/src/io/export.h
+++ b/src/io/export.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <iterator>
 #include <map>
 #include <iostream>
 #include <functional>

--- a/src/io/export_amf.cc
+++ b/src/io/export_amf.cc
@@ -34,6 +34,7 @@
 #include "geometry/cgal/CGAL_Nef_polyhedron.h"
 #endif
 
+#include <algorithm>
 #include <iterator>
 #include <cassert>
 #include <exception>

--- a/src/io/export_amf.cc
+++ b/src/io/export_amf.cc
@@ -34,6 +34,7 @@
 #include "geometry/cgal/CGAL_Nef_polyhedron.h"
 #endif
 
+#include <iterator>
 #include <cassert>
 #include <exception>
 #include <ostream>

--- a/src/io/export_stl.cc
+++ b/src/io/export_stl.cc
@@ -27,6 +27,7 @@
 #include "io/export.h"
 #include "geometry/PolySet.h"
 #include "geometry/PolySetUtils.h"
+#include <algorithm>
 #include <cassert>
 #include <array>
 #include <ios>

--- a/src/io/import_nef.cc
+++ b/src/io/import_nef.cc
@@ -1,5 +1,6 @@
 #include "io/import.h"
 
+#include <fstream>
 #include <ios>
 #include <memory>
 #include <string>

--- a/src/libsvg/path.cc
+++ b/src/libsvg/path.cc
@@ -24,6 +24,7 @@
  */
 #include "libsvg/path.h"
 
+#include <algorithm>
 #include <sstream>
 #include <cstdlib>
 #include <vector>

--- a/src/openscad.cc
+++ b/src/openscad.cc
@@ -48,6 +48,7 @@
 #include "core/customizer/ParameterObject.h"
 #include "core/customizer/ParameterSet.h"
 #include "openscad_mimalloc.h"
+#include <iomanip>
 #include <iterator>
 #include <stdexcept>
 #include <map>

--- a/src/openscad.cc
+++ b/src/openscad.cc
@@ -48,6 +48,7 @@
 #include "core/customizer/ParameterObject.h"
 #include "core/customizer/ParameterSet.h"
 #include "openscad_mimalloc.h"
+#include <iterator>
 #include <stdexcept>
 #include <map>
 #include <set>

--- a/src/platform/PlatformUtils-posix.cc
+++ b/src/platform/PlatformUtils-posix.cc
@@ -1,3 +1,4 @@
+#include <iterator>
 #include <ios>
 #include <mutex>
 #include <string>

--- a/src/utils/printutils.cc
+++ b/src/utils/printutils.cc
@@ -1,4 +1,5 @@
 #include "utils/printutils.h"
+#include <exception>
 #include <cassert>
 #include <set>
 #include <list>


### PR DESCRIPTION
Round of fixing up missing standard headers in various files. Similar to earlier clean-ups, one commit per header.
This is the last round (at least for now) of missing `std::` headers. Up next: _remove_ `std::`-headers in places that include it but don't need it. 

### Headers added
  * `<algorithm>`
  * `<chrono>`
  * `<cmath>`
  * `<cstring>`
  * `<ctime>`
  * `<deque>`
  * `<exception>`
  * `<fstream>`
  * `<functional>`
  * `<initializer_list>`
  * `<iomanip>`
  * `<ios>`
  * `<iterator>`
  * `<map>`
  * `<mutex>`
