### PR TITLE
Converting all manual connect() invocations to use the new style

### DIFF
--- a/src/gui/Animate.cc
+++ b/src/gui/Animate.cc
@@ -43,12 +43,11 @@ void Animate::initGUI()
   this->iconDisabled = QIcon::fromTheme("chokusen-animate-disabled");
 
   animate_timer = new QTimer(this);
-  connect(animate_timer, SIGNAL(timeout()), this, SLOT(incrementTVal()));
-
-  connect(this->e_tval, SIGNAL(textChanged(QString)), this, SLOT(updatedAnimTval()));
-  connect(this->e_fps, SIGNAL(textChanged(QString)), this, SLOT(updatedAnimFpsAndAnimSteps()));
-  connect(this->e_fsteps, SIGNAL(textChanged(QString)), this, SLOT(updatedAnimFpsAndAnimSteps()));
-  connect(this->e_dump, SIGNAL(toggled(bool)), this, SLOT(updatedAnimDump(bool)));
+  connect(animate_timer, &QTimer::timeout, this, &Animate::incrementTVal);
+  connect(this->e_tval, &QLineEdit::textChanged, this, &Animate::updatedAnimTval);
+  connect(this->e_fps, &QLineEdit::textChanged, this, &Animate::updatedAnimFpsAndAnimSteps);
+  connect(this->e_fsteps, &QLineEdit::textChanged, this, &Animate::updatedAnimFpsAndAnimSteps);
+  connect(this->e_dump, &QCheckBox::toggled, this, &Animate::updatedAnimDump);
 }
 
 void Animate::setMainWindow(MainWindow *mainWindow)

--- a/src/gui/Animate.cc
+++ b/src/gui/Animate.cc
@@ -44,21 +44,10 @@ void Animate::initGUI()
 
   animate_timer = new QTimer(this);
   connect(animate_timer, &QTimer::timeout, this, &Animate::incrementTVal);
-
-  #if QT_VERSION >= QT_VERSION_CHECK(5, 15, 0)
   connect(this->e_tval, &QLineEdit::textChanged, this, &Animate::updatedAnimTval);
   connect(this->e_fps, &QLineEdit::textChanged, this, &Animate::updatedAnimFpsAndAnimSteps);
   connect(this->e_fsteps, &QLineEdit::textChanged, this, &Animate::updatedAnimFpsAndAnimSteps);
-  #else
-  connect(this->e_tval, static_cast<void(QLineEdit::*)(const QString &)>(&QLineEdit::textChanged), this, &Animate::updatedAnimTval);
-  connect(this->e_fps, static_cast<void(QLineEdit::*)(const QString &)>(&QLineEdit::textChanged), this, &Animate::updatedAnimFpsAndAnimSteps);
-  connect(this->e_fsteps, static_cast<void(QLineEdit::*)(const QString &)>(&QLineEdit::textChanged), this, &Animate::updatedAnimFpsAndAnimSteps);
-  #endif
-  #if QT_VERSION >= QT_VERSION_CHECK(5, 15, 0)
   connect(this->e_dump, &QCheckBox::toggled, this, &Animate::updatedAnimDump);
-  #else
-  connect(this->e_dump, static_cast<void(QCheckBox::*)(bool)>(&QCheckBox::toggled), this, &Animate::updatedAnimDump);
-  #endif
 }
 
 void Animate::setMainWindow(MainWindow *mainWindow)

--- a/src/gui/Animate.cc
+++ b/src/gui/Animate.cc
@@ -44,10 +44,21 @@ void Animate::initGUI()
 
   animate_timer = new QTimer(this);
   connect(animate_timer, &QTimer::timeout, this, &Animate::incrementTVal);
+
+  #if QT_VERSION >= QT_VERSION_CHECK(5, 15, 0)
   connect(this->e_tval, &QLineEdit::textChanged, this, &Animate::updatedAnimTval);
   connect(this->e_fps, &QLineEdit::textChanged, this, &Animate::updatedAnimFpsAndAnimSteps);
   connect(this->e_fsteps, &QLineEdit::textChanged, this, &Animate::updatedAnimFpsAndAnimSteps);
+  #else
+  connect(this->e_tval, static_cast<void(QLineEdit::*)(const QString &)>(&QLineEdit::textChanged), this, &Animate::updatedAnimTval);
+  connect(this->e_fps, static_cast<void(QLineEdit::*)(const QString &)>(&QLineEdit::textChanged), this, &Animate::updatedAnimFpsAndAnimSteps);
+  connect(this->e_fsteps, static_cast<void(QLineEdit::*)(const QString &)>(&QLineEdit::textChanged), this, &Animate::updatedAnimFpsAndAnimSteps);
+  #endif
+  #if QT_VERSION >= QT_VERSION_CHECK(5, 15, 0)
   connect(this->e_dump, &QCheckBox::toggled, this, &Animate::updatedAnimDump);
+  #else
+  connect(this->e_dump, static_cast<void(QCheckBox::*)(bool)>(&QCheckBox::toggled), this, &Animate::updatedAnimDump);
+  #endif
 }
 
 void Animate::setMainWindow(MainWindow *mainWindow)

--- a/src/gui/AutoUpdater.cc
+++ b/src/gui/AutoUpdater.cc
@@ -14,8 +14,7 @@ void AutoUpdater::init()
     // Add to application menu
     this->updateAction->setMenuRole(QAction::ApplicationSpecificRole);
     this->updateAction->setEnabled(true);
-    this->connect(this->updateAction, SIGNAL(triggered()), this, SLOT(checkForUpdates()));
-
+    this->connect(this->updateAction, &QAction::triggered, this, &AutoUpdater::checkForUpdates);
     this->updateMenu->addAction(this->updateAction);
 
   }

--- a/src/gui/CGALWorker.cc
+++ b/src/gui/CGALWorker.cc
@@ -18,7 +18,7 @@ CGALWorker::CGALWorker()
   this->tree = nullptr;
   this->thread = new QThread();
   if (this->thread->stackSize() < 1024 * 1024) this->thread->setStackSize(1024 * 1024);
-  connect(this->thread, SIGNAL(started()), this, SLOT(work()));
+  connect(this->thread, &QThread::started, this, &CGALWorker::work);
   moveToThread(this->thread);
 }
 

--- a/src/gui/Console.cc
+++ b/src/gui/Console.cc
@@ -49,9 +49,9 @@
 Console::Console(QWidget *parent) : QPlainTextEdit(parent)
 {
   setupUi(this);
-  connect(this->actionClear, SIGNAL(triggered()), this, SLOT(actionClearConsole_triggered()));
-  connect(this->actionSaveAs, SIGNAL(triggered()), this, SLOT(actionSaveAs_triggered()));
-  connect(this, SIGNAL(linkActivated(QString)), this, SLOT(hyperlinkClicked(const QString&)));
+  connect(this->actionClear, &QAction::triggered, this, &Console::actionClearConsole_triggered);
+  connect(this->actionSaveAs, &QAction::triggered, this, &Console::actionSaveAs_triggered);
+  connect(this, &Console::linkActivated, this, &Console::hyperlinkClicked);
   this->setUndoRedoEnabled(false);
   this->appendCursor = this->textCursor();
 }

--- a/src/gui/Console.cc
+++ b/src/gui/Console.cc
@@ -51,11 +51,7 @@ Console::Console(QWidget *parent) : QPlainTextEdit(parent)
   setupUi(this);
   connect(this->actionClear, &QAction::triggered, this, &Console::actionClearConsole_triggered);
   connect(this->actionSaveAs, &QAction::triggered, this, &Console::actionSaveAs_triggered);
-  #if QT_VERSION >= QT_VERSION_CHECK(5, 15, 0)
-    connect(this, &Console::linkActivated, this, &Console::hyperlinkClicked);
-  #else
-    connect(this, static_cast<void(Console::*)(const QString &)>(&Console::linkActivated), this, &Console::hyperlinkClicked);
-  #endif
+  connect(this, &Console::linkActivated, this, &Console::hyperlinkClicked);
   this->setUndoRedoEnabled(false);
   this->appendCursor = this->textCursor();
 }

--- a/src/gui/Console.cc
+++ b/src/gui/Console.cc
@@ -51,7 +51,11 @@ Console::Console(QWidget *parent) : QPlainTextEdit(parent)
   setupUi(this);
   connect(this->actionClear, &QAction::triggered, this, &Console::actionClearConsole_triggered);
   connect(this->actionSaveAs, &QAction::triggered, this, &Console::actionSaveAs_triggered);
-  connect(this, &Console::linkActivated, this, &Console::hyperlinkClicked);
+  #if QT_VERSION >= QT_VERSION_CHECK(5, 15, 0)
+    connect(this, &Console::linkActivated, this, &Console::hyperlinkClicked);
+  #else
+    connect(this, static_cast<void(Console::*)(const QString &)>(&Console::linkActivated), this, &Console::hyperlinkClicked);
+  #endif
   this->setUndoRedoEnabled(false);
   this->appendCursor = this->textCursor();
 }

--- a/src/gui/ErrorLog.cc
+++ b/src/gui/ErrorLog.cc
@@ -33,8 +33,7 @@ void ErrorLog::initGUI()
   logTable->setColumnWidth(errorLog_column::lineNo, 80);
   logTable->addAction(actionRowSelected);
   //last column will stretch itself
-
-  connect(logTable->horizontalHeader(), SIGNAL(sectionResized(int,int,int)), this, SLOT(onSectionResized(int,int,int)));
+  connect(logTable->horizontalHeader(), &QHeaderView::sectionResized, this, &ErrorLog::onSectionResized);
 }
 
 void ErrorLog::toErrorLog(const Message& log_msg)

--- a/src/gui/FontList.cc
+++ b/src/gui/FontList.cc
@@ -462,7 +462,12 @@ void FontList::update_font_list()
   this->tableView->resizeColumnsToContents();
   this->tableView->setSortingEnabled(true);
 
-  connect(tableView->selectionModel(), &QItemSelectionModel::selectionChanged, this, &FontList::selection_changed);
+  #if QT_VERSION >= QT_VERSION_CHECK(5, 15, 0)
+    connect(tableView->selectionModel(), &QItemSelectionModel::selectionChanged, this, &FontList::selection_changed);
+  #else
+    connect(tableView->selectionModel(), static_cast<void(QItemSelectionModel::*)(const QItemSelection &, const QItemSelection &)>(&QItemSelectionModel::selectionChanged), this, &FontList::selection_changed);
+  #endif
+
 
   delete list;
 }

--- a/src/gui/FontList.cc
+++ b/src/gui/FontList.cc
@@ -461,12 +461,7 @@ void FontList::update_font_list()
   this->tableView->sortByColumn(COL_FONT_NAME, Qt::AscendingOrder);
   this->tableView->resizeColumnsToContents();
   this->tableView->setSortingEnabled(true);
-
-  #if QT_VERSION >= QT_VERSION_CHECK(5, 15, 0)
-    connect(tableView->selectionModel(), &QItemSelectionModel::selectionChanged, this, &FontList::selection_changed);
-  #else
-    connect(tableView->selectionModel(), static_cast<void(QItemSelectionModel::*)(const QItemSelection &, const QItemSelection &)>(&QItemSelectionModel::selectionChanged), this, &FontList::selection_changed);
-  #endif
+  connect(tableView->selectionModel(), &QItemSelectionModel::selectionChanged, this, &FontList::selection_changed);
 
 
   delete list;

