### PR TITLE
Add geometry/Geometry.h header in files that need it.

### DIFF
--- a/src/RenderStatistic.cc
+++ b/src/RenderStatistic.cc
@@ -33,6 +33,7 @@
 #include <iostream>
 #include <memory>
 #include <fstream>
+#include "geometry/Geometry.h"
 #include "json/json.hpp"
 #include <string>
 #include <vector>

--- a/src/core/CSGTreeEvaluator.cc
+++ b/src/core/CSGTreeEvaluator.cc
@@ -1,4 +1,5 @@
 #include "core/CSGTreeEvaluator.h"
+#include "geometry/Geometry.h"
 #include "core/State.h"
 #include "core/CsgOpNode.h"
 #include "core/ModuleInstantiation.h"

--- a/src/core/CSGTreeEvaluator.h
+++ b/src/core/CSGTreeEvaluator.h
@@ -6,6 +6,7 @@
 #include <cstddef>
 #include "core/NodeVisitor.h"
 #include <memory>
+#include "geometry/Geometry.h"
 #include "core/CSGNode.h"
 
 class CSGNode;

--- a/src/core/ImportNode.cc
+++ b/src/core/ImportNode.cc
@@ -26,6 +26,7 @@
 
 #include "core/ImportNode.h"
 
+#include "geometry/Geometry.h"
 #include "io/import.h"
 
 #include "core/module.h"

--- a/src/core/TextNode.cc
+++ b/src/core/TextNode.cc
@@ -30,6 +30,7 @@
 #include <memory>
 #include <vector>
 
+#include "geometry/Geometry.h"
 #include "core/Children.h"
 #include "core/module.h"
 #include "core/ModuleInstantiation.h"

--- a/src/core/primitives.cc
+++ b/src/core/primitives.cc
@@ -25,6 +25,7 @@
  */
 
 #include "core/primitives.h"
+#include "geometry/Geometry.h"
 #include "core/Builtins.h"
 #include "core/Children.h"
 #include "core/ModuleInstantiation.h"

--- a/src/core/primitives.h
+++ b/src/core/primitives.h
@@ -25,6 +25,7 @@
  */
 
 #include "geometry/GeometryUtils.h"
+#include "geometry/Geometry.h"
 #include "geometry/linalg.h"
 #include "core/node.h"
 

--- a/src/geometry/GeometryUtils.cc
+++ b/src/geometry/GeometryUtils.cc
@@ -12,6 +12,7 @@
 #include <string>
 #include <vector>
 
+#include "geometry/Geometry.h"
 #include "libtess2/Include/tesselator.h"
 #include "utils/printutils.h"
 #include "geometry/Reindexer.h"

--- a/src/geometry/PolySet.cc
+++ b/src/geometry/PolySet.cc
@@ -25,6 +25,7 @@
  */
 
 #include "geometry/PolySet.h"
+#include "geometry/Geometry.h"
 #include "geometry/PolySetUtils.h"
 #include "geometry/linalg.h"
 #include "utils/printutils.h"

--- a/src/geometry/PolySetBuilder.h
+++ b/src/geometry/PolySetBuilder.h
@@ -5,6 +5,7 @@
 #include <vector>
 
 #include "geometry/Reindexer.h"
+#include "geometry/Geometry.h"
 #include "geometry/Polygon2d.h"
 #include "utils/boost-utils.h"
 #include "geometry/GeometryUtils.h"

--- a/src/geometry/PolySetUtils.cc
+++ b/src/geometry/PolySetUtils.cc
@@ -9,6 +9,7 @@
 
 #include <boost/range/adaptor/reversed.hpp>
 
+#include "geometry/Geometry.h"
 #include "geometry/PolySet.h"
 #include "geometry/PolySetBuilder.h"
 #include "geometry/Polygon2d.h"

--- a/src/geometry/Polygon2d.cc
+++ b/src/geometry/Polygon2d.cc
@@ -6,6 +6,7 @@
 #include <string>
 #include <memory>
 
+#include "geometry/Geometry.h"
 #include "utils/printutils.h"
 #ifdef ENABLE_MANIFOLD
 #include "geometry/manifold/manifoldutils.h"

--- a/src/geometry/boolean_utils.cc
+++ b/src/geometry/boolean_utils.cc
@@ -9,6 +9,7 @@
 #include <vector>
 
 #ifdef ENABLE_CGAL
