### PR TITLE
Some small clang-tidy fixes

### DIFF
--- a/src/core/LinearExtrudeNode.cc
+++ b/src/core/LinearExtrudeNode.cc
@@ -43,7 +43,6 @@
 using namespace boost::assign; // bring 'operator+=()' into scope
 
 #include <filesystem>
-namespace fs = std::filesystem;
 
 namespace {
 std::shared_ptr<AbstractNode> builtin_linear_extrude(const ModuleInstantiation *inst, Arguments arguments, const Children& children)

--- a/src/core/Parameters.cc
+++ b/src/core/Parameters.cc
@@ -72,7 +72,7 @@ const Value& Parameters::get(const std::initializer_list<std::string> names) con
   std::string matchName;
   boost::optional<const Value&> matchValue;
 
-  for (std::string name: names) {
+  for (const std::string& name: names) {
     boost::optional<const Value&> value = lookup(name);
     if (value && value->isDefined()) {
       if (!matchValue) {

--- a/src/gui/input/HidApiInputDriver.cc
+++ b/src/gui/input/HidApiInputDriver.cc
@@ -182,7 +182,7 @@ void HidApiInputDriver::hidapi_decode_button(const unsigned char *buf, unsigned 
     const uint16_t current = buf[1] | buf[2] << 8;
 
     const std::bitset<16> bits_curr{current};
-    const std::bitset<16> bits_last{buttons};
+    const std::bitset<16> bits_last{buttons};  // NOLINT
 
     for (int i = 0; i < 16; ++i) {
       if (bits_curr.test(i) != bits_last.test(i)) {

--- a/src/openscad_gui.cc
+++ b/src/openscad_gui.cc
@@ -87,8 +87,8 @@ bool isDarkMode() {
   return scheme == Qt::ColorScheme::Dark;
 #else
   const QPalette defaultPalette;
-  const auto text = defaultPalette.color(QPalette::WindowText);
-  const auto window = defaultPalette.color(QPalette::Window);
+  const auto& text = defaultPalette.color(QPalette::WindowText);
+  const auto& window = defaultPalette.color(QPalette::Window);
   return text.lightness() > window.lightness();
 #endif // QT_VERSION
 }


### PR DESCRIPTION
  * performance-for-range-copy
  * misc-unused-alias-decls
  * NOLINT a bugprone-unused-local-non-trivial-variable clang-tidy was confused about.
  * performance-unnecessary-copy-initialization