--- a/src/gui/FontListDialog.cc
+++ b/src/gui/FontListDialog.cc
@@ -40,7 +40,7 @@ FontListDialog::FontListDialog()
   model = nullptr;
   proxy = nullptr;
   setupUi(this);
-  connect(this->okButton, SIGNAL(clicked()), this, SLOT(accept()));
+  connect(this->okButton, &QPushButton::clicked, this, &FontListDialog::accept);
 }
 
 void FontListDialog::on_copyButton_clicked()
@@ -115,7 +115,7 @@ void FontListDialog::update_font_list()
   this->tableView->resizeColumnsToContents();
   this->tableView->setSortingEnabled(true);
 
-  connect(tableView->selectionModel(), SIGNAL(selectionChanged(const QItemSelection&,const QItemSelection&)), this, SLOT(selection_changed(const QItemSelection&,const QItemSelection&)));
+  connect(tableView->selectionModel(), &QItemSelectionModel::selectionChanged, this, &FontListDialog::selection_changed);
 
   delete list;
 }

--- a/src/gui/FontListDialog.cc
+++ b/src/gui/FontListDialog.cc
@@ -115,7 +115,11 @@ void FontListDialog::update_font_list()
   this->tableView->resizeColumnsToContents();
   this->tableView->setSortingEnabled(true);
 
-  connect(tableView->selectionModel(), &QItemSelectionModel::selectionChanged, this, &FontListDialog::selection_changed);
+  #if QT_VERSION >= QT_VERSION_CHECK(5, 15, 0)
+    connect(tableView->selectionModel(), &QItemSelectionModel::selectionChanged, this, &FontListDialog::selection_changed);
+  #else
+    connect(tableView->selectionModel(), static_cast<void(QItemSelectionModel::*)(const QItemSelection &, const QItemSelection &)>(&QItemSelectionModel::selectionChanged), this, &FontListDialog::selection_changed);
+  #endif
 
   delete list;
 }

--- a/src/gui/FontListDialog.cc
+++ b/src/gui/FontListDialog.cc
@@ -114,13 +114,7 @@ void FontListDialog::update_font_list()
   this->tableView->sortByColumn(0, Qt::AscendingOrder);
   this->tableView->resizeColumnsToContents();
   this->tableView->setSortingEnabled(true);
-
-  #if QT_VERSION >= QT_VERSION_CHECK(5, 15, 0)
-    connect(tableView->selectionModel(), &QItemSelectionModel::selectionChanged, this, &FontListDialog::selection_changed);
-  #else
-    connect(tableView->selectionModel(), static_cast<void(QItemSelectionModel::*)(const QItemSelection &, const QItemSelection &)>(&QItemSelectionModel::selectionChanged), this, &FontListDialog::selection_changed);
-  #endif
-
+  connect(tableView->selectionModel(), &QItemSelectionModel::selectionChanged, this, &FontListDialog::selection_changed);
   delete list;
 }
 

--- a/src/gui/LaunchingScreen.cc
+++ b/src/gui/LaunchingScreen.cc
@@ -60,18 +60,16 @@ LaunchingScreen::LaunchingScreen(QWidget *parent) : QDialog(parent)
     this->treeWidget->addTopLevelItem(categoryItem);
   }
 
-  connect(this->pushButtonNew, SIGNAL(clicked()), this, SLOT(accept()));
-  connect(this->pushButtonOpen, SIGNAL(clicked()), this, SLOT(openUserFile()));
-  connect(this->pushButtonHelp, SIGNAL(clicked()), this, SLOT(openUserManualURL()));
-  connect(this->recentList->selectionModel(), SIGNAL(currentRowChanged(const QModelIndex&,const QModelIndex&)), this, SLOT(enableRecentButton(const QModelIndex&,const QModelIndex&)));
-
-  connect(this->recentList, SIGNAL(itemDoubleClicked(QListWidgetItem*)), this, SLOT(openRecent()));
-  connect(this->treeWidget, SIGNAL(currentItemChanged(QTreeWidgetItem*,QTreeWidgetItem*)), this, SLOT(enableExampleButton(QTreeWidgetItem*,QTreeWidgetItem*)));
-
-  connect(this->treeWidget, SIGNAL(itemDoubleClicked(QTreeWidgetItem*,int)), this, SLOT(openExample()));
-  connect(this->openRecentButton, SIGNAL(clicked()), this, SLOT(openRecent()));
-  connect(this->openExampleButton, SIGNAL(clicked()), this, SLOT(openExample()));
-  connect(this->checkBox, SIGNAL(toggled(bool)), this, SLOT(checkboxState(bool)));
+  connect(this->pushButtonNew, &QPushButton::clicked, this, &QDialog::accept);
+  connect(this->pushButtonOpen, &QPushButton::clicked, this, &LaunchingScreen::openUserFile);
+  connect(this->pushButtonHelp, &QPushButton::clicked, this, &LaunchingScreen::openUserManualURL);
+  connect(this->recentList->selectionModel(), &QItemSelectionModel::currentRowChanged, this, &LaunchingScreen::enableRecentButton);
+  connect(this->recentList, &QListWidget::itemDoubleClicked, this, &LaunchingScreen::openRecent);
+  connect(this->treeWidget, &QTreeWidget::currentItemChanged, this, &LaunchingScreen::enableExampleButton);
+  connect(this->treeWidget, &QTreeWidget::itemDoubleClicked, this, &LaunchingScreen::openExample);
+  connect(this->openRecentButton, &QPushButton::clicked, this, &LaunchingScreen::openRecent);
+  connect(this->openExampleButton, &QPushButton::clicked, this, &LaunchingScreen::openExample);
+  connect(this->checkBox, &QCheckBox::toggled, this, &LaunchingScreen::checkboxState);
 }
 
 LaunchingScreen::~LaunchingScreen()

--- a/src/gui/LaunchingScreen.cc
+++ b/src/gui/LaunchingScreen.cc
@@ -64,33 +64,12 @@ LaunchingScreen::LaunchingScreen(QWidget *parent) : QDialog(parent)
   connect(this->pushButtonOpen, &QPushButton::clicked, this, &LaunchingScreen::openUserFile);
   connect(this->pushButtonHelp, &QPushButton::clicked, this, &LaunchingScreen::openUserManualURL);
   connect(this->recentList->selectionModel(), &QItemSelectionModel::currentRowChanged, this, &LaunchingScreen::enableRecentButton);
-
-  #if QT_VERSION >= QT_VERSION_CHECK(5, 15, 0)
   connect(this->recentList, &QListWidget::itemDoubleClicked, this, &LaunchingScreen::openRecent);
-  #else
-  connect(this->recentList, static_cast<void(QListWidget::*)(QListWidgetItem*)>(&QListWidget::itemDoubleClicked), this, &LaunchingScreen::openRecent);
-  #endif
-
-  #if QT_VERSION >= QT_VERSION_CHECK(5, 15, 0)
   connect(this->treeWidget, &QTreeWidget::currentItemChanged, this, &LaunchingScreen::enableExampleButton);
-  #else
-  connect(this->treeWidget, static_cast<void(QTreeWidget::*)(QTreeWidgetItem*, QTreeWidgetItem*)>(&QTreeWidget::currentItemChanged), this, &LaunchingScreen::enableExampleButton);
-  #endif
-  
-  #if QT_VERSION >= QT_VERSION_CHECK(5, 15, 0)
   connect(this->treeWidget, &QTreeWidget::itemDoubleClicked, this, &LaunchingScreen::openExample);
-  #else
-  connect(this->treeWidget, static_cast<void(QTreeWidget::*)(QTreeWidgetItem*)>(&QTreeWidget::itemDoubleClicked), this, &LaunchingScreen::openExample);
-  #endif
-
   connect(this->openRecentButton, &QPushButton::clicked, this, &LaunchingScreen::openRecent);
   connect(this->openExampleButton, &QPushButton::clicked, this, &LaunchingScreen::openExample);
-  #if QT_VERSION >= QT_VERSION_CHECK(5, 15, 0)
   connect(this->checkBox, &QCheckBox::toggled, this, &LaunchingScreen::checkboxState);
-  #else
-  connect(this->checkBox, static_cast<void(QCheckBox::*)(bool)>(&QCheckBox::toggled), this, &LaunchingScreen::checkboxState);
-  #endif
-
 }
 
 LaunchingScreen::~LaunchingScreen()

--- a/src/gui/LaunchingScreen.cc
+++ b/src/gui/LaunchingScreen.cc
@@ -64,12 +64,33 @@ LaunchingScreen::LaunchingScreen(QWidget *parent) : QDialog(parent)
   connect(this->pushButtonOpen, &QPushButton::clicked, this, &LaunchingScreen::openUserFile);
   connect(this->pushButtonHelp, &QPushButton::clicked, this, &LaunchingScreen::openUserManualURL);
   connect(this->recentList->selectionModel(), &QItemSelectionModel::currentRowChanged, this, &LaunchingScreen::enableRecentButton);
+
+  #if QT_VERSION >= QT_VERSION_CHECK(5, 15, 0)
   connect(this->recentList, &QListWidget::itemDoubleClicked, this, &LaunchingScreen::openRecent);
+  #else
+  connect(this->recentList, static_cast<void(QListWidget::*)(QListWidgetItem*)>(&QListWidget::itemDoubleClicked), this, &LaunchingScreen::openRecent);
+  #endif
+
+  #if QT_VERSION >= QT_VERSION_CHECK(5, 15, 0)
   connect(this->treeWidget, &QTreeWidget::currentItemChanged, this, &LaunchingScreen::enableExampleButton);
+  #else
+  connect(this->treeWidget, static_cast<void(QTreeWidget::*)(QTreeWidgetItem*, QTreeWidgetItem*)>(&QTreeWidget::currentItemChanged), this, &LaunchingScreen::enableExampleButton);
+  #endif
+  
+  #if QT_VERSION >= QT_VERSION_CHECK(5, 15, 0)
   connect(this->treeWidget, &QTreeWidget::itemDoubleClicked, this, &LaunchingScreen::openExample);
+  #else
+  connect(this->treeWidget, static_cast<void(QTreeWidget::*)(QTreeWidgetItem*)>(&QTreeWidget::itemDoubleClicked), this, &LaunchingScreen::openExample);
+  #endif
+
   connect(this->openRecentButton, &QPushButton::clicked, this, &LaunchingScreen::openRecent);
   connect(this->openExampleButton, &QPushButton::clicked, this, &LaunchingScreen::openExample);
+  #if QT_VERSION >= QT_VERSION_CHECK(5, 15, 0)
   connect(this->checkBox, &QCheckBox::toggled, this, &LaunchingScreen::checkboxState);
+  #else
+  connect(this->checkBox, static_cast<void(QCheckBox::*)(bool)>(&QCheckBox::toggled), this, &LaunchingScreen::checkboxState);
+  #endif
+
 }
 
 LaunchingScreen::~LaunchingScreen()

