### PR TITLE
Fix check-dependencies.sh on Fedora 41

### DIFF
--- a/scripts/check-dependencies.sh
+++ b/scripts/check-dependencies.sh
@@ -180,6 +180,10 @@ gmp_sysver()
 
 qt_sysver()
 {
+  if [ -d '/usr/lib/qtchooser' ]; then
+    . <(/usr/lib/qtchooser/qtchooser -print-env)
+    PATH=$PATH:$QTTOOLDIR
+  fi
   if [ "`command -v qtchooser`" ]; then
     qtver=`qtchooser -run-tool=qmake -qt=5 -v 2>&1`
     if [ $? -eq 0 ] ; then

--- a/scripts/uni-get-dependencies.sh
+++ b/scripts/uni-get-dependencies.sh
@@ -26,6 +26,7 @@ get_fedora_deps_dnf()
  dnf -y install libxml2-devel
  dnf -y install libffi-devel
  dnf -y install redhat-rpm-config
+ dnf -y install qtchooser
 }
 
 get_qomo_deps()


### PR DESCRIPTION
After installing the dependencies using uni-get-dependencies.sh, Fedora 41 fails to recognize qscintilla2:

```
$ ./scripts/check-dependencies.sh 
depname           minimum           found             OKness            
qt                5.12              5.15.15           OK                
./scripts/check-dependencies.sh: line 230: -query: command not found
./scripts/check-dependencies.sh: line 230: -query: command not found
qscintilla2       2.9               unknown           NotOK             
cgal              5.4               5.6.2             OK                
gmp               5.0               6.3.0             OK                
mpfr              3.0               4.2.1             OK                
boost             1.61              1.83              OK                
opencsg           1.4.2             1.6.0             OK                
glew              1.5.4             1.7.0             OK                
eigen             3.0               3.4.0             OK                
glib2             2.0               2.82.2            OK                
fontconfig        2.10              2.15.0            OK                
freetype2         2.4               2.13.3            OK                
harfbuzz          0.9.19            9.0.0             OK                
libzip            0.10.1            1.11.2            OK                
bison             2.4               3.8.2             OK                
flex              2.5.35            2.6.4             OK                
make              3                 4.4.1             OK                
double-conversion 2.0.1             2.0.1             OK  
```

Installing qtchooser and adding the PATH provided by it fixes the detection.