### PR TITLE
Fix crash if "libraries" resource path is not used

### DIFF
--- a/src/core/parsersettings.cc
+++ b/src/core/parsersettings.cc
@@ -154,5 +154,7 @@ void parser_init()
 
   add_librarydir(PlatformUtils::userLibraryPath());
 
-  add_librarydir(fs::absolute(PlatformUtils::resourcePath("libraries")).string());
+  if (!PlatformUtils::resourcePath("libraries").empty()) {
+    add_librarydir(fs::absolute(PlatformUtils::resourcePath("libraries")).string());
+  }
 }


### PR DESCRIPTION
```
$ openscad
terminate called after throwing an instance of 'std::filesystem::__cxx11::filesystem_error'
  what():  filesystem error: cannot make absolute path: Invalid argument []
Aborted (core dumped)
```