--- a/src/gui/LibraryInfoDialog.cc
+++ b/src/gui/LibraryInfoDialog.cc
@@ -9,7 +9,7 @@
 LibraryInfoDialog::LibraryInfoDialog(const QString& rendererInfo)
 {
   setupUi(this);
-  connect(this->okButton, SIGNAL(clicked()), this, SLOT(accept()));
+  connect(this->okButton, &QPushButton::clicked, this, &LibraryInfoDialog::accept);
   update_library_info(rendererInfo);
 }
 

--- a/src/gui/MainWindow.cc
+++ b/src/gui/MainWindow.cc
@@ -592,12 +592,28 @@ MainWindow::MainWindow(const QStringList& filenames)
   this->setColorScheme(cs);
 
   //find and replace panel
+  #if QT_VERSION >= QT_VERSION_CHECK(5, 15, 0)
   connect(this->findTypeComboBox, &QComboBox::currentIndexChanged, this, &MainWindow::selectFindType);
+  #else
+  connect(this->findTypeComboBox, static_cast<void(QComboBox::*)(int)>(&QComboBox::currentIndexChanged), this, &MainWindow::selectFindType);
+  #endif
+
+  #if QT_VERSION >= QT_VERSION_CHECK(5, 15, 0)
   connect(this->findInputField, &QLineEdit::textChanged, this, &MainWindow::findString);
+  #else
+  connect(this->findInputField, static_cast<void(QLineEdit::*)(const QString &)>(&QLineEdit::textChanged), this, &MainWindow::findString);
+  #endif
+
   connect(this->findInputField, &QLineEdit::returnPressed, this->findNextButton, &QPushButton::animateClick);
   find_panel->installEventFilter(this);
   if (QApplication::clipboard()->supportsFindBuffer()) {
+    
+    #if QT_VERSION >= QT_VERSION_CHECK(5, 15, 0)
     connect(this->findInputField, &QLineEdit::textChanged, this, &MainWindow::updateFindBuffer);
+    #else
+    connect(this->findInputField, static_cast<void(QLineEdit::*)(const QString &)>(&QLineEdit::textChanged), this, &MainWindow::updateFindBuffer);
+    #endif
+
     connect(QApplication::clipboard(), &QClipboard::findBufferChanged, this, &MainWindow::findBufferChanged);
     // With Qt 4.8.6, there seems to be a bug that often gives an incorrect findbuffer content when
     // the app receives focus for the first time
@@ -2292,7 +2308,11 @@ void MainWindow::rightClick(QPoint mouse)
       auto action = tracemenu.addAction(QString::fromStdString(ss.str()));
       if (editorDock->isVisible()) {
         action->setProperty("id", step->idx);
+        #if QT_VERSION >= QT_VERSION_CHECK(5, 15, 0)
         connect(action, &QAction::hovered, this, &MainWindow::onHoveredObjectInSelectionMenu);
+        #else
+        connect(action, static_cast<void(QAction::*)()>(&QAction::hovered), this, &MainWindow::onHoveredObjectInSelectionMenu);
+        #endif
       }
     }
 

--- a/src/gui/MainWindow.cc
+++ b/src/gui/MainWindow.cc
@@ -396,11 +396,7 @@ MainWindow::MainWindow(const QStringList& filenames)
   connect(autoReloadTimer, &QTimer::timeout, this, &MainWindow::checkAutoReload);
 
   this->exportformat_mapper = new QSignalMapper(this);
-#if QT_VERSION >= QT_VERSION_CHECK(5, 15, 0)
   connect(this->exportformat_mapper, &QSignalMapper::mappedInt, this, &MainWindow::actionExportFileFormat);
-#else
-  connect(this->exportformat_mapper, static_cast<void (QSignalMapper::*)(int)>(&QSignalMapper::mapped), this, &MainWindow::actionExportFileFormat);
-#endif
 
   waitAfterReloadTimer = new QTimer(this);
   waitAfterReloadTimer->setSingleShot(true);
@@ -592,28 +588,13 @@ MainWindow::MainWindow(const QStringList& filenames)
   this->setColorScheme(cs);
 
   //find and replace panel
-  #if QT_VERSION >= QT_VERSION_CHECK(5, 15, 0)
+
   connect(this->findTypeComboBox, &QComboBox::currentIndexChanged, this, &MainWindow::selectFindType);
-  #else
-  connect(this->findTypeComboBox, static_cast<void(QComboBox::*)(int)>(&QComboBox::currentIndexChanged), this, &MainWindow::selectFindType);
-  #endif
-
-  #if QT_VERSION >= QT_VERSION_CHECK(5, 15, 0)
   connect(this->findInputField, &QLineEdit::textChanged, this, &MainWindow::findString);
-  #else
-  connect(this->findInputField, static_cast<void(QLineEdit::*)(const QString &)>(&QLineEdit::textChanged), this, &MainWindow::findString);
-  #endif
-
   connect(this->findInputField, &QLineEdit::returnPressed, this->findNextButton, &QPushButton::animateClick);
   find_panel->installEventFilter(this);
   if (QApplication::clipboard()->supportsFindBuffer()) {
-    
-    #if QT_VERSION >= QT_VERSION_CHECK(5, 15, 0)
     connect(this->findInputField, &QLineEdit::textChanged, this, &MainWindow::updateFindBuffer);
-    #else
-    connect(this->findInputField, static_cast<void(QLineEdit::*)(const QString &)>(&QLineEdit::textChanged), this, &MainWindow::updateFindBuffer);
-    #endif
-
     connect(QApplication::clipboard(), &QClipboard::findBufferChanged, this, &MainWindow::findBufferChanged);
     // With Qt 4.8.6, there seems to be a bug that often gives an incorrect findbuffer content when
     // the app receives focus for the first time
@@ -2308,11 +2289,7 @@ void MainWindow::rightClick(QPoint mouse)
       auto action = tracemenu.addAction(QString::fromStdString(ss.str()));
       if (editorDock->isVisible()) {
         action->setProperty("id", step->idx);
-        #if QT_VERSION >= QT_VERSION_CHECK(5, 15, 0)
         connect(action, &QAction::hovered, this, &MainWindow::onHoveredObjectInSelectionMenu);
-        #else
-        connect(action, static_cast<void(QAction::*)()>(&QAction::hovered), this, &MainWindow::onHoveredObjectInSelectionMenu);
-        #endif
       }
     }
 

--- a/src/gui/Network.h
+++ b/src/gui/Network.h
@@ -110,9 +110,9 @@ ResultType NetworkRequest<ResultType>::execute(const NetworkRequest::setup_func_
                               reply->abort();
                             }
                           }};
-  QObject::connect(&timer, SIGNAL(timeout()), &loop, SLOT(quit()));
-  QObject::connect(reply, SIGNAL(finished()), &loop, SLOT(quit()));
-  QObject::connect(reply, SIGNAL(uploadProgress(qint64,qint64)), &forwarder, SLOT(network_progress(qint64,qint64)));
+  QObject::connect(&timer, &QTimer::timeout, &loop, &QEventLoop::quit);
+  QObject::connect(reply, &QNetworkReply::finished, &loop, &QEventLoop::quit);
+  QObject::connect(reply, &QNetworkReply::uploadProgress, &forwarder, &NetworkSignal::network_progress);
   timer.setSingleShot(true);
   timer.start(timeout_seconds * 1000);
   loop.exec();

--- a/src/gui/OpenCSGWarningDialog.cc
+++ b/src/gui/OpenCSGWarningDialog.cc
@@ -6,13 +6,8 @@
 OpenCSGWarningDialog::OpenCSGWarningDialog(QWidget *)
 {
   setupUi(this);
-  #if QT_VERSION >= QT_VERSION_CHECK(5, 15, 0)
   connect(this->showBox, &QCheckBox::toggled, Preferences::inst()->openCSGWarningBox, &QCheckBox::setChecked);
   connect(this->showBox, &QCheckBox::toggled, Preferences::inst(), &Preferences::on_openCSGWarningBox_toggled);
-  #else
-  connect(this->showBox, static_cast<void(QCheckBox::*)(bool)>(&QCheckBox::toggled), Preferences::inst()->openCSGWarningBox, &QCheckBox::setChecked);
-  connect(this->showBox, static_cast<void(QCheckBox::*)(bool)>(&QCheckBox::toggled), Preferences::inst(), &Preferences::on_openCSGWarningBox_toggled);
-  #endif
 }
 
 void OpenCSGWarningDialog::setText(const QString& text)

--- a/src/gui/OpenCSGWarningDialog.cc
+++ b/src/gui/OpenCSGWarningDialog.cc
@@ -6,8 +6,13 @@
 OpenCSGWarningDialog::OpenCSGWarningDialog(QWidget *)
 {
   setupUi(this);
+  #if QT_VERSION >= QT_VERSION_CHECK(5, 15, 0)
   connect(this->showBox, &QCheckBox::toggled, Preferences::inst()->openCSGWarningBox, &QCheckBox::setChecked);
   connect(this->showBox, &QCheckBox::toggled, Preferences::inst(), &Preferences::on_openCSGWarningBox_toggled);
+  #else
+  connect(this->showBox, static_cast<void(QCheckBox::*)(bool)>(&QCheckBox::toggled), Preferences::inst()->openCSGWarningBox, &QCheckBox::setChecked);
+  connect(this->showBox, static_cast<void(QCheckBox::*)(bool)>(&QCheckBox::toggled), Preferences::inst(), &Preferences::on_openCSGWarningBox_toggled);
+  #endif
 }
 
 void OpenCSGWarningDialog::setText(const QString& text)

--- a/src/gui/OpenCSGWarningDialog.cc
+++ b/src/gui/OpenCSGWarningDialog.cc
@@ -6,11 +6,8 @@
 OpenCSGWarningDialog::OpenCSGWarningDialog(QWidget *)
 {
   setupUi(this);
-
-  connect(this->showBox, SIGNAL(toggled(bool)),
-          Preferences::inst()->openCSGWarningBox, SLOT(setChecked(bool)));
-  connect(this->showBox, SIGNAL(toggled(bool)),
-          Preferences::inst(), SLOT(on_openCSGWarningBox_toggled(bool)));
+  connect(this->showBox, &QCheckBox::toggled, Preferences::inst()->openCSGWarningBox, &QCheckBox::setChecked);
+  connect(this->showBox, &QCheckBox::toggled, Preferences::inst(), &Preferences::on_openCSGWarningBox_toggled);
 }
 
 void OpenCSGWarningDialog::setText(const QString& text)

