### PR TITLE
correct rotation view in export_pov.cc

### DIFF
--- a/src/io/export_pov.cc
+++ b/src/io/export_pov.cc
@@ -112,7 +112,7 @@ void export_pov(const std::shared_ptr<const Geometry>& geom, std::ostream& outpu
 
   output << "camera { look_at <" << bbox.center().x() << ", " << bbox.center().y() << ", " << bbox.center().z() << "> "
     "location <" << min_x + dx * move_away_factor << ", " << min_y - dy * move_away_factor << ", " << min_z + dz * move_away_factor << "> "
-    "up <0, 0, 1> right <1, 0, 0> sky <0, 0, 1> rotate <-55, clock * 3, clock + 25> right x*image_width/image_height }\n";
+    "up <0, 0, 1> right <1, 0, 0> sky <0, 0, 1> rotate <0, clock * 3, clock > right x*image_width/image_height }\n";
   output << "#include \"rad_def.inc\"\n";
   output << "global_settings { photons { count 20000 autostop 0 jitter .4 } radiosity { Rad_Settings(Radiosity_Normal, off, off) } }\n";
 }


### PR DESCRIPTION
fixed rotation issue so render orientation matches the [55,0,25] open SCAD "reset" view