### PR TITLE
Add null-coalescing operator '??'

### DIFF
--- a/src/core/Expression.h
+++ b/src/core/Expression.h
@@ -48,6 +48,7 @@ public:
   enum class Op {
     LogicalAnd,
     LogicalOr,
+    IfUndef,
     Exponent,
     Multiply,
     Divide,

--- a/src/core/lexer.l
+++ b/src/core/lexer.l
@@ -278,6 +278,7 @@ use[ \t\r\n]*"<"        { BEGIN(cond_use); LOCATION_COUNT_LINES(parserlloc, yyte
 "!="                    return NEQ;
 "&&"                    return AND;
 "||"                    return OR;
+"??"                    return IFUNDEF;
 
 .                       { return yytext[0]; }
 

--- a/src/core/parser.y
+++ b/src/core/parser.y
@@ -127,13 +127,14 @@ bool fileEnded=false;
 %token TOK_FALSE
 %token TOK_UNDEF
 
-%token LE GE EQ NEQ AND OR
+%token LE GE EQ NEQ AND OR IFUNDEF
 
 %nonassoc NO_ELSE
 %nonassoc TOK_ELSE
 
 %type <expr> expr
 %type <expr> call
+%type <expr> null_coalesce
 %type <expr> logic_or
 %type <expr> logic_and
 %type <expr> equality
@@ -329,7 +330,7 @@ single_module_instantiation
         ;
 
 expr
-        : logic_or
+        : null_coalesce
         | TOK_FUNCTION '(' parameters ')' expr %prec NO_ELSE
             {
               $$ = new FunctionDefinition($5, *$3, LOCD("anonfunc", @$));
@@ -355,6 +356,14 @@ expr
               delete $3;
             }
         ;
+
+null_coalesce
+        : logic_or
+        | logic_or IFUNDEF null_coalesce
+            {
+              $$ = new BinaryOp($1, BinaryOp::Op::IfUndef, $3, LOCD("ifundef", @$));
+            }
+		;
 
 logic_or
         : logic_and


### PR DESCRIPTION
Adds a new binary operator, `??`. The expression `x ?? y` evaluates `x`, and if it is not undefined, returns it. If `x` is undefined, it evaluates `y` and returns that.

It is equivalent to: `!is_undef(x) ? (x) : (y)`

This solves a common issue I run into when writing library functions.  I often use special `$` variables to define debugging flags and values, and these variables may not always be defined. Referencing an undefined variable always causes a warning except when calling `is_undef` on a single variable. This means that I have to resort to the long form `if (!is_undef($some_debug_flag) && $some_debug_flag)` to check it without causing a warning.

With this new operator, the code is shortened to `if ($some_debug_flag ?? false)`.

This also makes syntax for calculated defaults much nicer. Say I have a function with 3 arguments, `a`, `b`, and `c`, but `c` is optional and if not specified, should default to `a + b`. This function could  be written as:

`function f(a, b, c=undef) let(c = c ?? a + b) [a, b, c];`

This operator has lower precedence than logical operators `||` and `??` and higher precedence than the ternary operator `a ? b : c`. This is based on its precedence in C# as documented [here](https://learn.microsoft.com/en-us/dotnet/csharp/language-reference/operators/).

It is also right-associative, so `a ?? b ?? c` is equivalent to `a ?? (b ?? c)`. If it were left associative (i.e.) `(a ?? b) ?? c`, then the result would be the same, but would cause a warning if `b` were not defined.