--- a/src/gui/Preferences.cc
+++ b/src/gui/Preferences.cc
@@ -175,7 +175,7 @@ void Preferences::init() {
   addPrefPage(group, prefsActionAdvanced, pageAdvanced);
   addPrefPage(group, prefsActionDialogs, pageDialogs);
 
-  connect(group, SIGNAL(triggered(QAction*)), this, SLOT(actionTriggered(QAction*)));
+  connect(group, &QActionGroup::triggered, this, &Preferences::actionTriggered);
 
   prefsAction3DView->setChecked(true);
   this->actionTriggered(this->prefsAction3DView);
@@ -363,7 +363,7 @@ void Preferences::setupFeaturesPage()
     feature->enable(value);
     cb->setChecked(value);
     cb->setProperty(featurePropertyName, QVariant::fromValue<Feature *>(feature));
-    connect(cb, SIGNAL(toggled(bool)), this, SLOT(featuresCheckBoxToggled(bool)));
+    connect(cb, &QCheckBox::toggled, this, &Preferences::featuresCheckBoxToggled);
     gridLayoutExperimentalFeatures->addWidget(cb, row, 0, 1, 2, Qt::AlignLeading);
     row++;
 

--- a/src/gui/Preferences.cc
+++ b/src/gui/Preferences.cc
@@ -363,7 +363,13 @@ void Preferences::setupFeaturesPage()
     feature->enable(value);
     cb->setChecked(value);
     cb->setProperty(featurePropertyName, QVariant::fromValue<Feature *>(feature));
+
+    #if QT_VERSION >= QT_VERSION_CHECK(5, 15, 0)
     connect(cb, &QCheckBox::toggled, this, &Preferences::featuresCheckBoxToggled);
+    #else
+    connect(cb, static_cast<void(QCheckBox::*)(bool)>(&QCheckBox::toggled), this, &Preferences::featuresCheckBoxToggled);
+    #endif
+
     gridLayoutExperimentalFeatures->addWidget(cb, row, 0, 1, 2, Qt::AlignLeading);
     row++;
 

--- a/src/gui/Preferences.cc
+++ b/src/gui/Preferences.cc
@@ -363,12 +363,7 @@ void Preferences::setupFeaturesPage()
     feature->enable(value);
     cb->setChecked(value);
     cb->setProperty(featurePropertyName, QVariant::fromValue<Feature *>(feature));
-
-    #if QT_VERSION >= QT_VERSION_CHECK(5, 15, 0)
     connect(cb, &QCheckBox::toggled, this, &Preferences::featuresCheckBoxToggled);
-    #else
-    connect(cb, static_cast<void(QCheckBox::*)(bool)>(&QCheckBox::toggled), this, &Preferences::featuresCheckBoxToggled);
-    #endif
 
     gridLayoutExperimentalFeatures->addWidget(cb, row, 0, 1, 2, Qt::AlignLeading);
     row++;

--- a/src/gui/ProgressWidget.cc
+++ b/src/gui/ProgressWidget.cc
@@ -11,7 +11,7 @@ ProgressWidget::ProgressWidget(QWidget *parent)
   this->wascanceled = false;
   this->starttime.start();
 
-  connect(this->stopButton, SIGNAL(clicked()), this, SLOT(cancel()));
+  connect(this->stopButton, &QPushButton::clicked, this, &ProgressWidget::cancel);
   QTimer::singleShot(1000, this, SIGNAL(requestShow()));
 }
 

--- a/src/gui/QWordSearchField.cc
+++ b/src/gui/QWordSearchField.cc
@@ -15,7 +15,7 @@ QWordSearchField::QWordSearchField(QFrame *parent) : QLineEdit(parent)
   fieldLabel->setCursor(Qt::ArrowCursor);
   fieldLabel->setStyleSheet("QLabel { border: none; padding: 0px; }");
   fieldLabel->hide();
-  connect(this, SIGNAL(findCountChanged()), this, SLOT(updateFieldLabel()));
+  connect(this, &QWordSearchField::findCountChanged, this, &QWordSearchField::updateFieldLabel);
   auto frameWidth = style()->pixelMetric(QStyle::PM_DefaultFrameWidth);
   setStyleSheet(QString("QLineEdit { padding-right: %1px; } ").arg(fieldLabel->sizeHint().width() + frameWidth + 1));
   auto minsize = minimumSizeHint();

--- a/src/gui/ScintillaEditor.cc
+++ b/src/gui/ScintillaEditor.cc
@@ -231,7 +231,13 @@ ScintillaEditor::ScintillaEditor(QWidget *parent) : EditorInterface(parent)
 #endif
 
   initMargin();
+
+  #if QT_VERSION >= QT_VERSION_CHECK(5, 15, 0)
   connect(qsci, &QsciScintilla::textChanged, this, &ScintillaEditor::contentsChanged);
+  #else
+  connect(qsci, static_cast<void(QsciScintilla::*)(void)>(&QsciScintilla::textChanged), this, &ScintillaEditor::contentsChanged);
+  #endif
+
   connect(qsci, &QsciScintilla::modificationChanged, this, &ScintillaEditor::fireModificationChanged);
   connect(qsci, &QsciScintilla::userListActivated, this, &ScintillaEditor::onUserListSelected);
   qsci->installEventFilter(this);
@@ -242,9 +248,14 @@ ScintillaEditor::ScintillaEditor(QWidget *parent) : EditorInterface(parent)
 
   qsci->indicatorDefine(QsciScintilla::ThinCompositionIndicator, hyperlinkIndicatorNumber);
   qsci->SendScintilla(QsciScintilla::SCI_INDICSETSTYLE, hyperlinkIndicatorNumber, QsciScintilla::INDIC_HIDDEN);
-  connect(qsci, &QsciScintilla::indicatorClicked, this, &ScintillaEditor::onIndicatorClicked);
-  connect(qsci, &QsciScintilla::indicatorReleased, this, &ScintillaEditor::onIndicatorReleased);
-
+  #if QT_VERSION >= QT_VERSION_CHECK(5, 15, 0)
+    connect(qsci, &QsciScintilla::indicatorClicked, this, &ScintillaEditor::onIndicatorClicked);
+    connect(qsci, &QsciScintilla::indicatorReleased, this, &ScintillaEditor::onIndicatorReleased);
+  #else
+    connect(qsci, static_cast<void(QsciScintilla::*)(int)>(&QsciScintilla::indicatorClicked), this, &ScintillaEditor::onIndicatorClicked);
+    connect(qsci, static_cast<void(QsciScintilla::*)(int)>(&QsciScintilla::indicatorReleased), this, &ScintillaEditor::onIndicatorReleased);
+  #endif
+  
 #if QSCINTILLA_VERSION >= 0x020b00
   connect(qsci, &QsciScintilla::SCN_URIDROPPED, this, &ScintillaEditor::uriDropped);
 #endif
@@ -787,7 +798,11 @@ void ScintillaEditor::initFont(const QString& fontName, uint size)
 
 void ScintillaEditor::initMargin()
 {
+  #if QT_VERSION >= QT_VERSION_CHECK(5, 15, 0)
   connect(qsci, &QsciScintilla::textChanged, this, &ScintillaEditor::onTextChanged);
+  #else
+  connect(qsci, static_cast<void(QsciScintilla::*)(void)>(&QsciScintilla::textChanged), this, &ScintillaEditor::onTextChanged);
+  #endif
 }
 
 void ScintillaEditor::onTextChanged()

--- a/src/gui/ScintillaEditor.cc
+++ b/src/gui/ScintillaEditor.cc
@@ -231,25 +231,24 @@ ScintillaEditor::ScintillaEditor(QWidget *parent) : EditorInterface(parent)
 #endif
 
   initMargin();
-
-  connect(qsci, SIGNAL(textChanged()), this, SIGNAL(contentsChanged()));
-  connect(qsci, SIGNAL(modificationChanged(bool)), this, SLOT(fireModificationChanged()));
-  connect(qsci, SIGNAL(userListActivated(int,const QString&)), this, SLOT(onUserListSelected(const int,const QString&)));
+  connect(qsci, &QsciScintilla::textChanged, this, &ScintillaEditor::contentsChanged);
+  connect(qsci, &QsciScintilla::modificationChanged, this, &ScintillaEditor::fireModificationChanged);
+  connect(qsci, &QsciScintilla::userListActivated, this, &ScintillaEditor::onUserListSelected);
   qsci->installEventFilter(this);
   qsci->viewport()->installEventFilter(this);
 
   qsci->setContextMenuPolicy(Qt::CustomContextMenu);
-  connect(qsci, SIGNAL(customContextMenuRequested(const QPoint&)), this, SIGNAL(showContextMenuEvent(const QPoint&)));
+  connect(qsci, &QsciScintilla::customContextMenuRequested, this, &ScintillaEditor::showContextMenuEvent);
 
   qsci->indicatorDefine(QsciScintilla::ThinCompositionIndicator, hyperlinkIndicatorNumber);
   qsci->SendScintilla(QsciScintilla::SCI_INDICSETSTYLE, hyperlinkIndicatorNumber, QsciScintilla::INDIC_HIDDEN);
-  connect(qsci, SIGNAL(indicatorClicked(int,int,Qt::KeyboardModifiers)), this, SLOT(onIndicatorClicked(int,int,Qt::KeyboardModifiers)));
-  connect(qsci, SIGNAL(indicatorReleased(int,int,Qt::KeyboardModifiers)), this, SLOT(onIndicatorReleased(int,int,Qt::KeyboardModifiers)));
+  connect(qsci, &QsciScintilla::indicatorClicked, this, &ScintillaEditor::onIndicatorClicked);
+  connect(qsci, &QsciScintilla::indicatorReleased, this, &ScintillaEditor::onIndicatorReleased);
 
 #if QSCINTILLA_VERSION >= 0x020b00
-  connect(qsci, SIGNAL(SCN_URIDROPPED(const QUrl&)), this, SIGNAL(uriDropped(const QUrl&)));
+  connect(qsci, &QsciScintilla::SCN_URIDROPPED, this, &ScintillaEditor::uriDropped);
 #endif
-  connect(qsci, SIGNAL(SCN_FOCUSIN()), this, SIGNAL(focusIn()));
+  connect(qsci, &QsciScintilla::SCN_FOCUSIN, this, &ScintillaEditor::focusIn);
 
   // Disabling buffered drawing resolves non-integer HiDPI scaling.
   qsci->SendScintilla(QsciScintillaBase::SCI_SETBUFFEREDDRAW, false);
@@ -788,7 +787,7 @@ void ScintillaEditor::initFont(const QString& fontName, uint size)
 
 void ScintillaEditor::initMargin()
 {
-  connect(qsci, SIGNAL(textChanged()), this, SLOT(onTextChanged()));
+  connect(qsci, &QsciScintilla::textChanged, this, &ScintillaEditor::onTextChanged);
 }
 
 void ScintillaEditor::onTextChanged()

--- a/src/gui/ScintillaEditor.cc
+++ b/src/gui/ScintillaEditor.cc
@@ -231,13 +231,7 @@ ScintillaEditor::ScintillaEditor(QWidget *parent) : EditorInterface(parent)
 #endif
 
   initMargin();
-
-  #if QT_VERSION >= QT_VERSION_CHECK(5, 15, 0)
   connect(qsci, &QsciScintilla::textChanged, this, &ScintillaEditor::contentsChanged);
-  #else
-  connect(qsci, static_cast<void(QsciScintilla::*)(void)>(&QsciScintilla::textChanged), this, &ScintillaEditor::contentsChanged);
-  #endif
-
   connect(qsci, &QsciScintilla::modificationChanged, this, &ScintillaEditor::fireModificationChanged);
   connect(qsci, &QsciScintilla::userListActivated, this, &ScintillaEditor::onUserListSelected);
   qsci->installEventFilter(this);
@@ -248,13 +242,8 @@ ScintillaEditor::ScintillaEditor(QWidget *parent) : EditorInterface(parent)
 
   qsci->indicatorDefine(QsciScintilla::ThinCompositionIndicator, hyperlinkIndicatorNumber);
   qsci->SendScintilla(QsciScintilla::SCI_INDICSETSTYLE, hyperlinkIndicatorNumber, QsciScintilla::INDIC_HIDDEN);
