### PR TITLE
VBO refactoring bugfix

### DIFF
--- a/src/geometry/cgal/CGALCache.cc
+++ b/src/geometry/cgal/CGALCache.cc
@@ -28,9 +28,9 @@ std::shared_ptr<const Geometry> CGALCache::get(const std::string& id) const
 
 bool CGALCache::acceptsGeometry(const std::shared_ptr<const Geometry>& geom) {
   return
-    std::dynamic_pointer_cast<const CGAL_Nef_polyhedron>(geom)
+    std::dynamic_pointer_cast<const CGAL_Nef_polyhedron>(geom) != nullptr
 #ifdef ENABLE_MANIFOLD
-    || std::dynamic_pointer_cast<const ManifoldGeometry>(geom)
+    || std::dynamic_pointer_cast<const ManifoldGeometry>(geom) != nullptr
 #endif
     ;
 }

--- a/src/glview/GLView.cc
+++ b/src/glview/GLView.cc
@@ -206,8 +206,8 @@ void GLView::paintGL()
     // FIXME: This belongs in the OpenCSG renderer, but it doesn't know about this ID yet
     OpenCSG::setContext(this->opencsg_id);
 #endif
-    this->renderer->prepare(showedges, showedges ? edge_shader.get() : nullptr);
-    this->renderer->draw(showedges, showedges ? edge_shader.get() : nullptr);
+    this->renderer->prepare(showedges, edge_shader.get());
+    this->renderer->draw(showedges, edge_shader.get());
   }
   Vector3d eyedir(this->modelview[2],this->modelview[6],this->modelview[10]);
   glColor3f(1,0,0);

--- a/src/glview/preview/OpenCSGRenderer.cc
+++ b/src/glview/preview/OpenCSGRenderer.cc
@@ -119,7 +119,7 @@ void OpenCSGRenderer::draw(bool showedges, const ShaderUtils::ShaderInfo *shader
       GL_CHECKD(glDepthFunc(GL_EQUAL));
     }
 
-    if (shaderinfo) {
+    if (showedges && shaderinfo) {
       GL_TRACE("glUseProgram(%d)", shaderinfo->resource.shader_program);
       GL_CHECKD(glUseProgram(shaderinfo->resource.shader_program));
 
@@ -149,7 +149,7 @@ void OpenCSGRenderer::draw(bool showedges, const ShaderUtils::ShaderInfo *shader
       }
     }
 
-    if (shaderinfo) {
+    if (showedges && shaderinfo) {
       GL_TRACE0("glUseProgram(0)");
       GL_CHECKD(glUseProgram(0));
 
@@ -185,8 +185,6 @@ void OpenCSGRenderer::createCSGVBOProducts(
     vbo_builder.writeSurface();
     if (enable_barycentric) {
       vbo_builder.addShaderData();
-    } else {
-      LOG("Warning: Shader not available");
     }
 
     size_t num_vertices = 0;

--- a/src/glview/preview/ThrownTogetherRenderer.cc
+++ b/src/glview/preview/ThrownTogetherRenderer.cc
@@ -92,8 +92,6 @@ void ThrownTogetherRenderer::prepare(bool /*showedges*/, const ShaderUtils::Shad
     bool enable_barycentric = shaderinfo && shaderinfo->attributes.at("barycentric");
     if (enable_barycentric) {
       vbo_builder.addShaderData();
-    } else {
-      LOG("Warning: Shader not available");
     }
 
     size_t num_vertices = 0;
@@ -114,7 +112,7 @@ void ThrownTogetherRenderer::prepare(bool /*showedges*/, const ShaderUtils::Shad
 
 void ThrownTogetherRenderer::draw(bool showedges, const ShaderUtils::ShaderInfo *shaderinfo) const
 {
-  if (shaderinfo) {
+  if (showedges && shaderinfo) {
     glUseProgram(shaderinfo->resource.shader_program);
     if (shaderinfo->type == ShaderUtils::ShaderType::EDGE_RENDERING && showedges) {
       VBOUtils::shader_attribs_enable(*shaderinfo);
@@ -123,7 +121,7 @@ void ThrownTogetherRenderer::draw(bool showedges, const ShaderUtils::ShaderInfo 
 
   renderCSGProducts(std::make_shared<CSGProducts>(), showedges, shaderinfo);
   
-  if (shaderinfo) {
+  if (showedges && shaderinfo) {
     if (shaderinfo->type == ShaderUtils::ShaderType::EDGE_RENDERING && showedges) {
       VBOUtils::shader_attribs_disable(*shaderinfo);
     }


### PR DESCRIPTION
#5622 introduced two bugs:
* Doing a preview render _without_ edges, then turning edges on caused bad results or segmentation fault (depending on GL driver)
* A unnecessary warning, "Shader not available" was emitted sometimes
