### PR TITLE
[COSMETIC] Renames the method and attributes so they use camlCase

### DIFF
--- a/src/gui/Animate.cc
+++ b/src/gui/Animate.cc
@@ -32,18 +32,18 @@ Animate::Animate(QWidget *parent) : QWidget(parent)
 
 void Animate::initGUI()
 {
-  this->anim_step = 0;
-  this->anim_numsteps = 0;
-  this->anim_tval = 0.0;
-  this->anim_dumping = false;
-  this->anim_dump_start_step = 0;
+    this->animStep = 0;
+    this->animNumSteps = 0;
+  this->animTVal = 0.0;
+    this->animDumping = false;
+  this->animDumpStartStep = 0;
 
   this->iconRun = QIcon::fromTheme("chokusen-animate-play");
   this->iconPause = QIcon::fromTheme("chokusen-animate-pause");
   this->iconDisabled = QIcon::fromTheme("chokusen-animate-disabled");
 
-  animate_timer = new QTimer(this);
-  connect(animate_timer, SIGNAL(timeout()), this, SLOT(incrementTVal()));
+    animateTimer = new QTimer(this);
+    connect(animateTimer, SIGNAL(timeout()), this, SLOT(incrementTVal()));
 
   connect(this->e_tval, SIGNAL(textChanged(QString)), this, SLOT(updatedAnimTval()));
   connect(this->e_fps, SIGNAL(textChanged(QString)), this, SLOT(updatedAnimFpsAndAnimSteps()));
@@ -66,20 +66,20 @@ void Animate::setMainWindow(MainWindow *mainWindow)
 void Animate::connectAction(QAction *action, QPushButton *button)
 {
   connect(action, &QAction::triggered, button, &QPushButton::click);
-  this->action_list.append(action);
+  this->actionList.append(action);
 }
 
 void Animate::updatedAnimTval()
 {
-  double t = this->e_tval->text().toDouble(&this->t_ok);
+    double t = this->e_tval->text().toDouble(&this->tOK);
   // Clamp t to 0-1
-  if (this->t_ok) {
+    if (this->tOK) {
     t = t < 0 ? 0.0 : ((t > 1.0) ? 1.0 : t);
   } else {
     t = 0.0;
   }
 
-  this->anim_tval = t;
+  this->animTVal = t;
   emit mainWindow->actionRenderPreview();
 
   updatePauseButtonIcon();
@@ -87,23 +87,23 @@ void Animate::updatedAnimTval()
 
 void Animate::updatedAnimFpsAndAnimSteps()
 {
-  animate_timer->stop();
+    animateTimer->stop();
 
   int numsteps = this->e_fsteps->text().toInt(&this->steps_ok);
   if (this->steps_ok) {
-    this->anim_numsteps = numsteps;
+      this->animNumSteps = numsteps;
   } else {
-    this->anim_numsteps = 0;
+      this->animNumSteps = 0;
   }
-  this->anim_dumping = false;
+  this->animDumping = false;
 
-  double fps = this->e_fps->text().toDouble(&this->fps_ok);
-  animate_timer->stop();
-  if (this->fps_ok && fps > 0 && this->anim_numsteps > 0) {
-    this->anim_step = int(this->anim_tval * this->anim_numsteps) % this->anim_numsteps;
-    animate_timer->setSingleShot(false);
-    animate_timer->setInterval(int(1000 / fps));
-    animate_timer->start();
+  double fps = this->e_fps->text().toDouble(&this->fpsOK);
+  animateTimer->stop();
+  if (this->fpsOK && fps > 0 && this->animNumSteps > 0) {
+      this->animStep = int(this->animTVal * this->animNumSteps) % this->animNumSteps;
+      animateTimer->setSingleShot(false);
+      animateTimer->setInterval(int(1000 / fps));
+      animateTimer->start();
   }
 
   QPalette defaultPalette;
@@ -116,7 +116,7 @@ void Animate::updatedAnimFpsAndAnimSteps()
     this->e_fsteps->setStyleSheet(redStyleSheet);
   }
 
-  if (this->fps_ok || this->e_fps->text() == "") {
+  if (this->fpsOK || this->e_fps->text() == "") {
     this->e_fps->setStyleSheet("");
   } else {
     this->e_fps->setStyleSheet(redStyleSheet);
@@ -128,7 +128,7 @@ void Animate::updatedAnimFpsAndAnimSteps()
 
 void Animate::updatedAnimDump(bool checked)
 {
-  if (!checked) this->anim_dumping = false;
+    if (!checked) this->animDumping = false;
 
   updatePauseButtonIcon();
 }
@@ -136,21 +136,21 @@ void Animate::updatedAnimDump(bool checked)
 // Only called from animate_timer
 void Animate::incrementTVal()
 {
-  if (this->anim_numsteps == 0) return;
+    if (this->animNumSteps == 0) return;
 
   if (mainWindow->windowActionHideCustomizer->isVisible()) {
     if (mainWindow->activeEditor->parameterWidget->childHasFocus()) return;
   }
 
-  if (this->anim_numsteps > 1) {
-    this->anim_step = (this->anim_step + 1) % this->anim_numsteps;
-    this->anim_tval = 1.0 * this->anim_step / this->anim_numsteps;
-  } else if (this->anim_numsteps > 0) {
-    this->anim_step = 0;
-    this->anim_tval = 0.0;
+  if (this->animNumSteps > 1) {
+      this->animStep = (this->animStep + 1) % this->animNumSteps;
+      this->animTVal = 1.0 * this->animStep / this->animNumSteps;
+  } else if (this->animNumSteps > 0) {
+      this->animStep = 0;
+    this->animTVal = 0.0;
   }
 
-  const QString txt = QString::number(this->anim_tval, 'f', 5);
+  const QString txt = QString::number(this->animTVal, 'f', 5);
   this->e_tval->setText(txt);
 
   updatePauseButtonIcon();
@@ -158,35 +158,35 @@ void Animate::incrementTVal()
 
 void Animate::updateTVal()
 {
-  if (this->anim_numsteps == 0) return;
+    if (this->animNumSteps == 0) return;
 
-  if (this->anim_step < 0) {
-    this->anim_step = this->anim_numsteps - this->anim_step - 2;
+  if (this->animStep < 0) {
+      this->animStep = this->animNumSteps - this->animStep - 2;
   }
 
-  if (this->anim_numsteps > 1) {
-    this->anim_step = (this->anim_step) % this->anim_numsteps;
-    this->anim_tval = 1.0 * this->anim_step / this->anim_numsteps;
-  } else if (this->anim_numsteps > 0) {
-    this->anim_step = 0;
-    this->anim_tval = 0.0;
+  if (this->animNumSteps > 1) {
+      this->animStep = (this->animStep) % this->animNumSteps;
+      this->animTVal = 1.0 * this->animStep / this->animNumSteps;
+  } else if (this->animNumSteps > 0) {
+      this->animStep = 0;
+    this->animTVal = 0.0;
   }
 
-  const QString txt = QString::number(this->anim_tval, 'f', 5);
+  const QString txt = QString::number(this->animTVal, 'f', 5);
   this->e_tval->setText(txt);
 
   updatePauseButtonIcon();
 }
 
 void Animate::pauseAnimation(){
-  animate_timer->stop();
+    animateTimer->stop();
   updatePauseButtonIcon();
 }
 
 void Animate::on_pauseButton_pressed()
 {
-  if (animate_timer->isActive()) {
-    animate_timer->stop();
+    if (animateTimer->isActive()) {
+        animateTimer->stop();
     updatePauseButtonIcon();
   } else {
     this->updatedAnimFpsAndAnimSteps();
@@ -195,11 +195,11 @@ void Animate::on_pauseButton_pressed()
 
 void Animate::updatePauseButtonIcon()
 {
-  if (animate_timer->isActive()) {
+    if (animateTimer->isActive()) {
     pauseButton->setIcon(this->iconPause);
     pauseButton->setToolTip(_("press to pause animation") );
   } else {
-    if (this->fps_ok && this->steps_ok) {
+    if (this->fpsOK && this->steps_ok) {
       pauseButton->setIcon(this->iconRun);
       pauseButton->setToolTip(_("press to start animation") );
     } else {
@@ -220,31 +220,31 @@ void Animate::editorContentChanged(){
 void Animate::animateUpdate()
 {
   if (mainWindow->animateDockContents->isVisible()) {
-    double fps = this->e_fps->text().toDouble(&this->fps_ok);
-    if (this->fps_ok && fps <= 0 && !animate_timer->isActive()) {
-      animate_timer->stop();
-      animate_timer->setSingleShot(true);
-      animate_timer->setInterval(50);
-      animate_timer->start();
+    double fps = this->e_fps->text().toDouble(&this->fpsOK);
+    if (this->fpsOK && fps <= 0 && !animateTimer->isActive()) {
+        animateTimer->stop();
+        animateTimer->setSingleShot(true);
+        animateTimer->setInterval(50);
+        animateTimer->start();
     }
   }
 }
 
 bool Animate::dumpPictures(){
-  return this->e_dump->isChecked() && this->animate_timer->isActive();
+    return this->e_dump->isChecked() && this->animateTimer->isActive();
 }
 
 int Animate::nextFrame(){
-  if (anim_dumping && anim_dump_start_step == anim_step) {
-    anim_dumping = false;
+    if (animDumping && animDumpStartStep == animStep) {
+        animDumping = false;
     e_dump->setChecked(false);
   } else {
-    if (!anim_dumping) {
-      anim_dumping = true;
-      anim_dump_start_step = anim_step;
+        if (!animDumping) {
+            animDumping = true;
+            animDumpStartStep = animStep;
     }
   }
-  return anim_step;
+    return animStep;
 }
 
 void Animate::resizeEvent(QResizeEvent *event)
@@ -272,44 +272,44 @@ void Animate::resizeEvent(QResizeEvent *event)
 }
 
 const QList<QAction *>& Animate::actions(){
-  return action_list;
+  return actionList;
 }
 
 void Animate::onActionEvent(InputEventAction *event)
 {
   const std::string actionString = event->action;
   const std::string actionName = actionString.substr(actionString.find("::") + 2, std::string::npos);
-  for (auto action : action_list) {
+  for (auto action : actionList) {
     if (actionName == action->objectName().toStdString()) {
       action->trigger();
     }
   }
 }
 
-double Animate::getAnim_tval(){
-  return anim_tval;
+double Animate::getAnimTval(){
+  return animTVal;
 }
 
 void Animate::on_pushButton_MoveToBeginning_clicked(){
   pauseAnimation();
-  this->anim_step = 0;
+  this->animStep = 0;
   this->updateTVal();
 }
 
 void Animate::on_pushButton_StepBack_clicked(){
   pauseAnimation();
-  this->anim_step -= 1;
+  this->animStep -= 1;
   this->updateTVal();
 }
 
 void Animate::on_pushButton_StepForward_clicked(){
   pauseAnimation();
-  this->anim_step += 1;
+  this->animStep += 1;
   this->updateTVal();
 }
 
 void Animate::on_pushButton_MoveToEnd_clicked(){
   pauseAnimation();
-  this->anim_step = this->anim_numsteps - 1;
+  this->animStep = this->animNumSteps - 1;
   this->updateTVal();
 }

--- a/src/gui/Animate.h
+++ b/src/gui/Animate.h
@@ -31,12 +31,12 @@ public:
   bool dumpPictures();
   int nextFrame();
 
-  QTimer *animate_timer;
+  QTimer *animateTimer;
 
   void setMainWindow(MainWindow *mainWindow);
 
   const QList<QAction *>& actions();
-  double getAnim_tval();
+  double getAnimTval();
 
 public slots:
   void animateUpdate();
@@ -60,14 +60,14 @@ private:
   void updatePauseButtonIcon();
   void connectAction(QAction *, QPushButton *);
 
-  double anim_tval;
-  bool anim_dumping;
-  int anim_dump_start_step;
-  int anim_step;
-  int anim_numsteps;
+  double animTVal;
+  bool animDumping;
+  int animDumpStartStep;
+  int animStep;
+  int animNumSteps;
 
-  bool fps_ok;
-  bool t_ok;
+  bool fpsOK;
+  bool tOK;
   bool steps_ok;
 
   int initMinWidth;
@@ -75,7 +75,7 @@ private:
   QIcon iconRun;
   QIcon iconPause;
   QIcon iconDisabled;
-  QList<QAction *> action_list;
+  QList<QAction *> actionList;
   QColor errorBlendColor{"red"};
 
 signals:

--- a/src/gui/ErrorLog.cc
+++ b/src/gui/ErrorLog.cc
@@ -37,32 +37,32 @@ void ErrorLog::initGUI()
   connect(logTable->horizontalHeader(), SIGNAL(sectionResized(int,int,int)), this, SLOT(onSectionResized(int,int,int)));
 }
 
-void ErrorLog::toErrorLog(const Message& log_msg)
+void ErrorLog::toErrorLog(const Message& logMsg)
 {
-  lastMessages.push_back(log_msg);
+  lastMessages.push_back(logMsg);
   QString currGroup = errorLogComboBox->currentText();
 
   //handle combobox
   if (errorLogComboBox->currentIndex() == 0);
-  else if (currGroup.toStdString() != getGroupName(log_msg.group)) return;
+  else if (currGroup.toStdString() != getGroupName(logMsg.group)) return;
 
-  showtheErrorInGUI(log_msg);
+  showtheErrorInGUI(logMsg);
 }
 
-void ErrorLog::showtheErrorInGUI(const Message& log_msg)
+void ErrorLog::showtheErrorInGUI(const Message& logMsg)
 {
-  auto *groupName = new QStandardItem(QString::fromStdString(getGroupName(log_msg.group)));
+  auto *groupName = new QStandardItem(QString::fromStdString(getGroupName(logMsg.group)));
   groupName->setEditable(false);
 
-  if (log_msg.group == message_group::Error) groupName->setForeground(QColor::fromRgb(255, 0, 0)); //make this item red.
-  else if (log_msg.group == message_group::Warning) groupName->setForeground(QColor::fromRgb(252, 211, 3)); //make this item yellow
+  if (logMsg.group == message_group::Error) groupName->setForeground(QColor::fromRgb(255, 0, 0)); //make this item red.
+  else if (logMsg.group == message_group::Warning) groupName->setForeground(QColor::fromRgb(252, 211, 3)); //make this item yellow
 
   errorLogModel->setItem(row, errorLog_column::group, groupName);
 
   QStandardItem *fileName;
   QStandardItem *lineNo;
-  if (!log_msg.loc.isNone()) {
-    const auto& filePath = log_msg.loc.filePath();
+  if (!logMsg.loc.isNone()) {
+    const auto& filePath = logMsg.loc.filePath();
     if (is_regular_file(filePath)) {
       const auto path = QString::fromStdString(filePath.generic_string());
       fileName = new QStandardItem(QString::fromStdString(filePath.filename().generic_string()));
@@ -71,7 +71,7 @@ void ErrorLog::showtheErrorInGUI(const Message& log_msg)
     } else {
       fileName = new QStandardItem(QString());
     }
-    lineNo = new QStandardItem(QString::number(log_msg.loc.firstLine()));
+    lineNo = new QStandardItem(QString::number(logMsg.loc.firstLine()));
   } else {
     fileName = new QStandardItem(QString());
     lineNo = new QStandardItem(QString());
@@ -82,7 +82,7 @@ void ErrorLog::showtheErrorInGUI(const Message& log_msg)
   errorLogModel->setItem(row, errorLog_column::file, fileName);
   errorLogModel->setItem(row, errorLog_column::lineNo, lineNo);
 
-  auto *msg = new QStandardItem(QString::fromStdString(log_msg.msg));
+  auto *msg = new QStandardItem(QString::fromStdString(logMsg.msg));
   msg->setEditable(false);
   errorLogModel->setItem(row, errorLog_column::message, msg);
   errorLogModel->setRowCount(++row);

--- a/src/gui/ErrorLog.h
+++ b/src/gui/ErrorLog.h
@@ -26,8 +26,8 @@ public:
   ErrorLog& operator=(ErrorLog&& source) = delete;
   ~ErrorLog() override = default;
   void initGUI();
-  void toErrorLog(const Message& log_msg);
-  void showtheErrorInGUI(const Message& log_msg);
+  void toErrorLog(const Message& logMsg);
+  void showtheErrorInGUI(const Message& logMsg);
   void clearModel();
   int getLine(int row, int col);
   QStandardItemModel *errorLogModel;

--- a/src/gui/FontListDialog.cc
+++ b/src/gui/FontListDialog.cc
@@ -72,7 +72,7 @@ void FontListDialog::selection_changed(const QItemSelection& current, const QIte
   tableView->setDragText(selection);
 }
 
-void FontListDialog::update_font_list()
+void FontListDialog::updateFontList()
 {
   copyButton->setEnabled(false);
 

--- a/src/gui/FontListDialog.h
+++ b/src/gui/FontListDialog.h
@@ -15,7 +15,7 @@ class FontListDialog : public QDialog, public Ui::FontListDialog
 public:
   FontListDialog();
 
-  void update_font_list();
+  void updateFontList();
 
 public slots:
   void on_copyButton_clicked();

--- a/src/gui/LibraryInfoDialog.cc
+++ b/src/gui/LibraryInfoDialog.cc
@@ -10,10 +10,10 @@ LibraryInfoDialog::LibraryInfoDialog(const QString& rendererInfo)
 {
   setupUi(this);
   connect(this->okButton, SIGNAL(clicked()), this, SLOT(accept()));
-  update_library_info(rendererInfo);
+  updateLibraryInfo(rendererInfo);
 }
 
-void LibraryInfoDialog::update_library_info(const QString& rendererInfo)
+void LibraryInfoDialog::updateLibraryInfo(const QString& rendererInfo)
 {
   //Get library infos
   QString info(LibraryInfo::info().c_str());

--- a/src/gui/LibraryInfoDialog.h
+++ b/src/gui/LibraryInfoDialog.h
@@ -13,5 +13,5 @@ class LibraryInfoDialog : public QDialog, public Ui::LibraryInfoDialog
 public:
   LibraryInfoDialog(const QString& rendererInfo);
 
-  void update_library_info(const QString& rendererInfo);
+  void updateLibraryInfo(const QString& rendererInfo);
 };

--- a/src/gui/MainWindow.cc
+++ b/src/gui/MainWindow.cc
@@ -403,7 +403,7 @@ MainWindow::MainWindow(const QStringList& filenames)
 #if QT_VERSION >= QT_VERSION_CHECK(5, 15, 0)
   connect(this->exportFormatMapper, &QSignalMapper::mappedInt, this, &MainWindow::actionExportFileFormat);
 #else
-  connect(this->exportformat_mapper, static_cast<void (QSignalMapper::*)(int)>(&QSignalMapper::mapped), this, &MainWindow::actionExportFileFormat);
+  connect(this->exportFormatMapper, static_cast<void (QSignalMapper::*)(int)>(&QSignalMapper::mapped), this, &MainWindow::actionExportFileFormat);
 #endif
 
   waitAfterReloadTimer = new QTimer(this);

--- a/src/gui/MainWindow.cc
+++ b/src/gui/MainWindow.cc
@@ -1241,7 +1241,7 @@ void MainWindow::instantiateRoot()
 
     std::shared_ptr<const FileContext> file_context;
 #ifdef ENABLE_PYTHON
-    if (python_result_node != NULL && this->python_active) this->absolute_root_node = python_result_node;
+    if (python_result_node != NULL && this->python_active) this->absoluteRootNode = python_result_node;
     else
 #endif
     this->absoluteRootNode = this->rootFile->instantiate(*builtin_context, &file_context);

--- a/src/gui/MainWindow.cc
+++ b/src/gui/MainWindow.cc
@@ -1880,7 +1880,7 @@ void MainWindow::parseTopLevelDocument()
   this->python_active = false;
   if (fname != NULL) {
     if (boost::algorithm::ends_with(fname, ".py")) {
-      std::string content = std::string(this->last_compiled_doc.toUtf8().constData());
+      std::string content = std::string(this->lastCompiledDoc.toUtf8().constData());
       if (
         Feature::ExperimentalPythonEngine.is_enabled()
         && trust_python_file(std::string(fname), content)) this->python_active = true;

--- a/src/gui/MainWindow.cc
+++ b/src/gui/MainWindow.cc
@@ -199,7 +199,7 @@ std::string SHA256HashString(std::string aString){
 static const int autoReloadPollingPeriodMS = 200;
 
 // Global application state
-unsigned int GuiLocker::gui_locked = 0;
+unsigned int GuiLocker::guiLocked = 0;
 
 static char copyrighttext[] =
   "<p>Copyright (C) 2009-2024 The OpenSCAD Developers</p>"
@@ -253,9 +253,9 @@ void addExportActions(const MainWindow *mainWindow, QToolBar *toolbar, QAction *
                                         Settings::Settings::toolbarExport2D.value()}) {
     FileFormat format;
     fileformat::fromIdentifier(identifier, format);
-    const auto it=mainWindow->export_map.find(format);
+    const auto it=mainWindow->exportMap.find(format);
     // FIXME: Allow turning off the toolbar entry?
-    if (it != mainWindow->export_map.end()) {
+    if (it != mainWindow->exportMap.end()) {
       toolbar->insertAction(action, it->second);
     }
   }
@@ -325,9 +325,9 @@ MainWindow::MainWindow(const QStringList& filenames)
 #endif
   knownFileExtensions["csg"] = "";
 
-  root_file = nullptr;
-  parsed_file = nullptr;
-  absolute_root_node = nullptr;
+  rootFile = nullptr;
+  parsedFile = nullptr;
+  absoluteRootNode = nullptr;
 
   // Open Recent
   for (auto& recent : this->actionRecentFile) {
@@ -381,7 +381,7 @@ MainWindow::MainWindow(const QStringList& filenames)
   connect(this->cgalworker, SIGNAL(done(std::shared_ptr<const Geometry>)),
           this, SLOT(actionRenderDone(std::shared_ptr<const Geometry>)));
 
-  root_node = nullptr;
+  rootNode = nullptr;
 
   this->qglview->statusLabel = new QLabel(this);
   this->qglview->statusLabel->setMinimumWidth(100);
@@ -399,9 +399,9 @@ MainWindow::MainWindow(const QStringList& filenames)
   autoReloadTimer->setInterval(autoReloadPollingPeriodMS);
   connect(autoReloadTimer, SIGNAL(timeout()), this, SLOT(checkAutoReload()));
 
-  this->exportformat_mapper = new QSignalMapper(this);
+  this->exportFormatMapper = new QSignalMapper(this);
 #if QT_VERSION >= QT_VERSION_CHECK(5, 15, 0)
-  connect(this->exportformat_mapper, &QSignalMapper::mappedInt, this, &MainWindow::actionExportFileFormat);
+  connect(this->exportFormatMapper, &QSignalMapper::mappedInt, this, &MainWindow::actionExportFileFormat);
 #else
   connect(this->exportformat_mapper, static_cast<void (QSignalMapper::*)(int)>(&QSignalMapper::mapped), this, &MainWindow::actionExportFileFormat);
 #endif
@@ -482,23 +482,23 @@ MainWindow::MainWindow(const QStringList& filenames)
   connect(this->designActionDisplayCSGTree, SIGNAL(triggered()), this, SLOT(actionDisplayCSGTree()));
   connect(this->designActionDisplayCSGProducts, SIGNAL(triggered()), this, SLOT(actionDisplayCSGProducts()));
 
-  export_map[FileFormat::BINARY_STL] =this->fileActionExportBinarySTL;
-  export_map[FileFormat::ASCII_STL] =this->fileActionExportAsciiSTL;
-  export_map[FileFormat::_3MF] = this->fileActionExport3MF;
-  export_map[FileFormat::OBJ] =  this->fileActionExportOBJ;
-  export_map[FileFormat::OFF] =  this->fileActionExportOFF;
-  export_map[FileFormat::WRL] =  this->fileActionExportWRL;
-  export_map[FileFormat::POV] =  this->fileActionExportPOV;
-  export_map[FileFormat::AMF] =  this->fileActionExportAMF;
-  export_map[FileFormat::DXF] =  this->fileActionExportDXF;
-  export_map[FileFormat::SVG] =  this->fileActionExportSVG;
-  export_map[FileFormat::PDF] =  this->fileActionExportPDF;
-  export_map[FileFormat::CSG] =  this->fileActionExportCSG;
-  export_map[FileFormat::PNG] =  this->fileActionExportImage;
+  exportMap[FileFormat::BINARY_STL] =this->fileActionExportBinarySTL;
+  exportMap[FileFormat::ASCII_STL] =this->fileActionExportAsciiSTL;
+  exportMap[FileFormat::_3MF] = this->fileActionExport3MF;
+  exportMap[FileFormat::OBJ] =  this->fileActionExportOBJ;
+  exportMap[FileFormat::OFF] =  this->fileActionExportOFF;
+  exportMap[FileFormat::WRL] =  this->fileActionExportWRL;
+  exportMap[FileFormat::POV] =  this->fileActionExportPOV;
+  exportMap[FileFormat::AMF] =  this->fileActionExportAMF;
+  exportMap[FileFormat::DXF] =  this->fileActionExportDXF;
+  exportMap[FileFormat::SVG] =  this->fileActionExportSVG;
+  exportMap[FileFormat::PDF] =  this->fileActionExportPDF;
+  exportMap[FileFormat::CSG] =  this->fileActionExportCSG;
+  exportMap[FileFormat::PNG] =  this->fileActionExportImage;
 
-  for (auto &pair : export_map) {
-    connect(pair.second, SIGNAL(triggered()), this->exportformat_mapper, SLOT(map()));
-    this->exportformat_mapper->setMapping(pair.second, int(pair.first));
+  for (auto &pair : exportMap) {
+      connect(pair.second, SIGNAL(triggered()), this->exportFormatMapper, SLOT(map()));
+      this->exportFormatMapper->setMapping(pair.second, int(pair.first));
   }
 
   connect(this->designActionFlushCaches, SIGNAL(triggered()), this, SLOT(actionFlushCaches()));
@@ -957,7 +957,7 @@ MainWindow::~MainWindow()
 {
   // If root_file is not null then it will be the same as parsed_file,
   // so no need to delete it.
-  delete parsed_file;
+    delete parsedFile;
   scadApp->windowManager.remove(this);
   if (scadApp->windowManager.getWindows().size() == 0) {
     // Quit application even in case some other windows like
@@ -1057,7 +1057,7 @@ void MainWindow::compile(bool reload, bool forcedone)
       // if we haven't yet compiled the current text.
       else {
         auto current_doc = activeEditor->toPlainText();
-        if (current_doc.size() && last_compiled_doc.size() == 0) {
+        if (current_doc.size() && lastCompiledDoc.size() == 0) {
           shouldcompiletoplevel = true;
         }
       }
@@ -1065,10 +1065,10 @@ void MainWindow::compile(bool reload, bool forcedone)
       shouldcompiletoplevel = true;
     }
 
-    if (this->parsed_file) {
-      auto mtime = this->parsed_file->includesChanged();
-      if (mtime > this->includes_mtime) {
-        this->includes_mtime = mtime;
+    if (this->parsedFile) {
+        auto mtime = this->parsedFile->includesChanged();
+      if (mtime > this->includesMTime) {
+        this->includesMTime = mtime;
         shouldcompiletoplevel = true;
       }
     }
@@ -1086,16 +1086,16 @@ void MainWindow::compile(bool reload, bool forcedone)
       didcompile = true;
     }
 
-    if (didcompile && parser_error_pos != last_parser_error_pos) {
-      if (last_parser_error_pos >= 0) emit unhighlightLastError();
+    if (didcompile && parser_error_pos != lastParserErrorPos) {
+        if (lastParserErrorPos >= 0) emit unhighlightLastError();
       if (parser_error_pos >= 0) emit highlightError(parser_error_pos);
-      last_parser_error_pos = parser_error_pos;
+      lastParserErrorPos = parser_error_pos;
     }
 
-    if (this->root_file) {
-      auto mtime = this->root_file->handleDependencies();
-      if (mtime > this->deps_mtime) {
-        this->deps_mtime = mtime;
+    if (this->rootFile) {
+      auto mtime = this->rootFile->handleDependencies();
+      if (mtime > this->depsMTime) {
+          this->depsMTime = mtime;
         LOG("Used file cache size: %1$d files", SourceFileCache::instance()->size());
         didcompile = true;
       }
@@ -1105,8 +1105,8 @@ void MainWindow::compile(bool reload, bool forcedone)
     if (would_have_thrown()) throw HardWarningException("");
     // If we're auto-reloading, listen for a cascade of changes by starting a timer
     // if something changed _and_ there are any external dependencies
-    if (reload && didcompile && this->root_file) {
-      if (this->root_file->hasIncludes() || this->root_file->usesLibraries()) {
+    if (reload && didcompile && this->rootFile) {
+      if (this->rootFile->hasIncludes() || this->rootFile->usesLibraries()) {
         this->waitAfterReloadTimer->start();
         this->procevents = false;
         return;
@@ -1126,9 +1126,9 @@ void MainWindow::compile(bool reload, bool forcedone)
 void MainWindow::waitAfterReload()
 {
   no_exceptions_for_warnings();
-  auto mtime = this->root_file->handleDependencies();
+  auto mtime = this->rootFile->handleDependencies();
   auto stop = would_have_thrown();
-  if (mtime > this->deps_mtime) this->deps_mtime = mtime;
+  if (mtime > this->depsMTime) this->depsMTime = mtime;
   else if (!stop) {
     compile(true, true); // In case file itself or top-level includes changed during dependency updates
     return;
@@ -1216,19 +1216,19 @@ void MainWindow::instantiateRoot()
   this->thrownTogetherRenderer = nullptr;
 
   // Remove previous CSG tree
-  this->absolute_root_node.reset();
+  this->absoluteRootNode.reset();
 
   this->csgRoot.reset();
   this->normalizedRoot.reset();
-  this->root_products.reset();
+    this->rootProduct.reset();
 
-  this->root_node.reset();
+    this->rootNode.reset();
   this->tree.setRoot(nullptr);
 
   std::filesystem::path doc(activeEditor->filepath.toStdString());
   this->tree.setDocumentPath(doc.parent_path().string());
 
-  if (this->root_file) {
+  if (this->rootFile) {
     // Evaluate CSG tree
     LOG("Compiling design (CSG Tree generation)...");
     this->processEvents();
@@ -1244,28 +1244,28 @@ void MainWindow::instantiateRoot()
     if (python_result_node != NULL && this->python_active) this->absolute_root_node = python_result_node;
     else
 #endif
-    this->absolute_root_node = this->root_file->instantiate(*builtin_context, &file_context);
+    this->absoluteRootNode = this->rootFile->instantiate(*builtin_context, &file_context);
     if (file_context) {
       this->qglview->cam.updateView(file_context, false);
       viewportControlWidget->cameraChanged();
     }
 
-    if (this->absolute_root_node) {
+    if (this->absoluteRootNode) {
       // Do we have an explicit root node (! modifier)?
       const Location *nextLocation = nullptr;
-      if (!(this->root_node = find_root_tag(this->absolute_root_node, &nextLocation))) {
-        this->root_node = this->absolute_root_node;
+      if (!(this->rootNode = find_root_tag(this->absoluteRootNode, &nextLocation))) {
+          this->rootNode = this->absoluteRootNode;
       }
       if (nextLocation) {
         LOG(message_group::NONE, *nextLocation, builtin_context->documentRoot(), "More than one Root Modifier (!)");
       }
 
       // FIXME: Consider giving away ownership of root_node to the Tree, or use reference counted pointers
-      this->tree.setRoot(this->root_node);
+      this->tree.setRoot(this->rootNode);
     }
   }
 
-  if (!this->root_node) {
+  if (!this->rootNode) {
     if (parser_error_pos < 0) {
       LOG(message_group::Error, "Compilation failed! (no top level object found)");
     } else {
@@ -1284,7 +1284,7 @@ void MainWindow::compileCSG()
 {
   OpenSCAD::hardwarnings = Preferences::inst()->getValue("advanced/enableHardwarnings").toBool();
   try{
-    assert(this->root_node);
+      assert(this->rootNode);
     LOG("Compiling design (CSG Products generation)...");
     this->processEvents();
 
@@ -1297,12 +1297,12 @@ void MainWindow::compileCSG()
     CSGTreeEvaluator csgrenderer(this->tree, &geomevaluator);
 #endif
 
-    if (!isClosing) progress_report_prep(this->root_node, report_func, this);
+    if (!isClosing) progress_report_prep(this->rootNode, report_func, this);
     else return;
     try {
 #ifdef ENABLE_OPENCSG
       this->processEvents();
-      this->csgRoot = csgrenderer.buildCSGTree(*root_node);
+        this->csgRoot = csgrenderer.buildCSGTree(*rootNode);
 #endif
       renderStatistic.printCacheStatistic();
       this->processEvents();
@@ -1323,10 +1323,10 @@ void MainWindow::compileCSG()
     if (this->csgRoot) {
       this->normalizedRoot = normalizer.normalize(this->csgRoot);
       if (this->normalizedRoot) {
-        this->root_products.reset(new CSGProducts());
-        this->root_products->import(this->normalizedRoot);
+          this->rootProduct.reset(new CSGProducts());
+          this->rootProduct->import(this->normalizedRoot);
       } else {
-        this->root_products.reset();
+          this->rootProduct.reset();
         LOG(message_group::Warning, "CSG normalization resulted in an empty tree");
         this->processEvents();
       }
@@ -1337,15 +1337,15 @@ void MainWindow::compileCSG()
       LOG("Compiling highlights (%1$d CSG Trees)...", highlight_terms.size());
       this->processEvents();
 
-      this->highlights_products.reset(new CSGProducts());
+      this->highlightsProducts.reset(new CSGProducts());
       for (const auto& highlight_term : highlight_terms) {
         auto nterm = normalizer.normalize(highlight_term);
         if (nterm) {
-          this->highlights_products->import(nterm);
+          this->highlightsProducts->import(nterm);
         }
       }
     } else {
-      this->highlights_products.reset();
+      this->highlightsProducts.reset();
     }
 
     const auto& background_terms = csgrenderer.getBackgroundNodes();
@@ -1353,35 +1353,35 @@ void MainWindow::compileCSG()
       LOG("Compiling background (%1$d CSG Trees)...", background_terms.size());
       this->processEvents();
 
-      this->background_products.reset(new CSGProducts());
+      this->backgroundProducts.reset(new CSGProducts());
       for (const auto& background_term : background_terms) {
         auto nterm = normalizer.normalize(background_term);
         if (nterm) {
-          this->background_products->import(nterm);
+            this->backgroundProducts->import(nterm);
         }
       }
     } else {
-      this->background_products.reset();
+        this->backgroundProducts.reset();
     }
 
-    if (this->root_products &&
-        (this->root_products->size() >
+    if (this->rootProduct &&
+        (this->rootProduct->size() >
          Preferences::inst()->getValue("advanced/openCSGLimit").toUInt())) {
-      LOG(message_group::UI_Warning, "Normalized tree has %1$d elements!", this->root_products->size());
+        LOG(message_group::UI_Warning, "Normalized tree has %1$d elements!", this->rootProduct->size());
       LOG(message_group::UI_Warning, "OpenCSG rendering has been disabled.");
     }
 #ifdef ENABLE_OPENCSG
     else {
       LOG("Normalized tree has %1$d elements!",
-          (this->root_products ? this->root_products->size() : 0));
-      this->opencsgRenderer = std::make_shared<OpenCSGRenderer>(this->root_products,
-                                                                this->highlights_products,
-                                                                this->background_products);
+          (this->rootProduct ? this->rootProduct->size() : 0));
+      this->opencsgRenderer = std::make_shared<OpenCSGRenderer>(this->rootProduct,
+                                                                this->highlightsProducts,
+                                                                this->backgroundProducts);
     }
 #endif // ifdef ENABLE_OPENCSG
-    this->thrownTogetherRenderer = std::make_shared<ThrownTogetherRenderer>(this->root_products,
-                                                                            this->highlights_products,
-                                                                            this->background_products);
+    this->thrownTogetherRenderer = std::make_shared<ThrownTogetherRenderer>(this->rootProduct,
+                                                                            this->highlightsProducts,
+                                                                            this->backgroundProducts);
     LOG("Compile and preview finished.");
     renderStatistic.printRenderingTime();
     this->processEvents();
@@ -1775,8 +1775,8 @@ bool MainWindow::eventFilter(QObject *obj, QEvent *event)
 void MainWindow::setRenderVariables(ContextHandle<BuiltinContext>& context)
 {
   RenderVariables r = {
-    .preview = this->is_preview,
-    .time = this->animateWidget->getAnim_tval(),
+      .preview = this->isPreview,
+      .time = this->animateWidget->getAnimTval(),
     .camera = qglview->cam,
   };
   r.applyToContext(context);
@@ -1867,15 +1867,15 @@ void MainWindow::parseTopLevelDocument()
 {
   resetSuppressedMessages();
 
-  this->last_compiled_doc = activeEditor->toPlainText();
+  this->lastCompiledDoc = activeEditor->toPlainText();
 
   auto fulltext =
-    std::string(this->last_compiled_doc.toUtf8().constData()) +
+          std::string(this->lastCompiledDoc.toUtf8().constData()) +
     "\n\x03\n" + commandline_commands;
 
   auto fnameba = activeEditor->filepath.toLocal8Bit();
   const char *fname = activeEditor->filepath.isEmpty() ? "" : fnameba;
-  delete this->parsed_file;
+  delete this->parsedFile;
 #ifdef ENABLE_PYTHON
   this->python_active = false;
   if (fname != NULL) {
@@ -1897,18 +1897,18 @@ void MainWindow::parseTopLevelDocument()
     fulltext = "\n";
   }
 #endif // ifdef ENABLE_PYTHON
-  this->parsed_file = nullptr; // because the parse() call can throw and we don't want a stale pointer!
-  this->root_file = nullptr;  // ditto
-  this->root_file = parse(this->parsed_file, fulltext, fname, fname, false) ? this->parsed_file : nullptr;
+  this->parsedFile = nullptr; // because the parse() call can throw and we don't want a stale pointer!
+  this->rootFile = nullptr;  // ditto
+  this->rootFile = parse(this->parsedFile, fulltext, fname, fname, false) ? this->parsedFile : nullptr;
 
   this->activeEditor->resetHighlighting();
-  if (this->root_file != nullptr) {
+  if (this->rootFile != nullptr) {
     //add parameters as annotation in AST
-    CommentParser::collectParameters(fulltext, this->root_file);
-    this->activeEditor->parameterWidget->setParameters(this->root_file, fulltext);
-    this->activeEditor->parameterWidget->applyParameters(this->root_file);
+    CommentParser::collectParameters(fulltext, this->rootFile);
+    this->activeEditor->parameterWidget->setParameters(this->rootFile, fulltext);
+    this->activeEditor->parameterWidget->applyParameters(this->rootFile);
     this->activeEditor->parameterWidget->setEnabled(true);
-    this->activeEditor->setIndicator(this->root_file->indicatorData);
+    this->activeEditor->setIndicator(this->rootFile->indicatorData);
   } else {
     this->activeEditor->parameterWidget->setEnabled(false);
   }
@@ -1960,13 +1960,13 @@ void MainWindow::actionReloadRenderPreview()
 
   this->afterCompileSlot = "csgReloadRender";
   this->procevents = true;
-  this->is_preview = true;
+  this->isPreview = true;
   compile(true);
 }
 
 void MainWindow::csgReloadRender()
 {
-  if (this->root_node) compileCSG();
+    if (this->rootNode) compileCSG();
 
   // Go to non-CGAL view mode
   if (viewActionThrownTogether->isChecked()) {
@@ -1990,7 +1990,7 @@ void MainWindow::prepareCompile(const char *afterCompileSlot, bool procevents, b
   this->processEvents();
   this->afterCompileSlot = afterCompileSlot;
   this->procevents = procevents;
-  this->is_preview = preview;
+  this->isPreview = preview;
 }
 
 void MainWindow::actionRenderPreview()
@@ -2017,7 +2017,7 @@ void MainWindow::actionRenderPreview()
 
 void MainWindow::csgRender()
 {
-  if (this->root_node) compileCSG();
+    if (this->rootNode) compileCSG();
 
   // Go to non-CGAL view mode
   if (viewActionThrownTogether->isChecked()) {
@@ -2075,7 +2075,7 @@ void MainWindow::sendToExternalTool(ExternalToolInterface &externalToolService)
   
   activeFileName = activeFileName + QString::fromStdString("." + fileformat::toSuffix(externalToolService.fileFormat()));
 
-  bool export_status = externalToolService.exportTemporaryFile(this->root_geom, activeFileName, &qglview->cam);
+  bool export_status = externalToolService.exportTemporaryFile(rootGeom, activeFileName, &qglview->cam);
   
   this->progresswidget = new ProgressWidget(this);
   connect(this->progresswidget, SIGNAL(requestShow()), this, SLOT(showProgress()));
@@ -2136,14 +2136,14 @@ void MainWindow::actionRender()
 
 void MainWindow::cgalRender()
 {
-  if (!this->root_file || !this->root_node) {
+    if (!this->rootFile || !this->rootNode) {
     compileEnded();
     return;
   }
 
   this->qglview->setRenderer(nullptr);
   this->cgalRenderer = nullptr;
-  this->root_geom.reset();
+  rootGeom.reset();
 
   LOG("Rendering Polygon Mesh using %1$s...",
       renderBackend3DToString(RenderSettings::inst()->backend3D).c_str());
@@ -2151,7 +2151,7 @@ void MainWindow::cgalRender()
   this->progresswidget = new ProgressWidget(this);
   connect(this->progresswidget, SIGNAL(requestShow()), this, SLOT(showProgress()));
 
-  if (!isClosing) progress_report_prep(this->root_node, report_func, this);
+  if (!isClosing) progress_report_prep(this->rootNode, report_func, this);
   else return;
 
   this->cgalworker->start(this->tree);
@@ -2174,7 +2174,7 @@ void MainWindow::actionRenderDone(const std::shared_ptr<const Geometry>& root_ge
     renderStatistic.printAll(root_geom, qglview->cam, options);
     LOG("Rendering finished.");
 
-    this->root_geom = root_geom;
+    rootGeom = root_geom;
     this->cgalRenderer = std::make_shared<CGALRenderer>(root_geom);
     // Go to CGAL view mode
     viewModeRender();
@@ -2239,7 +2239,7 @@ void MainWindow::rightClick(QPoint mouse)
   }
 
   // Nothing to select
-  if (!this->root_products) {
+  if (!this->rootProduct) {
     return;
   }
 
@@ -2251,7 +2251,7 @@ void MainWindow::rightClick(QPoint mouse)
   // Select the object at mouse coordinates
   int index = this->selector->select(this->qglview->getRenderer(), mouse.x(), mouse.y());
   std::deque<std::shared_ptr<const AbstractNode>> path;
-  std::shared_ptr<const AbstractNode> result = this->root_node->getNodeByID(index, path);
+  std::shared_ptr<const AbstractNode> result = this->rootNode->getNodeByID(index, path);
 
   if (result) {
     // Create context menu with the backtrace
@@ -2377,7 +2377,7 @@ void getCodeLocation(const AbstractNode *self, int currentLevel,  int includeLev
 void MainWindow::setSelectionIndicatorStatus(int nodeIndex, EditorSelectionIndicatorStatus status)
 {
   std::deque<std::shared_ptr<const AbstractNode>> stack;
-  this->root_node->getNodeByID(nodeIndex, stack);
+  this->rootNode->getNodeByID(nodeIndex, stack);
 
   int level = 1;
 
@@ -2418,14 +2418,14 @@ void MainWindow::setSelectionIndicatorStatus(int nodeIndex, EditorSelectionIndic
 
 void MainWindow::setSelection(int index)
 {
-  if (currently_selected_object == index) return;
+  if (currentlySelectedObject == index) return;
 
   std::deque<std::shared_ptr<const AbstractNode>> path;
-  std::shared_ptr<const AbstractNode> selected_node = root_node->getNodeByID(index, path);
+  std::shared_ptr<const AbstractNode> selected_node = rootNode->getNodeByID(index, path);
 
   if (!selected_node) return;
 
-  currently_selected_object = index;
+  currentlySelectedObject = index;
 
   auto location = selected_node->modinst->location();
   auto file = location.fileName();
@@ -2442,18 +2442,18 @@ void MainWindow::setSelection(int index)
   clearAllSelectionIndicators();
 
   std::vector<std::shared_ptr<const AbstractNode>> nodesSameModule{};
-  findNodesWithSameMod(root_node, selected_node, nodesSameModule);
+  findNodesWithSameMod(rootNode, selected_node, nodesSameModule);
 
   // highlight in the text editor all the text fragment of the hierarchy of object with same mode.
   for (const auto& element : nodesSameModule) {
-    if (element->index() != currently_selected_object) {
+    if (element->index() != currentlySelectedObject) {
       setSelectionIndicatorStatus(element->index(), EditorSelectionIndicatorStatus::IMPACTED);
     }
   }
 
   // highlight in the text editor only the fragment correponding to the selected stack.
   // this step must be done after all the impacted element have been marked.
-  setSelectionIndicatorStatus(currently_selected_object, EditorSelectionIndicatorStatus::SELECTED);
+  setSelectionIndicatorStatus(currentlySelectedObject, EditorSelectionIndicatorStatus::SELECTED);
 
   activeEditor->setCursorPosition(line - 1, column - 1);
 }
@@ -2536,8 +2536,8 @@ void MainWindow::actionDisplayAST()
   e->setTabStopDistance(tabStopWidth);
   e->setWindowTitle("AST Dump");
   e->setReadOnly(true);
-  if (root_file) {
-    e->setPlainText(QString::fromStdString(root_file->dump("")));
+  if (rootFile) {
+    e->setPlainText(QString::fromStdString(rootFile->dump("")));
   } else {
     e->setPlainText("No AST to dump. Please try compiling first...");
   }
@@ -2555,8 +2555,8 @@ void MainWindow::actionDisplayCSGTree()
   e->setTabStopDistance(tabStopWidth);
   e->setWindowTitle("CSG Tree Dump");
   e->setReadOnly(true);
-  if (this->root_node) {
-    e->setPlainText(QString::fromStdString(this->tree.getString(*this->root_node, "  ")));
+  if (this->rootNode) {
+      e->setPlainText(QString::fromStdString(this->tree.getString(*this->rootNode, "  ")));
   } else {
     e->setPlainText("No CSG to dump. Please try compiling first...");
   }
@@ -2579,9 +2579,9 @@ void MainWindow::actionDisplayCSGProducts()
 
                   .arg(QString::fromStdString(this->csgRoot ? this->csgRoot->dump() : NA),
                        QString::fromStdString(this->normalizedRoot ? this->normalizedRoot->dump() : NA),
-                       QString::fromStdString(this->root_products ? this->root_products->dump() : NA),
-                       QString::fromStdString(this->highlights_products ? this->highlights_products->dump() : NA),
-                       QString::fromStdString(this->background_products ? this->background_products->dump() : NA)));
+                       QString::fromStdString(this->rootProduct ? this->rootProduct->dump() : NA),
+                       QString::fromStdString(this->highlightsProducts ? this->highlightsProducts->dump() : NA),
+                       QString::fromStdString(this->backgroundProducts ? this->backgroundProducts->dump() : NA)));
 
   e->resize(600, 400);
   e->show();
@@ -2594,13 +2594,13 @@ void MainWindow::actionCheckValidity()
   GuiLocker lock;
   setCurrentOutput();
 
-  if (!this->root_geom) {
+  if (!rootGeom) {
     LOG("Nothing to validate! Try building first (press F6).");
     clearCurrentOutput();
     return;
   }
 
-  if (this->root_geom->getDimension() != 3) {
+  if (rootGeom->getDimension() != 3) {
     LOG("Current top level object is not a 3D object.");
     clearCurrentOutput();
     return;
@@ -2608,12 +2608,12 @@ void MainWindow::actionCheckValidity()
 
   bool valid = true;
 #ifdef ENABLE_CGAL 
- if (auto N = std::dynamic_pointer_cast<const CGAL_Nef_polyhedron>(this->root_geom)) {
+ if (auto N = std::dynamic_pointer_cast<const CGAL_Nef_polyhedron>(rootGeom)) {
     valid = N->p3 ? const_cast<CGAL_Nef_polyhedron3&>(*N->p3).is_valid() : false;
   } else
 #endif
 #ifdef ENABLE_MANIFOLD
-  if (auto mani = std::dynamic_pointer_cast<const ManifoldGeometry>(this->root_geom)) {
+  if (auto mani = std::dynamic_pointer_cast<const ManifoldGeometry>(rootGeom)) {
     valid = mani->isValid();
   }
 #endif
@@ -2625,7 +2625,7 @@ void MainWindow::actionCheckValidity()
 //Separated into it's own function for re-use.
 bool MainWindow::canExport(unsigned int dim)
 {
-  if (!this->root_geom) {
+  if (!rootGeom) {
     LOG(message_group::Error, "Nothing to export! Try rendering first (press F6)");
     clearCurrentOutput();
     return false;
@@ -2653,26 +2653,26 @@ bool MainWindow::canExport(unsigned int dim)
     }
   }
 
-  if (this->root_geom->getDimension() != dim) {
+  if (rootGeom->getDimension() != dim) {
     LOG(message_group::UI_Error, "Current top level object is not a %1$dD object.", dim);
     clearCurrentOutput();
     return false;
   }
 
-  if (this->root_geom->isEmpty()) {
+  if (rootGeom->isEmpty()) {
     LOG(message_group::UI_Error, "Current top level object is empty.");
     clearCurrentOutput();
     return false;
   }
 
 #ifdef ENABLE_CGAL
-  auto N = dynamic_cast<const CGAL_Nef_polyhedron *>(this->root_geom.get());
+  auto N = dynamic_cast<const CGAL_Nef_polyhedron *>(rootGeom.get());
   if (N && !N->p3->is_simple()) {
     LOG(message_group::UI_Warning, "Object may not be a valid 2-manifold and may need repair! See https://en.wikibooks.org/wiki/OpenSCAD_User_Manual/STL_Import_and_Export");
   }
 #endif
 #ifdef ENABLE_MANIFOLD
-  auto manifold = dynamic_cast<const ManifoldGeometry *>(this->root_geom.get());
+  auto manifold = dynamic_cast<const ManifoldGeometry *>(rootGeom.get());
   if (manifold && !manifold->isValid() ) {
     LOG(message_group::UI_Warning, "Object may not be a valid manifold and may need repair! "
       "Error message: %1$s. See https://en.wikibooks.org/wiki/OpenSCAD_User_Manual/STL_Import_and_Export",
@@ -2704,9 +2704,9 @@ void MainWindow::actionExport(unsigned int dim, ExportInfo& exportInfo)
     clearCurrentOutput();
     return;
   }
-  this->export_paths[suffix] = exportFilename;
+  this->exportPaths[suffix] = exportFilename;
 
-  bool exportResult = exportFileByName(this->root_geom, exportFilename.toStdString(), exportInfo);
+  bool exportResult = exportFileByName(rootGeom, exportFilename.toStdString(), exportInfo);
 
   if (exportResult) fileExportedMessage(type_name, exportFilename);
   clearCurrentOutput();
@@ -2748,7 +2748,7 @@ void MainWindow::actionExportFileFormat(int fmt)
 {
   setCurrentOutput();
 
-  if (!this->root_node) {
+  if (!this->rootNode) {
     LOG(message_group::Error, "Nothing to export. Please try compiling first.");
     clearCurrentOutput();
     return;
@@ -2766,10 +2766,10 @@ void MainWindow::actionExportFileFormat(int fmt)
   if (!fstream.is_open()) {
     LOG("Can't open file \"%1$s\" for export", csg_filename.toLocal8Bit().constData());
   } else {
-    fstream << this->tree.getString(*this->root_node, "\t") << "\n";
+      fstream << this->tree.getString(*this->rootNode, "\t") << "\n";
     fstream.close();
     fileExportedMessage("CSG", csg_filename);
-    this->export_paths[suffix] = csg_filename;
+    this->exportPaths[suffix] = csg_filename;
   }
 
   clearCurrentOutput();
@@ -2784,7 +2784,7 @@ void MainWindow::actionExportFileFormat(int fmt)
   if (!img_filename.isEmpty()) {
     bool saveResult = qglview->save(img_filename.toLocal8Bit().constData());
     if (saveResult) {
-      this->export_paths[suffix] = img_filename;
+        this->exportPaths[suffix] = img_filename;
       setCurrentOutput();
       fileExportedMessage("PNG", img_filename);
       clearCurrentOutput();
@@ -2919,7 +2919,7 @@ bool MainWindow::isEmpty()
 void MainWindow::editorContentChanged()
 {
   auto current_doc = activeEditor->toPlainText();
-  if (current_doc != last_compiled_doc) {
+  if (current_doc != lastCompiledDoc) {
     animateWidget->editorContentChanged();
 
     // removes the live selection feedbacks in both the 3d view and editor.
@@ -3483,22 +3483,22 @@ void MainWindow::helpOfflineCheatSheet()
 
 void MainWindow::helpLibrary()
 {
-  if (!this->library_info_dialog) {
+    if (!this->libraryInfoDialog) {
     QString rendererInfo(qglview->getRendererInfo().c_str());
     auto dialog = new LibraryInfoDialog(rendererInfo);
-    this->library_info_dialog = dialog;
+    this->libraryInfoDialog = dialog;
   }
-  this->library_info_dialog->show();
+    this->libraryInfoDialog->show();
 }
 
 void MainWindow::helpFontInfo()
 {
-  if (!this->font_list_dialog) {
+    if (!this->fontListDialog) {
     auto dialog = new FontListDialog();
-    this->font_list_dialog = dialog;
+    this->fontListDialog = dialog;
   }
-  this->font_list_dialog->update_font_list();
-  this->font_list_dialog->show();
+    this->fontListDialog->updateFontList();
+    this->fontListDialog->show();
 }
 
 void MainWindow::closeEvent(QCloseEvent *event)
@@ -3631,10 +3631,10 @@ void MainWindow::processEvents()
 }
 
 QString MainWindow::exportPath(const QString& suffix) {
-  const auto path_it = this->export_paths.find(suffix);
+    const auto path_it = this->exportPaths.find(suffix);
   const auto basename = activeEditor->filepath.isEmpty() ? "Untitled" : QFileInfo(activeEditor->filepath).completeBaseName();
   QString dir;
-  if (path_it != export_paths.end()) {
+  if (path_it != exportPaths.end()) {
     dir = QFileInfo(path_it->second).absolutePath();
   } else if (activeEditor->filepath.isEmpty()) {
     dir = QString::fromStdString(PlatformUtils::userDocumentsPath());

--- a/src/gui/MainWindow.cc
+++ b/src/gui/MainWindow.cc
@@ -1890,9 +1890,9 @@ void MainWindow::parseTopLevelDocument()
 
   if (this->python_active) {
     auto fulltext_py =
-      std::string(this->last_compiled_doc.toUtf8().constData());
+      std::string(this->lastCompiledDoc.toUtf8().constData());
 
-    auto error = evaluatePython(fulltext_py, this->animateWidget->getAnim_tval());
+    auto error = evaluatePython(fulltext_py, this->animateWidget->getAnimTval());
     if (error.size() > 0) LOG(message_group::Error, Location::NONE, "", error.c_str());
     fulltext = "\n";
   }

--- a/src/gui/MainWindow.h
+++ b/src/gui/MainWindow.h
@@ -68,16 +68,16 @@ public:
 
   QTimer *consoleUpdater;
 
-  bool is_preview;
+  bool isPreview;
 
   QTimer *autoReloadTimer;
   QTimer *waitAfterReloadTimer;
   RenderStatistic renderStatistic;
 
-  SourceFile *root_file; // Result of parsing
-  SourceFile *parsed_file; // Last parse for include list
-  std::shared_ptr<AbstractNode> absolute_root_node; // Result of tree evaluation
-  std::shared_ptr<AbstractNode> root_node; // Root if the root modifier (!) is used
+  SourceFile *rootFile; // Result of parsing
+  SourceFile *parsedFile; // Last parse for include list
+  std::shared_ptr<AbstractNode> absoluteRootNode; // Result of tree evaluation
+  std::shared_ptr<AbstractNode> rootNode; // Root if the root modifier (!) is used
 #ifdef ENABLE_PYTHON
   bool python_active;
   std::string trusted_edit_document_name;
@@ -88,7 +88,7 @@ public:
   EditorInterface *activeEditor;
   TabManager *tabManager;
 
-  std::shared_ptr<const Geometry> root_geom;
+  std::shared_ptr<const Geometry> rootGeom;
   std::shared_ptr<Renderer> cgalRenderer;
 #ifdef ENABLE_OPENCSG
   std::shared_ptr<Renderer> opencsgRenderer;
@@ -96,7 +96,7 @@ public:
 #endif
   std::shared_ptr<Renderer> thrownTogetherRenderer;
 
-  QString last_compiled_doc;
+  QString lastCompiledDoc;
 
   QAction *actionRecentFile[UIUtils::maxRecentFiles];
   QMap<QString, QString> knownFileExtensions;
@@ -173,9 +173,9 @@ private:
   void updateStatusBar(ProgressWidget *progressWidget);
   void activateWindow(int);
 
-  LibraryInfoDialog *library_info_dialog{nullptr};
-  FontListDialog *font_list_dialog{nullptr};
-  QSignalMapper *exportformat_mapper;
+  LibraryInfoDialog *libraryInfoDialog{nullptr};
+  FontListDialog *fontListDialog{nullptr};
+  QSignalMapper *exportFormatMapper;
 
 public slots:
   void updateExportActions();
@@ -307,7 +307,7 @@ public:
 
   QList<double> getTranslation() const;
   QList<double> getRotation() const;
-  std::unordered_map<FileFormat, QAction*>  export_map;
+  std::unordered_map<FileFormat, QAction*>  exportMap;
 
 public slots:
   void actionReloadRenderPreview();
@@ -381,10 +381,10 @@ private:
 
   std::shared_ptr<CSGNode> csgRoot; // Result of the CSGTreeEvaluator
   std::shared_ptr<CSGNode> normalizedRoot; // Normalized CSG tree
-  std::shared_ptr<CSGProducts> root_products;
-  std::shared_ptr<CSGProducts> highlights_products;
-  std::shared_ptr<CSGProducts> background_products;
-  int currently_selected_object {-1};
+  std::shared_ptr<CSGProducts> rootProduct;
+  std::shared_ptr<CSGProducts> highlightsProducts;
+  std::shared_ptr<CSGProducts> backgroundProducts;
+  int currentlySelectedObject {-1};
 
   char const *afterCompileSlot;
   bool procevents{false};
@@ -393,11 +393,11 @@ private:
   CGALWorker *cgalworker;
   QMutex consolemutex;
   EditorInterface *renderedEditor; // stores pointer to editor which has been most recently rendered
-  time_t includes_mtime{0}; // latest include mod time
-  time_t deps_mtime{0}; // latest dependency mod time
-  std::unordered_map<QString, QString> export_paths; // for each file type, where it was exported to last
+  time_t includesMTime{0}; // latest include mod time
+  time_t depsMTime{0}; // latest dependency mod time
+  std::unordered_map<QString, QString> exportPaths; // for each file type, where it was exported to last
   QString exportPath(const QString& suffix); // look up the last export path and generate one if not found
-  int last_parser_error_pos{-1}; // last highlighted error position
+  int lastParserErrorPos{-1}; // last highlighted error position
   int tabCount = 0;
   ExportPdfPaperSize sizeString2Enum(const QString& current);
   ExportPdfPaperOrientation orientationsString2Enum(const QString& current);
@@ -419,14 +419,14 @@ public:
   ~GuiLocker() {
     GuiLocker::unlock();
   }
-  static bool isLocked() { return gui_locked > 0; }
+  static bool isLocked() { return guiLocked > 0; }
   static void lock() {
-    gui_locked++;
+    guiLocked++;
   }
   static void unlock() {
-    gui_locked--;
+    guiLocked--;
   }
 
 private:
-  static unsigned int gui_locked;
+  static unsigned int guiLocked;
 };

--- a/src/gui/MouseSelector.cc
+++ b/src/gui/MouseSelector.cc
@@ -24,7 +24,7 @@ MouseSelector::MouseSelector(GLView *view) {
   if (view && !view->has_shaders) {
     return;
   }
-  this->init_shader();
+  this->initShader();
 
   if (view) this->reset(view);
 }
@@ -34,13 +34,13 @@ MouseSelector::MouseSelector(GLView *view) {
  */
 void MouseSelector::reset(GLView *view) {
   this->view = view;
-  this->setup_framebuffer(view);
+  this->setupFramebuffer(view);
 }
 
 /**
  * Initialize the used shaders and setup the ShaderInfo struct
  */
-void MouseSelector::init_shader() {
+void MouseSelector::initShader() {
   /*
      Attributes:
    * frag_idcolor - (uniform) 24 bit of the selected object's id encoded into R/G/B components as float values
@@ -68,7 +68,7 @@ void MouseSelector::init_shader() {
 /**
  * Resize or create the framebuffer
  */
-void MouseSelector::setup_framebuffer(const GLView *view) {
+void MouseSelector::setupFramebuffer(const GLView *view) {
   if (!this->framebuffer ||
       static_cast<unsigned int>(this->framebuffer->width()) != view->cam.pixel_width ||
       static_cast<unsigned int>(this->framebuffer->height()) != view->cam.pixel_height) {

--- a/src/gui/MouseSelector.h
+++ b/src/gui/MouseSelector.h
@@ -22,8 +22,8 @@ public:
   ShaderUtils::ShaderInfo shaderinfo;
 
 private:
-  void init_shader();
-  void setup_framebuffer(const GLView *view);
+  void initShader();
+  void setupFramebuffer(const GLView *view);
 
   std::unique_ptr<QOpenGLFramebufferObject> framebuffer;
 

--- a/src/gui/TabManager.cc
+++ b/src/gui/TabManager.cc
@@ -514,7 +514,7 @@ void TabManager::openTabFile(const QString& filename)
     } catch (...) {
       par->UnknownExceptionCleanup();
     }
-    par->last_compiled_doc = ""; // undo the damage so F4 works
+    par->lastCompiledDoc = ""; // undo the damage so F4 works
     par->clearCurrentOutput();
   }
 }


### PR DESCRIPTION
It seems that both camlCase and joint_lower naming scheme are used in openScad, with more names in camlCase. In this PR I renames the ones that were using joint_lower scheme to unify with camlCase.

I didn't renamed the slot because the  automatic of signal/slot relying on naming like the following on_camlCaseName_triggered.