-  #if QT_VERSION >= QT_VERSION_CHECK(5, 15, 0)
-    connect(qsci, &QsciScintilla::indicatorClicked, this, &ScintillaEditor::onIndicatorClicked);
-    connect(qsci, &QsciScintilla::indicatorReleased, this, &ScintillaEditor::onIndicatorReleased);
-  #else
-    connect(qsci, static_cast<void(QsciScintilla::*)(int)>(&QsciScintilla::indicatorClicked), this, &ScintillaEditor::onIndicatorClicked);
-    connect(qsci, static_cast<void(QsciScintilla::*)(int)>(&QsciScintilla::indicatorReleased), this, &ScintillaEditor::onIndicatorReleased);
-  #endif
+  connect(qsci, &QsciScintilla::indicatorClicked, this, &ScintillaEditor::onIndicatorClicked);
+  connect(qsci, &QsciScintilla::indicatorReleased, this, &ScintillaEditor::onIndicatorReleased);
   
 #if QSCINTILLA_VERSION >= 0x020b00
   connect(qsci, &QsciScintilla::SCN_URIDROPPED, this, &ScintillaEditor::uriDropped);
@@ -798,11 +787,7 @@ void ScintillaEditor::initFont(const QString& fontName, uint size)
 
 void ScintillaEditor::initMargin()
 {
-  #if QT_VERSION >= QT_VERSION_CHECK(5, 15, 0)
   connect(qsci, &QsciScintilla::textChanged, this, &ScintillaEditor::onTextChanged);
-  #else
-  connect(qsci, static_cast<void(QsciScintilla::*)(void)>(&QsciScintilla::textChanged), this, &ScintillaEditor::onTextChanged);
-  #endif
 }
 
 void ScintillaEditor::onTextChanged()

--- a/src/gui/TabManager.cc
+++ b/src/gui/TabManager.cc
@@ -38,35 +38,35 @@ TabManager::TabManager(MainWindow *o, const QString& filename)
   tabWidget->setTabsClosable(true);
   tabWidget->setMovable(true);
   tabWidget->setContextMenuPolicy(Qt::CustomContextMenu);
-  connect(tabWidget, SIGNAL(currentTabChanged(int)), this, SLOT(tabSwitched(int)));
-  connect(tabWidget, SIGNAL(tabCloseRequested(int)), this, SLOT(closeTabRequested(int)));
-  connect(tabWidget, SIGNAL(tabCountChanged(int)), this, SIGNAL(tabCountChanged(int)));
-  connect(tabWidget, SIGNAL(middleMouseClicked(int)), this, SLOT(middleMouseClicked(int)));
-  connect(tabWidget, SIGNAL(customContextMenuRequested(const QPoint&)), this, SLOT(showTabHeaderContextMenu(const QPoint&)));
+  connect(tabWidget, &TabWidget::currentTabChanged, this, &TabManager::tabSwitched);
+  connect(tabWidget, &TabWidget::tabCloseRequested, this, &TabManager::closeTabRequested);
+  connect(tabWidget, &TabWidget::tabCountChanged, this, &TabManager::tabCountChanged);
+  connect(tabWidget, &TabWidget::middleMouseClicked, this, &TabManager::middleMouseClicked);
+  connect(tabWidget, &TabWidget::customContextMenuRequested, this, &TabManager::showTabHeaderContextMenu);
 
   createTab(filename);
 
-  connect(tabWidget, SIGNAL(currentTabChanged(int)), this, SLOT(stopAnimation()));
-  connect(tabWidget, SIGNAL(currentTabChanged(int)), this, SLOT(updateFindState()));
+  connect(tabWidget, &TabWidget::currentTabChanged, this, &TabManager::stopAnimation);
+  connect(tabWidget, &TabWidget::currentTabChanged, this, &TabManager::updateFindState);
 
-  connect(par, SIGNAL(highlightError(int)), this, SLOT(highlightError(int)));
-  connect(par, SIGNAL(unhighlightLastError()), this, SLOT(unhighlightLastError()));
+  connect(par, &MainWindow::highlightError, this, &TabManager::highlightError);
+  connect(par, &MainWindow::unhighlightLastError, this, &TabManager::unhighlightLastError);
 
-  connect(par->editActionUndo, SIGNAL(triggered()), this, SLOT(undo()));
-  connect(par->editActionRedo, SIGNAL(triggered()), this, SLOT(redo()));
-  connect(par->editActionRedo_2, SIGNAL(triggered()), this, SLOT(redo()));
-  connect(par->editActionCut, SIGNAL(triggered()), this, SLOT(cut()));
-  connect(par->editActionPaste, SIGNAL(triggered()), this, SLOT(paste()));
+  connect(par->editActionUndo, &QAction::triggered, this, &TabManager::undo);
+  connect(par->editActionRedo, &QAction::triggered, this, &TabManager::redo);
+  connect(par->editActionRedo_2, &QAction::triggered, this, &TabManager::redo);
+  connect(par->editActionCut, &QAction::triggered, this, &TabManager::cut);
+  connect(par->editActionPaste, &QAction::triggered, this, &TabManager::paste);
 
-  connect(par->editActionIndent, SIGNAL(triggered()), this, SLOT(indentSelection()));
-  connect(par->editActionUnindent, SIGNAL(triggered()), this, SLOT(unindentSelection()));
-  connect(par->editActionComment, SIGNAL(triggered()), this, SLOT(commentSelection()));
-  connect(par->editActionUncomment, SIGNAL(triggered()), this, SLOT(uncommentSelection()));
+  connect(par->editActionIndent, &QAction::triggered, this, &TabManager::indentSelection);
+  connect(par->editActionUnindent, &QAction::triggered, this, &TabManager::unindentSelection);
+  connect(par->editActionComment, &QAction::triggered, this, &TabManager::commentSelection);
+  connect(par->editActionUncomment, &QAction::triggered, this, &TabManager::uncommentSelection);
 
-  connect(par->editActionToggleBookmark, SIGNAL(triggered()), this, SLOT(toggleBookmark()));
-  connect(par->editActionNextBookmark, SIGNAL(triggered()), this, SLOT(nextBookmark()));
-  connect(par->editActionPrevBookmark, SIGNAL(triggered()), this, SLOT(prevBookmark()));
-  connect(par->editActionJumpToNextError, SIGNAL(triggered()), this, SLOT(jumpToNextError()));
+  connect(par->editActionToggleBookmark, &QAction::triggered, this, &TabManager::toggleBookmark);
+  connect(par->editActionNextBookmark, &QAction::triggered, this, &TabManager::nextBookmark);
+  connect(par->editActionPrevBookmark, &QAction::triggered, this, &TabManager::prevBookmark);
+  connect(par->editActionJumpToNextError, &QAction::triggered, this, &TabManager::jumpToNextError);
 }
 
 QWidget *TabManager::getTabHeader()
@@ -178,7 +178,7 @@ void TabManager::createTab(const QString& filename)
   Preferences::create(editor->colorSchemes()); // needs to be done only once, however handled
   par->activeEditor = editor;
   editor->parameterWidget = new ParameterWidget(par->parameterDock);
-  connect(editor->parameterWidget, SIGNAL(parametersChanged()), par, SLOT(actionRenderPreview()));
+  connect(editor->parameterWidget, &ScintillaEditor::parametersChanged, par, &MainWindow::actionRenderPreview);
   par->parameterDock->setWidget(editor->parameterWidget);
 
   // clearing default mapping of keyboard shortcut for font size
@@ -188,36 +188,34 @@ void TabManager::createTab(const QString& filename)
   qcmd = qcmdset->boundTo(Qt::ControlModifier | Qt::Key_Minus);
   qcmd->setKey(0);
 
-  connect(editor, SIGNAL(uriDropped(const QUrl&)), par, SLOT(handleFileDrop(const QUrl&)));
-  connect(editor, SIGNAL(previewRequest()), par, SLOT(actionRenderPreview()));
-  connect(editor, SIGNAL(showContextMenuEvent(const QPoint&)), this, SLOT(showContextMenuEvent(const QPoint&)));
+  connect(editor, &ScintillaEditor::uriDropped, par, &MainWindow::handleFileDrop);
+  connect(editor, &ScintillaEditor::previewRequest, par, &MainWindow::actionRenderPreview);
+  connect(editor, &ScintillaEditor::showContextMenuEvent, this, &TabManager::showContextMenuEvent);
   connect(editor, &EditorInterface::focusIn, this, [=]() { par->setLastFocus(editor); });
 
-  connect(Preferences::inst(), SIGNAL(editorConfigChanged()), editor, SLOT(applySettings()));
-  connect(Preferences::inst(), SIGNAL(autocompleteChanged(bool)), editor, SLOT(onAutocompleteChanged(bool)));
-  connect(Preferences::inst(), SIGNAL(characterThresholdChanged(int)), editor, SLOT(onCharacterThresholdChanged(int)));
+  connect(Preferences::inst(), &Preferences::editorConfigChanged, editor, &ScintillaEditor::applySettings);
+  connect(Preferences::inst(), &Preferences::autocompleteChanged, editor, &ScintillaEditor::onAutocompleteChanged);
+  connect(Preferences::inst(), &Preferences::characterThresholdChanged, editor, &ScintillaEditor::onCharacterThresholdChanged);
   ((ScintillaEditor *)editor)->public_applySettings();
   editor->addTemplate();
 
-  connect(par->editActionZoomTextIn, SIGNAL(triggered()), editor, SLOT(zoomIn()));
-  connect(par->editActionZoomTextOut, SIGNAL(triggered()), editor, SLOT(zoomOut()));
+  connect(par->editActionZoomTextIn, &QAction::triggered, editor, &ScintillaEditor::zoomIn);
+  connect(par->editActionZoomTextOut, &QAction::triggered, editor, &ScintillaEditor::zoomOut);
 
-  connect(editor, SIGNAL(contentsChanged()), this, SLOT(updateActionUndoState()));
-  connect(editor, SIGNAL(contentsChanged()), par,  SLOT(editorContentChanged()));
-  connect(editor, SIGNAL(contentsChanged()), this, SLOT(setContentRenderState()));
-  connect(editor, SIGNAL(modificationChanged(EditorInterface*)), this, SLOT(setTabModified(EditorInterface*)));
+  connect(editor, &ScintillaEditor::contentsChanged, this, &TabManager::updateActionUndoState);
+  connect(editor, &ScintillaEditor::contentsChanged, par, &MainWindow::editorContentChanged);
+  connect(editor, &ScintillaEditor::contentsChanged, this, &TabManager::setContentRenderState);
+  connect(editor, &ScintillaEditor::modificationChanged, this, &TabManager::setTabModified);
   connect(editor->parameterWidget, &ParameterWidget::modificationChanged, [editor = this->editor, this] {
     setTabModified(editor);
   });
 
-  connect(Preferences::inst(), SIGNAL(fontChanged(const QString&,uint)),
-          editor, SLOT(initFont(const QString&,uint)));
-  connect(Preferences::inst(), SIGNAL(syntaxHighlightChanged(const QString&)),
-          editor, SLOT(setHighlightScheme(const QString&)));
+  connect(Preferences::inst(), &Preferences::fontChanged, editor, &ScintillaEditor::initFont);
+  connect(Preferences::inst(), &Preferences::syntaxHighlightChanged, editor, &ScintillaEditor::setHighlightScheme);
   editor->initFont(Preferences::inst()->getValue("editor/fontfamily").toString(), Preferences::inst()->getValue("editor/fontsize").toUInt());
   editor->setHighlightScheme(Preferences::inst()->getValue("editor/syntaxhighlight").toString());
 
