### PR TITLE
Parameter aliases in linear_extrude, rotate_extrude.  Fixes #1609.

### DIFF
--- a/src/core/LinearExtrudeNode.cc
+++ b/src/core/LinearExtrudeNode.cc
@@ -67,19 +67,6 @@ std::shared_ptr<AbstractNode> builtin_linear_extrude(const ModuleInstantiation *
     }
     height = 1.0;
   }
-#if 0
-  if (parameters["height"].isDefined() && parameters["h"].isDefined()) {
-      LOG(message_group::Error, "Don't specify both %1$s and %2$s.",
-          quoteVar("height"), quoteVar("h"));
-  }
-  if (parameters["height"].isDefined() || parameters["h"].isDefined()) {
-    if(!parameters["height"].getFiniteDouble(height) && !parameters["h"].getFiniteDouble(height)) {
-      LOG(message_group::Error, "height when specified should be a number.");
-      height = 100.0;
-    }
-    node->height.normalize();
-  }
-#else
   const Value& heightValue = parameters[{"height", "h"}];
   if (heightValue.isDefined()) {
     if (!heightValue.getFiniteDouble(height)) {
@@ -88,7 +75,6 @@ std::shared_ptr<AbstractNode> builtin_linear_extrude(const ModuleInstantiation *
     }
     node->height.normalize();
   }
-#endif
   node->height *= height;
 
   parameters["convexity"].getPositiveInt(node->convexity);

--- a/src/core/LinearExtrudeNode.h
+++ b/src/core/LinearExtrudeNode.h
@@ -15,7 +15,7 @@ public:
   std::string toString() const override;
   std::string name() const override { return "linear_extrude"; }
 
-  Vector3d height=Vector3d(0, 0, 100);
+  Vector3d height=Vector3d(0, 0, 1);
   double fn = 0.0, fs = 0.0, fa = 0.0;
   double scale_x = 1.0, scale_y = 1.0;
   double twist = 0.0;

--- a/src/core/Parameters.cc
+++ b/src/core/Parameters.cc
@@ -67,6 +67,30 @@ const Value& Parameters::get(const std::string& name) const
   return *value;
 }
 
