### PR TITLE
Don't use the textActivated signal as it was introduced first in Qt-5.14

### DIFF
--- a/src/gui/Preferences.cc
+++ b/src/gui/Preferences.cc
@@ -418,7 +418,7 @@ void Preferences::on_fontSize_currentIndexChanged(int index)
   emit fontChanged(getValue("editor/fontfamily").toString(), intsize);
 }
 
-void Preferences::on_syntaxHighlight_textActivated(const QString & s)
+void Preferences::on_syntaxHighlight_currentTextChanged(const QString& s)
 {
   QSettingsCached settings;
   settings.setValue("editor/syntaxhighlight", s);
@@ -1147,7 +1147,7 @@ void Preferences::create(const QStringList& colorSchemes)
 
   instance = new Preferences();
   instance->syntaxHighlight->clear();
-  instance->syntaxHighlight->addItems(colorSchemes);
+  BlockSignals<QComboBox *>(instance->syntaxHighlight)->addItems(colorSchemes);
   instance->colorSchemeChooser->clear();
   instance->colorSchemeChooser->addItems(renderColorSchemes);
   instance->init();

--- a/src/gui/Preferences.h
+++ b/src/gui/Preferences.h
@@ -44,7 +44,7 @@ public slots:
   void on_colorSchemeChooser_itemSelectionChanged();
   void on_fontChooser_currentFontChanged(const QFont&);
   void on_fontSize_currentIndexChanged(int);
-  void on_syntaxHighlight_textActivated(const QString & s);
+  void on_syntaxHighlight_currentTextChanged(const QString&);
   void on_openCSGWarningBox_toggled(bool);
   void on_cgalCacheSizeMBEdit_textChanged(const QString&);
   void on_polysetCacheSizeMBEdit_textChanged(const QString&);


### PR DESCRIPTION
Fix remaining issue from #5026

Using `BlockSignals` instead, to avoid emitting signal when combobox is populated.