-  connect(editor, SIGNAL(hyperlinkIndicatorClicked(int)), this, SLOT(onHyperlinkIndicatorClicked(int)));
+  connect(editor, &ScintillaEditor::hyperlinkIndicatorClicked, this, &TabManager::onHyperlinkIndicatorClicked);
 
   int idx = tabWidget->addTab(editor, _("Untitled.scad"));
   if (!editorList.isEmpty()) {
@@ -411,24 +409,24 @@ void TabManager::showTabHeaderContextMenu(const QPoint& pos)
   copyFileNameAction->setData(idx);
   copyFileNameAction->setEnabled(!edt->filepath.isEmpty());
   copyFileNameAction->setText(_("Copy file name"));
-  connect(copyFileNameAction, SIGNAL(triggered()), SLOT(copyFileName()));
+  connect(copyFileNameAction, &QAction::triggered, this, &TabManager::copyFileName);
 
   auto *copyFilePathAction = new QAction(tabWidget);
   copyFilePathAction->setData(idx);
   copyFilePathAction->setEnabled(!edt->filepath.isEmpty());
   copyFilePathAction->setText(_("Copy full path"));
-  connect(copyFilePathAction, SIGNAL(triggered()), SLOT(copyFilePath()));
+  connect(copyFilePathAction, &QAction::triggered, this, &TabManager::copyFilePath);
 
   auto *openFolderAction = new QAction(tabWidget);
   openFolderAction->setData(idx);
   openFolderAction->setEnabled(!edt->filepath.isEmpty());
   openFolderAction->setText(_("Open folder"));
-  connect(openFolderAction, SIGNAL(triggered()), SLOT(openFolder()));
+  connect(openFolderAction, &QAction::triggered, this, &TabManager::openFolder);
 
   auto *closeAction = new QAction(tabWidget);
   closeAction->setData(idx);
   closeAction->setText(_("Close Tab"));
-  connect(closeAction, SIGNAL(triggered()), SLOT(closeTab()));
+  connect(closeAction, &QAction::triggered, this, &TabManager::closeTab);
 
   QMenu menu;
   menu.addAction(copyFileNameAction);

--- a/src/gui/TabWidget.cc
+++ b/src/gui/TabWidget.cc
@@ -11,9 +11,8 @@
 TabWidget::TabWidget(QWidget *parent) : QTabBar(parent)
 {
   stackWidget = new QStackedWidget(this);
-
-  connect(this, SIGNAL(currentChanged(int)), this, SLOT(handleCurrentChanged(int)));
-  connect(this, SIGNAL(tabMoved(int,int)), this, SLOT(handleTabMoved(int,int)));
+  connect(this, &QTabBar::currentChanged, this, &TabWidget::handleCurrentChanged);
+  connect(this, &QTabBar::tabMoved, this, &TabWidget::handleTabMoved);
 }
 
 QWidget *TabWidget::getContentWidget()

--- a/src/gui/ViewportControl.cc
+++ b/src/gui/ViewportControl.cc
@@ -32,15 +32,15 @@ void ViewportControl::initGUI()
   for (auto spinDoubleBox : spinDoubleBoxes) {
     spinDoubleBox->setMinimum(-DBL_MAX);
     spinDoubleBox->setMaximum(+DBL_MAX);
-    connect(spinDoubleBox, SIGNAL(valueChanged(double)), this, SLOT(updateCamera()));
+    connect(spinDoubleBox, &QDoubleSpinBox::valueChanged, this, &ViewportControl::updateCamera);
   }
 
   spinBoxWidth->setMinimum(1);
   spinBoxHeight->setMinimum(1);
   spinBoxWidth->setMaximum(8192);
   spinBoxHeight->setMaximum(8192);
-  connect(spinBoxWidth, SIGNAL(valueChanged(int)), this, SLOT(requestResize()));
-  connect(spinBoxHeight, SIGNAL(valueChanged(int)), this, SLOT(requestResize()));
+  connect(spinBoxWidth, &QSpinBox::valueChanged, this, &ViewportControl::requestResize);
+  connect(spinBoxHeight, &QSpinBox::valueChanged, this, &ViewportControl::requestResize);
 }
 
 void ViewportControl::setMainWindow(MainWindow *mainWindow)

--- a/src/gui/ViewportControl.cc
+++ b/src/gui/ViewportControl.cc
@@ -32,15 +32,24 @@ void ViewportControl::initGUI()
   for (auto spinDoubleBox : spinDoubleBoxes) {
     spinDoubleBox->setMinimum(-DBL_MAX);
     spinDoubleBox->setMaximum(+DBL_MAX);
+    #if QT_VERSION >= QT_VERSION_CHECK(5, 15, 0)
     connect(spinDoubleBox, &QDoubleSpinBox::valueChanged, this, &ViewportControl::updateCamera);
+    #else
+    connect(spinDoubleBox, static_cast<void(QDoubleSpinBox::*)(double)>(&QDoubleSpinBox::valueChanged), this, &ViewportControl::updateCamera);
+    #endif
   }
 
   spinBoxWidth->setMinimum(1);
   spinBoxHeight->setMinimum(1);
   spinBoxWidth->setMaximum(8192);
   spinBoxHeight->setMaximum(8192);
+  #if QT_VERSION >= QT_VERSION_CHECK(5, 15, 0)
   connect(spinBoxWidth, &QSpinBox::valueChanged, this, &ViewportControl::requestResize);
   connect(spinBoxHeight, &QSpinBox::valueChanged, this, &ViewportControl::requestResize);
+  #else
+  connect(spinBoxWidth, static_cast<void(QSpinBox::*)(int)>(&QSpinBox::valueChanged), this, &ViewportControl::requestResize);
+  connect(spinBoxHeight, static_cast<void(QSpinBox::*)(int)>(&QSpinBox::valueChanged), this, &ViewportControl::requestResize);
+  #endif
 }
 
 void ViewportControl::setMainWindow(MainWindow *mainWindow)

