### PR TITLE
Fix a few more fs::canonical on emscripten

### DIFF
--- a/src/core/parsersettings.cc
+++ b/src/core/parsersettings.cc
@@ -87,10 +87,18 @@ inline fs::path find_valid_path_(const fs::path& sourcepath,
                           const std::vector<std::string> *openfilenames)
 {
   if (localpath.is_absolute()) {
-    if (check_valid(localpath, openfilenames)) return fs::canonical(localpath);
+    if (check_valid(localpath, openfilenames)) {
+#ifndef __EMSCRIPTEN__
+      return fs::canonical(localpath);
+#else
+      return localpath;
+#endif
+    }
   } else {
     fs::path fpath = sourcepath / localpath;
+#ifndef __EMSCRIPTEN__
     if (fs::exists(fpath)) fpath = fs::canonical(fpath);
+#endif
     if (check_valid(fpath, openfilenames)) return fpath;
     fpath = search_libs(localpath);
     if (!fpath.empty() && check_valid(fpath, openfilenames)) return fpath;

--- a/src/platform/PlatformUtils.cc
+++ b/src/platform/PlatformUtils.cc
@@ -77,7 +77,10 @@ static std::string lookupResourcesPath()
   }
 
   // resourcedir defaults to applicationPath
-  std::string result = fs::canonical(resourcedir).generic_string();
+#ifndef __EMSCRIPTEN__
+  resourcedir = fs::canonical(resourcedir);
+#endif
+  std::string result = resourcedir.generic_string();
   PRINTDB("Using resource folder '%s'", result);
   return result;
 }

--- a/tests/wasm-check.html
+++ b/tests/wasm-check.html
@@ -15,11 +15,15 @@
       instance.FS.writeFile("/fonts/LiberationSans-Regular.ttf",
         new Uint8Array(await (await fetch("../fonts/Liberation-2.00.1/ttf/LiberationSans-Regular.ttf")).arrayBuffer()));
 
+      instance.FS.writeFile("lib.scad", `
+        test_text = "Hello";
+      `);
       instance.FS.writeFile("input.scad", `
+        include <lib.scad>;
         $fn=64;
         difference() {
             linear_extrude(height = 20, center=true)
-                text("Hello", size=10, halign="center", valign="center", font="Liberation Sans");
+                text(test_text, size=10, halign="center", valign="center", font="Liberation Sans");
             sphere(r=10);
         }
       `);


### PR DESCRIPTION
This fixes file imports in web wasm builds.

Similar to https://github.com/openscad/openscad/pull/5210 & https://github.com/openscad/openscad/pull/5515
