### PR TITLE
Consistent quoting of variable names (via central function).  Fixes #2833.

### DIFF
--- a/src/core/Context.cc
+++ b/src/core/Context.cc
@@ -88,7 +88,7 @@ const Value& Context::lookup_variable(const std::string& name, const Location& l
 {
   boost::optional<const Value&> result = try_lookup_variable(name);
   if (!result) {
-    LOG(message_group::Warning, loc, documentRoot(), "Ignoring unknown variable '%1$s'", name);
+    LOG(message_group::Warning, loc, documentRoot(), "Ignoring unknown variable %1$s", quoteVar(name));
     return Value::undefined;
   }
   return *result;

--- a/src/core/EvaluationSession.cc
+++ b/src/core/EvaluationSession.cc
@@ -67,7 +67,7 @@ const Value& EvaluationSession::lookup_special_variable(const std::string& name,
 {
   boost::optional<const Value&> result = try_lookup_special_variable(name);
   if (!result) {
-    LOG(message_group::Warning, loc, documentRoot(), "Ignoring unknown variable '%1$s'", name);
+    LOG(message_group::Warning, loc, documentRoot(), "Ignoring unknown variable %1$s", quoteVar(name));
     return Value::undefined;
   }
   return *result;

--- a/src/core/Expression.cc
+++ b/src/core/Expression.cc
@@ -701,7 +701,7 @@ void Let::doSequentialAssignment(const AssignmentList& assignments, const Locati
     if (assignment->getName().empty()) {
       LOG(message_group::Warning, location, targetContext->documentRoot(), "Assignment without variable name %1$s", value.toEchoStringNoThrow());
     } else if (seen.find(assignment->getName()) != seen.end()) {
-      LOG(message_group::Warning, location, targetContext->documentRoot(), "Ignoring duplicate variable assignment %1$s = %2$s", assignment->getName(), value.toEchoStringNoThrow());
+      LOG(message_group::Warning, location, targetContext->documentRoot(), "Ignoring duplicate variable assignment %1$s = %2$s", quoteVar(assignment->getName()), value.toEchoStringNoThrow());
     } else {
       targetContext->set_variable(assignment->getName(), std::move(value));
       seen.insert(assignment->getName());

--- a/src/core/Expression.cc
+++ b/src/core/Expression.cc
@@ -701,6 +701,7 @@ void Let::doSequentialAssignment(const AssignmentList& assignments, const Locati
     if (assignment->getName().empty()) {
       LOG(message_group::Warning, location, targetContext->documentRoot(), "Assignment without variable name %1$s", value.toEchoStringNoThrow());
     } else if (seen.find(assignment->getName()) != seen.end()) {
+      // TODO Should maybe quote the entire assignment with a new quoteExpr() or quoteStmt().
       LOG(message_group::Warning, location, targetContext->documentRoot(), "Ignoring duplicate variable assignment %1$s = %2$s", quoteVar(assignment->getName()), value.toEchoStringNoThrow());
     } else {
       targetContext->set_variable(assignment->getName(), std::move(value));

--- a/src/core/Parameters.cc
+++ b/src/core/Parameters.cc
@@ -90,12 +90,14 @@ bool Parameters::valid(const std::string& name, const Value& value,
   return false;
 }
 
+// Note:  unused, doesn't really work right because in some cases where the parameter
+// is not supplied, lookup() returns an existing Value with a value of undef.
 bool Parameters::valid_required(const std::string& name, Value::Type type)
 {
   boost::optional<const Value&> value = lookup(name);
   if (!value) {
     LOG(message_group::Warning, loc, documentRoot(),
-        "%1$s: missing argument \"%2$s\"", caller, name);
+        "%1$s: missing argument %2$s", caller, quoteVar(name));
     return false;
   }
   return valid(name, *value, type);
@@ -154,9 +156,9 @@ static ContextFrame parse_without_defaults(
     if (argument.name) {
       name = *argument.name;
       if (named_arguments.count(name)) {
-        LOG(message_group::Warning, loc, arguments.documentRoot(), "argument %1$s supplied more than once", name);
+        LOG(message_group::Warning, loc, arguments.documentRoot(), "argument %1$s supplied more than once", quoteVar(name));
       } else if (output.lookup_local_variable(name)) {
-        LOG(message_group::Warning, loc, arguments.documentRoot(), "argument %1$s overrides positional argument", name);
+        LOG(message_group::Warning, loc, arguments.documentRoot(), "argument %1$s overrides positional argument", quoteVar(name));
       } else if (warn_for_unexpected_arguments && !ContextFrame::is_config_variable(name)) {
         bool found = false;
         for (const auto& parameter : required_parameters) {
@@ -172,7 +174,7 @@ static ContextFrame parse_without_defaults(
           }
         }
         if (!found) {
-          LOG(message_group::Warning, loc, arguments.documentRoot(), "variable %1$s not specified as parameter", name);
+          LOG(message_group::Warning, loc, arguments.documentRoot(), "variable %1$s not specified as parameter", quoteVar(name));
         }
       }
       named_arguments.insert(name);

--- a/src/core/ScopeContext.cc
+++ b/src/core/ScopeContext.cc
@@ -59,17 +59,17 @@ void ScopeContext::init()
 {
   for (const auto& assignment : scope->assignments) {
     if (assignment->getExpr()->isLiteral() && lookup_local_variable(assignment->getName())) {
-      LOG(message_group::Warning, assignment->location(), this->documentRoot(), "Parameter %1$s is overwritten with a literal", assignment->getName());
+      LOG(message_group::Warning, assignment->location(), this->documentRoot(), "Parameter %1$s is overwritten with a literal", quoteVar(assignment->getName()));
     }
     try{
       set_variable(assignment->getName(), assignment->getExpr()->evaluate(get_shared_ptr()));
     } catch (EvaluationException& e) {
       if (e.traceDepth > 0) {
         if(assignment->locationOfOverwrite().isNone()){
-          LOG(message_group::Trace, assignment->location(), this->documentRoot(), "assignment to '%1$s'", assignment->getName());
+          LOG(message_group::Trace, assignment->location(), this->documentRoot(), "assignment to %1$s", quoteVar(assignment->getName()));
         } else {
-          LOG(message_group::Trace, assignment->location(), this->documentRoot(), "overwritten assignment to '%1$s' (this is where the assignment is evaluated)", assignment->getName());
-          LOG(message_group::Trace, assignment->locationOfOverwrite(), this->documentRoot(), "overwriting assignment to '%1$s'", assignment->getName());
+          LOG(message_group::Trace, assignment->location(), this->documentRoot(), "overwritten assignment to %1$s (this is where the assignment is evaluated)", quoteVar(assignment->getName()));
+          LOG(message_group::Trace, assignment->locationOfOverwrite(), this->documentRoot(), "overwriting assignment to %1$s", quoteVar(assignment->getName()));
         }
         e.traceDepth--;
       }

--- a/src/core/control.cc
+++ b/src/core/control.cc
@@ -191,6 +191,7 @@ static std::shared_ptr<AbstractNode> builtin_assign(const ModuleInstantiation *i
       LOG(message_group::Warning, inst->location(), context->documentRoot(), "Assignment without variable name %1$s", argument->toEchoStringNoThrow());
     } else {
       if (assignContext->lookup_local_variable(*argument.name)) {
+        // TODO Should maybe quote the entire assignment with a new quoteExpr() or quoteStmt().
         LOG(message_group::Warning, inst->location(), context->documentRoot(), "Duplicate variable assignment %1$s = %2$s", quoteVar(*argument.name), argument->toEchoStringNoThrow());
       }
       assignContext->set_variable(*argument.name, std::move(argument.value));

--- a/src/core/control.cc
+++ b/src/core/control.cc
@@ -191,7 +191,7 @@ static std::shared_ptr<AbstractNode> builtin_assign(const ModuleInstantiation *i
       LOG(message_group::Warning, inst->location(), context->documentRoot(), "Assignment without variable name %1$s", argument->toEchoStringNoThrow());
     } else {
       if (assignContext->lookup_local_variable(*argument.name)) {
-        LOG(message_group::Warning, inst->location(), context->documentRoot(), "Duplicate variable assignment %1$s = %2$s", *argument.name, argument->toEchoStringNoThrow());
+        LOG(message_group::Warning, inst->location(), context->documentRoot(), "Duplicate variable assignment %1$s = %2$s", quoteVar(*argument.name), argument->toEchoStringNoThrow());
       }
       assignContext->set_variable(*argument.name, std::move(argument.value));
     }

--- a/src/core/parser.y
+++ b/src/core/parser.y
@@ -703,7 +703,7 @@ static void warn_reassignment(const Location& loc, const std::shared_ptr<Assignm
 			loc,
 			path.parent_path().generic_string(),
 			"%1$s was assigned on line %2$i but was overwritten",
-			assignment->getName(),
+			quoteVar(assignment->getName()),
 			assignment->location().firstLine());
 
 }
@@ -714,7 +714,7 @@ static void warn_reassignment(const Location& loc, const std::shared_ptr<Assignm
 			loc,
 			path1.parent_path().generic_string(),
 			"%1$s was assigned on line %2$i of %3$s but was overwritten",
-			assignment->getName(),
+			quoteVar(assignment->getName()),
 			assignment->location().firstLine(),
 			path2);
 }

--- a/src/core/primitives.cc
+++ b/src/core/primitives.cc
@@ -81,7 +81,8 @@ static Value lookup_radius(const Parameters& parameters, const ModuleInstantiati
   if (d.type() == Value::Type::NUMBER) {
     if (r_defined) {
       LOG(message_group::Warning, inst->location(), parameters.documentRoot(),
-          "Ignoring radius variable '%1$s' as diameter '%2$s' is defined too.", radius_var, diameter_var);
+          "Ignoring radius variable %1$s as diameter %2$s is defined too.",
+          quoteVar(radius_var), quoteVar(diameter_var));
     }
     return d.toDouble() / 2.0;
   } else if (r_defined) {

--- a/src/utils/printutils.cc
+++ b/src/utils/printutils.cc
@@ -229,3 +229,9 @@ bool getGroupTextPlain(const enum message_group& group)
 {
   return group == message_group::NONE || group == message_group::Echo;
 }
+
+std::string
+quoteVar(const std::string& varname)
+{
+  return '"' + varname + '"';
+}

--- a/src/utils/printutils.h
+++ b/src/utils/printutils.h
@@ -46,6 +46,8 @@ inline const char *_(const char *msgid, const char *msgctxt) {
 }
 // NOLINTEND(bugprone-reserved-identifier)
 
+std::string quoteVar(const std::string& varname);
+
 enum class message_group {
   NONE, Error, Warning, UI_Warning, Font_Warning, Export_Warning, Export_Error, UI_Error, Parser_Error, Trace, Deprecated, Echo
 };

--- a/tests/regression/echotest/arg-permutations-expected.echo
+++ b/tests/regression/echotest/arg-permutations-expected.echo
@@ -10,7 +10,7 @@ ECHO: "2 args, 0 named"
 ECHO: "f(1,2)", [1, 2, "c"]
 ECHO: "2 args, 1 named"
 ECHO: "f(a=1,2)", [1, 2, "c"]
-WARNING: argument a overrides positional argument in file arg-permutations.scad, line 14
+WARNING: argument "a" overrides positional argument in file arg-permutations.scad, line 14
 ECHO: "f(2,a=1)", [1, "b", "c"]
 ECHO: "f(b=2,1)", [1, 2, "c"]
 ECHO: "f(1,b=2)", [1, 2, "c"]
@@ -24,46 +24,46 @@ ECHO: "f(c=3,a=1)", [1, "b", 3]
 ECHO: "f(b=2,c=3)", ["a", 2, 3]
 ECHO: "f(c=3,b=2)", ["a", 2, 3]
 ECHO: "2 args, duplicate naming"
-WARNING: argument a supplied more than once in file arg-permutations.scad, line 27
+WARNING: argument "a" supplied more than once in file arg-permutations.scad, line 27
 ECHO: "f(a=1,a=1)", [1, "b", "c"]
-WARNING: argument b supplied more than once in file arg-permutations.scad, line 28
+WARNING: argument "b" supplied more than once in file arg-permutations.scad, line 28
 ECHO: "f(b=2,b=2)", ["a", 2, "c"]
-WARNING: argument c supplied more than once in file arg-permutations.scad, line 29
+WARNING: argument "c" supplied more than once in file arg-permutations.scad, line 29
 ECHO: "f(c=3,c=3)", ["a", "b", 3]
 ECHO: "3 args, 0 named"
 ECHO: "f(1,2,3)", [1, 2, 3]
 ECHO: "3 args, 1 named"
 ECHO: "f(a=1,2,3)", [1, 2, 3]
-WARNING: argument a overrides positional argument in file arg-permutations.scad, line 34
+WARNING: argument "a" overrides positional argument in file arg-permutations.scad, line 34
 ECHO: "f(2,a=1,3)", [1, 3, "c"]
-WARNING: argument a overrides positional argument in file arg-permutations.scad, line 35
+WARNING: argument "a" overrides positional argument in file arg-permutations.scad, line 35
 ECHO: "f(2,3,a=1)", [1, 3, "c"]
 ECHO: "f(b=2,1,3)", [1, 2, 3]
 ECHO: "f(1,b=2,3)", [1, 2, 3]
-WARNING: argument b overrides positional argument in file arg-permutations.scad, line 38
+WARNING: argument "b" overrides positional argument in file arg-permutations.scad, line 38
 ECHO: "f(1,3,b=2)", [1, 2, "c"]
 ECHO: "f(c=3,1,2)", [1, 2, 3]
 ECHO: "f(1,c=3,2)", [1, 2, 3]
 ECHO: "f(1,2,c=3)", [1, 2, 3]
 ECHO: "3 args, 2 named"
 ECHO: "f(a=1,b=2,3)", [1, 2, 3]
-WARNING: argument b overrides positional argument in file arg-permutations.scad, line 44
+WARNING: argument "b" overrides positional argument in file arg-permutations.scad, line 44
 ECHO: "f(a=1,3,b=2)", [1, 2, "c"]
-WARNING: argument a overrides positional argument in file arg-permutations.scad, line 45
+WARNING: argument "a" overrides positional argument in file arg-permutations.scad, line 45
 ECHO: "f(3,a=1,b=2)", [1, 2, "c"]
 ECHO: "f(b=2,a=1,3)", [1, 2, 3]
-WARNING: argument a overrides positional argument in file arg-permutations.scad, line 47
+WARNING: argument "a" overrides positional argument in file arg-permutations.scad, line 47
 ECHO: "f(b=2,3,a=1)", [1, 2, "c"]
-WARNING: argument a overrides positional argument in file arg-permutations.scad, line 48
+WARNING: argument "a" overrides positional argument in file arg-permutations.scad, line 48
 ECHO: "f(3,b=2,a=1)", [1, 2, "c"]
 ECHO: "f(a=1,c=3,2)", [1, 2, 3]
 ECHO: "f(a=1,2,c=3)", [1, 2, 3]
-WARNING: argument a overrides positional argument in file arg-permutations.scad, line 51
+WARNING: argument "a" overrides positional argument in file arg-permutations.scad, line 51
 ECHO: "f(2,a=1,c=3)", [1, "b", 3]
 ECHO: "f(c=3,a=1,2)", [1, 2, 3]
-WARNING: argument a overrides positional argument in file arg-permutations.scad, line 53
+WARNING: argument "a" overrides positional argument in file arg-permutations.scad, line 53
 ECHO: "f(c=3,2,a=1)", [1, "b", 3]
-WARNING: argument a overrides positional argument in file arg-permutations.scad, line 54
+WARNING: argument "a" overrides positional argument in file arg-permutations.scad, line 54
 ECHO: "f(2,c=3,a=1)", [1, "b", 3]
 ECHO: "f(b=2,c=3,1)", [1, 2, 3]
 ECHO: "f(b=2,1,c=3)", [1, 2, 3]
@@ -79,29 +79,29 @@ ECHO: "f(b=2,c=3,a=1)", [1, 2, 3]
 ECHO: "f(c=3,a=1,b=2)", [1, 2, 3]
 ECHO: "f(c=3,b=2,a=1)", [1, 2, 3]
 ECHO: "3 args, duplicate naming"
-WARNING: argument a supplied more than once in file arg-permutations.scad, line 69
+WARNING: argument "a" supplied more than once in file arg-permutations.scad, line 69
 ECHO: "f(a=1,b=2,a=1)", [1, 2, "c"]
-WARNING: argument a supplied more than once in file arg-permutations.scad, line 70
+WARNING: argument "a" supplied more than once in file arg-permutations.scad, line 70
 ECHO: "f(a=1,a=1,b=2)", [1, 2, "c"]
-WARNING: argument b supplied more than once in file arg-permutations.scad, line 71
+WARNING: argument "b" supplied more than once in file arg-permutations.scad, line 71
 ECHO: "f(b=2,a=1,b=2)", [1, 2, "c"]
-WARNING: argument b supplied more than once in file arg-permutations.scad, line 72
+WARNING: argument "b" supplied more than once in file arg-permutations.scad, line 72
 ECHO: "f(b=2,b=2,a=1)", [1, 2, "c"]
-WARNING: argument a supplied more than once in file arg-permutations.scad, line 73
+WARNING: argument "a" supplied more than once in file arg-permutations.scad, line 73
 ECHO: "f(a=1,c=3,a=1)", [1, "b", 3]
-WARNING: argument a supplied more than once in file arg-permutations.scad, line 74
+WARNING: argument "a" supplied more than once in file arg-permutations.scad, line 74
 ECHO: "f(a=1,a=1,c=3)", [1, "b", 3]
-WARNING: argument c supplied more than once in file arg-permutations.scad, line 75
+WARNING: argument "c" supplied more than once in file arg-permutations.scad, line 75
 ECHO: "f(c=3,a=1,c=3)", [1, "b", 3]
-WARNING: argument c supplied more than once in file arg-permutations.scad, line 76
+WARNING: argument "c" supplied more than once in file arg-permutations.scad, line 76
 ECHO: "f(c=3,c=3,a=1)", [1, "b", 3]
-WARNING: argument b supplied more than once in file arg-permutations.scad, line 77
+WARNING: argument "b" supplied more than once in file arg-permutations.scad, line 77
 ECHO: "f(b=2,c=3,b=2)", ["a", 2, 3]
-WARNING: argument b supplied more than once in file arg-permutations.scad, line 78
+WARNING: argument "b" supplied more than once in file arg-permutations.scad, line 78
 ECHO: "f(b=2,b=2,c=3)", ["a", 2, 3]
-WARNING: argument c supplied more than once in file arg-permutations.scad, line 79
+WARNING: argument "c" supplied more than once in file arg-permutations.scad, line 79
 ECHO: "f(c=3,b=2,c=3)", ["a", 2, 3]
-WARNING: argument c supplied more than once in file arg-permutations.scad, line 80
+WARNING: argument "c" supplied more than once in file arg-permutations.scad, line 80
 ECHO: "f(c=3,c=3,b=2)", ["a", 2, 3]
 ECHO: "4 args (1 extra)"
 WARNING: Too many unnamed arguments supplied in file arg-permutations.scad, line 82
@@ -110,76 +110,76 @@ ECHO: "f($d=4,1,2,3)", [1, 2, 3]
 ECHO: "f(1,$d=4,2,3)", [1, 2, 3]
 ECHO: "f(1,2,$d=4,3)", [1, 2, 3]
 ECHO: "f(1,2,3,$d=4)", [1, 2, 3]
-WARNING: variable d not specified as parameter in file arg-permutations.scad, line 87
+WARNING: variable "d" not specified as parameter in file arg-permutations.scad, line 87
 ECHO: "f(d=4,1,2,3)", [1, 2, 3]
-WARNING: variable d not specified as parameter in file arg-permutations.scad, line 88
+WARNING: variable "d" not specified as parameter in file arg-permutations.scad, line 88
 ECHO: "f(1,d=4,2,3)", [1, 2, 3]
-WARNING: variable d not specified as parameter in file arg-permutations.scad, line 89
+WARNING: variable "d" not specified as parameter in file arg-permutations.scad, line 89
 ECHO: "f(1,2,d=4,3)", [1, 2, 3]
-WARNING: variable d not specified as parameter in file arg-permutations.scad, line 90
+WARNING: variable "d" not specified as parameter in file arg-permutations.scad, line 90
 ECHO: "f(1,2,3,d=4)", [1, 2, 3]
 ECHO: "f($d=4,a=1,b=2,c=3)", [1, 2, 3]
 ECHO: "f(a=1,$d=4,b=2,c=3)", [1, 2, 3]
 ECHO: "f(a=1,b=2,$d=4,c=3)", [1, 2, 3]
 ECHO: "f(a=1,b=2,c=3,$d=4)", [1, 2, 3]
-WARNING: variable d not specified as parameter in file arg-permutations.scad, line 95
+WARNING: variable "d" not specified as parameter in file arg-permutations.scad, line 95
 ECHO: "f(d=4,a=1,b=2,c=3)", [1, 2, 3]
-WARNING: variable d not specified as parameter in file arg-permutations.scad, line 96
+WARNING: variable "d" not specified as parameter in file arg-permutations.scad, line 96
 ECHO: "f(a=1,d=4,b=2,c=3)", [1, 2, 3]
-WARNING: variable d not specified as parameter in file arg-permutations.scad, line 97
+WARNING: variable "d" not specified as parameter in file arg-permutations.scad, line 97
 ECHO: "f(a=1,b=2,d=4,c=3)", [1, 2, 3]
-WARNING: variable d not specified as parameter in file arg-permutations.scad, line 98
+WARNING: variable "d" not specified as parameter in file arg-permutations.scad, line 98
 ECHO: "f(a=1,b=2,c=3,d=4)", [1, 2, 3]
 ECHO: "5 args (2 extra)"
 WARNING: Too many unnamed arguments supplied in file arg-permutations.scad, line 100
 ECHO: "f(1,2,3,4,5)", [1, 2, 3]
-WARNING: argument $d supplied more than once in file arg-permutations.scad, line 101
+WARNING: argument "$d" supplied more than once in file arg-permutations.scad, line 101
 ECHO: "f($d=4,$d=4,a=1,b=2,c=3)", [1, 2, 3]
-WARNING: argument $d supplied more than once in file arg-permutations.scad, line 102
+WARNING: argument "$d" supplied more than once in file arg-permutations.scad, line 102
 ECHO: "f($d=4,a=1,$d=4,b=2,c=3)", [1, 2, 3]
-WARNING: argument $d supplied more than once in file arg-permutations.scad, line 103
+WARNING: argument "$d" supplied more than once in file arg-permutations.scad, line 103
 ECHO: "f($d=4,a=1,b=2,$d=4,c=3)", [1, 2, 3]
-WARNING: argument $d supplied more than once in file arg-permutations.scad, line 104
+WARNING: argument "$d" supplied more than once in file arg-permutations.scad, line 104
 ECHO: "f($d=4,a=1,b=2,c=3,$d=4)", [1, 2, 3]
-WARNING: argument $d supplied more than once in file arg-permutations.scad, line 105
+WARNING: argument "$d" supplied more than once in file arg-permutations.scad, line 105
 ECHO: "f(a=1,$d=4,$d=4,b=2,c=3)", [1, 2, 3]
-WARNING: argument $d supplied more than once in file arg-permutations.scad, line 106
+WARNING: argument "$d" supplied more than once in file arg-permutations.scad, line 106
 ECHO: "f(a=1,$d=4,b=2,$d=4,c=3)", [1, 2, 3]
-WARNING: argument $d supplied more than once in file arg-permutations.scad, line 107
+WARNING: argument "$d" supplied more than once in file arg-permutations.scad, line 107
 ECHO: "f(a=1,$d=4,b=2,c=3,$d=4)", [1, 2, 3]
-WARNING: argument $d supplied more than once in file arg-permutations.scad, line 108
+WARNING: argument "$d" supplied more than once in file arg-permutations.scad, line 108
 ECHO: "f(a=1,b=2,$d=4,$d=4,c=3)", [1, 2, 3]
-WARNING: argument $d supplied more than once in file arg-permutations.scad, line 109
+WARNING: argument "$d" supplied more than once in file arg-permutations.scad, line 109
 ECHO: "f(a=1,b=2,$d=4,c=3,$d=4)", [1, 2, 3]
-WARNING: argument $d supplied more than once in file arg-permutations.scad, line 110
+WARNING: argument "$d" supplied more than once in file arg-permutations.scad, line 110
 ECHO: "f(a=1,b=2,c=3,$d=4,$d=4)", [1, 2, 3]
-WARNING: variable d not specified as parameter in file arg-permutations.scad, line 111
-WARNING: argument d supplied more than once in file arg-permutations.scad, line 111
+WARNING: variable "d" not specified as parameter in file arg-permutations.scad, line 111
+WARNING: argument "d" supplied more than once in file arg-permutations.scad, line 111
 ECHO: "f(d=4,d=4,a=1,b=2,c=3)", [1, 2, 3]
-WARNING: variable d not specified as parameter in file arg-permutations.scad, line 112
-WARNING: argument d supplied more than once in file arg-permutations.scad, line 112
+WARNING: variable "d" not specified as parameter in file arg-permutations.scad, line 112
+WARNING: argument "d" supplied more than once in file arg-permutations.scad, line 112
 ECHO: "f(d=4,a=1,d=4,b=2,c=3)", [1, 2, 3]
-WARNING: variable d not specified as parameter in file arg-permutations.scad, line 113
-WARNING: argument d supplied more than once in file arg-permutations.scad, line 113
+WARNING: variable "d" not specified as parameter in file arg-permutations.scad, line 113
+WARNING: argument "d" supplied more than once in file arg-permutations.scad, line 113
 ECHO: "f(d=4,a=1,b=2,d=4,c=3)", [1, 2, 3]
-WARNING: variable d not specified as parameter in file arg-permutations.scad, line 114
-WARNING: argument d supplied more than once in file arg-permutations.scad, line 114
+WARNING: variable "d" not specified as parameter in file arg-permutations.scad, line 114
+WARNING: argument "d" supplied more than once in file arg-permutations.scad, line 114
 ECHO: "f(d=4,a=1,b=2,c=3,d=4)", [1, 2, 3]
-WARNING: variable d not specified as parameter in file arg-permutations.scad, line 115
-WARNING: argument d supplied more than once in file arg-permutations.scad, line 115
+WARNING: variable "d" not specified as parameter in file arg-permutations.scad, line 115
+WARNING: argument "d" supplied more than once in file arg-permutations.scad, line 115
 ECHO: "f(a=1,d=4,d=4,b=2,c=3)", [1, 2, 3]
-WARNING: variable d not specified as parameter in file arg-permutations.scad, line 116
-WARNING: argument d supplied more than once in file arg-permutations.scad, line 116
+WARNING: variable "d" not specified as parameter in file arg-permutations.scad, line 116
+WARNING: argument "d" supplied more than once in file arg-permutations.scad, line 116
 ECHO: "f(a=1,d=4,b=2,d=4,c=3)", [1, 2, 3]
-WARNING: variable d not specified as parameter in file arg-permutations.scad, line 117
-WARNING: argument d supplied more than once in file arg-permutations.scad, line 117
+WARNING: variable "d" not specified as parameter in file arg-permutations.scad, line 117
+WARNING: argument "d" supplied more than once in file arg-permutations.scad, line 117
 ECHO: "f(a=1,d=4,b=2,c=3,d=4)", [1, 2, 3]
-WARNING: variable d not specified as parameter in file arg-permutations.scad, line 118
-WARNING: argument d supplied more than once in file arg-permutations.scad, line 118
+WARNING: variable "d" not specified as parameter in file arg-permutations.scad, line 118
+WARNING: argument "d" supplied more than once in file arg-permutations.scad, line 118
 ECHO: "f(a=1,b=2,d=4,d=4,c=3)", [1, 2, 3]
-WARNING: variable d not specified as parameter in file arg-permutations.scad, line 119
-WARNING: argument d supplied more than once in file arg-permutations.scad, line 119
+WARNING: variable "d" not specified as parameter in file arg-permutations.scad, line 119
+WARNING: argument "d" supplied more than once in file arg-permutations.scad, line 119
 ECHO: "f(a=1,b=2,d=4,c=3,d=4)", [1, 2, 3]
-WARNING: variable d not specified as parameter in file arg-permutations.scad, line 120
-WARNING: argument d supplied more than once in file arg-permutations.scad, line 120
+WARNING: variable "d" not specified as parameter in file arg-permutations.scad, line 120
+WARNING: argument "d" supplied more than once in file arg-permutations.scad, line 120
 ECHO: "f(a=1,b=2,c=3,d=4,d=4)", [1, 2, 3]

--- a/tests/regression/echotest/assert-expression-fail1-test-expected.echo
+++ b/tests/regression/echotest/assert-expression-fail1-test-expected.echo
@@ -1,2 +1,2 @@
 ERROR: Assertion 'false' failed in file assert-expression-fail1-test.scad, line 1
-TRACE: assignment to 'v' in file assert-expression-fail1-test.scad, line 1
+TRACE: assignment to "v" in file assert-expression-fail1-test.scad, line 1

--- a/tests/regression/echotest/assert-expression-fail2-test-expected.echo
+++ b/tests/regression/echotest/assert-expression-fail2-test-expected.echo
@@ -1,2 +1,2 @@
 ERROR: Assertion '((a < 20) && (b < 20))' failed: "Test! <html>&</html>" in file assert-expression-fail2-test.scad, line 3
-TRACE: assignment to 'v' in file assert-expression-fail2-test.scad, line 3
+TRACE: assignment to "v" in file assert-expression-fail2-test.scad, line 3

--- a/tests/regression/echotest/assert-expression-fail3-test-expected.echo
+++ b/tests/regression/echotest/assert-expression-fail3-test-expected.echo
@@ -1,3 +1,3 @@
 ERROR: Assertion '(f(angle) > 0)' failed in file assert-expression-fail3-test.scad, line 4
-TRACE: assignment to 'v' in file assert-expression-fail3-test.scad, line 4
+TRACE: assignment to "v" in file assert-expression-fail3-test.scad, line 4
 TRACE: called by 'm' in file assert-expression-fail3-test.scad, line 7

--- a/tests/regression/echotest/errors-warnings-expected.echo
+++ b/tests/regression/echotest/errors-warnings-expected.echo
@@ -3,23 +3,23 @@ WARNING: dxf_cross(..., origin=[inf, nan]) could not be converted in file errors
 WARNING: Can't open DXF file 'doesNotExist.dxf'! in file errors-warnings.scad, line 71
 WARNING: dxf_dim(..., origin=[1, 2, 3]) could not be converted in file errors-warnings.scad, line 76
 WARNING: Can't open DXF file 'doesNotExist.dxf'! in file errors-warnings.scad, line 76
-WARNING: variable notSupported not specified as parameter in file errors-warnings.scad, line 84
+WARNING: variable "notSupported" not specified as parameter in file errors-warnings.scad, line 84
 WARNING: dxf_cross(..., origin=[inf, 0]) could not be converted in file errors-warnings.scad, line 84
 WARNING: Can't find cross in 'dim-all.dxf', layer 'SCAD.Origin'! in file errors-warnings.scad, line 84
-WARNING: variable notSupported not specified as parameter in file errors-warnings.scad, line 90
+WARNING: variable "notSupported" not specified as parameter in file errors-warnings.scad, line 90
 WARNING: Can't find dimension 'TotalWidth' in 'dim-all.dxf', layer 'SCAD.Origin'! in file errors-warnings.scad, line 90
-WARNING: Ignoring unknown variable 'a' in file errors-warnings.scad, line 1
+WARNING: Ignoring unknown variable "a" in file errors-warnings.scad, line 1
 ECHO: undef
 ERROR: Unable to convert points[3] = [30] to a vec2 of numbers in file errors-warnings.scad, line 3
 ERROR: Unable to convert points[4] = [0] to a vec3 of numbers in file errors-warnings.scad, line 5
 WARNING: Unable to convert import(..., origin="string") parameter to vec2 in file errors-warnings.scad, line 15
 WARNING: Ignoring unknown module 'hello' in file errors-warnings.scad, line 17
-WARNING: Ignoring radius variable 'r' as diameter 'd' is defined too. in file errors-warnings.scad, line 21
-WARNING: Ignoring radius variable 'r1' as diameter 'd1' is defined too. in file errors-warnings.scad, line 22
+WARNING: Ignoring radius variable "r" as diameter "d" is defined too. in file errors-warnings.scad, line 21
+WARNING: Ignoring radius variable "r1" as diameter "d1" is defined too. in file errors-warnings.scad, line 22
 WARNING: Problem converting rotate(a=inf) parameter in file errors-warnings.scad, line 24
 WARNING: Problem converting rotate(a=[inf, inf]) parameter in file errors-warnings.scad, line 25
 WARNING: Problem converting rotate(a=nan) parameter in file errors-warnings.scad, line 26
-WARNING: variable rad not specified as parameter in file errors-warnings.scad, line 29
+WARNING: variable "rad" not specified as parameter in file errors-warnings.scad, line 29
 WARNING: Too many unnamed arguments supplied in file errors-warnings.scad, line 31
 WARNING: Cylinder parameters ambiguous in file errors-warnings.scad, line 33
 WARNING: Cylinder parameters ambiguous in file errors-warnings.scad, line 34
@@ -33,8 +33,8 @@ WARNING: $fs too small - clamping to 0.010000 in file errors-warnings.scad, line
 WARNING: $fa too small - clamping to 0.010000 in file errors-warnings.scad, line 47
 WARNING: $fs too small - clamping to 0.010000 in file errors-warnings.scad, line 54
 WARNING: $fa too small - clamping to 0.010000 in file errors-warnings.scad, line 55
-WARNING: argument center supplied more than once in file errors-warnings.scad, line 58
-WARNING: argument r supplied more than once in file errors-warnings.scad, line 59
+WARNING: argument "center" supplied more than once in file errors-warnings.scad, line 58
+WARNING: argument "r" supplied more than once in file errors-warnings.scad, line 59
 ECHO: 10
 ECHO: 15
 ECHO: 20

--- a/tests/regression/echotest/errors-warnings-included-expected.echo
+++ b/tests/regression/echotest/errors-warnings-included-expected.echo
@@ -3,24 +3,24 @@ WARNING: dxf_cross(..., origin=[inf, nan]) could not be converted in file errors
 WARNING: Can't open DXF file 'doesNotExist.dxf'! in file errors-warnings.scad, line 71
 WARNING: dxf_dim(..., origin=[1, 2, 3]) could not be converted in file errors-warnings.scad, line 76
 WARNING: Can't open DXF file 'doesNotExist.dxf'! in file errors-warnings.scad, line 76
-WARNING: variable notSupported not specified as parameter in file errors-warnings.scad, line 84
+WARNING: variable "notSupported" not specified as parameter in file errors-warnings.scad, line 84
 WARNING: dxf_cross(..., origin=[inf, 0]) could not be converted in file errors-warnings.scad, line 84
 WARNING: Can't find cross in 'dim-all.dxf', layer 'SCAD.Origin'! in file errors-warnings.scad, line 84
-WARNING: variable notSupported not specified as parameter in file errors-warnings.scad, line 90
+WARNING: variable "notSupported" not specified as parameter in file errors-warnings.scad, line 90
 WARNING: Can't find dimension 'TotalWidth' in 'dim-all.dxf', layer 'SCAD.Origin'! in file errors-warnings.scad, line 90
 ECHO: "include"
-WARNING: Ignoring unknown variable 'a' in file errors-warnings.scad, line 1
+WARNING: Ignoring unknown variable "a" in file errors-warnings.scad, line 1
 ECHO: undef
 ERROR: Unable to convert points[3] = [30] to a vec2 of numbers in file errors-warnings.scad, line 3
 ERROR: Unable to convert points[4] = [0] to a vec3 of numbers in file errors-warnings.scad, line 5
 WARNING: Unable to convert import(..., origin="string") parameter to vec2 in file errors-warnings.scad, line 15
 WARNING: Ignoring unknown module 'hello' in file errors-warnings.scad, line 17
-WARNING: Ignoring radius variable 'r' as diameter 'd' is defined too. in file errors-warnings.scad, line 21
-WARNING: Ignoring radius variable 'r1' as diameter 'd1' is defined too. in file errors-warnings.scad, line 22
+WARNING: Ignoring radius variable "r" as diameter "d" is defined too. in file errors-warnings.scad, line 21
+WARNING: Ignoring radius variable "r1" as diameter "d1" is defined too. in file errors-warnings.scad, line 22
 WARNING: Problem converting rotate(a=inf) parameter in file errors-warnings.scad, line 24
 WARNING: Problem converting rotate(a=[inf, inf]) parameter in file errors-warnings.scad, line 25
 WARNING: Problem converting rotate(a=nan) parameter in file errors-warnings.scad, line 26
-WARNING: variable rad not specified as parameter in file errors-warnings.scad, line 29
+WARNING: variable "rad" not specified as parameter in file errors-warnings.scad, line 29
 WARNING: Too many unnamed arguments supplied in file errors-warnings.scad, line 31
 WARNING: Cylinder parameters ambiguous in file errors-warnings.scad, line 33
 WARNING: Cylinder parameters ambiguous in file errors-warnings.scad, line 34
@@ -34,8 +34,8 @@ WARNING: $fs too small - clamping to 0.010000 in file errors-warnings.scad, line
 WARNING: $fa too small - clamping to 0.010000 in file errors-warnings.scad, line 47
 WARNING: $fs too small - clamping to 0.010000 in file errors-warnings.scad, line 54
 WARNING: $fa too small - clamping to 0.010000 in file errors-warnings.scad, line 55
-WARNING: argument center supplied more than once in file errors-warnings.scad, line 58
-WARNING: argument r supplied more than once in file errors-warnings.scad, line 59
+WARNING: argument "center" supplied more than once in file errors-warnings.scad, line 58
+WARNING: argument "r" supplied more than once in file errors-warnings.scad, line 59
 ECHO: 10
 ECHO: 15
 ECHO: 20
@@ -94,18 +94,18 @@ ECHO: "diff=", 0, ", i==5000"
 ECHO: "[0:1] difference from 1"
 ECHO: "diff=", 0, ", i==1"
 ECHO: "mainfile"
-WARNING: Ignoring unknown variable 'notDefinedVariable' in file errors-warnings-included.scad, line 5
+WARNING: Ignoring unknown variable "notDefinedVariable" in file errors-warnings-included.scad, line 5
 ECHO: undef
 ECHO: "use"
-WARNING: Ignoring unknown variable 'a' in file errors-warnings-use.scad, line 2
+WARNING: Ignoring unknown variable "a" in file errors-warnings-use.scad, line 2
 ECHO: undef
 ERROR: Unable to convert points[3] = [30] to a vec2 of numbers in file errors-warnings-use.scad, line 3
 WARNING: Ignoring unknown module 'unknown' in file sub2/useuse.scad, line 3
-WARNING: Ignoring unknown variable 'a' in file errors-warnings-use.scad, line 2
+WARNING: Ignoring unknown variable "a" in file errors-warnings-use.scad, line 2
 ECHO: undef
 ERROR: Unable to convert points[3] = [30] to a vec2 of numbers in file errors-warnings-use.scad, line 3
 WARNING: Ignoring unknown module 'unknownIncuse' in file sub2/incuse.scad, line 2
-WARNING: Ignoring unknown variable 'xyz' in file sub1/errors-warnings-incuse.scad, line 2
+WARNING: Ignoring unknown variable "xyz" in file sub1/errors-warnings-incuse.scad, line 2
 ECHO: undef
 WARNING: Ignoring unknown function 'test' in file sub1/errors-warnings-incuse.scad, line 3
 WARNING: Unable to convert $vpr="[1,2,3]" to a vec3 or vec2 of numbers

--- a/tests/regression/echotest/function-scope-expected.echo
+++ b/tests/regression/echotest/function-scope-expected.echo
@@ -1,5 +1,5 @@
 ECHO: duplicate_let = 33
 ECHO: defaults = 42
-WARNING: Ignoring unknown variable 'x' in file function-scope.scad, line 10
+WARNING: Ignoring unknown variable "x" in file function-scope.scad, line 10
 ECHO: scope_leak = undef
 ECHO: scope_leak_config = 42

--- a/tests/regression/echotest/include-overwrite-main-expected.echo
+++ b/tests/regression/echotest/include-overwrite-main-expected.echo
@@ -1,6 +1,6 @@
-WARNING: overwritten was assigned on line 12 but was overwritten in file include-overwrite-main.scad, line 16
-WARNING: after was assigned on line 15 of "include-overwrite-main.scad" but was overwritten in file include-overwrite-after.scad, line 2
-WARNING: overwriteInuse was assigned on line 1 of "include-overwrite-use.scad" but was overwritten in file include-overwrite-use.scad, line 2
+WARNING: "overwritten" was assigned on line 12 but was overwritten in file include-overwrite-main.scad, line 16
+WARNING: "after" was assigned on line 15 of "include-overwrite-main.scad" but was overwritten in file include-overwrite-after.scad, line 2
+WARNING: "overwriteInuse" was assigned on line 1 of "include-overwrite-use.scad" but was overwritten in file include-overwrite-use.scad, line 2
 ECHO: "Can a variable be used when it assigned later? true"
 ECHO: "Is overwriting possible? true"
 ECHO: "Does an include before the assignment take priority? false"

--- a/tests/regression/echotest/include-overwrite-main2-expected.echo
+++ b/tests/regression/echotest/include-overwrite-main2-expected.echo
@@ -1,4 +1,4 @@
-WARNING: Ignoring unknown variable 'overwriteTrue' in file include-overwrite-main2.scad, line 16
+WARNING: Ignoring unknown variable "overwriteTrue" in file include-overwrite-main2.scad, line 16
 ECHO: "after"
 ECHO: after = false
 ECHO: "before"

--- a/tests/regression/echotest/isundef-test-expected.echo
+++ b/tests/regression/echotest/isundef-test-expected.echo
@@ -2,7 +2,7 @@ ECHO: "Normal variables"
 ECHO: true
 ECHO: false
 ECHO: true
-WARNING: Ignoring unknown variable 'a' in file isundef-test.scad, line 8
+WARNING: Ignoring unknown variable "a" in file isundef-test.scad, line 8
 ECHO: undef
 ECHO: "hallo"
 ECHO: undef
@@ -11,13 +11,13 @@ ECHO: false
 ECHO: true
 ECHO: true
 ECHO: true
-WARNING: Ignoring unknown variable 'd' in file isundef-test.scad, line 21
+WARNING: Ignoring unknown variable "d" in file isundef-test.scad, line 21
 ECHO: undef
 ECHO: "Special variables"
 ECHO: true
 ECHO: false
 ECHO: true
-WARNING: Ignoring unknown variable '$a' in file isundef-test.scad, line 30
+WARNING: Ignoring unknown variable "$a" in file isundef-test.scad, line 30
 ECHO: undef
 ECHO: 132465
 ECHO: undef

--- a/tests/regression/echotest/let-tests-expected.echo
+++ b/tests/regression/echotest/let-tests-expected.echo
@@ -3,12 +3,12 @@ ECHO: 6
 ECHO: 6
 ECHO: 2
 ECHO: 3
-WARNING: Ignoring duplicate variable assignment $a = 4 in file let-tests.scad, line 9
+WARNING: Ignoring duplicate variable assignment "$a" = 4 in file let-tests.scad, line 9
 ECHO: 6
-WARNING: Ignoring duplicate variable assignment b = 5 in file let-tests.scad, line 10
+WARNING: Ignoring duplicate variable assignment "b" = 5 in file let-tests.scad, line 10
 ECHO: 6
-WARNING: Ignoring duplicate variable assignment $a = 4 in file let-tests.scad, line 11
-WARNING: Ignoring duplicate variable assignment b = 5 in file let-tests.scad, line 11
+WARNING: Ignoring duplicate variable assignment "$a" = 4 in file let-tests.scad, line 11
+WARNING: Ignoring duplicate variable assignment "b" = 5 in file let-tests.scad, line 11
 ECHO: 6
 ECHO: 12
 ECHO: 6

--- a/tests/regression/echotest/localfiles-compatibility-test-expected.echo
+++ b/tests/regression/echotest/localfiles-compatibility-test-expected.echo
@@ -1,3 +1,3 @@
-WARNING: variable h not specified as parameter in file localfiles_subdir/localfiles_submodule.scad, line 3
+WARNING: variable "h" not specified as parameter in file localfiles_subdir/localfiles_submodule.scad, line 3
 DEPRECATED: Imported file (localfile.dxf) found in document root instead of relative to the importing module. This behavior is deprecated
 DEPRECATED: Imported file (localfile.dat) found in document root instead of relative to the importing module. This behavior is deprecated

--- a/tests/regression/echotest/localfiles-test-expected.echo
+++ b/tests/regression/echotest/localfiles-test-expected.echo
@@ -1,1 +1,1 @@
-WARNING: variable h not specified as parameter in file localfiles_dir/localfiles_module.scad, line 3
+WARNING: variable "h" not specified as parameter in file localfiles_dir/localfiles_module.scad, line 3

--- a/tests/regression/echotest/norm-tests-expected.echo
+++ b/tests/regression/echotest/norm-tests-expected.echo
@@ -30,7 +30,7 @@ WARNING: norm() parameter could not be converted: argument 0: expected vector, f
 ECHO: undef
 WARNING: norm() number of parameters does not match: expected 1, found 2 in file norm-tests.scad, line 26
 ECHO: undef
-WARNING: Ignoring unknown variable 'a' in file norm-tests.scad, line 27
-WARNING: Ignoring unknown variable 'a' in file norm-tests.scad, line 27
+WARNING: Ignoring unknown variable "a" in file norm-tests.scad, line 27
+WARNING: Ignoring unknown variable "a" in file norm-tests.scad, line 27
 WARNING: norm() number of parameters does not match: expected 1, found 2 in file norm-tests.scad, line 27
 ECHO: undef

--- a/tests/regression/echotest/rands-expected.echo
+++ b/tests/regression/echotest/rands-expected.echo
@@ -4,9 +4,9 @@ WARNING: rands() number of parameters does not match: expected 3 or 4, found 2 i
 WARNING: rands() number of parameters does not match: expected 3 or 4, found 2 in file rands.scad, line 25
 WARNING: rands() number of parameters does not match: expected 3 or 4, found 1 in file rands.scad, line 26
 WARNING: rands() number of parameters does not match: expected 3 or 4, found 0 in file rands.scad, line 27
-WARNING: Ignoring unknown variable 'v' in file rands.scad, line 28
-WARNING: Ignoring unknown variable 'v' in file rands.scad, line 28
-WARNING: Ignoring unknown variable 'v' in file rands.scad, line 28
+WARNING: Ignoring unknown variable "v" in file rands.scad, line 28
+WARNING: Ignoring unknown variable "v" in file rands.scad, line 28
+WARNING: Ignoring unknown variable "v" in file rands.scad, line 28
 WARNING: rands() parameter could not be converted: argument 0: expected number, found undefined (undef) in file rands.scad, line 28
 ECHO: "i hope rands() did not crash"
 ECHO: [1, 1, 1, 1]

--- a/tests/regression/echotest/recursion-test-function2-expected.echo
+++ b/tests/regression/echotest/recursion-test-function2-expected.echo
@@ -1,3 +1,3 @@
 ERROR: Recursion detected calling function 'crash' in file recursion-test-function2.scad, line 2
 TRACE: called by 'crash' in file recursion-test-function2.scad, line 2
-TRACE: assignment to 'a' in file recursion-test-function2.scad, line 3
+TRACE: assignment to "a" in file recursion-test-function2.scad, line 3

--- a/tests/regression/echotest/scope-assignment-tests-expected.echo
+++ b/tests/regression/echotest/scope-assignment-tests-expected.echo
@@ -1,19 +1,19 @@
-WARNING: e was assigned on line 49 but was overwritten in file scope-assignment-tests.scad, line 52
-WARNING: f was assigned on line 58 but was overwritten in file scope-assignment-tests.scad, line 61
-WARNING: g was assigned on line 67 but was overwritten in file scope-assignment-tests.scad, line 69
-WARNING: h was assigned on line 73 but was overwritten in file scope-assignment-tests.scad, line 75
-WARNING: Ignoring unknown variable 'h' in file scope-assignment-tests.scad, line 75
+WARNING: "e" was assigned on line 49 but was overwritten in file scope-assignment-tests.scad, line 52
+WARNING: "f" was assigned on line 58 but was overwritten in file scope-assignment-tests.scad, line 61
+WARNING: "g" was assigned on line 67 but was overwritten in file scope-assignment-tests.scad, line 69
+WARNING: "h" was assigned on line 73 but was overwritten in file scope-assignment-tests.scad, line 75
+WARNING: Ignoring unknown variable "h" in file scope-assignment-tests.scad, line 75
 WARNING: undefined operation (undefined * number) in file scope-assignment-tests.scad, line 75
 ECHO: "union scope"
 ECHO: "local a (5):", 5
 ECHO: "global a (4):", 4
 ECHO: "module scope:"
-WARNING: Parameter b is overwritten with a literal in file scope-assignment-tests.scad, line 12
+WARNING: Parameter "b" is overwritten with a literal in file scope-assignment-tests.scad, line 12
 ECHO: "local b (7)", 7
-WARNING: Parameter b is overwritten with a literal in file scope-assignment-tests.scad, line 12
+WARNING: Parameter "b" is overwritten with a literal in file scope-assignment-tests.scad, line 12
 ECHO: "local b (7)", 7
 ECHO: "module children scope:"
-WARNING: Parameter b2 is overwritten with a literal in file scope-assignment-tests.scad, line 20
+WARNING: Parameter "b2" is overwritten with a literal in file scope-assignment-tests.scad, line 20
 ECHO: "b2 (3)", 3
 ECHO: "for loop (c = 0,1,25):"
 ECHO: "c", 0

--- a/tests/regression/echotest/search-tests-expected.echo
+++ b/tests/regression/echotest/search-tests-expected.echo
@@ -1,4 +1,4 @@
-WARNING: vTable1 was assigned on line 29 but was overwritten in file search-tests.scad, line 32
+WARNING: "vTable1" was assigned on line 29 but was overwritten in file search-tests.scad, line 32
 ECHO: "Characters in string ("a"): [0]"
 ECHO: "Characters in string ("adeq"): [[0, 5], [3, 8], [4], []]"
 ECHO: "Default string search ("abe"): [0, 1, 8]"

--- a/tests/regression/echotest/special-consts-expected.echo
+++ b/tests/regression/echotest/special-consts-expected.echo
@@ -3,19 +3,19 @@ ECHO: "undef is undef"
 ECHO: "a is undef"
 ECHO: "undef is a"
 ECHO: "a is b"
-WARNING: Ignoring unknown variable 'c' in file special-consts.scad, line 21
+WARNING: Ignoring unknown variable "c" in file special-consts.scad, line 21
 ECHO: "c is undef"
-WARNING: Ignoring unknown variable 'c' in file special-consts.scad, line 25
+WARNING: Ignoring unknown variable "c" in file special-consts.scad, line 25
 ECHO: "undef is c"
-WARNING: Ignoring unknown variable '$customSpecialVariable' in file special-consts.scad, line 29
+WARNING: Ignoring unknown variable "$customSpecialVariable" in file special-consts.scad, line 29
 ECHO: "$customSpecialVariable is undef"
 ECHO: "-- comparing undef --"
 ECHO: "undef evaluates false"
-WARNING: Ignoring unknown variable 'c' in file special-consts.scad, line 40
+WARNING: Ignoring unknown variable "c" in file special-consts.scad, line 40
 ECHO: "undef evaluates false"
 ECHO: "-- echo undef --"
 ECHO: undef
-WARNING: Ignoring unknown variable 'c' in file special-consts.scad, line 44
+WARNING: Ignoring unknown variable "c" in file special-consts.scad, line 44
 ECHO: undef
 ECHO: "-- calculating with undef --"
 WARNING: undefined operation (undefined / number) in file special-consts.scad, line 47

--- a/tests/regression/echotest/text-metrics-test-expected.echo
+++ b/tests/regression/echotest/text-metrics-test-expected.echo
@@ -14,7 +14,7 @@ WARNING: textmetrics(..., script=0) Invalid type: expected string, found number 
 WARNING: textmetrics(..., halign=0) Invalid type: expected string, found number in file text-metrics-test.scad, line 20
 WARNING: textmetrics(..., valign=0) Invalid type: expected string, found number in file text-metrics-test.scad, line 20
 ECHO: { position = [0, 0]; size = [0, 0]; ascent = 0; descent = 0; offset = [0, 0]; advance = [0, 0]; }
-WARNING: variable text not specified as parameter in file text-metrics-test.scad, line 25
+WARNING: variable "text" not specified as parameter in file text-metrics-test.scad, line 25
 WARNING: fontmetrics(..., size=true) Invalid type: expected number, found bool in file text-metrics-test.scad, line 25
 WARNING: fontmetrics(..., font=0) Invalid type: expected string, found number in file text-metrics-test.scad, line 25
 ECHO: { nominal = { ascent = 12.5733; descent = -2.9433; }; max = { ascent = 13.6109; descent = -4.2114; }; interline = 15.9709; font = { family = "Liberation Sans"; style = "Regular"; }; }

--- a/tests/regression/echotest/use-tests-expected.echo
+++ b/tests/regression/echotest/use-tests-expected.echo
@@ -4,4 +4,4 @@ WARNING: Can't open library 'test/'. in file ../../tests/data/scad/misc/use-test
 WARNING: Can't open library '/'. in file ../../tests/data/scad/misc/use-tests.scad, line 23
 WARNING: Ignoring unknown module 'test3' in file use-tests.scad, line 42
 WARNING: Ignoring unknown module 'test4' in file use-tests.scad, line 43
-WARNING: Ignoring unknown variable 'test2_variable' in file use-tests.scad, line 49
+WARNING: Ignoring unknown variable "test2_variable" in file use-tests.scad, line 49

--- a/tests/regression/echotest/value-reassignment-tests-expected.echo
+++ b/tests/regression/echotest/value-reassignment-tests-expected.echo
@@ -1,4 +1,4 @@
-WARNING: myval was assigned on line 5 but was overwritten in file value-reassignment-tests.scad, line 7
-WARNING: Ignoring unknown variable 'i' in file value-reassignment-tests.scad, line 7
+WARNING: "myval" was assigned on line 5 but was overwritten in file value-reassignment-tests.scad, line 7
+WARNING: Ignoring unknown variable "i" in file value-reassignment-tests.scad, line 7
 WARNING: undefined operation (undefined * number) in file value-reassignment-tests.scad, line 7
 ECHO: undef, 2

--- a/tests/regression/echotest/value-reassignment-tests2-expected.echo
+++ b/tests/regression/echotest/value-reassignment-tests2-expected.echo
@@ -1,2 +1,2 @@
-WARNING: myval was assigned on line 5 but was overwritten in file value-reassignment-tests2.scad, line 7
+WARNING: "myval" was assigned on line 5 but was overwritten in file value-reassignment-tests2.scad, line 7
 ECHO: 3, 3

--- a/tests/regression/echotest/variable-overwrite-expected.echo
+++ b/tests/regression/echotest/variable-overwrite-expected.echo
@@ -1,5 +1,5 @@
-WARNING: a was assigned on line 2 but was overwritten in file variable-overwrite.scad, line 4
-WARNING: Ignoring unknown variable 'b' in file variable-overwrite.scad, line 4
+WARNING: "a" was assigned on line 2 but was overwritten in file variable-overwrite.scad, line 4
+WARNING: Ignoring unknown variable "b" in file variable-overwrite.scad, line 4
 ERROR: Assertion 'b' failed in file variable-overwrite.scad, line 4
-TRACE: overwritten assignment to 'a' (this is where the assignment is evaluated) in file variable-overwrite.scad, line 2
-TRACE: overwriting assignment to 'a' in file variable-overwrite.scad, line 4
+TRACE: overwritten assignment to "a" (this is where the assignment is evaluated) in file variable-overwrite.scad, line 2
+TRACE: overwriting assignment to "a" in file variable-overwrite.scad, line 4

--- a/tests/regression/echotest/variable-scope-tests-expected.echo
+++ b/tests/regression/echotest/variable-scope-tests-expected.echo
@@ -1,6 +1,6 @@
 ECHO: "special variable inheritance"
 ECHO: 23, 5
-WARNING: Ignoring unknown variable 'a' in file variable-scope-tests.scad, line 8
+WARNING: Ignoring unknown variable "a" in file variable-scope-tests.scad, line 8
 ECHO: undef
 ECHO: 23, 5
 ECHO: "$children scope"
@@ -13,18 +13,18 @@ ECHO: "child_module_2 child 1"
 ECHO: "copy $children"
 ECHO: "copy_children_module: ", 2, 2
 ECHO: "inner variables shadows parameter"
-WARNING: Parameter b is overwritten with a literal in file variable-scope-tests.scad, line 45
+WARNING: Parameter "b" is overwritten with a literal in file variable-scope-tests.scad, line 45
 ECHO: 5, 24
 ECHO: "user-defined special variables as parameter"
 ECHO: 7
 ECHO: 7
 ECHO: "assign only visible in children's scope"
 DEPRECATED: The assign() module will be removed in future releases. Use a regular assignment instead. in file variable-scope-tests.scad, line 72
-WARNING: Ignoring unknown variable 'c' in file variable-scope-tests.scad, line 65
+WARNING: Ignoring unknown variable "c" in file variable-scope-tests.scad, line 65
 ECHO: undef
 ECHO: 5
 ECHO: "undeclared variable can still be passed and used"
-WARNING: variable d not specified as parameter in file variable-scope-tests.scad, line 81
+WARNING: variable "d" not specified as parameter in file variable-scope-tests.scad, line 81
 ECHO: 6
 ECHO: "attempt to assign from a not-yet-defined variable which also exists globally"
 ECHO: 5, 1


### PR DESCRIPTION
Add a new function `qVariable(name)` that returns the name appropriately wrapped in quote markup.  The current implementation of `qVariable()` wraps the name in double quotes, but could be changed to single quotes, angle brackets, et cetera.

Similar efforts might be appropriate for module names, function names, file names, enumerated constants (like halign/valign).  One step at a time.  (For one thing, it's less obvious what the right quoting is for modules and functions.  Should they get quotes, or parentheses (`foo()`), or words (`module foo`), or something else?)

Note that although this addresses the top-line comment in #2833, it doesn't address secondary comments (quoting file names, "UI-ERROR".  If this PR is accepted, I'll split those into a new issue.