--- a/src/gui/input/AxisConfigWidget.cc
+++ b/src/gui/input/AxisConfigWidget.cc
@@ -77,9 +77,9 @@ void AxisConfigWidget::AxesChanged(int nr, double val) const {
 }
 
 void AxisConfigWidget::init() {
-  connect(this->pushButtonAxisTrim, SIGNAL(clicked()), this, SLOT(on_AxisTrim()));
-  connect(this->pushButtonAxisTrimReset, SIGNAL(clicked()), this, SLOT(on_AxisTrimReset()));
-  connect(this->pushButtonUpdate, SIGNAL(clicked()), this, SLOT(updateStates()));
+  connect(this->pushButtonAxisTrim, &QPushButton::clicked, this, &AxisConfigWidget::on_AxisTrim);
+  connect(this->pushButtonAxisTrimReset, &QPushButton::clicked, this, &AxisConfigWidget::on_AxisTrimReset);
+  connect(this->pushButtonUpdate, &QPushButton::clicked, this, &AxisConfigWidget::updateStates);
 
   initComboBox(this->comboBoxTranslationX, Settings::Settings::inputTranslationX);
   initComboBox(this->comboBoxTranslationY, Settings::Settings::inputTranslationY);

--- a/src/gui/input/InputDriverManager.cc
+++ b/src/gui/input/InputDriverManager.cc
@@ -85,10 +85,10 @@ void InputDriverManager::registerActions(const QList<QAction *>& actions, const 
 void InputDriverManager::init()
 {
   timer = new QTimer(this);
-  connect(QApplication::instance(), SIGNAL(focusChanged(QWidget*,QWidget*)), this, SLOT(onFocusChanged(QWidget*,QWidget*)));
+  connect(QApplication::instance(), &QApplication::focusChanged, this, &InputDriverManager::onFocusChanged);
 
   doOpen(true);
-  connect(timer, SIGNAL(timeout()), this, SLOT(onTimeout()));
+  connect(timer, &QTimer::timeout, this, &InputDriverManager::onTimeout);
   timer->start(10 * 1000);
 }
 

--- a/src/gui/input/InputEventMapper.cc
+++ b/src/gui/input/InputEventMapper.cc
@@ -61,7 +61,7 @@ InputEventMapper::InputEventMapper()
   zoomGain = 1.00;
 
   timer = new QTimer(this);
-  connect(timer, SIGNAL(timeout()), this, SLOT(onTimer()));
+  connect(timer, &QTimer::timeout, this, &InputEventMapper::onTimer);
   timer->start(30);
 
   onInputMappingUpdated();

--- a/src/gui/parameter/GroupWidget.cc
+++ b/src/gui/parameter/GroupWidget.cc
@@ -27,8 +27,8 @@ GroupWidget::GroupWidget(const QString& title, QWidget *parent) : QWidget(parent
   this->mainLayout.addWidget(&contentArea, 1, 0);
   setSizePolicy(QSizePolicy::Minimum, QSizePolicy::Maximum);
   setLayout(&mainLayout);
-
-  QObject::connect(&toggleButton, SIGNAL(toggled(bool)), this, SLOT(setExpanded(bool)));
+  
+  QObject::connect(&toggleButton, &QToolButton::toggled, this, &GroupWidget::setExpanded);
 }
 
 void GroupWidget::addWidget(QWidget *widget)

--- a/src/gui/parameter/ParameterCheckBox.cc
+++ b/src/gui/parameter/ParameterCheckBox.cc
@@ -12,8 +12,7 @@ ParameterCheckBox::ParameterCheckBox(QWidget *parent, BoolParameter *parameter, 
     //large checkbox, when we have the space
     checkBox->setStyleSheet("QCheckBox::indicator { width: 20px; height: 20px; } QCheckBox { spacing: 0px; }");
   }
-
-  connect(checkBox, SIGNAL(clicked()), this, SLOT(onChanged()));
+  connect(checkBox, &QCheckBox::clicked, this, &ParameterCheckBox::onChanged);
   ParameterCheckBox::setValue();
 }
 

--- a/src/gui/parameter/ParameterComboBox.cc
+++ b/src/gui/parameter/ParameterComboBox.cc
@@ -16,11 +16,7 @@ ParameterComboBox::ParameterComboBox(QWidget *parent, EnumParameter *parameter, 
   for (const auto& item : parameter->items) {
     comboBox->addItem(QString::fromStdString(item.key));
   }
-  #if QT_VERSION >= QT_VERSION_CHECK(5, 15, 0)
   connect(comboBox, &QComboBox::activated, this, &ParameterComboBox::onChanged);
-  #else
-  connect(comboBox, static_cast<void(QComboBox::*)(int)>(&QComboBox::activated), this, &ParameterComboBox::onChanged);
-  #endif
 
   ParameterComboBox::setValue();
 }

--- a/src/gui/parameter/ParameterComboBox.cc
+++ b/src/gui/parameter/ParameterComboBox.cc
@@ -16,8 +16,7 @@ ParameterComboBox::ParameterComboBox(QWidget *parent, EnumParameter *parameter, 
   for (const auto& item : parameter->items) {
     comboBox->addItem(QString::fromStdString(item.key));
   }
-
-  connect(comboBox, SIGNAL(activated(int)), this, SLOT(onChanged(int)));
+  connect(comboBox, &QComboBox::activated, this, &ParameterComboBox::onChanged);
   ParameterComboBox::setValue();
 }
 

--- a/src/gui/parameter/ParameterComboBox.cc
+++ b/src/gui/parameter/ParameterComboBox.cc
@@ -16,7 +16,12 @@ ParameterComboBox::ParameterComboBox(QWidget *parent, EnumParameter *parameter, 
   for (const auto& item : parameter->items) {
     comboBox->addItem(QString::fromStdString(item.key));
   }
+  #if QT_VERSION >= QT_VERSION_CHECK(5, 15, 0)
   connect(comboBox, &QComboBox::activated, this, &ParameterComboBox::onChanged);
+  #else
+  connect(comboBox, static_cast<void(QComboBox::*)(int)>(&QComboBox::activated), this, &ParameterComboBox::onChanged);
+  #endif
+
   ParameterComboBox::setValue();
 }
 

--- a/src/gui/parameter/ParameterSlider.cc
+++ b/src/gui/parameter/ParameterSlider.cc
@@ -55,10 +55,20 @@ ParameterSlider::ParameterSlider(QWidget *parent, NumberParameter *parameter, De
   //connect(slider, SIGNAL(sliderPressed()), this, SLOT(onSliderPressed()));
   connect(slider, &QSlider::sliderReleased, this, &ParameterSlider::onSliderReleased);
   connect(slider, &QSlider::sliderMoved, this, &ParameterSlider::onSliderMoved);
+  
+  #if QT_VERSION >= QT_VERSION_CHECK(5, 15, 0)
   connect(slider, &QSlider::valueChanged, this, &ParameterSlider::onSliderChanged);
+  #else
+  connect(slider, static_cast<void(QSlider::*)(int)>(&QSlider::valueChanged), this, &ParameterSlider::onSliderChanged);
+  #endif
 
-  connect(doubleSpinBox, &QDoubleSpinBox::valueChanged, this, &ParameterSlider::onSpinBoxChanged);
-  connect(doubleSpinBox, &QDoubleSpinBox::editingFinished, this, &ParameterSlider::onSpinBoxEditingFinished);
+  #if QT_VERSION >= QT_VERSION_CHECK(5, 15, 0)
+    connect(doubleSpinBox, &QDoubleSpinBox::valueChanged, this, &ParameterSlider::onSpinBoxChanged);
+    connect(doubleSpinBox, &QDoubleSpinBox::editingFinished, this, &ParameterSlider::onSpinBoxEditingFinished);
+  #else
+    connect(doubleSpinBox, static_cast<void(QDoubleSpinBox::*)(double)>(&QDoubleSpinBox::valueChanged), this, &ParameterSlider::onSpinBoxChanged);
+    connect(doubleSpinBox, static_cast<void(QDoubleSpinBox::*)()>(&QDoubleSpinBox::editingFinished), this, &ParameterSlider::onSpinBoxEditingFinished);
+  #endif
 
   ParameterSlider::setValue();
 }

--- a/src/gui/parameter/ParameterSlider.cc
+++ b/src/gui/parameter/ParameterSlider.cc
@@ -55,13 +55,7 @@ ParameterSlider::ParameterSlider(QWidget *parent, NumberParameter *parameter, De
   //connect(slider, SIGNAL(sliderPressed()), this, SLOT(onSliderPressed()));
   connect(slider, &QSlider::sliderReleased, this, &ParameterSlider::onSliderReleased);
   connect(slider, &QSlider::sliderMoved, this, &ParameterSlider::onSliderMoved);
-  
-  #if QT_VERSION >= QT_VERSION_CHECK(5, 15, 0)
   connect(slider, &QSlider::valueChanged, this, &ParameterSlider::onSliderChanged);
-  #else
-  connect(slider, static_cast<void(QSlider::*)(int)>(&QSlider::valueChanged), this, &ParameterSlider::onSliderChanged);
-  #endif
-
   #if QT_VERSION >= QT_VERSION_CHECK(5, 15, 0)
     connect(doubleSpinBox, &QDoubleSpinBox::valueChanged, this, &ParameterSlider::onSpinBoxChanged);
   #else

--- a/src/gui/parameter/ParameterSlider.cc
+++ b/src/gui/parameter/ParameterSlider.cc
@@ -53,12 +53,12 @@ ParameterSlider::ParameterSlider(QWidget *parent, NumberParameter *parameter, De
   doubleSpinBox->setSingleStep(this->step);
 
   //connect(slider, SIGNAL(sliderPressed()), this, SLOT(onSliderPressed()));
-  connect(slider, SIGNAL(sliderReleased()), this, SLOT(onSliderReleased()));
-  connect(slider, SIGNAL(sliderMoved(int)), this, SLOT(onSliderMoved(int)));
-  connect(slider, SIGNAL(valueChanged(int)), this, SLOT(onSliderChanged(int)));
+  connect(slider, &QSlider::sliderReleased, this, &ParameterSlider::onSliderReleased);
+  connect(slider, &QSlider::sliderMoved, this, &ParameterSlider::onSliderMoved);
+  connect(slider, &QSlider::valueChanged, this, &ParameterSlider::onSliderChanged);
 
-  connect(doubleSpinBox, SIGNAL(valueChanged(double)), this, SLOT(onSpinBoxChanged(double)));
-  connect(doubleSpinBox, SIGNAL(editingFinished()), this, SLOT(onSpinBoxEditingFinished()));
+  connect(doubleSpinBox, &QDoubleSpinBox::valueChanged, this, &ParameterSlider::onSpinBoxChanged);
+  connect(doubleSpinBox, &QDoubleSpinBox::editingFinished, this, &ParameterSlider::onSpinBoxEditingFinished);
 
   ParameterSlider::setValue();
 }

--- a/src/gui/parameter/ParameterSlider.cc
+++ b/src/gui/parameter/ParameterSlider.cc
@@ -64,12 +64,10 @@ ParameterSlider::ParameterSlider(QWidget *parent, NumberParameter *parameter, De
 
   #if QT_VERSION >= QT_VERSION_CHECK(5, 15, 0)
     connect(doubleSpinBox, &QDoubleSpinBox::valueChanged, this, &ParameterSlider::onSpinBoxChanged);
-    connect(doubleSpinBox, &QDoubleSpinBox::editingFinished, this, &ParameterSlider::onSpinBoxEditingFinished);
   #else
     connect(doubleSpinBox, static_cast<void(QDoubleSpinBox::*)(double)>(&QDoubleSpinBox::valueChanged), this, &ParameterSlider::onSpinBoxChanged);
-    connect(doubleSpinBox, static_cast<void(QDoubleSpinBox::*)()>(&QDoubleSpinBox::editingFinished), this, &ParameterSlider::onSpinBoxEditingFinished);
   #endif
-
+  connect(doubleSpinBox, &QDoubleSpinBox::editingFinished, this, &ParameterSlider::onSpinBoxEditingFinished);
   ParameterSlider::setValue();
 }
 

--- a/src/gui/parameter/ParameterSpinBox.cc
+++ b/src/gui/parameter/ParameterSpinBox.cc
@@ -45,8 +45,13 @@ ParameterSpinBox::ParameterSpinBox(QWidget *parent, NumberParameter *parameter, 
   doubleSpinBox->setRange(minimum, maximum);
   doubleSpinBox->setSingleStep(step);
 
+  #if QT_VERSION >= QT_VERSION_CHECK(5, 15, 0)
   connect(doubleSpinBox, &QDoubleSpinBox::valueChanged, this, &ParameterSpinBox::onChanged);
   connect(doubleSpinBox, &QDoubleSpinBox::editingFinished, this, &ParameterSpinBox::onEditingFinished);
+  #else
+  connect(doubleSpinBox, static_cast<void(QDoubleSpinBox::*)(double)>(&QDoubleSpinBox::valueChanged), this, &ParameterSpinBox::onChanged);
+  connect(doubleSpinBox, static_cast<void(QDoubleSpinBox::*)()>(&QDoubleSpinBox::editingFinished), this, &ParameterSpinBox::onEditingFinished);
+  #endif
   ParameterSpinBox::setValue();
 }
 

--- a/src/gui/parameter/ParameterSpinBox.cc
+++ b/src/gui/parameter/ParameterSpinBox.cc
@@ -47,11 +47,10 @@ ParameterSpinBox::ParameterSpinBox(QWidget *parent, NumberParameter *parameter, 
 
   #if QT_VERSION >= QT_VERSION_CHECK(5, 15, 0)
   connect(doubleSpinBox, &QDoubleSpinBox::valueChanged, this, &ParameterSpinBox::onChanged);
-  connect(doubleSpinBox, &QDoubleSpinBox::editingFinished, this, &ParameterSpinBox::onEditingFinished);
   #else
   connect(doubleSpinBox, static_cast<void(QDoubleSpinBox::*)(double)>(&QDoubleSpinBox::valueChanged), this, &ParameterSpinBox::onChanged);
-  connect(doubleSpinBox, static_cast<void(QDoubleSpinBox::*)()>(&QDoubleSpinBox::editingFinished), this, &ParameterSpinBox::onEditingFinished);
   #endif
+  connect(doubleSpinBox, &QDoubleSpinBox::editingFinished, this, &ParameterSpinBox::onEditingFinished);
   ParameterSpinBox::setValue();
 }
 

--- a/src/gui/parameter/ParameterSpinBox.cc
+++ b/src/gui/parameter/ParameterSpinBox.cc
@@ -45,8 +45,8 @@ ParameterSpinBox::ParameterSpinBox(QWidget *parent, NumberParameter *parameter, 
   doubleSpinBox->setRange(minimum, maximum);
   doubleSpinBox->setSingleStep(step);
 
-  connect(doubleSpinBox, SIGNAL(valueChanged(double)), this, SLOT(onChanged(double)));
-  connect(doubleSpinBox, SIGNAL(editingFinished()), this, SLOT(onEditingFinished()));
+  connect(doubleSpinBox, &QDoubleSpinBox::valueChanged, this, &ParameterSpinBox::onChanged);
+  connect(doubleSpinBox, &QDoubleSpinBox::editingFinished, this, &ParameterSpinBox::onEditingFinished);
   ParameterSpinBox::setValue();
 }
 

--- a/src/gui/parameter/ParameterText.cc
+++ b/src/gui/parameter/ParameterText.cc
@@ -15,8 +15,9 @@ ParameterText::ParameterText(QWidget *parent, StringParameter *parameter, Descri
     lineEdit->setMaxLength(*parameter->maximumSize);
   }
 
-  connect(lineEdit, SIGNAL(textEdited(const QString&)), this, SLOT(onEdit(const QString&)));
-  connect(lineEdit, SIGNAL(editingFinished()), this, SLOT(onEditingFinished()));
+  connect(lineEdit, &QLineEdit::textEdited, this, &ParameterText::onEdit);
+  connect(lineEdit, &QLineEdit::editingFinished, this, &ParameterText::onEditingFinished);
+
   ParameterText::setValue();
 }
 

--- a/src/gui/parameter/ParameterVector.cc
+++ b/src/gui/parameter/ParameterVector.cc
@@ -80,8 +80,8 @@ ParameterVector::ParameterVector(QWidget *parent, VectorParameter *parameter, De
     spinbox->setRange(minimum, maximum);
     spinbox->setSingleStep(step);
     spinbox->show();
-    connect(spinbox, SIGNAL(valueChanged(double)), this, SLOT(onChanged()));
-    connect(spinbox, SIGNAL(editingFinished()), this, SLOT(onEditingFinished()));
+    connect(spinbox, &QDoubleSpinBox::valueChanged, this, &ParameterVector::onChanged);
+    connect(spinbox, &QDoubleSpinBox::editingFinished, this, &ParameterVector::onEditingFinished);
   }
 
   ParameterVector::setValue();

--- a/src/gui/parameter/ParameterVector.cc
+++ b/src/gui/parameter/ParameterVector.cc
@@ -80,9 +80,14 @@ ParameterVector::ParameterVector(QWidget *parent, VectorParameter *parameter, De
     spinbox->setRange(minimum, maximum);
     spinbox->setSingleStep(step);
     spinbox->show();
+    #if QT_VERSION >= QT_VERSION_CHECK(5, 15, 0)
     connect(spinbox, &QDoubleSpinBox::valueChanged, this, &ParameterVector::onChanged);
     connect(spinbox, &QDoubleSpinBox::editingFinished, this, &ParameterVector::onEditingFinished);
-  }
+    #else
+    connect(spinbox, static_cast<void(QDoubleSpinBox::*)(double)>(&QDoubleSpinBox::valueChanged), this, &ParameterVector::onChanged);
+    connect(spinbox, static_cast<void(QDoubleSpinBox::*)()>(&QDoubleSpinBox::editingFinished), this, &ParameterVector::onEditingFinished);
+    #endif
+}
 
   ParameterVector::setValue();
 }

