### PR TITLE
Remove std::-headers in files not needing them

### DIFF
--- a/src/Feature.cc
+++ b/src/Feature.cc
@@ -1,7 +1,6 @@
 #include "Feature.h"
 
 #include <cstdio>
-#include <iostream>
 #include <sstream>
 #include <string>
 #include <map>

--- a/src/Feature.cc
+++ b/src/Feature.cc
@@ -1,7 +1,6 @@
 #include "Feature.h"
 
 #include <cstdio>
-#include <sstream>
 #include <string>
 #include <boost/algorithm/string/join.hpp>
 #include <boost/range/adaptor/transformed.hpp>

--- a/src/Feature.cc
+++ b/src/Feature.cc
@@ -3,7 +3,6 @@
 #include <cstdio>
 #include <sstream>
 #include <string>
-#include <map>
 #include <boost/algorithm/string/join.hpp>
 #include <boost/range/adaptor/transformed.hpp>
 #include <utility>

--- a/src/Feature.h
+++ b/src/Feature.h
@@ -1,7 +1,6 @@
 #pragma once
 
 #include <cstdio>
-#include <iostream>
 #include <string>
 #include <map>
 #include <vector>

--- a/src/FontCache.h
+++ b/src/FontCache.h
@@ -29,7 +29,6 @@
 #include <cstdint>
 #include <map>
 #include <string>
-#include <iostream>
 
 #include <ctime>
 

--- a/src/core/Assignment.cc
+++ b/src/core/Assignment.cc
@@ -28,7 +28,6 @@
 #include "core/customizer/Annotation.h"
 #include "core/Expression.h"
 #include <ostream>
-#include <sstream>
 #include <string>
 
 void Assignment::addAnnotations(AnnotationList *annotations)

--- a/src/core/BaseVisitable.h
+++ b/src/core/BaseVisitable.h
@@ -1,6 +1,5 @@
 #pragma once
 
-#include <iostream>
 
 // FIXME: Default constructor Response()
 enum class Response {ContinueTraversal, AbortTraversal, PruneTraversal};

--- a/src/core/BuiltinContext.h
+++ b/src/core/BuiltinContext.h
@@ -1,7 +1,6 @@
 #pragma once
 
 #include <string>
-#include <memory>
 
 #include "core/Context.h"
 

--- a/src/core/ColorNode.cc
+++ b/src/core/ColorNode.cc
@@ -36,7 +36,6 @@
 #include <memory>
 #include <cctype>
 #include <cstddef>
-#include <sstream>
 #include <string>
 #include <iterator>
 #include <unordered_map>

--- a/src/core/CsgOpNode.cc
+++ b/src/core/CsgOpNode.cc
@@ -34,7 +34,6 @@
 
 #include <utility>
 #include <memory>
-#include <sstream>
 #include <string>
 #include <cassert>
 

--- a/src/core/DrawingCallback.cc
+++ b/src/core/DrawingCallback.cc
@@ -27,7 +27,6 @@
 
 #include <memory>
 #include <cmath>
-#include <iostream>
 #include <vector>
 
 #include "geometry/Polygon2d.h"

--- a/src/core/DrawingCallback.cc
+++ b/src/core/DrawingCallback.cc
@@ -26,7 +26,6 @@
 #include "core/DrawingCallback.h"
 
 #include <memory>
-#include <algorithm>
 #include <cmath>
 #include <iostream>
 #include <vector>

--- a/src/core/Expression.cc
+++ b/src/core/Expression.cc
@@ -38,7 +38,6 @@
 #include <sstream>
 #include <algorithm>
 #include <typeinfo>
-#include <forward_list>
 #include <utility>
 #include <variant>
 #include "utils/printutils.h"

--- a/src/core/Expression.h
+++ b/src/core/Expression.h
@@ -5,7 +5,6 @@
 #include <cstddef>
 #include <functional>
 #include <string>
-#include <variant>
 #include <vector>
 #include <memory>
 #include <boost/logic/tribool.hpp>

--- a/src/core/FreetypeRenderer.cc
+++ b/src/core/FreetypeRenderer.cc
@@ -33,7 +33,6 @@
 #include <cstdio>
 #include <vector>
 
