### PR TITLE
Centralize checking for children of modules that don't accept children.

### DIFF
--- a/src/core/ImportNode.cc
+++ b/src/core/ImportNode.cc
@@ -56,13 +56,8 @@ namespace fs = std::filesystem;
 using namespace boost::assign; // bring 'operator+=()' into scope
 
 
-static std::shared_ptr<AbstractNode> do_import(const ModuleInstantiation *inst, Arguments arguments, const Children& children, ImportType type)
+static std::shared_ptr<AbstractNode> do_import(const ModuleInstantiation *inst, Arguments arguments, ImportType type)
 {
-  if (!children.empty()) {
-    LOG(message_group::Warning, inst->location(), arguments.documentRoot(),
-        "module %1$s() does not support child modules", inst->name());
-  }
-
   Parameters parameters = Parameters::parse(std::move(arguments), inst->location(),
                                             {"file", "layer", "convexity", "origin", "scale"},
                                             {"width", "height", "filename", "layername", "center", "dpi", "id"}
@@ -154,17 +149,17 @@ static std::shared_ptr<AbstractNode> do_import(const ModuleInstantiation *inst, 
   return node;
 }
 
-static std::shared_ptr<AbstractNode> builtin_import(const ModuleInstantiation *inst, Arguments arguments, const Children& children)
-{ return do_import(inst, std::move(arguments), children, ImportType::UNKNOWN); }
+static std::shared_ptr<AbstractNode> builtin_import(const ModuleInstantiation *inst, Arguments arguments)
+{ return do_import(inst, std::move(arguments), ImportType::UNKNOWN); }
 
-static std::shared_ptr<AbstractNode> builtin_import_stl(const ModuleInstantiation *inst, Arguments arguments, const Children& children)
-{ return do_import(inst, std::move(arguments), children, ImportType::STL); }
+static std::shared_ptr<AbstractNode> builtin_import_stl(const ModuleInstantiation *inst, Arguments arguments)
+{ return do_import(inst, std::move(arguments), ImportType::STL); }
 
-static std::shared_ptr<AbstractNode> builtin_import_off(const ModuleInstantiation *inst, Arguments arguments, const Children& children)
-{ return do_import(inst, std::move(arguments), children, ImportType::OFF); }
+static std::shared_ptr<AbstractNode> builtin_import_off(const ModuleInstantiation *inst, Arguments arguments)
+{ return do_import(inst, std::move(arguments), ImportType::OFF); }
 
-static std::shared_ptr<AbstractNode> builtin_import_dxf(const ModuleInstantiation *inst, Arguments arguments, const Children& children)
-{ return do_import(inst, std::move(arguments), children, ImportType::DXF); }
+static std::shared_ptr<AbstractNode> builtin_import_dxf(const ModuleInstantiation *inst, Arguments arguments)
+{ return do_import(inst, std::move(arguments), ImportType::DXF); }
 
 
 

--- a/src/core/LinearExtrudeNode.cc
+++ b/src/core/LinearExtrudeNode.cc
@@ -85,6 +85,7 @@ static std::shared_ptr<AbstractNode> builtin_linear_extrude(const ModuleInstanti
 
   if (!parameters["file"].isUndefined() && parameters["file"].type() == Value::Type::STRING) {
     LOG(message_group::Deprecated, "Support for reading files in linear_extrude will be removed in future releases. Use a child import() instead.");
+    BuiltinModule::noChildren(inst, arguments, "when importing a file");
     auto filename = lookup_file(parameters["file"].toString(), inst->location().filePath().parent_path().string(), parameters.documentRoot());
     node->filename = filename;
     handle_dep(filename);
@@ -149,9 +150,6 @@ static std::shared_ptr<AbstractNode> builtin_linear_extrude(const ModuleInstanti
 
   if (node->filename.empty()) {
     children.instantiate(node);
-  } else if (!children.empty()) {
-    LOG(message_group::Warning, inst->location(), parameters.documentRoot(),
-        "module %1$s() does not support child modules when importing a file", inst->name());
   }
 
   return node;

--- a/src/core/RotateExtrudeNode.cc
+++ b/src/core/RotateExtrudeNode.cc
@@ -59,6 +59,7 @@ static std::shared_ptr<AbstractNode> builtin_rotate_extrude(const ModuleInstanti
 
   if (!parameters["file"].isUndefined()) {
     LOG(message_group::Deprecated, "Support for reading files in rotate_extrude will be removed in future releases. Use a child import() instead.");
+    BuiltinModule::noChildren(inst, arguments, "when importing a file");
     auto filename = lookup_file(parameters["file"].toString(), inst->location().filePath().parent_path().string(), parameters.documentRoot());
     node->filename = filename;
     handle_dep(filename);
@@ -83,9 +84,6 @@ static std::shared_ptr<AbstractNode> builtin_rotate_extrude(const ModuleInstanti
 
   if (node->filename.empty()) {
     children.instantiate(node);
-  } else if (!children.empty()) {
-    LOG(message_group::Warning, inst->location(), parameters.documentRoot(),
-        "module %1$s() does not support child modules when importing a file", inst->name());
   }
 
 

--- a/src/core/SurfaceNode.cc
+++ b/src/core/SurfaceNode.cc
@@ -63,13 +63,8 @@ using namespace boost::assign; // bring 'operator+=()' into scope
 namespace fs = std::filesystem;
 
 
-static std::shared_ptr<AbstractNode> builtin_surface(const ModuleInstantiation *inst, Arguments arguments, const Children& children)
+static std::shared_ptr<AbstractNode> builtin_surface(const ModuleInstantiation *inst, Arguments arguments)
 {
-  if (!children.empty()) {
-    LOG(message_group::Warning, inst->location(), arguments.documentRoot(),
-        "module %1$s() does not support child modules", inst->name());
-  }
-
   auto node = std::make_shared<SurfaceNode>(inst);
 
   Parameters parameters = Parameters::parse(std::move(arguments), inst->location(), {"file", "center", "convexity"}, {"invert"});

--- a/src/core/TextNode.cc
+++ b/src/core/TextNode.cc
@@ -42,13 +42,8 @@
 #include <boost/assign/std/vector.hpp>
 using namespace boost::assign; // bring 'operator+=()' into scope
 
-static std::shared_ptr<AbstractNode> builtin_text(const ModuleInstantiation *inst, Arguments arguments, const Children& children)
+static std::shared_ptr<AbstractNode> builtin_text(const ModuleInstantiation *inst, Arguments arguments)
 {
-  if (!children.empty()) {
-    LOG(message_group::Warning, inst->location(), arguments.documentRoot(),
-        "module %1$s() does not support child modules", inst->name());
-  }
-
   auto node = std::make_shared<TextNode>(inst);
 
   auto *session = arguments.session();

--- a/src/core/control.cc
+++ b/src/core/control.cc
@@ -71,12 +71,10 @@ static std::shared_ptr<AbstractNode> builtin_child(const ModuleInstantiation *in
 {
   LOG(message_group::Deprecated, "child() will be removed in future releases. Use children() instead.");
 
-  if (!inst->scope.moduleInstantiations.empty()) {
-    LOG(message_group::Warning, inst->location(), context->documentRoot(),
-        "module %1$s() does not support child modules", inst->name());
-  }
-
   Arguments arguments{inst->arguments, context};
+
+  BuiltinModule::noChildren(inst, arguments);
+
   Parameters parameters = Parameters::parse(std::move(arguments), inst->location(), {}, std::vector<std::string>{"index"});
   const Children *children = context->user_module_children();
   if (!children) {
@@ -98,12 +96,10 @@ static std::shared_ptr<AbstractNode> builtin_child(const ModuleInstantiation *in
 
 static std::shared_ptr<AbstractNode> builtin_children(const ModuleInstantiation *inst, const std::shared_ptr<const Context>& context)
 {
-  if (!inst->scope.moduleInstantiations.empty()) {
-    LOG(message_group::Warning, inst->location(), context->documentRoot(),
-        "module %1$s() does not support child modules", inst->name());
-  }
-
   Arguments arguments{inst->arguments, context};
+
+  BuiltinModule::noChildren(inst, arguments);
+
   Parameters parameters = Parameters::parse(std::move(arguments), inst->location(), {}, std::vector<std::string>{"index"});
   const Children *children = context->user_module_children();
   if (!children) {

--- a/src/core/module.h
+++ b/src/core/module.h
@@ -29,7 +29,9 @@ class BuiltinModule : public AbstractModule
 public:
   BuiltinModule(std::shared_ptr<AbstractNode>(*instantiate)(const ModuleInstantiation *, const std::shared_ptr<const Context>&), const Feature *feature = nullptr);
   BuiltinModule(std::shared_ptr<AbstractNode>(*instantiate)(const ModuleInstantiation *, Arguments, const Children&), const Feature *feature = nullptr);
+  BuiltinModule(std::shared_ptr<AbstractNode>(*instantiate)(const ModuleInstantiation *, Arguments), const Feature *feature = nullptr);
   std::shared_ptr<AbstractNode> instantiate(const std::shared_ptr<const Context>& defining_context, const ModuleInstantiation *inst, const std::shared_ptr<const Context>& context) const override;
+  static void noChildren(const ModuleInstantiation *, Arguments&, std::string auxmsg = {});
 
 private:
   std::function<std::shared_ptr<AbstractNode>(const ModuleInstantiation *, const std::shared_ptr<const Context>&)> do_instantiate;

--- a/src/core/primitives.cc
+++ b/src/core/primitives.cc
@@ -151,14 +151,9 @@ std::unique_ptr<const Geometry> CubeNode::createGeometry() const
   return ps;
 }
 
-static std::shared_ptr<AbstractNode> builtin_cube(const ModuleInstantiation *inst, Arguments arguments, const Children& children)
+static std::shared_ptr<AbstractNode> builtin_cube(const ModuleInstantiation *inst, Arguments arguments)
 {
   auto node = std::make_shared<CubeNode>(inst);
-
-  if (!children.empty()) {
-    LOG(message_group::Warning, inst->location(), arguments.documentRoot(),
-        "module %1$s() does not support child modules", node->name());
-  }
 
   Parameters parameters = Parameters::parse(std::move(arguments), inst->location(), {"size", "center"});
 
@@ -234,14 +229,9 @@ std::unique_ptr<const Geometry> SphereNode::createGeometry() const
   return polyset;
 }
 
-static std::shared_ptr<AbstractNode> builtin_sphere(const ModuleInstantiation *inst, Arguments arguments, const Children& children)
+static std::shared_ptr<AbstractNode> builtin_sphere(const ModuleInstantiation *inst, Arguments arguments)
 {
   auto node = std::make_shared<SphereNode>(inst);
-
-  if (!children.empty()) {
-    LOG(message_group::Warning, inst->location(), arguments.documentRoot(),
-        "module %1$s() does not support child modules", node->name());
-  }
 
   Parameters parameters = Parameters::parse(std::move(arguments), inst->location(), {"r"}, {"d"});
 
@@ -323,14 +313,9 @@ std::unique_ptr<const Geometry> CylinderNode::createGeometry() const
   return polyset;
 }
 
-static std::shared_ptr<AbstractNode> builtin_cylinder(const ModuleInstantiation *inst, Arguments arguments, const Children& children)
+static std::shared_ptr<AbstractNode> builtin_cylinder(const ModuleInstantiation *inst, Arguments arguments)
 {
   auto node = std::make_shared<CylinderNode>(inst);
-
-  if (!children.empty()) {
-    LOG(message_group::Warning, inst->location(), arguments.documentRoot(),
-        "module %1$s() does not support child modules", node->name());
-  }
 
   Parameters parameters = Parameters::parse(std::move(arguments), inst->location(), {"h", "r1", "r2", "center"}, {"r", "d", "d1", "d2"});
 
@@ -433,14 +418,9 @@ std::unique_ptr<const Geometry> PolyhedronNode::createGeometry() const
   return p;
 }
 
-static std::shared_ptr<AbstractNode> builtin_polyhedron(const ModuleInstantiation *inst, Arguments arguments, const Children& children)
+static std::shared_ptr<AbstractNode> builtin_polyhedron(const ModuleInstantiation *inst, Arguments arguments)
 {
   auto node = std::make_shared<PolyhedronNode>(inst);
-
-  if (!children.empty()) {
-    LOG(message_group::Warning, inst->location(), arguments.documentRoot(),
-        "module %1$s() does not support child modules", node->name());
-  }
 
   Parameters parameters = Parameters::parse(std::move(arguments), inst->location(), {"points", "faces", "convexity"}, {"triangles"});
 
@@ -528,14 +508,9 @@ std::unique_ptr<const Geometry> SquareNode::createGeometry() const
   return std::make_unique<Polygon2d>(o);
 }
 
-static std::shared_ptr<AbstractNode> builtin_square(const ModuleInstantiation *inst, Arguments arguments, const Children& children)
+static std::shared_ptr<AbstractNode> builtin_square(const ModuleInstantiation *inst, Arguments arguments)
 {
   auto node = std::make_shared<SquareNode>(inst);
-
-  if (!children.empty()) {
-    LOG(message_group::Warning, inst->location(), arguments.documentRoot(),
-        "module %1$s() does not support child modules", node->name());
-  }
 
   Parameters parameters = Parameters::parse(std::move(arguments), inst->location(), {"size", "center"});
 
@@ -579,14 +554,9 @@ std::unique_ptr<const Geometry> CircleNode::createGeometry() const
   return std::make_unique<Polygon2d>(o);
 }
 
-static std::shared_ptr<AbstractNode> builtin_circle(const ModuleInstantiation *inst, Arguments arguments, const Children& children)
+static std::shared_ptr<AbstractNode> builtin_circle(const ModuleInstantiation *inst, Arguments arguments)
 {
   auto node = std::make_shared<CircleNode>(inst);
-
-  if (!children.empty()) {
-    LOG(message_group::Warning, inst->location(), arguments.documentRoot(),
-        "module %1$s() does not support child modules", node->name());
-  }
 
   Parameters parameters = Parameters::parse(std::move(arguments), inst->location(), {"r"}, {"d"});
 
@@ -677,14 +647,9 @@ std::unique_ptr<const Geometry> PolygonNode::createGeometry() const
   return p;
 }
 
-static std::shared_ptr<AbstractNode> builtin_polygon(const ModuleInstantiation *inst, Arguments arguments, const Children& children)
+static std::shared_ptr<AbstractNode> builtin_polygon(const ModuleInstantiation *inst, Arguments arguments)
 {
   auto node = std::make_shared<PolygonNode>(inst);
-
-  if (!children.empty()) {
-    LOG(message_group::Warning, inst->location(), arguments.documentRoot(),
-        "module %1$s() does not support child modules", node->name());
-  }
 
   Parameters parameters = Parameters::parse(std::move(arguments), inst->location(), {"points", "paths", "convexity"});
 


### PR DESCRIPTION
I got annoyed by how many times I saw the exact same "check for children and warn if there are any" sequence, so I centralized it.  The mechanism is kind of cool:  since the registration mechanism passes the builtin_* function to the constructor, it was easy to just have an alternate constructor that wanted a builtin_function that didn't have a children argument.