### PR TITLE
Bump Clipper2 to 1.5.2

### DIFF
--- a/scripts/macosx-build-dependencies.sh
+++ b/scripts/macosx-build-dependencies.sh
@@ -61,7 +61,7 @@ PACKAGES=(
     "opencsg 1.7.0"
     "qscintilla 2.14.1"
     "onetbb 2021.12.0"
-    "clipper2 1.5.0"
+    "clipper2 1.5.2"
     "manifold 3.0.1"
 )
 DEPLOY_PACKAGES=(


### PR DESCRIPTION
Clipper 1.5.0 reported itself as 1.4.0. 1.5.2 fixes that issue.