+#include "geometry/Geometry.h"
 #include "geometry/cgal/cgal.h"
 #include "geometry/cgal/CGALHybridPolyhedron.h"
 #include "geometry/cgal/CGAL_Nef_polyhedron.h"

--- a/src/geometry/cgal/CGALCache.cc
+++ b/src/geometry/cgal/CGALCache.cc
@@ -5,6 +5,7 @@
 #include <cstddef>
 #include <string>
 
+#include "geometry/Geometry.h"
 #include "utils/printutils.h"
 #include "geometry/cgal/CGAL_Nef_polyhedron.h"
 #include "geometry/cgal/CGALHybridPolyhedron.h"

--- a/src/geometry/cgal/CGALHybridPolyhedron.cc
+++ b/src/geometry/cgal/CGALHybridPolyhedron.cc
@@ -1,6 +1,7 @@
 // Portions of this file are Copyright 2021 Google LLC, and licensed under GPL2+. See COPYING.
 #include "geometry/cgal/CGALHybridPolyhedron.h"
 
+#include "geometry/Geometry.h"
 #include "geometry/cgal/cgalutils.h"
 #include "Feature.h"
 #include <cassert>

--- a/src/geometry/cgal/CGAL_Nef_polyhedron.cc
+++ b/src/geometry/cgal/CGAL_Nef_polyhedron.cc
@@ -4,6 +4,7 @@
 #include <cstddef>
 #include <string>
 
+#include "geometry/Geometry.h"
 #include "geometry/cgal/cgal.h"
 #include "geometry/cgal/cgalutils.h"
 #include "utils/printutils.h"

--- a/src/geometry/cgal/cgalutils-applyops-hybrid-minkowski.cc
+++ b/src/geometry/cgal/cgalutils-applyops-hybrid-minkowski.cc
@@ -4,6 +4,7 @@
 #ifdef ENABLE_CGAL
 
 #include "geometry/cgal/cgal.h"
+#include "geometry/Geometry.h"
 #include "geometry/cgal/cgalutils.h"
 #include "geometry/PolySet.h"
 #include "utils/printutils.h"

--- a/src/geometry/cgal/cgalutils-applyops-hybrid.cc
+++ b/src/geometry/cgal/cgalutils-applyops-hybrid.cc
@@ -11,6 +11,7 @@
 #include <vector>
 
 #include "geometry/cgal/cgalutils.h"
+#include "geometry/Geometry.h"
 #include "geometry/cgal/CGALHybridPolyhedron.h"
 #include "core/node.h"
 #include "core/progress.h"

--- a/src/geometry/cgal/cgalutils-applyops.cc
+++ b/src/geometry/cgal/cgalutils-applyops.cc
@@ -4,6 +4,7 @@
 #ifdef ENABLE_CGAL
 
 #include "geometry/cgal/cgal.h"
+#include "geometry/Geometry.h"
 #include "geometry/cgal/cgalutils.h"
 #include "Feature.h"
 #include "geometry/PolySet.h"

--- a/src/geometry/cgal/cgalutils-hybrid.cc
+++ b/src/geometry/cgal/cgalutils-hybrid.cc
@@ -1,5 +1,6 @@
 // Portions of this file are Copyright 2021 Google LLC, and licensed under GPL2+. See COPYING.
 #include "geometry/cgal/cgalutils.h"
+#include "geometry/Geometry.h"
 #include "geometry/cgal/CGALHybridPolyhedron.h"
 
 

--- a/src/geometry/cgal/cgalutils.cc
+++ b/src/geometry/cgal/cgalutils.cc
@@ -5,6 +5,7 @@
 
 #include "geometry/cgal/cgalutils.h"
 
+#include "geometry/Geometry.h"
 #include "geometry/cgal/cgal.h"
 #include "geometry/PolySet.h"
 #include "utils/printutils.h"

--- a/src/geometry/cgal/cgalutils.h
+++ b/src/geometry/cgal/cgalutils.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "geometry/cgal/cgal.h"
+#include "geometry/Geometry.h"
 #include "geometry/PolySet.h"
 #include "geometry/cgal/CGAL_Nef_polyhedron.h"
 #include "core/enums.h"

--- a/src/geometry/linear_extrude.cc
+++ b/src/geometry/linear_extrude.cc
@@ -12,6 +12,7 @@
 
 #include <boost/logic/tribool.hpp>
 
