### PR TITLE
Sync tests/CMakeLists.txt cmake versions requirement with top level requirements

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -2,7 +2,7 @@
 
 #set(DEBUG_OSCD 1) # print debug info during cmake
 
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.13)
 if(POLICY CMP0017)
   # Explicitly use new include policy to avoid globally shadowing included modules
   # https://cmake.org/cmake/help/v2.8.8/cmake.html#policy:CMP0017


### PR DESCRIPTION
Fixes: 
```
CMake Deprecation Warning at tests/CMakeLists.txt:5 (cmake_minimum_required):
  Compatibility with CMake < 3.5 will be removed from a future version of
  CMake.

  Update the VERSION argument <min> value or use a ...<max> suffix to tell
  CMake that the project does not need compatibility with older versions.
```