### PR TITLE
std::optional is now always used in manifoldutils.cc

### DIFF
--- a/src/geometry/manifold/manifoldutils.cc
+++ b/src/geometry/manifold/manifoldutils.cc
@@ -6,7 +6,6 @@
 #include "utils/printutils.h"
 #ifdef ENABLE_CGAL
 #include "geometry/cgal/cgalutils.h"
-#include <optional>
 #include <cassert>
 #include <map>
 #include <set>
@@ -22,6 +21,7 @@
 #include <manifold/polygon.h>
 
 #include <cstddef>
+#include <optional>
 #include <vector>
 
 using Error = manifold::Manifold::Error;


### PR DESCRIPTION
Can be seen by attempting to build without CGAL:

```
src/geometry/manifold/manifoldutils.cc:118:17: error: 'optional' is not a member of 'std'
  118 |   std::map<std::optional<Color4f>, std::vector<size_t>> colorToFaceIndices;
```