--- a/src/gui/parameter/ParameterVector.cc
+++ b/src/gui/parameter/ParameterVector.cc
@@ -82,11 +82,10 @@ ParameterVector::ParameterVector(QWidget *parent, VectorParameter *parameter, De
     spinbox->show();
     #if QT_VERSION >= QT_VERSION_CHECK(5, 15, 0)
     connect(spinbox, &QDoubleSpinBox::valueChanged, this, &ParameterVector::onChanged);
-    connect(spinbox, &QDoubleSpinBox::editingFinished, this, &ParameterVector::onEditingFinished);
     #else
     connect(spinbox, static_cast<void(QDoubleSpinBox::*)(double)>(&QDoubleSpinBox::valueChanged), this, &ParameterVector::onChanged);
-    connect(spinbox, static_cast<void(QDoubleSpinBox::*)()>(&QDoubleSpinBox::editingFinished), this, &ParameterVector::onEditingFinished);
     #endif
+    connect(spinbox, &QDoubleSpinBox::editingFinished, this, &ParameterVector::onEditingFinished);
 }
 
   ParameterVector::setValue();

--- a/src/gui/parameter/ParameterWidget.cc
+++ b/src/gui/parameter/ParameterWidget.cc
@@ -65,18 +65,10 @@ ParameterWidget::ParameterWidget(QWidget *parent) : QWidget(parent)
   connect(checkBoxAutoPreview, &QCheckBox::toggled, [this]() {
     this->autoPreview(true);
   });
-  #if QT_VERSION >= QT_VERSION_CHECK(5, 15, 0)
-    connect(comboBoxDetails, &QComboBox::currentIndexChanged, this, &ParameterWidget::rebuildWidgets);
-  #else
-    connect(comboBoxDetails, static_cast<void(QComboBox::*)(int)>(&QComboBox::currentIndexChanged), this, &ParameterWidget::rebuildWidgets);
-  #endif
+  connect(comboBoxDetails, &QComboBox::currentIndexChanged, this, &ParameterWidget::rebuildWidgets);
   //connect(comboBoxPreset, SIGNAL(editTextChanged(const QString&)), this, SLOT(onSetNameChanged()));
   
-  #if QT_VERSION >= QT_VERSION_CHECK(5, 15, 0)
   connect(comboBoxPreset, &QComboBox::activated, this, &ParameterWidget::onSetChanged);
-  #else
-  connect(comboBoxPreset, static_cast<void(QComboBox::*)(int)>(&QComboBox::activated), this, &ParameterWidget::onSetChanged);
-  #endif
 
   connect(addButton, &QPushButton::clicked, this, &ParameterWidget::onSetAdd);
   connect(deleteButton, &QPushButton::clicked, this, &ParameterWidget::onSetDelete);

--- a/src/gui/parameter/ParameterWidget.cc
+++ b/src/gui/parameter/ParameterWidget.cc
@@ -61,22 +61,20 @@ ParameterWidget::ParameterWidget(QWidget *parent) : QWidget(parent)
   autoPreviewTimer.setInterval(1000);
   autoPreviewTimer.setSingleShot(true);
 
-  connect(&autoPreviewTimer, SIGNAL(timeout()), this, SLOT(emitParametersChanged()));
+  connect(&autoPreviewTimer, &QTimer::timeout, this, &ParameterWidget::emitParametersChanged);
   connect(checkBoxAutoPreview, &QCheckBox::toggled, [this]() {
     this->autoPreview(true);
   });
-  connect(comboBoxDetails, SIGNAL(currentIndexChanged(int)), this, SLOT(rebuildWidgets()));
-  connect(comboBoxPreset, SIGNAL(activated(int)), this, SLOT(onSetChanged(int)));
+  connect(comboBoxDetails, &QComboBox::currentIndexChanged, this, &ParameterWidget::rebuildWidgets);
   //connect(comboBoxPreset, SIGNAL(editTextChanged(const QString&)), this, SLOT(onSetNameChanged()));
-  connect(addButton, SIGNAL(clicked()), this, SLOT(onSetAdd()));
-  connect(deleteButton, SIGNAL(clicked()), this, SLOT(onSetDelete()));
+  connect(comboBoxPreset, &QComboBox::activated, this, &ParameterWidget::onSetChanged);
+  connect(addButton, &QPushButton::clicked, this, &ParameterWidget::onSetAdd);
+  connect(deleteButton, &QPushButton::clicked, this, &ParameterWidget::onSetDelete);
 
   QString fontfamily = Preferences::inst()->getValue("advanced/customizerFontFamily").toString();
   uint fontsize = Preferences::inst()->getValue("advanced/customizerFontSize").toUInt();
   setFontFamilySize(fontfamily, fontsize);
-
-  connect(Preferences::inst(), SIGNAL(customizerFontChanged(const QString&, uint)), this,
-    SLOT(setFontFamilySize(const QString&, uint)));
+  connect(Preferences::inst(), &Preferences::customizerFontChanged, this, &ParameterWidget::setFontFamilySize);
 }
 
 // Can only be called before the initial setParameters().
@@ -313,7 +311,7 @@ void ParameterWidget::updateSetEditability()
   } else {
     if (!comboBoxPreset->isEditable()) {
       comboBoxPreset->setEditable(true);
-      connect(comboBoxPreset->lineEdit(), SIGNAL(textEdited(const QString&)), this, SLOT(onSetNameChanged()));
+      connect(comboBoxPreset->lineEdit(), &QLineEdit::textEdited, this, &ParameterWidget::onSetNameChanged);
     }
     deleteButton->setEnabled(true);
   }
@@ -340,7 +338,7 @@ void ParameterWidget::rebuildWidgets()
     auto *groupWidget = new GroupWidget(group.name);
     for (ParameterObject *parameter : group.parameters) {
       ParameterVirtualWidget *parameterWidget = createParameterWidget(parameter, descriptionStyle);
-      connect(parameterWidget, SIGNAL(changed(bool)), this, SLOT(parameterModified(bool)));
+      connect(parameterWidget, &ParameterVirtualWidget::changed, this, &ParameterWidget::parameterModified);
       if (!widgets.count(parameter)) {
         widgets[parameter] = {};
       }

--- a/src/gui/parameter/ParameterWidget.cc
+++ b/src/gui/parameter/ParameterWidget.cc
@@ -65,9 +65,19 @@ ParameterWidget::ParameterWidget(QWidget *parent) : QWidget(parent)
   connect(checkBoxAutoPreview, &QCheckBox::toggled, [this]() {
     this->autoPreview(true);
   });
-  connect(comboBoxDetails, &QComboBox::currentIndexChanged, this, &ParameterWidget::rebuildWidgets);
+  #if QT_VERSION >= QT_VERSION_CHECK(5, 15, 0)
+    connect(comboBoxDetails, &QComboBox::currentIndexChanged, this, &ParameterWidget::rebuildWidgets);
+  #else
+    connect(comboBoxDetails, static_cast<void(QComboBox::*)(int)>(&QComboBox::currentIndexChanged), this, &ParameterWidget::rebuildWidgets);
+  #endif
   //connect(comboBoxPreset, SIGNAL(editTextChanged(const QString&)), this, SLOT(onSetNameChanged()));
+  
+  #if QT_VERSION >= QT_VERSION_CHECK(5, 15, 0)
   connect(comboBoxPreset, &QComboBox::activated, this, &ParameterWidget::onSetChanged);
+  #else
+  connect(comboBoxPreset, static_cast<void(QComboBox::*)(int)>(&QComboBox::activated), this, &ParameterWidget::onSetChanged);
+  #endif
+
   connect(addButton, &QPushButton::clicked, this, &ParameterWidget::onSetAdd);
   connect(deleteButton, &QPushButton::clicked, this, &ParameterWidget::onSetDelete);
 

--- a/src/openscad_gui.cc
+++ b/src/openscad_gui.cc
@@ -118,7 +118,7 @@ void dialogThreadFunc(FontCacheInitializer *initializer)
 void dialogInitHandler(FontCacheInitializer *initializer, void *)
 {
   QFutureWatcher<void> futureWatcher;
-  QObject::connect(&futureWatcher, SIGNAL(finished()), scadApp, SLOT(hideFontCacheDialog()));
+  QObject::connect(&futureWatcher,&QFutureWatcher<void>::finished, scadApp, &OpenSCADApp::hideFontCacheDialog);
 
   auto future = QtConcurrent::run([initializer] {
     return dialogThreadFunc(initializer);
@@ -238,8 +238,8 @@ int gui(std::vector<std::string>& inputFiles, const std::filesystem::path& origi
     inputFilesList.append(assemblePath(original_path, infile));
   }
   new MainWindow(inputFilesList);
-  app.connect(&app, SIGNAL(lastWindowClosed()), &app, SLOT(releaseQSettingsCached()));
-  app.connect(&app, SIGNAL(lastWindowClosed()), &app, SLOT(quit()));
+  app.connect(&app, &OpenSCADApp::lastWindowClosed, &app, &OpenSCADApp::releaseQSettingsCached);
+  app.connect(&app, &OpenSCADApp::lastWindowClosed, &app, &OpenSCADApp::quit);
 
 #ifdef ENABLE_HIDAPI
   if (Settings::Settings::inputEnableDriverHIDAPI.value()) {


### PR DESCRIPTION
WIP to fix #5547

I have converted all the connect() invocations from the old syntax to the new syntax : 

Old syntax
:
connect(
    sender, SIGNAL( valueChanged( QString, QString ) ),
    receiver, SLOT( updateValue( QString ) )
);

New syntax:
connect(
    sender, &Sender::valueChanged,
    receiver, &Receiver::updateValue
);