### PR TITLE
Include core/AST.h when using class Location

### DIFF
--- a/src/core/BuiltinContext.cc
+++ b/src/core/BuiltinContext.cc
@@ -2,6 +2,7 @@
 
 #include <cmath>
 
+#include "core/AST.h"
 #include "core/Builtins.h"
 #include "core/Expression.h"
 #include "core/function.h"

--- a/src/core/BuiltinContext.h
+++ b/src/core/BuiltinContext.h
@@ -2,6 +2,7 @@
 
 #include <string>
 
+#include "core/AST.h"
 #include "core/Context.h"
 
 class BuiltinContext : public Context

--- a/src/core/Builtins.cc
+++ b/src/core/Builtins.cc
@@ -5,6 +5,7 @@
 #include <string>
 #include <vector>
 
+#include "core/AST.h"
 #include "core/function.h"
 #include "core/module.h"
 #include "core/Expression.h"

--- a/src/core/Context.cc
+++ b/src/core/Context.cc
@@ -32,6 +32,7 @@
 #include <string>
 #include <vector>
 
+#include "core/AST.h"
 #include "core/function.h"
 #include "utils/printutils.h"
 

--- a/src/core/Context.h
+++ b/src/core/Context.h
@@ -7,6 +7,7 @@
 #include <vector>
 
 #include "core/ContextFrame.h"
+#include "core/AST.h"
 #include "core/ContextMemoryManager.h"
 
 /**

--- a/src/core/ContextFrame.cc
+++ b/src/core/ContextFrame.cc
@@ -24,6 +24,7 @@
  *
  */
 
+#include "core/AST.h"
 #include "core/ContextFrame.h"
 
 #include <utility>

--- a/src/core/ContextFrame.h
+++ b/src/core/ContextFrame.h
@@ -6,6 +6,7 @@
 #include <vector>
 
 #include "core/EvaluationSession.h"
+#include "core/AST.h"
 #include "core/ValueMap.h"
 
 class ContextFrame

--- a/src/core/EvaluationSession.cc
+++ b/src/core/EvaluationSession.cc
@@ -30,6 +30,7 @@
 #include <cstddef>
 #include <string>
 
+#include "core/AST.h"
 #include "core/ContextFrame.h"
 #include "utils/printutils.h"
 

--- a/src/core/EvaluationSession.h
+++ b/src/core/EvaluationSession.h
@@ -7,6 +7,7 @@
 #include <boost/optional.hpp>
 
 #include "core/ContextMemoryManager.h"
+#include "core/AST.h"
 #include "core/function.h"
 #include "core/module.h"
 #include "core/Value.h"

--- a/src/core/Expression.h
+++ b/src/core/Expression.h
@@ -9,6 +9,7 @@
 #include <memory>
 #include <boost/logic/tribool.hpp>
 #include "core/Assignment.h"
+#include "core/AST.h"
 #include "core/function.h"
 #include "core/Value.h"
 

--- a/src/core/FreetypeRenderer.h
+++ b/src/core/FreetypeRenderer.h
@@ -30,6 +30,7 @@
 #include <vector>
 #include <ostream>
 
+#include "core/AST.h"
 #include "core/Parameters.h"
 #include <hb.h>
 #include <ft2build.h>

--- a/src/core/Parameters.cc
+++ b/src/core/Parameters.cc
@@ -36,6 +36,7 @@
 #include <utility>
 #include <vector>
 
+#include "core/AST.h"
 #include "core/Expression.h"
 
 Parameters::Parameters(ContextFrame&& frame, Location loc) :

--- a/src/core/Parameters.h
+++ b/src/core/Parameters.h
@@ -7,6 +7,7 @@
 #include <vector>
 
 #include "core/Arguments.h"
