### PR TITLE
Bugfix: Alt-scroll with event dx if dy is 0 (address openscad/openscad#4997)

### DIFF
--- a/src/gui/ScintillaEditor.cc
+++ b/src/gui/ScintillaEditor.cc
@@ -1193,12 +1193,16 @@ bool ScintillaEditor::handleWheelEventNavigateNumber(QWheelEvent *wheelEvent)
   }
 
   if (modifier) {
-    if (wheelEvent->angleDelta().y() < 0) {
+    int delta = wheelEvent->angleDelta().y() != 0
+      ? wheelEvent->angleDelta().y()
+      : wheelEvent->angleDelta().x();
+
+    if (delta < 0) {
       if (modifyNumber(Qt::Key_Down)) {
         previewAfterUndo = true;
       }
     } else {
-      // wheelEvent->delta() > 0
+      // delta > 0
       if (modifyNumber(Qt::Key_Up)) {
         previewAfterUndo = true;
       }


### PR DESCRIPTION
Turns out alt+scroll on my Linux machine (and probably Windows, given openscad/openscad#4997) switches between horizontal and vertical scroll. If you're holding alt (the default modifier key for the scroll-number feature), the scroll direction is switched, dy is 0, and the code in `master` will always take the false branch. One workaround is to just change the modifier key to LMB.

Here, we just look to see if there _is_ a y delta, and if not, grab the x one instead.

Tested with vertical and horizontal scroll with both LMB and alt as modifiers. Awkwardly, when using an actual horizontal scroll wheel, scrolling right is considered negative (since it moves down the page). Negating `deltaX` would affect the alt+vscroll behavior, though (which currently behaves as expected). Couldn't find a way to determine whether this is a true horizontal scroll or an alt+vscroll (I think this comes from the OS). In theory the OS could send `inverted()` to indicate that it's flipping the scroll wheel, but I think that's more for 'natural scrolling' features. On my machine, `inverted()` is false with or without alt held.

(issue probably introduced in e3c2bc8)