+const Value& Parameters::get(const std::initializer_list<std::string> names) const
+{
+  std::string match;
+  for (std::string name: names) {
+    boost::optional<const Value&> value = lookup(name);
+    if (value && value->isDefined()) {
+      if (match.empty()) {
+        match = name;
+      } else {
+        LOG(message_group::Error, loc, documentRoot(),
+            "Specified both %1$s and %2$s", quoteVar(match), quoteVar(name));
+      }
+    }
+  }
+
+  for (std::string name : names) {
+    boost::optional<const Value&> value = lookup(name);
+    if (value && value->isDefined()) {
+      return *value;
+    }
+  }
+  return Value::undefined;
+}
+
 double Parameters::get(const std::string& name, double default_value) const
 {
   boost::optional<const Value&> value = lookup(name);

--- a/src/core/Parameters.cc
+++ b/src/core/Parameters.cc
@@ -69,26 +69,23 @@ const Value& Parameters::get(const std::string& name) const
 
 const Value& Parameters::get(const std::initializer_list<std::string> names) const
 {
-  std::string match;
+  std::string matchName;
+  boost::optional<const Value&> matchValue;
+
   for (std::string name: names) {
     boost::optional<const Value&> value = lookup(name);
     if (value && value->isDefined()) {
-      if (match.empty()) {
-        match = name;
+      if (!matchValue) {
+        matchName = name;
+        matchValue = value;
       } else {
-        LOG(message_group::Error, loc, documentRoot(),
-            "Specified both %1$s and %2$s", quoteVar(match), quoteVar(name));
+        LOG(message_group::Warning, loc, documentRoot(),
+            "Specified both %1$s and %2$s", quoteVar(matchName), quoteVar(name));
       }
     }
   }
 
-  for (std::string name : names) {
-    boost::optional<const Value&> value = lookup(name);
-    if (value && value->isDefined()) {
-      return *value;
-    }
-  }
-  return Value::undefined;
+  return matchValue ? *matchValue : Value::undefined;
 }
 
 double Parameters::get(const std::string& name, double default_value) const

--- a/src/core/Parameters.h
+++ b/src/core/Parameters.h
@@ -51,11 +51,13 @@ public:
 
   void set_caller(const std::string& caller);
   const Value& get(const std::string& name) const;
+  const Value& get(const std::initializer_list<std::string> names) const;
   double get(const std::string& name, double default_value) const;
   const std::string& get(const std::string& name, const std::string& default_value) const;
 
   bool contains(const std::string& name) const { return bool(lookup(name)); }
   const Value& operator[](const std::string& name) const { return get(name); }
+  const Value& operator[](const std::initializer_list<std::string> names) const { return get(names); }
   bool valid(const std::string& name, Value::Type type);
   bool valid_required(const std::string& name, Value::Type type);
   bool validate_number(const std::string& name, double& out);

--- a/src/core/RotateExtrudeNode.cc
+++ b/src/core/RotateExtrudeNode.cc
@@ -48,7 +48,7 @@ std::shared_ptr<AbstractNode> builtin_rotate_extrude(const ModuleInstantiation *
   auto node = std::make_shared<RotateExtrudeNode>(inst);
 
   const Parameters parameters = Parameters::parse(std::move(arguments), inst->location(),
-                                            {"angle", "start"}, {"convexity"});
+                                            {"angle", "start"}, {"convexity", "a"});
 
   node->fn = parameters["$fn"].toDouble();
   node->fs = parameters["$fs"].toDouble();
@@ -58,7 +58,7 @@ std::shared_ptr<AbstractNode> builtin_rotate_extrude(const ModuleInstantiation *
   // If an angle is specified, use it, defaulting to starting at zero.
   // If no angle is specified, use 360 and default to starting at 180.
   // Regardless, if a start angle is specified, use it.
-  bool hasAngle = parameters["angle"].getFiniteDouble(node->angle);
+  bool hasAngle = parameters[{"angle","a"}].getFiniteDouble(node->angle);
   if (hasAngle) {
     node->start = 0;
     if ((node->angle <= -360) || (node->angle > 360)) node->angle = 360;

--- a/tests/data/scad/3D/features/linear_extrude-parameter-tests.scad
+++ b/tests/data/scad/3D/features/linear_extrude-parameter-tests.scad
@@ -13,11 +13,15 @@ color("yellow") linear_extrude(height = 10, convexity = undef, scale = 1, twist 
 for (a = params) translate([0, 0, oz * a[0]])
 color("gray") linear_extrude(height = 10, convexity = undef, scale = 1, twist = 0, slices = a[1]) square(20);
 
+// Test that when both height and h are specified there's a warning and height wins.
+// Specify height first.
 for (a = params) translate([ox, 0, oz * a[0]])
-color("purple") linear_extrude(height = 10, convexity = undef, scale = 1, twist = 30, slices = a[1]) square(20);
+color("purple") linear_extrude(height = 10, h=27, convexity = undef, scale = 1, twist = 30, slices = a[1]) square(20);
 
+// Test that when both height and h are specified there's a warning and height wins.
+// Specify h first.
 for (a = params) translate([2*ox, 0, oz * a[0]])
-color("blue") linear_extrude(height = 10, convexity = 2, scale = a[1]) square(20);
+color("blue") linear_extrude(h=27, height = 10, convexity = 2, scale = a[1]) square(20);
 
 for (a = params) translate([(a[0] - 3) * 30, -138, 0])
 color("green") linear_extrude(height = a[1]) square(20);

--- a/tests/data/scad/3D/features/linear_extrude-tests.scad
+++ b/tests/data/scad/3D/features/linear_extrude-tests.scad
@@ -39,3 +39,5 @@ translate([0,-25,0]) linear_extrude(-1) square(10, center=true);
 // vector has negative z coordinate
 translate([0,-25,0]) linear_extrude(v=[10,10,-5]) square(10, center=true);
 
+// Specify both "height" and "h"
+translate([45,-15,0]) linear_extrude(height=8, h=4, v=[3, 2, 5]) square([10,10]);

--- a/tests/data/scad/3D/features/linear_extrude-tests.scad
+++ b/tests/data/scad/3D/features/linear_extrude-tests.scad
@@ -6,8 +6,10 @@ rotate_extrude() { }
 rotate_extrude() { cube(); }
 
 linear_extrude(height=10) square([10,10]);
-translate([19,5,0]) linear_extrude(height=10, center=true) difference() {circle(5); circle(3);}
-translate([31.5,2.5,0]) linear_extrude(height=10, twist=-45) polygon(points = [[-5,-2.5], [5,-2.5], [0,2.5]]);
+// h is an alias for height.
+translate([19,5,0]) linear_extrude(h=10, center=true) difference() {circle(5); circle(3);}
+// If both height and h are specified, there's a warning and height wins.
+translate([31.5,2.5,0]) linear_extrude(h=5, height=10, twist=-45) polygon(points = [[-5,-2.5], [5,-2.5], [0,2.5]]);
 
 translate([1,21,0]) linear_extrude(height=20, twist=30, slices=2, segments=0) {
     difference() {
@@ -17,6 +19,7 @@ translate([1,21,0]) linear_extrude(height=20, twist=30, slices=2, segments=0) {
 }
 translate([19,20,0]) linear_extrude(height=20, twist=45, slices=10) square([10,10]);
 
+// Height is first positional parameter.
 translate([0,-15,0]) linear_extrude(5) square([10,10]);
 
 translate([15,-15,0]) linear_extrude(v=[3 ,2 ,5]) square([10, 10]);
@@ -38,6 +41,3 @@ translate([0,-25,0]) linear_extrude(-1) square(10, center=true);
 
 // vector has negative z coordinate
 translate([0,-25,0]) linear_extrude(v=[10,10,-5]) square(10, center=true);
-
-// Specify both "height" and "h"
-translate([45,-15,0]) linear_extrude(height=8, h=4, v=[3, 2, 5]) square([10,10]);

--- a/tests/data/scad/3D/features/rotate_extrude-angle.scad
+++ b/tests/data/scad/3D/features/rotate_extrude-angle.scad
@@ -13,11 +13,15 @@ module face2() {
 }
 
 // test negative partial angles and geometries on -X side
-// also test that the first positional parameter is the angle
+// Also:
+// - First positional parameter is angle
+// - Explicitly specify angle
+// - "a" is an alias for "angle"
+// - If both "angle" and "a" are specified, there's a warning and "angle" wins.
 rotate_extrude(45) face(10);
-rotate_extrude(45) face(-10);
-rotate_extrude(-45) face(21);
-rotate_extrude(-45) face(-21);
+rotate_extrude(angle=45) face(-10);
+rotate_extrude(a=-45) face(21);
+rotate_extrude(angle=-45, a=10) face(-21);
 
 // test small angles, angle < $fa, render a single segment
 rotate([0,0,90]) {

--- a/tests/regression/echotest/linear_extrude-parameter-tests-expected.echo
+++ b/tests/regression/echotest/linear_extrude-parameter-tests-expected.echo
@@ -4,18 +4,34 @@ WARNING: linear_extrude(..., slices=nan) argument cannot be infinite or nan in f
 WARNING: linear_extrude(..., slices="") Invalid type: expected number, found string in file linear_extrude-parameter-tests.scad, line 14
 WARNING: linear_extrude(..., slices=true) Invalid type: expected number, found bool in file linear_extrude-parameter-tests.scad, line 14
 WARNING: linear_extrude(..., slices=[1 : 1 : 3]) Invalid type: expected number, found range in file linear_extrude-parameter-tests.scad, line 14
-WARNING: linear_extrude(..., slices=inf) argument cannot be infinite or nan in file linear_extrude-parameter-tests.scad, line 17
-WARNING: linear_extrude(..., slices=-inf) argument cannot be infinite or nan in file linear_extrude-parameter-tests.scad, line 17
-WARNING: linear_extrude(..., slices=nan) argument cannot be infinite or nan in file linear_extrude-parameter-tests.scad, line 17
-WARNING: linear_extrude(..., slices="") Invalid type: expected number, found string in file linear_extrude-parameter-tests.scad, line 17
-WARNING: linear_extrude(..., slices=true) Invalid type: expected number, found bool in file linear_extrude-parameter-tests.scad, line 17
-WARNING: linear_extrude(..., slices=[1 : 1 : 3]) Invalid type: expected number, found range in file linear_extrude-parameter-tests.scad, line 17
-WARNING: linear_extrude(..., scale=inf) could not be converted in file linear_extrude-parameter-tests.scad, line 20
-WARNING: linear_extrude(..., scale=-inf) could not be converted in file linear_extrude-parameter-tests.scad, line 20
-WARNING: linear_extrude(..., scale=nan) could not be converted in file linear_extrude-parameter-tests.scad, line 20
-WARNING: linear_extrude(..., scale="") could not be converted in file linear_extrude-parameter-tests.scad, line 20
-WARNING: linear_extrude(..., scale=true) could not be converted in file linear_extrude-parameter-tests.scad, line 20
-WARNING: linear_extrude(..., scale=[1 : 1 : 3]) could not be converted in file linear_extrude-parameter-tests.scad, line 20
+WARNING: Specified both "height" and "h" in file linear_extrude-parameter-tests.scad, line 19
+WARNING: Specified both "height" and "h" in file linear_extrude-parameter-tests.scad, line 19
+WARNING: linear_extrude(..., slices=inf) argument cannot be infinite or nan in file linear_extrude-parameter-tests.scad, line 19
+WARNING: Specified both "height" and "h" in file linear_extrude-parameter-tests.scad, line 19
+WARNING: linear_extrude(..., slices=-inf) argument cannot be infinite or nan in file linear_extrude-parameter-tests.scad, line 19
+WARNING: Specified both "height" and "h" in file linear_extrude-parameter-tests.scad, line 19
+WARNING: linear_extrude(..., slices=nan) argument cannot be infinite or nan in file linear_extrude-parameter-tests.scad, line 19
+WARNING: Specified both "height" and "h" in file linear_extrude-parameter-tests.scad, line 19
+WARNING: linear_extrude(..., slices="") Invalid type: expected number, found string in file linear_extrude-parameter-tests.scad, line 19
+WARNING: Specified both "height" and "h" in file linear_extrude-parameter-tests.scad, line 19
+WARNING: linear_extrude(..., slices=true) Invalid type: expected number, found bool in file linear_extrude-parameter-tests.scad, line 19
+WARNING: Specified both "height" and "h" in file linear_extrude-parameter-tests.scad, line 19
+WARNING: linear_extrude(..., slices=[1 : 1 : 3]) Invalid type: expected number, found range in file linear_extrude-parameter-tests.scad, line 19
+WARNING: Specified both "height" and "h" in file linear_extrude-parameter-tests.scad, line 19
+WARNING: Specified both "height" and "h" in file linear_extrude-parameter-tests.scad, line 24
+WARNING: Specified both "height" and "h" in file linear_extrude-parameter-tests.scad, line 24
+WARNING: linear_extrude(..., scale=inf) could not be converted in file linear_extrude-parameter-tests.scad, line 24
+WARNING: Specified both "height" and "h" in file linear_extrude-parameter-tests.scad, line 24
+WARNING: linear_extrude(..., scale=-inf) could not be converted in file linear_extrude-parameter-tests.scad, line 24
+WARNING: Specified both "height" and "h" in file linear_extrude-parameter-tests.scad, line 24
+WARNING: linear_extrude(..., scale=nan) could not be converted in file linear_extrude-parameter-tests.scad, line 24
+WARNING: Specified both "height" and "h" in file linear_extrude-parameter-tests.scad, line 24
+WARNING: linear_extrude(..., scale="") could not be converted in file linear_extrude-parameter-tests.scad, line 24
+WARNING: Specified both "height" and "h" in file linear_extrude-parameter-tests.scad, line 24
+WARNING: linear_extrude(..., scale=true) could not be converted in file linear_extrude-parameter-tests.scad, line 24
+WARNING: Specified both "height" and "h" in file linear_extrude-parameter-tests.scad, line 24
+WARNING: linear_extrude(..., scale=[1 : 1 : 3]) could not be converted in file linear_extrude-parameter-tests.scad, line 24
+WARNING: Specified both "height" and "h" in file linear_extrude-parameter-tests.scad, line 24
 ERROR: height when specified should be a number.
 ERROR: height when specified should be a number.
 ERROR: height when specified should be a number.

--- a/tests/regression/echotest/linear_extrude-parameter-tests-expected.echo
+++ b/tests/regression/echotest/linear_extrude-parameter-tests-expected.echo
@@ -16,8 +16,8 @@ WARNING: linear_extrude(..., scale=nan) could not be converted in file linear_ex
 WARNING: linear_extrude(..., scale="") could not be converted in file linear_extrude-parameter-tests.scad, line 20
 WARNING: linear_extrude(..., scale=true) could not be converted in file linear_extrude-parameter-tests.scad, line 20
 WARNING: linear_extrude(..., scale=[1 : 1 : 3]) could not be converted in file linear_extrude-parameter-tests.scad, line 20
-ERROR: height when specified should be a double.
-ERROR: height when specified should be a double.
-ERROR: height when specified should be a double.
-ERROR: height when specified should be a double.
-ERROR: height when specified should be a double.
+ERROR: height when specified should be a number.
+ERROR: height when specified should be a number.
+ERROR: height when specified should be a number.
+ERROR: height when specified should be a number.
+ERROR: height when specified should be a number.

--- a/tests/regression/echotest/localfiles-compatibility-test-expected.echo
+++ b/tests/regression/echotest/localfiles-compatibility-test-expected.echo
@@ -1,3 +1,2 @@
-WARNING: variable "h" not specified as parameter in file localfiles_subdir/localfiles_submodule.scad, line 3
 DEPRECATED: Imported file (localfile.dxf) found in document root instead of relative to the importing module. This behavior is deprecated
 DEPRECATED: Imported file (localfile.dat) found in document root instead of relative to the importing module. This behavior is deprecated

--- a/tests/regression/echotest/localfiles-test-expected.echo
+++ b/tests/regression/echotest/localfiles-test-expected.echo
@@ -1,1 +1,0 @@
-WARNING: variable "h" not specified as parameter in file localfiles_dir/localfiles_module.scad, line 3


### PR DESCRIPTION
linear_extrude allows "h" as an alias for "height". rotate_extrude allows "a" as an alias for "angle". Provides a general-purpose alias-capable lookup function in Parameters. Cleans up linear_extrude parameter processing.