+#include "core/AST.h"
 #include "core/ContextFrame.h"
 
 /*

--- a/src/core/ScopeContext.h
+++ b/src/core/ScopeContext.h
@@ -5,6 +5,7 @@
 #include <vector>
 
 #include "core/Arguments.h"
+#include "core/AST.h"
 #include "core/Children.h"
 #include "core/Context.h"
 #include "core/SourceFile.h"

--- a/src/core/SourceFile.h
+++ b/src/core/SourceFile.h
@@ -8,6 +8,7 @@
 #include <vector>
 
 #include "core/module.h"
+#include "core/AST.h"
 #include "core/LocalScope.h"
 #include "core/IndicatorData.h"
 

--- a/src/core/UserModule.cc
+++ b/src/core/UserModule.cc
@@ -30,6 +30,7 @@
 #include <memory>
 #include <vector>
 
+#include "core/AST.h"
 #include "core/ModuleInstantiation.h"
 #include "core/node.h"
 #include "utils/exceptions.h"

--- a/src/core/UserModule.h
+++ b/src/core/UserModule.h
@@ -6,6 +6,7 @@
 #include <vector>
 
 #include "core/module.h"
+#include "core/AST.h"
 #include "core/LocalScope.h"
 
 class Feature;

--- a/src/core/builtin_functions.cc
+++ b/src/core/builtin_functions.cc
@@ -25,6 +25,7 @@
  */
 
 #include "core/function.h"
+#include "core/AST.h"
 #include "core/Arguments.h"
 #include "core/Expression.h"
 #include "core/Builtins.h"

--- a/src/core/customizer/ParameterObject.cc
+++ b/src/core/customizer/ParameterObject.cc
@@ -1,5 +1,6 @@
 #include "core/customizer/ParameterObject.h"
 
+#include "core/AST.h"
 #include "core/customizer/Annotation.h"
 #include "core/Assignment.h"
 #include "core/Expression.h"

--- a/src/core/function.cc
+++ b/src/core/function.cc
@@ -26,6 +26,7 @@
 
 #include "core/function.h"
 
+#include "core/AST.h"
 #include "core/Arguments.h"
 #include "core/Expression.h"
 

--- a/src/core/node.cc
+++ b/src/core/node.cc
@@ -25,6 +25,7 @@
  */
 
 #include "core/node.h"
+#include "core/AST.h"
 #include "core/ModuleInstantiation.h"
 #include "core/progress.h"
 

--- a/src/geometry/manifold/manifold-applyops.cc
+++ b/src/geometry/manifold/manifold-applyops.cc
@@ -5,6 +5,7 @@
 
 #include <memory>
 #include "geometry/manifold/manifoldutils.h"
+#include "core/AST.h"
 #include "geometry/manifold/ManifoldGeometry.h"
 #include "core/node.h"
 #include "core/progress.h"

--- a/src/gui/MainWindow.cc
+++ b/src/gui/MainWindow.cc
@@ -59,6 +59,7 @@
 #include <QToolBar>
 #include <QWidget>
 
+#include "core/AST.h"
 #include "openscad_gui.h"
 
 #ifdef ENABLE_MANIFOLD

--- a/src/io/dxfdim.cc
+++ b/src/io/dxfdim.cc
@@ -25,6 +25,7 @@
  */
 
 #include "io/dxfdim.h"
+#include "core/AST.h"
 #include "core/Value.h"
 #include "core/function.h"
 #include "io/DxfData.h"

--- a/src/io/import_3mf_dummy.cc
+++ b/src/io/import_3mf_dummy.cc
@@ -27,6 +27,7 @@
 #include <memory>
 #include <string>
 #include "io/import.h"
+#include "core/AST.h"
 #include "utils/printutils.h"
 #include "geometry/PolySet.h"
 

--- a/src/io/import_json.cc
+++ b/src/io/import_json.cc
@@ -30,6 +30,7 @@
 #include <string>
 #include "json/json.hpp"
 
+#include "core/AST.h"
 #include "core/Value.h"
 #include "utils/printutils.h"
 #include "core/EvaluationSession.h"

--- a/src/io/import_obj.cc
+++ b/src/io/import_obj.cc
@@ -1,4 +1,5 @@
 #include "io/import.h"
+#include "core/AST.h"
 #include "geometry/PolySet.h"
 #include "geometry/PolySetBuilder.h"
 #include <ios>

--- a/src/openscad.cc
+++ b/src/openscad.cc
@@ -38,6 +38,7 @@
 #include <string>
 #include <tuple>
 #include <unordered_map>
+#include "core/AST.h"
 #include "core/ColorUtil.h"
 #include "core/Context.h"
 #include "core/Settings.h"


### PR DESCRIPTION
Done semi-automatically using the output from clang tidy.

```
../dev-tools/insert-header "core/AST.h" $(awk -F: '/^src.*no header providing.*"Location"/ {print $1}' OpenSCAD_clang-tidy.out)
```