### PR TITLE
Include some missing system headers

### DIFF
--- a/src/core/AST.cc
+++ b/src/core/AST.cc
@@ -1,4 +1,5 @@
 #include "core/AST.h"
+#include <filesystem>
 #include <ostream>
 #include <memory>
 #include <sstream>

--- a/src/core/ColorUtil.cc
+++ b/src/core/ColorUtil.cc
@@ -1,3 +1,4 @@
+#include <string>
 #include "core/ColorUtil.h"
 
 namespace OpenSCAD {

--- a/src/core/Parameters.cc
+++ b/src/core/Parameters.cc
@@ -26,6 +26,7 @@
 
 #include "core/Parameters.h"
 
+#include <initializer_list>
 #include <cassert>
 #include <sstream>
 #include <memory>

--- a/src/core/Parameters.h
+++ b/src/core/Parameters.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <initializer_list>
 #include <limits>
 #include <memory>
 #include <string>

--- a/src/core/Settings.cc
+++ b/src/core/Settings.cc
@@ -1,5 +1,6 @@
 #include "core/Settings.h"
 
+#include <ostream>
 #include <cassert>
 #include <cstddef>
 #include <istream>

--- a/src/core/Value.cc
+++ b/src/core/Value.cc
@@ -26,6 +26,7 @@
 
 #include "core/Value.h"
 
+#include <filesystem>
 #include <cmath>
 #include <variant>
 #include <limits>

--- a/src/core/module.cc
+++ b/src/core/module.cc
@@ -26,6 +26,7 @@
 
 #include "core/module.h"
 
+#include <string>
 #include <memory>
 #include "core/Arguments.h"
 #include "core/Children.h"

--- a/src/core/module.cc
+++ b/src/core/module.cc
@@ -26,6 +26,7 @@
 
 #include "core/module.h"
 
+#include <utility>
 #include <string>
 #include <memory>
 #include "core/Arguments.h"

--- a/src/core/module.h
+++ b/src/core/module.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <string>
 #include <memory>
 #include <functional>
 #include "Feature.h"

--- a/src/geometry/roof_ss.cc
+++ b/src/geometry/roof_ss.cc
@@ -3,6 +3,7 @@
 
 #include "geometry/roof_ss.h"
 
+#include <vector>
 #include <clipper2/clipper.engine.h>
 #include <iterator>
 #include <functional>

--- a/src/glview/ShaderUtils.cc
+++ b/src/glview/ShaderUtils.cc
@@ -1,5 +1,6 @@
 #include "glview/ShaderUtils.h"
 
+#include <sstream>
 #include <string>
 #include <fstream>
 

--- a/src/glview/ShaderUtils.cc
+++ b/src/glview/ShaderUtils.cc
@@ -1,5 +1,6 @@
 #include "glview/ShaderUtils.h"
 
+#include <string>
 #include <fstream>
 
 #include "platform/PlatformUtils.h"

--- a/src/glview/ShaderUtils.h
+++ b/src/glview/ShaderUtils.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <unordered_map>
 #include <string>
 #include "glview/system-gl.h"
 

--- a/src/glview/ShaderUtils.h
+++ b/src/glview/ShaderUtils.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <string>
 #include "glview/system-gl.h"
 
 namespace ShaderUtils {

--- a/src/glview/VBOBuilder.cc
+++ b/src/glview/VBOBuilder.cc
@@ -1,5 +1,6 @@
 #include "glview/VBOBuilder.h"
 
+#include <unordered_map>
 #include <cstring>
 #include <cassert>
 #include <array>

--- a/src/glview/VertexState.h
+++ b/src/glview/VertexState.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <utility>
 #include <memory>
 #include <cstddef>
 #include <functional>

--- a/src/gui/Animate.cc
+++ b/src/gui/Animate.cc
@@ -1,5 +1,6 @@
 #include "gui/Animate.h"
 
+#include <string>
 #include <QAction>
 #include <QBoxLayout>
 #include <QIcon>

--- a/src/gui/Export3mfDialog.cc
+++ b/src/gui/Export3mfDialog.cc
@@ -26,6 +26,7 @@
 
 #include "gui/Export3mfDialog.h"
 
+#include <string>
 #include <QString>
 #include <QCheckBox>
 #include <QColor>

--- a/src/gui/ExternalToolInterface.cc
+++ b/src/gui/ExternalToolInterface.cc
@@ -26,6 +26,7 @@
 
 #include "gui/ExternalToolInterface.h"
 
+#include <functional>
 #include <memory>
 #include <QDir>
 #include <QString>

--- a/src/gui/ExternalToolInterface.cc
+++ b/src/gui/ExternalToolInterface.cc
@@ -26,6 +26,7 @@
 
 #include "gui/ExternalToolInterface.h"
 
+#include <memory>
 #include <QDir>
 #include <QString>
 #include <QFileInfo>

--- a/src/gui/ExternalToolInterface.h
+++ b/src/gui/ExternalToolInterface.h
@@ -26,6 +26,7 @@
 
 #pragma once
 
+#include <functional>
 #include <string>
 #include <memory>
 

--- a/src/gui/ExternalToolInterface.h
+++ b/src/gui/ExternalToolInterface.h
@@ -26,6 +26,7 @@
 
 #pragma once
 
+#include <string>
 #include <memory>
 
 #include <QDir>

--- a/src/gui/MainWindow.cc
+++ b/src/gui/MainWindow.cc
@@ -26,6 +26,7 @@
 
 #include "gui/MainWindow.h"
 
+#include <filesystem>
 #include <deque>
 #include <cassert>
 #include <array>

--- a/src/gui/Preferences.cc
+++ b/src/gui/Preferences.cc
@@ -26,6 +26,7 @@
 
 #include "gui/Preferences.h"
 
+#include <unordered_map>
 #include <vector>
 #include <QFont>
 #include <QFontComboBox>

--- a/src/gui/Preferences.cc
+++ b/src/gui/Preferences.cc
@@ -26,6 +26,7 @@
 
 #include "gui/Preferences.h"
 
+#include <vector>
 #include <QFont>
 #include <QFontComboBox>
 #include <QMainWindow>

--- a/src/gui/PrintInitDialog.cc
+++ b/src/gui/PrintInitDialog.cc
@@ -26,6 +26,7 @@
 
 #include "gui/PrintInitDialog.h"
 
+#include <vector>
 #include <QDialog>
 #include <QString>
 

--- a/src/gui/PrintInitDialog.h
+++ b/src/gui/PrintInitDialog.h
@@ -26,6 +26,7 @@
 
 #pragma once
 
+#include <vector>
 #include <QDialog>
 #include "gui/InitConfigurator.h"
 #include "gui/qtgettext.h"

--- a/src/gui/PrintService.cc
+++ b/src/gui/PrintService.cc
@@ -26,6 +26,7 @@
 
 #include "gui/PrintService.h"
 
+#include <mutex>
 #include <utility>
 #include <unordered_map>
 #include <memory>

--- a/src/gui/PrintService.cc
+++ b/src/gui/PrintService.cc
@@ -26,6 +26,7 @@
 
 #include "gui/PrintService.h"
 
+#include <unordered_map>
 #include <memory>
 #include <string>
 

--- a/src/gui/PrintService.cc
+++ b/src/gui/PrintService.cc
@@ -26,6 +26,7 @@
 
 #include "gui/PrintService.h"
 
+#include <utility>
 #include <unordered_map>
 #include <memory>
 #include <string>

--- a/src/gui/PrintService.h
+++ b/src/gui/PrintService.h
@@ -26,6 +26,7 @@
 
 #pragma once
 
+#include <unordered_map>
 #include <string>
 #include <vector>
 #include <QJsonObject>

--- a/src/gui/PrintService.h
+++ b/src/gui/PrintService.h
@@ -26,6 +26,7 @@
 
 #pragma once
 
+#include <memory>
 #include <unordered_map>
 #include <string>
 #include <vector>

--- a/src/gui/PrintService.h
+++ b/src/gui/PrintService.h
@@ -26,6 +26,7 @@
 
 #pragma once
 
+#include <vector>
 #include <QJsonObject>
 #include <mutex>
 

--- a/src/gui/PrintService.h
+++ b/src/gui/PrintService.h
@@ -26,6 +26,7 @@
 
 #pragma once
 
+#include <string>
 #include <vector>
 #include <QJsonObject>
 #include <mutex>

--- a/src/gui/QSettingsCached.cc
+++ b/src/gui/QSettingsCached.cc
@@ -1,5 +1,6 @@
 #include "gui/QSettingsCached.h"
 
+#include <mutex>
 #include <QSettings>
 #include <memory>
 

--- a/src/gui/ScintillaEditor.h
+++ b/src/gui/ScintillaEditor.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <filesystem>
 #include <QStringList>
 #include <map>
 #include <functional>

--- a/src/gui/ScintillaEditor.h
+++ b/src/gui/ScintillaEditor.h
@@ -1,7 +1,7 @@
 #pragma once
 
-#include <filesystem>
 #include <QStringList>
+#include <filesystem>
 #include <map>
 #include <functional>
 #include <memory>

--- a/src/gui/UIUtils.cc
+++ b/src/gui/UIUtils.cc
@@ -26,6 +26,7 @@
 
 #include "gui/UIUtils.h"
 
+#include <filesystem>
 #include <QString>
 #include <QStringList>
 #include <QWidget>

--- a/src/gui/input/InputEventMapper.cc
+++ b/src/gui/input/InputEventMapper.cc
@@ -29,6 +29,7 @@
 #include "gui/Preferences.h"
 #include "gui/input/AxisConfigWidget.h"
 #include "gui/input/ButtonConfigWidget.h"
+#include <array>
 #include <QMetaObject>
 #include <QTimer>
 #include <cstddef>

--- a/src/io/export.cc
+++ b/src/io/export.cc
@@ -33,6 +33,7 @@
 #include "geometry/Geometry.h"
 #include "glview/RenderSettings.h"
 
+#include <unordered_map>
 #include <algorithm>
 #include <functional>
 #include <cassert>

--- a/src/io/export.h
+++ b/src/io/export.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <filesystem>
 #include <iterator>
 #include <map>
 #include <iostream>

--- a/src/io/export.h
+++ b/src/io/export.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <unordered_map>
 #include <filesystem>
 #include <iterator>
 #include <map>

--- a/src/io/export_param.cc
+++ b/src/io/export_param.cc
@@ -24,6 +24,7 @@
  *
  */
 
+#include <filesystem>
 #include <iostream>
 #include <string>
 #include "json/json.hpp"

--- a/src/io/export_stl.cc
+++ b/src/io/export_stl.cc
@@ -27,6 +27,7 @@
 #include "io/export.h"
 #include "geometry/PolySet.h"
 #include "geometry/PolySetUtils.h"
+#include <sstream>
 #include <algorithm>
 #include <cassert>
 #include <array>

--- a/src/io/import_3mf_v2.cc
+++ b/src/io/import_3mf_v2.cc
@@ -33,6 +33,7 @@
 #include "core/AST.h"
 #include "glview/RenderSettings.h"
 
+#include <string>
 #include <cstdint>
 #include <unordered_map>
 #include <utility>

--- a/src/openscad.cc
+++ b/src/openscad.cc
@@ -26,6 +26,7 @@
 
 #include "openscad.h"
 
+#include <sstream>
 #include <array>
 #include <memory>
 #include <utility>

--- a/src/openscad.cc
+++ b/src/openscad.cc
@@ -26,6 +26,7 @@
 
 #include "openscad.h"
 
+#include <memory>
 #include <utility>
 #include <vector>
 #include <chrono>

--- a/src/openscad.cc
+++ b/src/openscad.cc
@@ -26,6 +26,7 @@
 
 #include "openscad.h"
 
+#include <vector>
 #include <chrono>
 #include <iomanip>
 #include <fstream>

--- a/src/openscad.cc
+++ b/src/openscad.cc
@@ -26,6 +26,7 @@
 
 #include "openscad.h"
 
+#include <utility>
 #include <vector>
 #include <chrono>
 #include <iomanip>

--- a/src/openscad.cc
+++ b/src/openscad.cc
@@ -26,6 +26,7 @@
 
 #include "openscad.h"
 
+#include <ostream>
 #include <sstream>
 #include <array>
 #include <memory>

--- a/src/openscad.cc
+++ b/src/openscad.cc
@@ -26,6 +26,7 @@
 
 #include "openscad.h"
 
+#include <array>
 #include <memory>
 #include <utility>
 #include <vector>

--- a/src/openscad_gui.cc
+++ b/src/openscad_gui.cc
@@ -26,6 +26,7 @@
 
 #include "openscad_gui.h"
 
+#include <filesystem>
 #include <string>
 #include <vector>
 #include <QDir>

--- a/src/openscad_gui.cc
+++ b/src/openscad_gui.cc
@@ -26,6 +26,7 @@
 
 #include "openscad_gui.h"
 
+#include <memory>
 #include <filesystem>
 #include <string>
 #include <vector>

--- a/src/openscad_gui.cc
+++ b/src/openscad_gui.cc
@@ -26,6 +26,7 @@
 
 #include "openscad_gui.h"
 
+#include <vector>
 #include <QDir>
 #include <QIcon>
 #include <QFileInfo>

--- a/src/openscad_gui.cc
+++ b/src/openscad_gui.cc
@@ -26,6 +26,7 @@
 
 #include "openscad_gui.h"
 
+#include <string>
 #include <vector>
 #include <QDir>
 #include <QIcon>

--- a/src/platform/PlatformUtils-win.cc
+++ b/src/platform/PlatformUtils-win.cc
@@ -1,5 +1,6 @@
 #include "platform/PlatformUtils.h"
 
+#include <filesystem>
 #include <ios>
 #include <string>
 #include <map>

--- a/src/platform/PlatformUtils.cc
+++ b/src/platform/PlatformUtils.cc
@@ -1,5 +1,6 @@
 #include "platform/PlatformUtils.h"
 
+#include <filesystem>
 #include <stdexcept>
 #include <cstdint>
 #include <cstdlib>


### PR DESCRIPTION
At least instances where we have more than one file affected. One commit per header.

All done essentially semi-automatic by taking the output of `scripts/run-clang-tidy-cached.cc`, then using an awk-script to find files with relevant reports to then be using [`insert-header.cc`](https://github.com/hzeller/dev-tools/blob/main/insert-header.cc) to add the missing header.

So typically something like

```bash
../dev-tools/insert-header.cc '<ostream>' $(awk -F: '/^src.*no header providing.*std::ostream/ {print $1}' OpenSCAD_clang-tidy.out)
```