### PR TITLE
3mf color import / export

### DIFF
--- a/src/core/parsersettings.cc
+++ b/src/core/parsersettings.cc
@@ -87,10 +87,18 @@ inline fs::path find_valid_path_(const fs::path& sourcepath,
                           const std::vector<std::string> *openfilenames)
 {
   if (localpath.is_absolute()) {
-    if (check_valid(localpath, openfilenames)) return fs::canonical(localpath);
+    if (check_valid(localpath, openfilenames)) {
+#ifndef __EMSCRIPTEN__
+      return fs::canonical(localpath);
+#else
+      return localpath;
+#endif
+    }
   } else {
     fs::path fpath = sourcepath / localpath;
+#ifndef __EMSCRIPTEN__
     if (fs::exists(fpath)) fpath = fs::canonical(fpath);
+#endif
     if (check_valid(fpath, openfilenames)) return fpath;
     fpath = search_libs(localpath);
     if (!fpath.empty() && check_valid(fpath, openfilenames)) return fpath;

--- a/src/geometry/PolySetBuilder.cc
+++ b/src/geometry/PolySetBuilder.cc
@@ -138,12 +138,25 @@ void PolySetBuilder::addVertex(const Vector3d &v)
   addVertex(vertexIndex(v));
 }
 
-void PolySetBuilder::endPolygon() {
+void PolySetBuilder::endPolygon(const Color4f &color) {
   // FIXME: Should we check for self-touching polygons (non-consecutive duplicate indices)?
 
   // FIXME: Can we move? What would the state of current_polygon_ be after move?
   if (current_polygon_.size() >= 3) {
     indices_.push_back(current_polygon_);
+
+    if (color.isValid()) {
+      if (color_indices_.empty() && indices_.size() > 1) {
+        color_indices_.resize(indices_.size() - 1, -1);
+      }
+      auto it = std::find(colors_.begin(), colors_.end(), color);
+      if (it == colors_.end()) {
+        color_indices_.push_back(colors_.size());
+        colors_.push_back(color);
+      } else {
+        color_indices_.push_back(it - colors_.begin());
+      }
+    }
   }
   current_polygon_.clear();
 }

--- a/src/geometry/PolySetBuilder.h
+++ b/src/geometry/PolySetBuilder.h
@@ -30,7 +30,7 @@ public:
   void addVertex(int ind);
   void addVertex(const Vector3d &v);
   // Calling this is optional; will be called automatically when adding a new polygon or building the PolySet
-  void endPolygon();
+  void endPolygon(const Color4f &color = {});
 
   std::unique_ptr<PolySet> build();
 private:

--- a/src/io/export_3mf_v2.cc
+++ b/src/io/export_3mf_v2.cc
@@ -72,12 +72,29 @@ static void export_3mf_error(std::string msg)
 /*
  * PolySet must be triangulated.
  */
-static bool append_polyset(std::shared_ptr<const PolySet> ps, Lib3MF::PWrapper& wrapper, Lib3MF::PModel& model)
+static bool append_polyset(const std::shared_ptr<const PolySet> & ps, Lib3MF::PWrapper& wrapper, Lib3MF::PModel& model)
 {
   try {
     auto mesh = model->AddMeshObject();
     if (!mesh) return false;
     mesh->SetName("OpenSCAD Model");
+
+    Lib3MF::PBaseMaterialGroup baseMaterialGroup = model->AddBaseMaterialGroup();
+    std::vector<Lib3MF_uint32> colorResourceIDs;
+    for (size_t i = 0; i < ps->colors.size(); i++) {
+      const auto & color = ps->colors[i];
+      Lib3MF::sColor sc {
+        (Lib3MF_uint8) (color[0] * 255),
+        (Lib3MF_uint8) (color[1] * 255),
+        (Lib3MF_uint8) (color[2] * 255),
+        (Lib3MF_uint8) (color[3] * 255)
+      };
+      auto name = "color_" + std::to_string(i);
+      colorResourceIDs.push_back(baseMaterialGroup->AddMaterial(name, sc));
+    }
+    if (!ps->colors.empty()) {
+      mesh->SetObjectLevelProperty(baseMaterialGroup->GetResourceID(), colorResourceIDs[0]);
+    }
 
     auto vertexFunc = [&](const Vector3d& coords) -> bool {
       const auto f = coords.cast<float>();
@@ -91,10 +108,18 @@ static bool append_polyset(std::shared_ptr<const PolySet> ps, Lib3MF::PWrapper& 
       return true;
     };
 
-    auto triangleFunc = [&](const IndexedFace& indices) -> bool {
+    auto triangleFunc = [&](const IndexedFace& indices, int color_index) -> bool {
       try {
         Lib3MF::sTriangle t{(Lib3MF_uint32)indices[0], (Lib3MF_uint32)indices[1], (Lib3MF_uint32)indices[2]};
-        mesh->AddTriangle(t);
+        auto iTriangle = mesh->AddTriangle(t);
+        if (color_index >= 0 && color_index < colorResourceIDs.size()) {
+          auto colorResourceID = colorResourceIDs[color_index];
+          Lib3MF::sTriangleProperties props {
+            baseMaterialGroup->GetResourceID(), 
+            { colorResourceID, colorResourceID, colorResourceID}
+          };
+          mesh->SetTriangleProperties(iTriangle, props);
+        }
       } catch (Lib3MF::ELib3MFException& e) {
         export_3mf_error(e.what());
         return false;
@@ -114,8 +139,9 @@ static bool append_polyset(std::shared_ptr<const PolySet> ps, Lib3MF::PWrapper& 
       }
     }
 
-    for (const auto& poly : out_ps->indices) {
-      if (!triangleFunc(poly)) {
+    for (size_t i = 0; i < out_ps->indices.size(); i++) {
+      auto color_index = i < out_ps->color_indices.size() ? out_ps->color_indices[i] : -1;
+      if (!triangleFunc(out_ps->indices[i], color_index)) {
         export_3mf_error("Can't add triangle to 3MF model.");
         return false;
       }

--- a/src/platform/PlatformUtils.cc
+++ b/src/platform/PlatformUtils.cc
@@ -77,7 +77,10 @@ static std::string lookupResourcesPath()
   }
 
   // resourcedir defaults to applicationPath
-  std::string result = fs::canonical(resourcedir).generic_string();
+#ifndef __EMSCRIPTEN__
+  resourcedir = fs::canonical(resourcedir);
+#endif
+  std::string result = resourcedir.generic_string();
   PRINTDB("Using resource folder '%s'", result);
   return result;
 }

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1245,6 +1245,7 @@ add_cmdline_test(stlexportsanitytest  SCRIPT ${STLEXPORTSANITYTEST_PY} SUFFIX tx
 
 # Export/import color support
 add_cmdline_test(offcolorpngtest EXPERIMENTAL SCRIPT ${EXPORT_IMPORT_PNGTEST_PY} SUFFIX png FILES ${COLOR_3D_TEST_FILES} EXPECTEDDIR rendermanifoldtest-different ARGS ${OPENSCAD_EXE_ARG} --format=OFF --backend=manifold --render)
+add_cmdline_test(3mfcolorpngtest EXPERIMENTAL SCRIPT ${EXPORT_IMPORT_PNGTEST_PY} SUFFIX png FILES ${COLOR_3D_TEST_FILES} EXPECTEDDIR rendermanifoldtest-different ARGS ${OPENSCAD_EXE_ARG} --format=3MF --backend=manifold --render)
 
 # PDF Export
 add_cmdline_test(pdfexporttest SCRIPT ${EXPORT_PNGTEST_PY} SUFFIX png FILES ${SCAD_PDF_FILES} ARGS ${OPENSCAD_EXE_ARG} --format=PDF KERNEL Square:2)

--- a/tests/wasm-check.html
+++ b/tests/wasm-check.html
@@ -15,11 +15,15 @@
       instance.FS.writeFile("/fonts/LiberationSans-Regular.ttf",
         new Uint8Array(await (await fetch("../fonts/Liberation-2.00.1/ttf/LiberationSans-Regular.ttf")).arrayBuffer()));
 
+      instance.FS.writeFile("lib.scad", `
+        test_text = "Hello";
+      `);
       instance.FS.writeFile("input.scad", `
+        include <lib.scad>;
         $fn=64;
         difference() {
             linear_extrude(height = 20, center=true)
-                text("Hello", size=10, halign="center", valign="center", font="Liberation Sans");
+                text(test_text, size=10, halign="center", valign="center", font="Liberation Sans");
             sphere(r=10);
         }
       `);


### PR DESCRIPTION
Follow up to https://github.com/openscad/openscad/pull/5185

I was initially planning to rely on assimp for all color import/export beyond OFF format, but I still have 3 patches to upstream for it to work (see https://github.com/openscad/openscad/pull/5180), so updating our 3mf import/export code is the path of least resistance atm.

Note that this PR does NOT include multimaterial support for PrusaSlicer & BambuStudio, which needs a non-standard "triangle" attribute (cf. playground's [materialize](https://github.com/openscad/openscad-playground/compare/main...ochafik:openscad-playground:color-assimp3#diff-4aa3f4c63c5170faa373ef7161c9e870676ee4f9789a26d9b0c84889203af4cd) code).

TODO:
- [ ] Tests still need a bit of love.