### PR TITLE
also reset camera translation in viewAngle* to make one axis disappear

### DIFF
--- a/src/gui/MainWindow.cc
+++ b/src/gui/MainWindow.cc
@@ -2922,42 +2922,49 @@ void MainWindow::editorContentChanged()
 void MainWindow::viewAngleTop()
 {
   qglview->cam.object_rot << 90, 0, 0;
+  qglview->cam.object_trans << 0, 0, 0;
   this->qglview->update();
 }
 
 void MainWindow::viewAngleBottom()
 {
   qglview->cam.object_rot << 270, 0, 0;
+  qglview->cam.object_trans << 0, 0, 0;
   this->qglview->update();
 }
 
 void MainWindow::viewAngleLeft()
 {
   qglview->cam.object_rot << 0, 0, 90;
+  qglview->cam.object_trans << 0, 0, 0;
   this->qglview->update();
 }
 
 void MainWindow::viewAngleRight()
 {
   qglview->cam.object_rot << 0, 0, 270;
+  qglview->cam.object_trans << 0, 0, 0;
   this->qglview->update();
 }
 
 void MainWindow::viewAngleFront()
 {
   qglview->cam.object_rot << 0, 0, 0;
+  qglview->cam.object_trans << 0, 0, 0;
   this->qglview->update();
 }
 
 void MainWindow::viewAngleBack()
 {
   qglview->cam.object_rot << 0, 0, 180;
+  qglview->cam.object_trans << 0, 0, 0;
   this->qglview->update();
 }
 
 void MainWindow::viewAngleDiagonal()
 {
   qglview->cam.object_rot << 35, 0, -25;
+  qglview->cam.object_trans << 0, 0, 0;
   this->qglview->update();
 }
 


### PR DESCRIPTION
it was noticable that even when i pressed "view from Top" stil Z axis was visible in perspective projection.
This was due to camera translation not reset.
This PR will make 3d View look more perfect.

BTW: messing with the axes instead is not a good idea as they would not be precise anymore to read dimension