### PR TITLE
Update manifold to v3.0.0; print manifold version in library info.

### DIFF
--- a/src/LibraryInfo.cc
+++ b/src/LibraryInfo.cc
@@ -44,6 +44,16 @@
 #define OPENCSG_VERSION_STRING "<not enabled>"
 #endif
 
+#ifdef ENABLE_MANIFOLD
+#include <manifold/version.h>  // if it is new enough for us, it has version.h
+#define MANIFOLD_VERSION_STRING \
+  TOSTRING(MANIFOLD_VERSION_MAJOR) "." \
+  TOSTRING(MANIFOLD_VERSION_MINOR) "." \
+  TOSTRING(MANIFOLD_VERSION_PATCH)
+#else
+#define MANIFOLD_VERSION_STRING "<not enabled>"
+#endif
+
 extern std::vector<std::string> librarypath;
 extern std::vector<std::string> fontpath;
 extern const std::string get_cairo_version();
@@ -129,6 +139,7 @@ std::string LibraryInfo::info()
     << "\nCGAL version, kernels: " << TOSTRING(CGAL_VERSION) << ", " << cgal_3d_kernel << ", " << cgal_2d_kernel << ", " << cgal_2d_kernelEx
 #endif
     << "\nOpenCSG version: " << OPENCSG_VERSION_STRING
+    << "\nManifold version: " << MANIFOLD_VERSION_STRING
     << "\nQt version: " << qtVersion
 #ifndef OPENSCAD_NOGUI
     << "\nQScintilla version: " << QSCINTILLA_VERSION_STR


### PR DESCRIPTION
Update to v3.0.0 release of Manifold.
    
This release provides a version.h which we can use to print
the library info.

Fixes #5432