### PR TITLE
Add protection/workaround for every possible call to fs::absolute with empty path

### DIFF
--- a/src/FontCache.cc
+++ b/src/FontCache.cc
@@ -130,7 +130,8 @@ FontCache::FontCache()
   // For system installs and dev environments, we leave this alone
   fs::path fontdir(PlatformUtils::resourcePath("fonts"));
   if (fs::is_regular_file(fontdir / "fonts.conf")) {
-    PlatformUtils::setenv("FONTCONFIG_PATH", (fs::absolute(fontdir).generic_string()).c_str(), 0);
+    auto abspath = fontdir.empty() ? fs::current_path() : fs::absolute(fontdir);
+    PlatformUtils::setenv("FONTCONFIG_PATH", (abspath.generic_string()).c_str(), 0);
   }
 
   // Just load the configs. We'll build the fonts once all configs are loaded

--- a/src/core/parsersettings.cc
+++ b/src/core/parsersettings.cc
@@ -148,11 +148,18 @@ void parser_init()
     std::string sep = PlatformUtils::pathSeparatorChar();
     using string_split_iterator = boost::split_iterator<std::string::iterator>;
     for (string_split_iterator it = boost::make_split_iterator(paths, boost::first_finder(sep, boost::is_iequal())); it != string_split_iterator(); ++it) {
-      add_librarydir(fs::absolute(fs::path(boost::copy_range<std::string>(*it))).generic_string());
+      auto str{boost::copy_range<std::string>(*it)};
+      fs::path abspath = str.empty() ? fs::current_path() : fs::absolute(fs::path(str));
+      add_librarydir(abspath.generic_string());
     }
   }
 
   add_librarydir(PlatformUtils::userLibraryPath());
 
-  add_librarydir(fs::absolute(PlatformUtils::resourcePath("libraries")).string());
+  fs::path libpath = PlatformUtils::resourcePath("libraries");
+  // std::filesystem::absolute() will throw if passed empty path
+  if (libpath.empty()) {
+    libpath = fs::current_path();
+  }
+  add_librarydir(fs::absolute(libpath).string());
 }

--- a/src/openscad.cc
+++ b/src/openscad.cc
@@ -329,7 +329,8 @@ struct CommandLine
 int do_export(const CommandLine& cmd, const RenderVariables& render_variables, FileFormat export_format, SourceFile *root_file)
 {
   auto filename_str = fs::path(cmd.output_file).generic_string();
-  auto fpath = fs::absolute(fs::path(cmd.filename));
+  // Avoid possibility of fs::absolute throwing when passed an empty path
+  auto fpath = cmd.filename.empty() ? fs::current_path() : fs::absolute(fs::path(cmd.filename));
   auto fparent = fpath.parent_path();
 
   // set CWD relative to source file


### PR DESCRIPTION
This addresses a difference in behavior between `boost::filesystem::absolute` and `std::filesystem::absolute` where passing an empty path to boost would return `fs::current_path()`, and the std library now throws a `std::filesystem_error`.

I don't know if an empty path can even necessarily reach all these calls, but better to just handle the possibility regardless, than wait for another bug report.