### PR TITLE
Improve quality of temporary file name  for Local Slicer

### DIFF
--- a/src/gui/MainWindow.cc
+++ b/src/gui/MainWindow.cc
@@ -2257,7 +2257,8 @@ void MainWindow::sendToLocalSlicer()
     exportFileFormat = FileFormat::STL;
   }
 
-  const auto tmpPath = QDir::temp().filePath("OpenSCAD.XXXXXX."+fileFormat.toLower());
+  QString basename = QString(std::filesystem::path(activeEditor->filePath.toStdString()).stem().c_str());
+  const auto tmpPath = QDir::temp().filePath(basename+".XXXXXX."+fileFormat.toLower());
   auto exportFile = std::make_unique<QTemporaryFile>(tmpPath);
   if (!exportFile->open()) {
     LOG(message_group::Error, "Could not open temporary file '%1$s'.", tmpPath.toStdString());


### PR DESCRIPTION
When using Local Slicer Feature and writing GCodes to SD cards, all of the files are called "OpenSCAD" and its
hard to distinguish them.
This fix should help