### PR TITLE
Fix Console output on save error

### DIFF
--- a/src/gui/TabManager.cc
+++ b/src/gui/TabManager.cc
@@ -618,8 +618,8 @@ bool TabManager::shouldClose()
 
 void TabManager::saveError(const QIODevice& file, const std::string& msg, const QString& filepath)
 {
-  const char *fileName = filepath.toLocal8Bit().constData();
-  LOG("%1$s %2$s (%3$s)", msg.c_str(), fileName, file.errorString().toLocal8Bit().constData());
+  const std::string fileName = filepath.toStdString();
+  LOG("%1$s %2$s (%3$s)", msg.c_str(), fileName, file.errorString().toStdString());
 
   const std::string dialogFormatStr = msg + "\n\"%1\"\n(%2)";
   const QString dialogFormat(dialogFormatStr.c_str());


### PR DESCRIPTION
"File/Save As..." to a read-only directory can cause invalid characters to be written to the Console.

---

I get a lot of  `�` and a few other characters written to the console - Qt 6.8.1 and Qt 6.8.2 on GNOME on Linux.

It kind of makes sense, and to let Qt do the conversion to std:string. But there are a number of other `toLocal8Bit()` used with `LOG()` and I haven't seen the invalid characters before - not that I have checked carefully. Maybe it still makes sense to replace them all?