-#include <iostream>
 
 #include <fontconfig/fontconfig.h>
 

--- a/src/core/ImportNode.cc
+++ b/src/core/ImportNode.cc
@@ -56,7 +56,6 @@ namespace fs = boost::filesystem;
 #include <boost/assign/std/vector.hpp>
 using namespace boost::assign; // bring 'operator+=()' into scope
 
-#include <cstdint>
 
 static std::shared_ptr<AbstractNode> do_import(const ModuleInstantiation *inst, Arguments arguments, const Children& children, ImportType type)
 {

--- a/src/core/NodeDumper.h
+++ b/src/core/NodeDumper.h
@@ -4,7 +4,6 @@
 #include <memory>
 #include <string>
 #include <unordered_map>
-#include <list>
 #include <utility>
 #include "core/NodeVisitor.h"
 #include "core/node.h"

--- a/src/core/RangeType.h
+++ b/src/core/RangeType.h
@@ -2,7 +2,6 @@
 
 #include <iterator>
 #include <limits>
-#include <utility>
 #include <cstdint>
 #include <ostream>
 #include <cmath>

--- a/src/core/RenderNode.cc
+++ b/src/core/RenderNode.cc
@@ -33,7 +33,6 @@
 
 #include <utility>
 #include <memory>
-#include <sstream>
 #include <boost/assign/std/vector.hpp>
 using namespace boost::assign; // bring 'operator+=()' into scope
 

--- a/src/core/SourceFile.h
+++ b/src/core/SourceFile.h
@@ -4,7 +4,6 @@
 #include <memory>
 #include <string>
 #include <unordered_map>
-#include <unordered_set>
 #include <ctime>
 #include <vector>
 

--- a/src/core/Tree.cc
+++ b/src/core/Tree.cc
@@ -3,7 +3,6 @@
 
 #include <memory>
 #include <cassert>
-#include <sstream>
 #include <string>
 #include <tuple>
 

--- a/src/core/Tree.cc
+++ b/src/core/Tree.cc
@@ -3,7 +3,6 @@
 
 #include <memory>
 #include <cassert>
-#include <algorithm>
 #include <sstream>
 #include <string>
 #include <tuple>

--- a/src/core/Value.cc
+++ b/src/core/Value.cc
@@ -35,7 +35,6 @@
 #include <cassert>
 #include <cstddef>
 #include <memory>
-#include <numeric>
 #include <sstream>
 #include <string>
 #include <vector>

--- a/src/core/Value.h
+++ b/src/core/Value.h
@@ -6,7 +6,6 @@
 #include <vector>
 #include <string>
 #include <algorithm>
-#include <cstdint>
 #include <cstddef>
 #include <limits>
 #include <ostream>

--- a/src/core/Value.h
+++ b/src/core/Value.h
@@ -7,7 +7,6 @@
 #include <string>
 #include <algorithm>
 #include <cstddef>
-#include <limits>
 #include <ostream>
 #include <memory>
 #include <type_traits>

--- a/src/core/builtin_functions.cc
+++ b/src/core/builtin_functions.cc
@@ -69,7 +69,6 @@ void initialize_rng() {
   seed_val ^= distributor(deterministic_rng);
 }
 
-#include <array>
 
 static inline bool check_arguments(const char *function_name, const Arguments& arguments, const Location& loc, unsigned int expected_count, bool warn = true)
 {

--- a/src/core/function.h
+++ b/src/core/function.h
@@ -10,7 +10,6 @@
 #include <functional>
 #include <string>
 #include <variant>
-#include <vector>
 
 class Arguments;
 class FunctionCall;

--- a/src/core/module.h
+++ b/src/core/module.h
@@ -2,7 +2,6 @@
 
 #include <memory>
 #include <functional>
-#include <string>
 #include "Feature.h"
 
 class AbstractNode;

--- a/src/geometry/GeometryEvaluator.cc
+++ b/src/geometry/GeometryEvaluator.cc
@@ -33,7 +33,6 @@
 #include <list>
 #include <utility>
 #include <memory>
-#include <ciso646> // C alternative tokens (xor)
 #include <algorithm>
 #include "utils/boost-utils.h"
 #include "geometry/boolean_utils.h"

--- a/src/geometry/GeometryEvaluator.h
+++ b/src/geometry/GeometryEvaluator.h
@@ -7,7 +7,6 @@
 #include <cassert>
 #include <memory>
 #include <utility>
-#include <list>
 #include <vector>
 #include <map>
 

--- a/src/geometry/PolySet.cc
+++ b/src/geometry/PolySet.cc
@@ -35,7 +35,6 @@
 #include <Eigen/LU>
 #include <cstddef>
 #include <string>
-#include <utility>
 #include <vector>
 
 /*! /class PolySet

--- a/src/geometry/Reindexer.h
+++ b/src/geometry/Reindexer.h
@@ -2,7 +2,6 @@
 
 #include <cstddef>
 #include <unordered_map>
-#include <functional>
 #include <vector>
 #include <algorithm>
 #include "utils/hash.h" // IWYU pragma: keep

--- a/src/geometry/cgal/cgalutils-applyops-hybrid-minkowski.cc
+++ b/src/geometry/cgal/cgalutils-applyops-hybrid-minkowski.cc
@@ -27,7 +27,6 @@
 
 #include <cstddef>
 #include <memory>
-#include <map>
 #include <queue>
 #include <unordered_set>
 #include <vector>

--- a/src/geometry/cgal/cgalutils-applyops-hybrid-minkowski.cc
+++ b/src/geometry/cgal/cgalutils-applyops-hybrid-minkowski.cc
@@ -27,7 +27,6 @@
 
 #include <cstddef>
 #include <memory>
-#include <queue>
 #include <unordered_set>
 #include <vector>
 

--- a/src/geometry/cgal/cgalutils-applyops-hybrid-minkowski.cc
+++ b/src/geometry/cgal/cgalutils-applyops-hybrid-minkowski.cc
@@ -27,7 +27,6 @@
 
 #include <cstddef>
 #include <memory>
-#include <unordered_set>
 #include <vector>
 
 namespace CGALUtils {

--- a/src/geometry/cgal/cgalutils-applyops.cc
+++ b/src/geometry/cgal/cgalutils-applyops.cc
@@ -34,7 +34,6 @@
 #include <cstddef>
 #include <memory>
 #include <queue>
-#include <unordered_set>
 #include <vector>
 
 namespace CGALUtils {

--- a/src/geometry/cgal/cgalutils-applyops.cc
+++ b/src/geometry/cgal/cgalutils-applyops.cc
@@ -33,7 +33,6 @@
 
 #include <cstddef>
 #include <memory>
-#include <map>
 #include <queue>
 #include <unordered_set>
 #include <vector>

--- a/src/geometry/cgal/cgalutils-project.cc
+++ b/src/geometry/cgal/cgalutils-project.cc
@@ -22,7 +22,6 @@
 
 #include "utils/svg.h"
 
-#include <queue>
 #include <vector>
 
 static void add_outline_to_poly(CGAL_Nef_polyhedron2::Explorer& explorer,

--- a/src/geometry/cgal/cgalutils-project.cc
+++ b/src/geometry/cgal/cgalutils-project.cc
@@ -22,7 +22,6 @@
 
 #include "utils/svg.h"
 
-#include <map>
 #include <queue>
 #include <vector>
 

--- a/src/geometry/cgal/cgalutils-triangulate.cc
+++ b/src/geometry/cgal/cgalutils-triangulate.cc
@@ -5,7 +5,6 @@
 #include <cassert>
 #include <list>
 #include <memory>
-#include <utility>
 
 #include <CGAL/Constrained_Delaunay_triangulation_2.h>
 #include <CGAL/Exact_predicates_inexact_constructions_kernel.h>

--- a/src/geometry/manifold/Polygon2d-manifold.cc
+++ b/src/geometry/manifold/Polygon2d-manifold.cc
@@ -2,7 +2,6 @@
 #include "geometry/PolySet.h"
 #include "utils/printutils.h"
 
-#include <iostream>
 
 #ifndef ENABLE_CGAL
 /*!

--- a/src/glview/ColorMap.cc
+++ b/src/glview/ColorMap.cc
@@ -5,7 +5,6 @@
 #include <algorithm>
 #include <iomanip>
 #include <stdexcept>
-#include <set>
 #include <list>
 #include <utility>
 #include <exception>

--- a/src/glview/GLView.h
+++ b/src/glview/GLView.h
@@ -21,7 +21,6 @@
 #include <Eigen/Core>
 #include <Eigen/Geometry>
 #include <string>
-#include <iostream>
 #include <vector>
 #include "glview/Camera.h"
 #include "glview/ColorMap.h"

--- a/src/glview/LegacyRendererUtils.cc
+++ b/src/glview/LegacyRendererUtils.cc
@@ -8,7 +8,6 @@
 
 #include <Eigen/LU>
 #include <cstddef>
-#include <fstream>
 
 #ifdef ENABLE_OPENCSG
 static void draw_triangle(const Renderer::shaderinfo_t *shaderinfo, const Vector3d& p0, const Vector3d& p1, const Vector3d& p2,

--- a/src/glview/OffscreenContextEGL.cc
+++ b/src/glview/OffscreenContextEGL.cc
@@ -3,7 +3,6 @@
 #include <memory>
 #include <fcntl.h>
 #include <cstddef>
-#include <iostream>
 #include <set>
 #include <sstream>
 #include <string>

--- a/src/glview/OffscreenContextEGL.h
+++ b/src/glview/OffscreenContextEGL.h
@@ -2,7 +2,6 @@
 
 #include <cstddef>
 #include <memory>
-#include <string>
 
 #include "glview/OffscreenContext.h"
 

--- a/src/glview/VBORenderer.cc
+++ b/src/glview/VBORenderer.cc
@@ -36,7 +36,6 @@
 #include <utility>
 #include <memory>
 #include <cstddef>
-#include <iomanip>
 #include <sstream>
 
 VBORenderer::VBORenderer()

--- a/src/glview/VBORenderer.cc
+++ b/src/glview/VBORenderer.cc
@@ -36,7 +36,6 @@
 #include <utility>
 #include <memory>
 #include <cstddef>
-#include <sstream>
 
 VBORenderer::VBORenderer()
   : Renderer()

--- a/src/glview/VertexArray.cc
+++ b/src/glview/VertexArray.cc
@@ -3,7 +3,6 @@
 #include <array>
 #include <utility>
 #include <iostream>
-#include <iomanip>
 #include <sstream>
 #include <vector>
 #include <memory>

--- a/src/glview/VertexArray.cc
+++ b/src/glview/VertexArray.cc
@@ -8,7 +8,6 @@
 #include <vector>
 #include <memory>
 #include <cstdio>
-#include <functional>
 #include "glview/VertexArray.h"
 
 #include "utils/printutils.h"

--- a/src/glview/VertexArray.cc
+++ b/src/glview/VertexArray.cc
@@ -2,7 +2,6 @@
 #include <cassert>
 #include <array>
 #include <utility>
-#include <sstream>
 #include <vector>
 #include <memory>
 #include <cstdio>

--- a/src/glview/VertexArray.cc
+++ b/src/glview/VertexArray.cc
@@ -2,7 +2,6 @@
 #include <cassert>
 #include <array>
 #include <utility>
-#include <iostream>
 #include <sstream>
 #include <vector>
 #include <memory>

--- a/src/glview/offscreen-old/OffscreenContextEGL.h
+++ b/src/glview/offscreen-old/OffscreenContextEGL.h
@@ -2,7 +2,6 @@
 
 #include <cstdint>
 #include <memory>
-#include <string>
 
 #include "glview/OffscreenContext.h"
 

--- a/src/glview/offscreen-old/OffscreenContextWGL.cc
+++ b/src/glview/offscreen-old/OffscreenContextWGL.cc
@@ -19,7 +19,6 @@
 #include <windows.h>
 
 #include <vector>
-#include <map>
 #include <string>
 #include <sstream>
 #include "utils/printutils.h"

--- a/src/glview/offscreen-old/OffscreenContextWGL.cc
+++ b/src/glview/offscreen-old/OffscreenContextWGL.cc
@@ -18,7 +18,6 @@
 #include <memory>
 #include <windows.h>
 
-#include <vector>
 #include <string>
 #include <sstream>
 #include "utils/printutils.h"

--- a/src/gui/Dock.cc
+++ b/src/gui/Dock.cc
@@ -1,6 +1,5 @@
 #include "gui/Dock.h"
 
-#include <iostream>
 #include "gui/QSettingsCached.h"
 
 

--- a/src/gui/FontList.cc
+++ b/src/gui/FontList.cc
@@ -4,7 +4,6 @@
 #include <cstdint>
 #include <qitemselectionmodel.h>
 #include <string>
-#include <iostream>
 #include <vector>
 
 #include <QClipboard>

--- a/src/gui/Measurement.cc
+++ b/src/gui/Measurement.cc
@@ -28,7 +28,6 @@
 
 #include <cmath>
 #include <sstream>
-#include <string>
 
 Measurement::Measurement()
 {

--- a/src/gui/OctoPrint.h
+++ b/src/gui/OctoPrint.h
@@ -27,7 +27,6 @@
 #pragma once
 
 #include <utility>
-#include <tuple>
 #include <string>
 #include <vector>
 

--- a/src/gui/OpenSCADApp.cc
+++ b/src/gui/OpenSCADApp.cc
@@ -7,7 +7,6 @@
 #include <cassert>
 #include <exception>
 #include <QProgressDialog>
-#include <iostream>
 #include <boost/foreach.hpp>
 #include "gui/QSettingsCached.h"
 

--- a/src/gui/QSettingsCached.h
+++ b/src/gui/QSettingsCached.h
@@ -3,7 +3,6 @@
 #include <QSettings>
 #include <memory>
 #include <mutex>
-#include <thread>
 
 #include "utils/printutils.h"
 

--- a/src/gui/QSettingsCached.h
+++ b/src/gui/QSettingsCached.h
@@ -1,7 +1,6 @@
 #pragma once
 
 #include <QSettings>
-#include <map>
 #include <memory>
 #include <mutex>
 #include <thread>

--- a/src/gui/QSettingsCached.h
+++ b/src/gui/QSettingsCached.h
@@ -2,7 +2,6 @@
 
 #include <QSettings>
 #include <map>
-#include <iostream>
 #include <memory>
 #include <mutex>
 #include <thread>

--- a/src/gui/ScintillaEditor.cc
+++ b/src/gui/ScintillaEditor.cc
@@ -3,7 +3,6 @@
 #include <functional>
 #include <exception>
 #include <memory>
-#include <ciso646> // C alternative tokens (xor)
 #include <cstdlib>
 #include <string>
 #include <vector>

--- a/src/gui/Settings.h
+++ b/src/gui/Settings.h
@@ -2,7 +2,6 @@
 
 #include <cstddef>
 #include <map>
-#include <list>
 #include <string>
 #include <utility>
 #include <vector>

--- a/src/gui/Settings.h
+++ b/src/gui/Settings.h
@@ -1,7 +1,6 @@
 #pragma once
 
 #include <cstddef>
-#include <map>
 #include <string>
 #include <utility>
 #include <vector>

--- a/src/gui/input/HidApiInputDriver.cc
+++ b/src/gui/input/HidApiInputDriver.cc
@@ -41,7 +41,6 @@
 #include <codecvt>
 #include <fstream>
 #include <iomanip>
-#include <ostream>
 #include <string>
 
 #include "gui/Settings.h"

--- a/src/gui/input/HidApiInputDriver.h
+++ b/src/gui/input/HidApiInputDriver.h
@@ -28,7 +28,6 @@
 
 #include <cstddef>
 #include <string>
-#include <utility>
 #include <hidapi.h>
 
 #include "gui/input/InputDriver.h"

--- a/src/gui/input/InputEventMapper.cc
+++ b/src/gui/input/InputEventMapper.cc
@@ -29,7 +29,6 @@
 #include "gui/Preferences.h"
 #include "gui/input/AxisConfigWidget.h"
 #include "gui/input/ButtonConfigWidget.h"
-#include <ciso646> // C alternative tokens
 #include <cstddef>
 #include <string>
 #include <cmath>

--- a/src/gui/input/QGamepadInputDriver.h
+++ b/src/gui/input/QGamepadInputDriver.h
@@ -28,7 +28,6 @@
 #include "gui/input/InputDriver.h"
 
 #include <cstddef>
-#include <memory>
 #include <string>
 #include <QtGamepad/QGamepad>
 

--- a/src/gui/parameter/ParameterSlider.cc
+++ b/src/gui/parameter/ParameterSlider.cc
@@ -1,6 +1,5 @@
 #include "gui/parameter/ParameterSlider.h"
 #include <cmath>
-#include <iterator>
 #include <cassert>
 #include <limits>
 #include "gui/IgnoreWheelWhenNotFocused.h"

--- a/src/handle_dep.cc
+++ b/src/handle_dep.cc
@@ -2,7 +2,6 @@
 #include "utils/printutils.h"
 #include <iostream>
 #include <string>
-#include <sstream>
 #include <cstdlib> // for system()
 #include <unordered_set>
 #include <vector>

--- a/src/io/dxfdim.cc
+++ b/src/io/dxfdim.cc
@@ -39,7 +39,6 @@
 #include <utility>
 #include <cstddef>
 #include <cmath>
-#include <sstream>
 #include <cstdint>
 #include <string>
 #include <vector>

--- a/src/io/export.h
+++ b/src/io/export.h
@@ -3,7 +3,6 @@
 #include <iterator>
 #include <map>
 #include <iostream>
-#include <functional>
 #include <array>
 #include <memory>
 #include <string>

--- a/src/io/export_3mf_v2.cc
+++ b/src/io/export_3mf_v2.cc
@@ -57,7 +57,6 @@ static uint32_t lib3mf_seek_callback(uint64_t pos, std::ostream *stream)
 
 #include "lib3mf_implicit.hpp"
 
-#include <algorithm>
 
 #ifdef ENABLE_CGAL
 #include "geometry/cgal/cgal.h"

--- a/src/io/imageutils-lodepng.cc
+++ b/src/io/imageutils-lodepng.cc
@@ -4,7 +4,6 @@
 #include <cstdio>
 #include <cstdlib>
 #include <vector>
-#include <iterator>
 
 bool write_png(std::ostream& output, unsigned char *pixels, int width, int height)
 {

--- a/src/io/imageutils-lodepng.cc
+++ b/src/io/imageutils-lodepng.cc
@@ -5,7 +5,6 @@
 #include <cstdlib>
 #include <vector>
 #include <iterator>
-#include <algorithm>
 
 bool write_png(std::ostream& output, unsigned char *pixels, int width, int height)
 {

--- a/src/io/import_amf.cc
+++ b/src/io/import_amf.cc
@@ -39,7 +39,6 @@
 #include <sys/types.h>
 #include <cstddef>
 #include <map>
-#include <fstream>
 #include <cassert>
 #include <string>
 #include <vector>

--- a/src/io/import_off.cc
+++ b/src/io/import_off.cc
@@ -11,7 +11,6 @@
 #include <charconv>
 #include <cstddef>
 #include <fstream>
-#include <sstream>
 #include <string>
 #include <vector>
 #include <boost/regex.hpp>

--- a/src/io/import_off.cc
+++ b/src/io/import_off.cc
@@ -13,7 +13,6 @@
 #include <fstream>
 #include <sstream>
 #include <string>
-#include <locale>
 #include <vector>
 #include <boost/regex.hpp>
 #include <boost/lexical_cast.hpp>

--- a/src/libsvg/libsvg.cc
+++ b/src/libsvg/libsvg.cc
@@ -28,7 +28,6 @@
 #include <iostream>
 #include <memory>
 #include <map>
-#include <stack>
 #include <string>
 #include <vector>
 #include <Eigen/Core>

--- a/src/openscad.cc
+++ b/src/openscad.cc
@@ -75,7 +75,6 @@
 #include "core/CSGTreeEvaluator.h"
 
 #include "glview/Camera.h"
-#include <chrono>
 #include <boost/algorithm/string.hpp>
 #include <boost/algorithm/string/split.hpp>
 #include <boost/bind/bind.hpp>

--- a/src/openscad.cc
+++ b/src/openscad.cc
@@ -52,7 +52,6 @@
 #include <iterator>
 #include <stdexcept>
 #include <map>
-#include <set>
 #include <utility>
 #include <exception>
 #include <sstream>

--- a/src/platform/PlatformUtils-posix.cc
+++ b/src/platform/PlatformUtils-posix.cc
@@ -3,7 +3,6 @@
 #include <mutex>
 #include <string>
 #include <fstream>
-#include <streambuf>
 #include <unistd.h>
 #include <sys/resource.h>
 #include <sys/utsname.h>

--- a/src/platform/PlatformUtils-win.cc
+++ b/src/platform/PlatformUtils-win.cc
@@ -207,7 +207,6 @@ const std::string PlatformUtils::sysinfo(bool extended)
 
 #include <io.h>
 #include <cstdio>
-#include <fstream>
 
 #ifdef USE_MIMALLOC
 #include <mimalloc.h>

--- a/src/platform/PlatformUtils-win.cc
+++ b/src/platform/PlatformUtils-win.cc
@@ -1,7 +1,6 @@
 #include "platform/PlatformUtils.h"
 
 #include <ios>
-#include <map>
 #include <string>
 
 #include "utils/printutils.h"

--- a/src/platform/PlatformUtils-win.cc
+++ b/src/platform/PlatformUtils-win.cc
@@ -2,6 +2,7 @@
 
 #include <ios>
 #include <string>
+#include <map>
 
 #include "utils/printutils.h"
 #include "utils/findversion.h"

--- a/src/utils/boost-utils.cc
+++ b/src/utils/boost-utils.cc
@@ -2,7 +2,6 @@
 #include <stdexcept>
 #include <cstdio>
 #include <string>
-#include <iostream>
 
 namespace fs = boost::filesystem;
 

--- a/src/utils/exceptions.h
+++ b/src/utils/exceptions.h
@@ -1,7 +1,6 @@
 #pragma once
 
 #include <stdexcept>
-#include <sstream>
 #include <utility>
 #include <string>
 #include "core/AST.h"

--- a/src/utils/printutils.cc
+++ b/src/utils/printutils.cc
@@ -4,7 +4,6 @@
 #include <set>
 #include <list>
 #include <iostream>
-#include <sstream>
 #include <string>
 #include <cstdio>
 #include <boost/algorithm/string.hpp>

--- a/src/utils/svg.cc
+++ b/src/utils/svg.cc
@@ -5,7 +5,6 @@
 #include <sstream>
 #include <boost/algorithm/string.hpp>
 #include <boost/lexical_cast.hpp>
-#include <map>
 #include <string>
 #include <vector>
 

--- a/src/utils/svg.h
+++ b/src/utils/svg.h
@@ -3,7 +3,6 @@
 #include "geometry/cgal/cgal.h"
 #include <boost/algorithm/string.hpp>
 #include <string>
-#include <map>
 
 namespace OpenSCAD {
 


### PR DESCRIPTION
There were a few files that included headers they didn't need.
These can be removed now that all the _necessary_ `std::`-headers are included (after a previous set of pull requests), so we know that there are no headers left that accidentally provide symbols in other files - all headers not needed directly in a header or *.cc file can be removed now.

One commit per include.

Auto-generated with

```bash
./scripts/run-clang-tidy-cached.cc
grep "not used directly" OpenSCAD_clang-tidy.out  | awk '{print $5 " " $1}' | egrep  "^(sstream|fstream|algorithm|memory|map|vector|array|chrono|ciso646|cstdint|forward_list|functional|streambuf|string|thread|tuple|unordered_set|utility|variant|stack|set|ostream|queue|numeric|list|limits|iterator|iostream|iomanip|locale) " | awk -F: '{print $1}' | sort > to-remove.txt
for f in $(awk '{print $1}' < to-remove.txt | uniq); do awk -vinc="$f" 'BEGIN { printf("sed -i \"/#include <%s>/d\" ", inc); } /^'$f'/ { printf("%s ", $2) } END { printf("\ngit commit -a -m \"Remove not-needed <%s>\"\n", inc); }' < to-remove.txt; done > /tmp/allremove.sh
. /tmp/allremove.sh
```