### PR TITLE
Bump Clipper2 to 1.5.0

### DIFF
--- a/scripts/macosx-build-dependencies.sh
+++ b/scripts/macosx-build-dependencies.sh
@@ -61,7 +61,7 @@ PACKAGES=(
     "opencsg 1.6.0"
     "qscintilla 2.14.1"
     "onetbb 2021.12.0"
-    "clipper2 1.4.0"
+    "clipper2 1.5.0"
     "manifold 3.0.1"
 )
 DEPLOY_PACKAGES=(

--- a/scripts/release-common.sh
+++ b/scripts/release-common.sh
@@ -97,8 +97,7 @@ fi
 case $OS in
     MACOSX)
         . ./scripts/setenv-macos.sh
-        # Note: Need built-in Clipper since the latest Clipper release (1.4.0) is too old
-        CMAKE_CONFIG="$CMAKE_CONFIG -DUSE_BUILTIN_CLIPPER2=ON -DUSE_BUILTIN_MANIFOLD=OFF -DCMAKE_OSX_ARCHITECTURES=x86_64;arm64"
+        CMAKE_CONFIG="$CMAKE_CONFIG -DUSE_BUILTIN_CLIPPER2=OFF -DUSE_BUILTIN_MANIFOLD=OFF -DCMAKE_OSX_ARCHITECTURES=x86_64;arm64"
     ;;
     LINUX)
         TARGET=


### PR DESCRIPTION
Clipper2 1.5.0 was released, including bugfixes needed by OpenSCAD.