+#include "geometry/Geometry.h"
 #include "geometry/GeometryUtils.h"
 #include "glview/RenderSettings.h"
 #include "core/LinearExtrudeNode.h"

--- a/src/geometry/manifold/ManifoldGeometry.cc
+++ b/src/geometry/manifold/ManifoldGeometry.cc
@@ -1,5 +1,6 @@
 // Portions of this file are Copyright 2023 Google LLC, and licensed under GPL2+. See COPYING.
 #include "geometry/manifold/ManifoldGeometry.h"
+#include "geometry/Geometry.h"
 #include "geometry/Polygon2d.h"
 #include <map>
 #include <set>

--- a/src/geometry/manifold/manifold-applyops-minkowski.cc
+++ b/src/geometry/manifold/manifold-applyops-minkowski.cc
@@ -11,6 +11,7 @@
 #include <CGAL/convex_hull_3.h>
 
 #include "geometry/cgal/cgal.h"
+#include "geometry/Geometry.h"
 #include "geometry/cgal/cgalutils.h"
 #include "geometry/PolySet.h"
 #include "utils/printutils.h"

--- a/src/geometry/manifold/manifold-applyops.cc
+++ b/src/geometry/manifold/manifold-applyops.cc
@@ -5,6 +5,7 @@
 
 #include <memory>
 #include "geometry/manifold/manifoldutils.h"
+#include "geometry/Geometry.h"
 #include "geometry/manifold/ManifoldGeometry.h"
 #include "core/node.h"
 #include "core/progress.h"

--- a/src/geometry/manifold/manifoldutils.cc
+++ b/src/geometry/manifold/manifoldutils.cc
@@ -1,5 +1,6 @@
 // Portions of this file are Copyright 2023 Google LLC, and licensed under GPL2+. See COPYING.
 #include "geometry/manifold/manifoldutils.h"
+#include "geometry/Geometry.h"
 #include "geometry/manifold/ManifoldGeometry.h"
 #include "geometry/PolySetBuilder.h"
 #include "Feature.h"

--- a/src/glview/cgal/CGALRenderer.cc
+++ b/src/glview/cgal/CGALRenderer.cc
@@ -36,6 +36,7 @@
 #include <mpfr.h>
 #endif
 
+#include "geometry/Geometry.h"
 #include "Feature.h"
 #include "geometry/PolySet.h"
 #include "geometry/PolySetUtils.h"

--- a/src/glview/cgal/CGALRenderer.h
+++ b/src/glview/cgal/CGALRenderer.h
@@ -6,6 +6,7 @@
 
 #include "glview/VBORenderer.h"
 #ifdef ENABLE_CGAL
+#include "geometry/Geometry.h"
 #include "glview/cgal/CGAL_OGL_Polyhedron.h"
 #include "geometry/cgal/CGAL_Nef_polyhedron.h"
 #include "core/Selection.h"

--- a/src/glview/cgal/LegacyCGALRenderer.cc
+++ b/src/glview/cgal/LegacyCGALRenderer.cc
@@ -35,6 +35,7 @@
 #include <mpfr.h>
 #endif
 
+#include "geometry/Geometry.h"
 #include "geometry/PolySet.h"
 #include "geometry/Polygon2d.h"
 #include "geometry/PolySetUtils.h"

--- a/src/glview/cgal/LegacyCGALRenderer.h
+++ b/src/glview/cgal/LegacyCGALRenderer.h
@@ -5,6 +5,7 @@
 #include <vector>
 
 #include "glview/Renderer.h"
+#include "geometry/Geometry.h"
 #include "geometry/PolySet.h"
 #include "geometry/Polygon2d.h"
 #ifdef ENABLE_CGAL

--- a/src/gui/MainWindow.cc
+++ b/src/gui/MainWindow.cc
@@ -53,6 +53,7 @@
 #include <vector>
 
 #ifdef ENABLE_MANIFOLD
+#include "geometry/Geometry.h"
 #include "geometry/manifold/manifoldutils.h"
 #endif
 #include "utils/boost-utils.h"

--- a/src/io/export.h
+++ b/src/io/export.h
@@ -12,6 +12,7 @@
 #include <boost/range/adaptor/map.hpp>
 
 #include "core/Tree.h"
+#include "geometry/Geometry.h"
 #include "glview/Camera.h"
 
 class PolySet;

