### PR TITLE
Rename some of the methods so there is a consistent naming scheme in classes

### DIFF
--- a/src/gui/ErrorLog.cc
+++ b/src/gui/ErrorLog.cc
@@ -37,32 +37,32 @@ void ErrorLog::initGUI()
   connect(logTable->horizontalHeader(), SIGNAL(sectionResized(int,int,int)), this, SLOT(onSectionResized(int,int,int)));
 }
 
-void ErrorLog::toErrorLog(const Message& log_msg)
+void ErrorLog::toErrorLog(const Message& logMsg)
 {
-  lastMessages.push_back(log_msg);
+  lastMessages.push_back(logMsg);
   QString currGroup = errorLogComboBox->currentText();
 
   //handle combobox
   if (errorLogComboBox->currentIndex() == 0);
-  else if (currGroup.toStdString() != getGroupName(log_msg.group)) return;
+  else if (currGroup.toStdString() != getGroupName(logMsg.group)) return;
 
-  showtheErrorInGUI(log_msg);
+  showtheErrorInGUI(logMsg);
 }
 
-void ErrorLog::showtheErrorInGUI(const Message& log_msg)
+void ErrorLog::showtheErrorInGUI(const Message& logMsg)
 {
-  auto *groupName = new QStandardItem(QString::fromStdString(getGroupName(log_msg.group)));
+  auto *groupName = new QStandardItem(QString::fromStdString(getGroupName(logMsg.group)));
   groupName->setEditable(false);
 
-  if (log_msg.group == message_group::Error) groupName->setForeground(QColor::fromRgb(255, 0, 0)); //make this item red.
-  else if (log_msg.group == message_group::Warning) groupName->setForeground(QColor::fromRgb(252, 211, 3)); //make this item yellow
+  if (logMsg.group == message_group::Error) groupName->setForeground(QColor::fromRgb(255, 0, 0)); //make this item red.
+  else if (logMsg.group == message_group::Warning) groupName->setForeground(QColor::fromRgb(252, 211, 3)); //make this item yellow
 
   errorLogModel->setItem(row, errorLog_column::group, groupName);
 
   QStandardItem *fileName;
   QStandardItem *lineNo;
-  if (!log_msg.loc.isNone()) {
-    const auto& filePath = log_msg.loc.filePath();
+  if (!logMsg.loc.isNone()) {
+    const auto& filePath = logMsg.loc.filePath();
     if (is_regular_file(filePath)) {
       const auto path = QString::fromStdString(filePath.generic_string());
       fileName = new QStandardItem(QString::fromStdString(filePath.filename().generic_string()));
@@ -71,7 +71,7 @@ void ErrorLog::showtheErrorInGUI(const Message& log_msg)
     } else {
       fileName = new QStandardItem(QString());
     }
-    lineNo = new QStandardItem(QString::number(log_msg.loc.firstLine()));
+    lineNo = new QStandardItem(QString::number(logMsg.loc.firstLine()));
   } else {
     fileName = new QStandardItem(QString());
     lineNo = new QStandardItem(QString());
@@ -82,7 +82,7 @@ void ErrorLog::showtheErrorInGUI(const Message& log_msg)
   errorLogModel->setItem(row, errorLog_column::file, fileName);
   errorLogModel->setItem(row, errorLog_column::lineNo, lineNo);
 
-  auto *msg = new QStandardItem(QString::fromStdString(log_msg.msg));
+  auto *msg = new QStandardItem(QString::fromStdString(logMsg.msg));
   msg->setEditable(false);
   errorLogModel->setItem(row, errorLog_column::message, msg);
   errorLogModel->setRowCount(++row);
@@ -121,7 +121,7 @@ int ErrorLog::getLine(int row, int col)
   return logTable->model()->index(row, col).data().toInt();
 }
 
-void ErrorLog::on_errorLogComboBox_currentTextChanged(const QString& group)
+void ErrorLog::onErrorLogComboBoxCurrentTextChanged(const QString& group)
 {
   errorLogModel->clear();
   initGUI();
@@ -133,12 +133,12 @@ void ErrorLog::on_errorLogComboBox_currentTextChanged(const QString& group)
   }
 }
 
-void ErrorLog::on_logTable_doubleClicked(const QModelIndex& index)
+void ErrorLog::onLogTableDoubleClicked(const QModelIndex& index)
 {
   onIndexSelected(index);
 }
 
-void ErrorLog::on_actionRowSelected_triggered(bool)
+void ErrorLog::onActionRowSelectedTriggered(bool)
 {
   const auto indexes = logTable->selectionModel()->selectedRows(0);
   if (indexes.size() == 1) {

--- a/src/gui/ErrorLog.h
+++ b/src/gui/ErrorLog.h
@@ -26,8 +26,8 @@ public:
   ErrorLog& operator=(ErrorLog&& source) = delete;
   ~ErrorLog() override = default;
   void initGUI();
-  void toErrorLog(const Message& log_msg);
-  void showtheErrorInGUI(const Message& log_msg);
+  void toErrorLog(const Message& logMsg);
+  void showtheErrorInGUI(const Message& logMsg);
   void clearModel();
   int getLine(int row, int col);
   QStandardItemModel *errorLogModel;
@@ -48,8 +48,8 @@ signals:
   void openFile(const QString, int);
 
 private slots:
-  void on_logTable_doubleClicked(const QModelIndex& index);
-  void on_errorLogComboBox_currentTextChanged(const QString& arg1);
-  void on_actionRowSelected_triggered(bool);
+  void onLogTableDoubleClicked(const QModelIndex& index);
+  void onErrorLogComboBoxCurrentTextChanged(const QString& arg1);
+  void onActionRowSelectedTriggered(bool);
   void onSectionResized(int, int, int);
 };

--- a/src/gui/LibraryInfoDialog.cc
+++ b/src/gui/LibraryInfoDialog.cc
@@ -10,10 +10,10 @@ LibraryInfoDialog::LibraryInfoDialog(const QString& rendererInfo)
 {
   setupUi(this);
   connect(this->okButton, SIGNAL(clicked()), this, SLOT(accept()));
-  update_library_info(rendererInfo);
+  updateLibraryInfo(rendererInfo);
 }
 
-void LibraryInfoDialog::update_library_info(const QString& rendererInfo)
+void LibraryInfoDialog::updateLibraryInfo(const QString& rendererInfo)
 {
   //Get library infos
   QString info(LibraryInfo::info().c_str());

--- a/src/gui/LibraryInfoDialog.h
+++ b/src/gui/LibraryInfoDialog.h
@@ -13,5 +13,5 @@ class LibraryInfoDialog : public QDialog, public Ui::LibraryInfoDialog
 public:
   LibraryInfoDialog(const QString& rendererInfo);
 
-  void update_library_info(const QString& rendererInfo);
+  void updateLibraryInfo(const QString& rendererInfo);
 };

--- a/src/gui/MainWindow.h
+++ b/src/gui/MainWindow.h
@@ -68,16 +68,16 @@ public:
 
   QTimer *consoleUpdater;
 
-  bool is_preview;
+  bool isPreview;
 
   QTimer *autoReloadTimer;
   QTimer *waitAfterReloadTimer;
   RenderStatistic renderStatistic;
 
-  SourceFile *root_file; // Result of parsing
-  SourceFile *parsed_file; // Last parse for include list
-  std::shared_ptr<AbstractNode> absolute_root_node; // Result of tree evaluation
-  std::shared_ptr<AbstractNode> root_node; // Root if the root modifier (!) is used
+  SourceFile *rootFile; // Result of parsing
+  SourceFile *parsedFile; // Last parse for include list
+  std::shared_ptr<AbstractNode> absoluteRootNode; // Result of tree evaluation
+  std::shared_ptr<AbstractNode> rootNode; // Root if the root modifier (!) is used
 #ifdef ENABLE_PYTHON
   bool python_active;
   std::string trusted_edit_document_name;
@@ -88,7 +88,7 @@ public:
   EditorInterface *activeEditor;
   TabManager *tabManager;
 
-  std::shared_ptr<const Geometry> root_geom;
+  std::shared_ptr<const Geometry> rootGeom;
   std::shared_ptr<Renderer> cgalRenderer;
 #ifdef ENABLE_OPENCSG
   std::shared_ptr<Renderer> opencsgRenderer;
@@ -96,7 +96,7 @@ public:
 #endif
   std::shared_ptr<Renderer> thrownTogetherRenderer;
 
-  QString last_compiled_doc;
+  QString lastCompiledDoc;
 
   QAction *actionRecentFile[UIUtils::maxRecentFiles];
   QMap<QString, QString> knownFileExtensions;
@@ -151,7 +151,7 @@ public:
   void parseTopLevelDocument();
   void exceptionCleanup();
   void setLastFocus(QWidget *widget);
-  void UnknownExceptionCleanup(std::string msg = "");
+  void unknownExceptionCleanup(std::string msg = "");
 
 private:
   void setRenderVariables(ContextHandle<BuiltinContext>& context);
@@ -167,15 +167,15 @@ private:
   void updateWindowSettings(bool console, bool editor, bool customizer, bool errorLog, bool editorToolbar, bool viewToolbar, bool animate, bool fontList, bool ViewportControlWidget);
   void saveBackup();
   void writeBackup(QFile *file);
-  void show_examples();
+  void showExamples();
   void setDockWidgetTitle(QDockWidget *dockWidget, QString prefix, bool topLevel);
   void addKeyboardShortCut(const QList<QAction *>& actions);
   void updateStatusBar(ProgressWidget *progressWidget);
   void activateWindow(int);
 
-  LibraryInfoDialog *library_info_dialog{nullptr};
-  FontListDialog *font_list_dialog{nullptr};
-  QSignalMapper *exportformat_mapper;
+  LibraryInfoDialog *libraryInfoDialog{nullptr};
+  FontListDialog *fontListDialog{nullptr};
+  QSignalMapper *exportFormatMapper;
 
 public slots:
   void updateExportActions();
@@ -227,17 +227,17 @@ private slots:
   void hideAnimate();
   void showFontList();
   void hideFontList();
-  void on_windowActionSelectEditor_triggered();
-  void on_windowActionSelectConsole_triggered();
-  void on_windowActionSelectCustomizer_triggered();
-  void on_windowActionSelectErrorLog_triggered();
-  void on_windowActionSelectAnimate_triggered();
-  void on_windowActionSelectFontList_triggered();
-  void on_windowActionSelectViewportControl_triggered();
-  void on_windowActionNextWindow_triggered();
-  void on_windowActionPreviousWindow_triggered();
-  void on_editActionInsertTemplate_triggered();
-  void on_editActionFoldAll_triggered();
+  void onWindowActionSelectEditorTriggered();
+  void onWindowActionSelectConsoleTriggered();
+  void onWindowActionSelectCustomizerTriggered();
+  void onWindowActionSelectErrorLogTriggered();
+  void onWindowActionSelectAnimateTriggered();
+  void onwindowActionSelectFontListTriggered();
+  void onWindowActionSelectViewportControlTriggered();
+  void onWindowActionNextWindowTriggered();
+  void onWindowActionPreviousWindowTriggered();
+  void onEditActionInsertTemplateTriggered();
+  void onEditActionFoldAllTriggered();
 
 public slots:
   void hideFind();
@@ -307,7 +307,7 @@ public:
 
   QList<double> getTranslation() const;
   QList<double> getRotation() const;
-  std::unordered_map<FileFormat, QAction*>  export_map;
+  std::unordered_map<FileFormat, QAction*>  exportMap;
 
 public slots:
   void actionReloadRenderPreview();
@@ -372,8 +372,8 @@ public slots:
   void autoReloadSet(bool);
 
 private:
-  bool network_progress_func(const double permille);
-  static void report_func(const std::shared_ptr<const AbstractNode>&, void *vp, int mark);
+  bool networkProgressFunc(const double permille);
+  static void reportFunc(const std::shared_ptr<const AbstractNode>&, void *vp, int mark);
   static bool undockMode;
   static bool reorderMode;
   static const int tabStopWidth;
@@ -382,10 +382,10 @@ private:
 
   std::shared_ptr<CSGNode> csgRoot; // Result of the CSGTreeEvaluator
   std::shared_ptr<CSGNode> normalizedRoot; // Normalized CSG tree
-  std::shared_ptr<CSGProducts> root_products;
-  std::shared_ptr<CSGProducts> highlights_products;
-  std::shared_ptr<CSGProducts> background_products;
-  int currently_selected_object {-1};
+  std::shared_ptr<CSGProducts> rootProducts;
+  std::shared_ptr<CSGProducts> highlightsProducts;
+  std::shared_ptr<CSGProducts> backgroundProducts;
+  int currentlySelectedObject {-1};
 
   char const *afterCompileSlot;
   bool procevents{false};
@@ -394,11 +394,11 @@ private:
   CGALWorker *cgalworker;
   QMutex consolemutex;
   EditorInterface *renderedEditor; // stores pointer to editor which has been most recently rendered
-  time_t includes_mtime{0}; // latest include mod time
-  time_t deps_mtime{0}; // latest dependency mod time
+  time_t includesTime{0}; // latest include mod time
+  time_t dependencyTime{0}; // latest dependency mod time
   std::unordered_map<QString, QString> export_paths; // for each file type, where it was exported to last
   QString exportPath(const QString& suffix); // look up the last export path and generate one if not found
-  int last_parser_error_pos{-1}; // last highlighted error position
+  int lastParserErrorPosition{-1}; // last highlighted error position
   int tabCount = 0;
   ExportPdfPaperSize sizeString2Enum(const QString& current);
   ExportPdfPaperOrientation orientationsString2Enum(const QString& current);

--- a/src/gui/MouseSelector.cc
+++ b/src/gui/MouseSelector.cc
@@ -24,7 +24,7 @@ MouseSelector::MouseSelector(GLView *view) {
   if (view && !view->has_shaders) {
     return;
   }
-  this->init_shader();
+  this->initShader();
 
   if (view) this->reset(view);
 }
@@ -34,13 +34,13 @@ MouseSelector::MouseSelector(GLView *view) {
  */
 void MouseSelector::reset(GLView *view) {
   this->view = view;
-  this->setup_framebuffer(view);
+    this->setupFramebuffer(view);
 }
 
 /**
  * Initialize the used shaders and setup the ShaderInfo struct
  */
-void MouseSelector::init_shader() {
+void MouseSelector::initShader() {
   /*
      Attributes:
    * frag_idcolor - (uniform) 24 bit of the selected object's id encoded into R/G/B components as float values
@@ -65,7 +65,7 @@ void MouseSelector::init_shader() {
 /**
  * Resize or create the framebuffer
  */
-void MouseSelector::setup_framebuffer(const GLView *view) {
+void MouseSelector::setupFramebuffer(const GLView *view) {
   if (!this->framebuffer ||
       static_cast<unsigned int>(this->framebuffer->width()) != view->cam.pixel_width ||
       static_cast<unsigned int>(this->framebuffer->height()) != view->cam.pixel_height) {

--- a/src/gui/MouseSelector.h
+++ b/src/gui/MouseSelector.h
@@ -22,8 +22,8 @@ public:
   RendererUtils::ShaderInfo shaderinfo;
 
 private:
-  void init_shader();
-  void setup_framebuffer(const GLView *view);
+  void initShader();
+  void setupFramebuffer(const GLView *view);
 
   std::unique_ptr<QOpenGLFramebufferObject> framebuffer;
 

--- a/src/gui/TabManager.cc
+++ b/src/gui/TabManager.cc
@@ -510,11 +510,11 @@ void TabManager::openTabFile(const QString& filename)
     } catch (const HardWarningException&) {
       par->exceptionCleanup();
     } catch (const std::exception& ex) {
-      par->UnknownExceptionCleanup(ex.what());
+      par->unknownExceptionCleanup(ex.what());
     } catch (...) {
-      par->UnknownExceptionCleanup();
+      par->unknownExceptionCleanup();
     }
-    par->last_compiled_doc = ""; // undo the damage so F4 works
+    par->lastCompiledDoc = ""; // undo the damage so F4 works
     par->clearCurrentOutput();
   }
 }

--- a/src/gui/TabManager.h
+++ b/src/gui/TabManager.h
@@ -53,8 +53,6 @@ private slots:
   void tabSwitched(int);
   void closeTabRequested(int);
   void middleMouseClicked(int);
-
-private slots:
   void highlightError(int);
   void unhighlightLastError();
   void undo();


### PR DESCRIPTION
Current situation:
In the codebase there is several different style used which make the code less clear. 

After the PR:
fix some of the inconsistancies by applying camelCaseNaming

The PR shouldn't have impact on the application behavior. 