### PR TITLE
Allow to do --animate work in shards.

### DIFF
--- a/src/openscad.cc
+++ b/src/openscad.cc
@@ -241,6 +241,57 @@ void localization_init() {
   }
 }
 
+struct AnimateArgs {
+  unsigned frames = 0;
+  unsigned num_shards = 1;
+  unsigned shard = 0;
+};
+
+struct CommandLine
+{
+  const bool is_stdin;
+  const std::string& filename;
+  const bool is_stdout;
+  std::string output_file;
+  const fs::path& original_path;
+  const std::string& parameterFile;
+  const std::string& setName;
+  const ViewOptions& viewOptions;
+  const Camera& camera;
+  const boost::optional<FileFormat> export_format;
+  const AnimateArgs animate;
+  const std::vector<std::string> summaryOptions;
+  const std::string summaryFile;
+};
+
+AnimateArgs get_animate(const po::variables_map& vm) {
+  AnimateArgs animate;
+  if (vm.count("animate")) {
+    animate.frames = vm["animate"].as<unsigned>();
+  }
+  if (vm.count("animate_sharding")) {
+    std::vector<std::string> strs;
+    boost::split(strs, vm["animate_sharding"].as<std::string>(),
+                 boost::is_any_of(","));
+    if (strs.size() != 2) {
+      LOG("--animate_sharding requires <num_shards>,<shard>");
+      exit(1);
+    }
+    try {
+      animate.num_shards = boost::lexical_cast<unsigned>(strs[0]);
+      animate.shard = boost::lexical_cast<unsigned>(strs[1]);
+    } catch (const boost::bad_lexical_cast&) {
+      LOG("--animate_sharding parameter to be two comma-separated positive integers");
+      exit(1);
+    }
+    if (animate.shard >= animate.num_shards) {
+      LOG("--animate_sharding needs to be in range <num_shards>,<0..num_shards-1>");
+      exit(1);
+    }
+  }
+  return animate;
+}
+
 Camera get_camera(const po::variables_map& vm)
 {
   Camera camera;
@@ -309,23 +360,6 @@ Camera get_camera(const po::variables_map& vm)
 
   return camera;
 }
-
-struct CommandLine
-{
-  const bool is_stdin;
-  const std::string& filename;
-  const bool is_stdout;
-  std::string output_file;
-  const fs::path& original_path;
-  const std::string& parameterFile;
-  const std::string& setName;
-  const ViewOptions& viewOptions;
-  const Camera& camera;
-  const boost::optional<FileFormat> export_format;
-  unsigned animate_frames;
-  const std::vector<std::string> summaryOptions;
-  const std::string summaryFile;
-};
 
 int do_export(const CommandLine& cmd, const RenderVariables& render_variables, FileFormat export_format, SourceFile *root_file)
 {
@@ -572,13 +606,16 @@ int cmdline(const CommandLine& cmd)
     .camera = cmd.camera,
   };
 
-  if (cmd.animate_frames == 0) {
+  if (cmd.animate.frames == 0) {
     render_variables.time = 0;
     return do_export(cmd, render_variables, export_format, root_file);
   } else {
     // export the requested number of animated frames
-    for (unsigned frame = 0; frame < cmd.animate_frames; ++frame) {
-      render_variables.time = frame * (1.0 / cmd.animate_frames);
+    for (unsigned frame = 0; frame < cmd.animate.frames; ++frame) {
+      if (frame % cmd.animate.num_shards != cmd.animate.shard) {
+        continue;
+      }
+      render_variables.time = frame * (1.0 / cmd.animate.frames);
 
       std::ostringstream oss;
       oss << std::setw(5) << std::setfill('0') << frame;
@@ -714,6 +751,7 @@ int main(int argc, char **argv)
     ("render", po::value<std::string>()->implicit_value(""), "for full geometry evaluation when exporting png")
     ("preview", po::value<std::string>()->implicit_value(""), "[=throwntogether] -for ThrownTogether preview png")
     ("animate", po::value<unsigned>(), "export N animated frames")
+    ("animate_sharding", po::value<std::string>(), "Parameter <num_shards>,<shard> - Divide work into <num_shards> and only output frames for <shard>. E.g. 5,2 only outputs frames that match frame# % 5 == 2. Use to parallize work on multiple cores or machines.")
     ("view", po::value<CommaSeparatedVector>(), ("=view options: " + boost::algorithm::join(viewOptions.names(), " | ")).c_str())
     ("projection", po::value<std::string>(), "=(o)rtho or (p)erspective when exporting png")
     ("csglimit", po::value<unsigned int>(), "=n -stop rendering at n CSG elements when exporting png")
@@ -908,14 +946,10 @@ int main(int argc, char **argv)
     }
   }
 
-  unsigned animate_frames = 0;
-  if (vm.count("animate")) {
-    animate_frames = vm["animate"].as<unsigned>();
-  }
-
+  AnimateArgs animate = get_animate(vm);
   Camera camera = get_camera(vm);
 
-  if (animate_frames) {
+  if (animate.frames) {
     for (const auto& filename : output_files) {
       if (filename == "-") {
         LOG("Option --animate is not supported when exporting to stdout.");
@@ -959,7 +993,7 @@ int main(int argc, char **argv)
             viewOptions,
             camera,
             export_format,
-            animate_frames,
+            animate,
             vm.count("summary") ? vm["summary"].as<std::vector<std::string>>() : std::vector<std::string>{},
             vm.count("summary-file") ? vm["summary-file"].as<std::string>() : ""
           };


### PR DESCRIPTION
Introduce new `--animate_sharding=<num_shards>,<shard>` flag that allows to output a subset of animation frames given simple modulo sharding: Divide the work in `num_shards`, and only output frames that match `frame# % num_shards == shard`.
So an invocation only outputs `frames/num_shards` reducing wall-time for that process.

This allows an easy parallelization on a machine with multiple cores, or even distribute the work to multiple machines.

A typical use could be like this: run two instances and divide the work into two shards; have one output all the even frames and the other the odd frames:

```bash
   openscad -q --animate=42 --animate_sharding=2,0 foo.scad &
   openscad -q --animate=42 --animate_sharding=2,1 foo.scad &
   wait
```

(of course, one would use probably more shards closer to the number of cores on the machine).

Issues: #5467