--- a/src/io/export_3mf_dummy.cc
+++ b/src/io/export_3mf_dummy.cc
@@ -27,6 +27,7 @@
 #include <memory>
 #include <ostream>
 #include "io/export.h"
+#include "geometry/Geometry.h"
 #include "utils/printutils.h"
 
 void export_3mf(const std::shared_ptr<const class Geometry>&, std::ostream&)

--- a/src/io/export_3mf_v1.cc
+++ b/src/io/export_3mf_v1.cc
@@ -25,6 +25,7 @@
  */
 
 #include "geometry/GeometryUtils.h"
+#include "geometry/Geometry.h"
 #include "io/export.h"
 #include "geometry/PolySet.h"
 #include "geometry/PolySetUtils.h"

--- a/src/io/export_3mf_v2.cc
+++ b/src/io/export_3mf_v2.cc
@@ -25,6 +25,7 @@
  */
 
 #include "geometry/GeometryUtils.h"
+#include "geometry/Geometry.h"
 #include "io/export.h"
 #include "geometry/PolySet.h"
 #include "geometry/PolySetUtils.h"

--- a/src/io/export_dxf.cc
+++ b/src/io/export_dxf.cc
@@ -29,6 +29,7 @@
 #include <ostream>
 #include <memory>
 #include "io/export.h"
+#include "geometry/Geometry.h"
 #include "geometry/PolySet.h"
 
 /*!

--- a/src/io/export_obj.cc
+++ b/src/io/export_obj.cc
@@ -29,6 +29,7 @@
 #include <memory>
 #include "io/export.h"
 
+#include "geometry/Geometry.h"
 #include "geometry/PolySetUtils.h"
 #include "geometry/PolySet.h"
 

--- a/src/io/export_off.cc
+++ b/src/io/export_off.cc
@@ -26,6 +26,7 @@
  */
 
 #include "io/export.h"
+#include "geometry/Geometry.h"
 #include "geometry/linalg.h"
 #include "Feature.h"
 #include "geometry/Reindexer.h"

--- a/src/io/export_pdf.cc
+++ b/src/io/export_pdf.cc
@@ -1,4 +1,5 @@
 #include "io/export.h"
+#include "geometry/Geometry.h"
 #include "geometry/PolySet.h"
 // #include "geometry/PolySetUtils.h"
 #include "utils/printutils.h"

--- a/src/io/export_png.cc
+++ b/src/io/export_png.cc
@@ -1,4 +1,5 @@
 #include "io/export.h"
+#include "geometry/Geometry.h"
 #include "utils/printutils.h"
 #include "glview/OffscreenView.h"
 #include "glview/CsgInfo.h"

--- a/src/io/export_stl.cc
+++ b/src/io/export_stl.cc
@@ -25,6 +25,7 @@
  */
 
 #include "io/export.h"
+#include "geometry/Geometry.h"
 #include "geometry/PolySet.h"
 #include "geometry/PolySetUtils.h"
 #include <algorithm>

--- a/src/io/export_svg.cc
+++ b/src/io/export_svg.cc
@@ -28,6 +28,7 @@
 #include <ostream>
 #include <memory>
 #include "io/export.h"
+#include "geometry/Geometry.h"
 #include "geometry/PolySet.h"
 
 static void append_svg(const Polygon2d& poly, std::ostream& output)

--- a/src/io/export_wrl.cc
+++ b/src/io/export_wrl.cc
@@ -25,6 +25,7 @@
 
 #include "io/export.h"
 
+#include "geometry/Geometry.h"
 #include "geometry/PolySet.h"
 #include "geometry/PolySetUtils.h"
 

--- a/src/io/import_amf.cc
+++ b/src/io/import_amf.cc
@@ -25,6 +25,7 @@
  */
 
 #include "geometry/PolySet.h"
+#include "geometry/Geometry.h"
 #include "geometry/PolySetBuilder.h"
 #include "geometry/PolySetUtils.h"
 #include "utils/printutils.h"


### PR DESCRIPTION
Created with missing header findings of `clang-tidy`:

```
scripts/run-clang-tidy-cached.cc
../dev-tools/insert-header "geometry/Geometry.h" $(grep "no header providing.*misc-include-cleaner" OpenSCAD_clang-tidy.out  | awk -F: '/"Geometry"/ { print $1}' | sort | uniq)
```