### PR TITLE
Build OpenSCAD with Qt6 for macOS

### DIFF
--- a/scripts/release-common.sh
+++ b/scripts/release-common.sh
@@ -97,7 +97,7 @@ fi
 case $OS in
     MACOSX)
         . ./scripts/setenv-macos.sh
-        CMAKE_CONFIG="$CMAKE_CONFIG -DCMAKE_OSX_ARCHITECTURES=x86_64;arm64"
+        CMAKE_CONFIG="$CMAKE_CONFIG -DUSE_QT6=ON -DCMAKE_OSX_ARCHITECTURES=x86_64;arm64"
     ;;
     LINUX)
         TARGET=


### PR DESCRIPTION
Forgot to add the USE_QT6 CMake option