### PR TITLE
Include geometry/linalg.h to files using symbols from it.

### DIFF
--- a/src/RenderStatistic.cc
+++ b/src/RenderStatistic.cc
@@ -33,6 +33,7 @@
 #include <iostream>
 #include <memory>
 #include <fstream>
+#include "geometry/linalg.h"
 #include "json/json.hpp"
 #include <string>
 #include <vector>

--- a/src/core/CSGTreeEvaluator.cc
+++ b/src/core/CSGTreeEvaluator.cc
@@ -1,4 +1,5 @@
 #include "core/CSGTreeEvaluator.h"
+#include "geometry/linalg.h"
 #include "core/State.h"
 #include "core/CsgOpNode.h"
 #include "core/ModuleInstantiation.h"

--- a/src/core/ColorNode.cc
+++ b/src/core/ColorNode.cc
@@ -25,6 +25,7 @@
  */
 
 #include "core/ColorNode.h"
+#include "geometry/linalg.h"
 #include "core/module.h"
 #include "core/ModuleInstantiation.h"
 #include "core/Builtins.h"

--- a/src/core/ColorUtil.cc
+++ b/src/core/ColorUtil.cc
@@ -1,4 +1,5 @@
 #include <string>
+#include "geometry/linalg.h"
 #include "core/ColorUtil.h"
 
 namespace OpenSCAD {

--- a/src/core/DrawingCallback.h
+++ b/src/core/DrawingCallback.h
@@ -29,6 +29,7 @@
 #include <vector>
 #include <cmath>
 #include <Eigen/Core>
+#include "geometry/linalg.h"
 #include "geometry/Polygon2d.h"
 
 class Polygon2d;

--- a/src/core/FreetypeRenderer.cc
+++ b/src/core/FreetypeRenderer.cc
@@ -36,6 +36,7 @@
 
 #include <fontconfig/fontconfig.h>
 
+#include "geometry/linalg.h"
 #include "utils/printutils.h"
 
 #include "FontCache.h"

--- a/src/core/TransformNode.cc
+++ b/src/core/TransformNode.cc
@@ -25,6 +25,7 @@
  */
 
 #include "core/TransformNode.h"
+#include "geometry/linalg.h"
 #include "core/ModuleInstantiation.h"
 #include "core/Children.h"
 #include "core/Builtins.h"

--- a/src/core/primitives.cc
+++ b/src/core/primitives.cc
@@ -25,6 +25,7 @@
  */
 
 #include "core/primitives.h"
+#include "geometry/linalg.h"
 #include "core/Builtins.h"
 #include "core/Children.h"
 #include "core/ModuleInstantiation.h"

--- a/src/geometry/ClipperUtils.cc
+++ b/src/geometry/ClipperUtils.cc
@@ -1,4 +1,5 @@
 #include "geometry/ClipperUtils.h"
+#include "geometry/linalg.h"
 #include "geometry/Polygon2d.h"
 #include "clipper2/clipper.h"
 #include "utils/printutils.h"

--- a/src/geometry/ClipperUtils.h
+++ b/src/geometry/ClipperUtils.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "clipper2/clipper.h"
+#include "geometry/linalg.h"
 #include "geometry/Polygon2d.h"
 
 #include <memory>

--- a/src/geometry/Geometry.cc
+++ b/src/geometry/Geometry.cc
@@ -1,4 +1,5 @@
 #include "geometry/Geometry.h"
+#include "geometry/linalg.h"
 #include "utils/printutils.h"
 #include <sstream>
 #include <memory>

--- a/src/geometry/GeometryEvaluator.cc
+++ b/src/geometry/GeometryEvaluator.cc
@@ -1,4 +1,5 @@
 #include "geometry/GeometryEvaluator.h"
+#include "geometry/linalg.h"
 #include "core/Tree.h"
 #include "geometry/GeometryCache.h"
 #include "geometry/Polygon2d.h"

--- a/src/geometry/GeometryEvaluator.h
+++ b/src/geometry/GeometryEvaluator.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "core/NodeVisitor.h"
+#include "geometry/linalg.h"
 #include "core/enums.h"
 #include "geometry/Geometry.h"
 

--- a/src/geometry/GeometryUtils.cc
+++ b/src/geometry/GeometryUtils.cc
@@ -12,6 +12,7 @@
 #include <string>
 #include <vector>
 
+#include "geometry/linalg.h"
 #include "libtess2/Include/tesselator.h"
 #include "utils/printutils.h"
 #include "geometry/Reindexer.h"

--- a/src/geometry/PolySetBuilder.cc
+++ b/src/geometry/PolySetBuilder.cc
@@ -25,6 +25,7 @@
  */
 
 #include "geometry/PolySetBuilder.h"
+#include "geometry/linalg.h"
 #include "geometry/PolySet.h"
 #include "geometry/Geometry.h"
 

--- a/src/geometry/PolySetBuilder.h
+++ b/src/geometry/PolySetBuilder.h
@@ -5,6 +5,7 @@
 #include <vector>
 
 #include "geometry/Reindexer.h"
+#include "geometry/linalg.h"
 #include "geometry/Polygon2d.h"
 #include "utils/boost-utils.h"
 #include "geometry/GeometryUtils.h"

--- a/src/geometry/PolySetUtils.cc
+++ b/src/geometry/PolySetUtils.cc
@@ -9,6 +9,7 @@
 
 #include <boost/range/adaptor/reversed.hpp>
 
+#include "geometry/linalg.h"
 #include "geometry/PolySet.h"
 #include "geometry/PolySetBuilder.h"
 #include "geometry/Polygon2d.h"

--- a/src/geometry/Polygon2d.cc
+++ b/src/geometry/Polygon2d.cc
@@ -6,6 +6,7 @@
 #include <string>
 #include <memory>
 
+#include "geometry/linalg.h"
 #include "utils/printutils.h"
 #ifdef ENABLE_MANIFOLD
 #include "geometry/manifold/manifoldutils.h"

--- a/src/geometry/cgal/CGAL_Nef_polyhedron.cc
+++ b/src/geometry/cgal/CGAL_Nef_polyhedron.cc
@@ -4,6 +4,7 @@
 #include <cstddef>
 #include <string>
 
+#include "geometry/linalg.h"
 #include "geometry/cgal/cgal.h"
 #include "geometry/cgal/cgalutils.h"
 #include "utils/printutils.h"

--- a/src/geometry/cgal/cgalutils-polyhedron.cc
+++ b/src/geometry/cgal/cgalutils-polyhedron.cc
@@ -1,6 +1,7 @@
 #ifdef ENABLE_CGAL
 
 #include "geometry/cgal/cgalutils.h"
+#include "geometry/linalg.h"
 #include "geometry/PolySet.h"
 #include "geometry/PolySetBuilder.h"
 #include "utils/printutils.h"

--- a/src/geometry/cgal/cgalutils.cc
+++ b/src/geometry/cgal/cgalutils.cc
@@ -5,6 +5,7 @@
 
 #include "geometry/cgal/cgalutils.h"
 
+#include "geometry/linalg.h"
 #include "geometry/cgal/cgal.h"
 #include "geometry/PolySet.h"
 #include "utils/printutils.h"

--- a/src/geometry/cgal/cgalutils.h
+++ b/src/geometry/cgal/cgalutils.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "geometry/cgal/cgal.h"
+#include "geometry/linalg.h"
 #include "geometry/Polygon2d.h"
 #include "geometry/PolySet.h"
 #include "geometry/cgal/CGAL_Nef_polyhedron.h"

--- a/src/geometry/linear_extrude.cc
+++ b/src/geometry/linear_extrude.cc
@@ -12,6 +12,7 @@
 
 #include <boost/logic/tribool.hpp>
 
+#include "geometry/linalg.h"
 #include "geometry/GeometryUtils.h"
 #include "glview/RenderSettings.h"
 #include "core/LinearExtrudeNode.h"

--- a/src/geometry/manifold/ManifoldGeometry.cc
+++ b/src/geometry/manifold/ManifoldGeometry.cc
@@ -1,5 +1,6 @@
 // Portions of this file are Copyright 2023 Google LLC, and licensed under GPL2+. See COPYING.
 #include "geometry/manifold/ManifoldGeometry.h"
+#include "geometry/linalg.h"
 #include "geometry/Polygon2d.h"
 #include <map>
 #include <set>

--- a/src/geometry/manifold/manifoldutils.cc
+++ b/src/geometry/manifold/manifoldutils.cc
@@ -1,5 +1,6 @@
 // Portions of this file are Copyright 2023 Google LLC, and licensed under GPL2+. See COPYING.
 #include "geometry/manifold/manifoldutils.h"
+#include "geometry/linalg.h"
 #include "geometry/manifold/ManifoldGeometry.h"
 #include "geometry/PolySetBuilder.h"
 #include "Feature.h"

--- a/src/geometry/roof_ss.cc
+++ b/src/geometry/roof_ss.cc
@@ -21,6 +21,7 @@
 #include <algorithm>
 #include <map>
 
+#include "geometry/linalg.h"
 #include "geometry/Polygon2d.h"
 #include "geometry/GeometryUtils.h"
 #include "geometry/ClipperUtils.h"

--- a/src/geometry/roof_vd.cc
+++ b/src/geometry/roof_vd.cc
@@ -12,6 +12,7 @@
 #include <map>
 #include <boost/polygon/voronoi.hpp>
 #include <vector>
+#include "geometry/linalg.h"
 #include "geometry/Polygon2d.h"
 #include "geometry/PolySetBuilder.h"
 

--- a/src/glview/Camera.cc
+++ b/src/glview/Camera.cc
@@ -1,4 +1,5 @@
 #include "glview/Camera.h"
+#include "geometry/linalg.h"
 #include "glview/RenderSettings.h"
 #include "utils/printutils.h"
 #include "utils/degree_trig.h"

--- a/src/glview/GLView.cc
+++ b/src/glview/GLView.cc
@@ -1,4 +1,5 @@
 #include "glview/GLView.h"
+#include "geometry/linalg.h"
 #include "glview/system-gl.h"
 #include "glview/ColorMap.h"
 #include "glview/RenderSettings.h"

--- a/src/glview/GLView.h
+++ b/src/glview/GLView.h
@@ -23,6 +23,7 @@
 #include <string>
 #include <vector>
 #include "glview/Camera.h"
+#include "geometry/linalg.h"
 #include "glview/ColorMap.h"
 #include "glview/system-gl.h"
 #include "core/Selection.h"

--- a/src/glview/NULLGL.cc
+++ b/src/glview/NULLGL.cc
@@ -20,6 +20,7 @@ void GLView::showCrosshairs(const Color4f& col) {}
 void GLView::setColorScheme(const ColorScheme& cs){assert(false && "not implemented");}
 void GLView::setColorScheme(const std::string& cs) {assert(false && "not implemented");}
 
+#include "geometry/linalg.h"
 #include "glview/system-gl.h"
 
 double gl_version() { return -1; }

--- a/src/glview/Renderer.cc
+++ b/src/glview/Renderer.cc
@@ -1,4 +1,5 @@
 #include "glview/Renderer.h"
+#include "geometry/linalg.h"
 #include "glview/ColorMap.h"
 #include "utils/printutils.h"
 #include "platform/PlatformUtils.h"

--- a/src/glview/VBOBuilder.cc
+++ b/src/glview/VBOBuilder.cc
@@ -9,6 +9,7 @@
 #include <memory>
 #include <cstdio>
 
+#include "geometry/linalg.h"
 #include "geometry/Polygon2d.h"
 #include "utils/printutils.h"
 #include "utils/hash.h"  // IWYU pragma: keep

--- a/src/glview/VBORenderer.cc
+++ b/src/glview/VBORenderer.cc
@@ -25,6 +25,7 @@
  */
 
 #include "glview/VBORenderer.h"
+#include "geometry/linalg.h"
 #include "geometry/Polygon2d.h"
 #include "geometry/PolySet.h"
 #include "core/CSGNode.h"

--- a/src/glview/VBORenderer.h
+++ b/src/glview/VBORenderer.h
@@ -5,6 +5,7 @@
 #include <memory>
 #include <cstddef>
 #include "glview/Renderer.h"
+#include "geometry/linalg.h"
 #include "geometry/Polygon2d.h"
 #include "glview/system-gl.h"
 #ifdef ENABLE_OPENCSG

--- a/src/glview/cgal/CGALRenderUtils.cc
+++ b/src/glview/cgal/CGALRenderUtils.cc
@@ -1,3 +1,4 @@
+#include "geometry/linalg.h"
 #include "glview/cgal/CGALRenderUtils.h"
 
 #include <algorithm>

--- a/src/glview/cgal/CGALRenderer.cc
+++ b/src/glview/cgal/CGALRenderer.cc
@@ -36,6 +36,7 @@
 #include <mpfr.h>
 #endif
 
+#include "geometry/linalg.h"
 #include "Feature.h"
 #include "geometry/PolySet.h"
 #include "geometry/PolySetUtils.h"

--- a/src/glview/cgal/CGALRenderer.h
+++ b/src/glview/cgal/CGALRenderer.h
@@ -5,6 +5,7 @@
 #include <vector>
 
 #include "glview/VBORenderer.h"
+#include "geometry/linalg.h"
 #include "geometry/Polygon2d.h"
 #ifdef ENABLE_CGAL
 #include "geometry/cgal/CGAL_Nef_polyhedron.h"

--- a/src/glview/preview/OpenCSGRenderer.h
+++ b/src/glview/preview/OpenCSGRenderer.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "glview/VertexState.h"
+#include "geometry/linalg.h"
 #include "glview/Renderer.h"
 #include "glview/system-gl.h"
 #include <memory>

--- a/src/glview/preview/ThrownTogetherRenderer.cc
+++ b/src/glview/preview/ThrownTogetherRenderer.cc
@@ -29,6 +29,7 @@
 #include <memory>
 #include <cstddef>
 #include <utility>
+#include "geometry/linalg.h"
 #include "Feature.h"
 #include "glview/VertexState.h"
 #include "geometry/PolySet.h"

--- a/src/glview/preview/ThrownTogetherRenderer.h
+++ b/src/glview/preview/ThrownTogetherRenderer.h
@@ -5,6 +5,7 @@
 #include <vector>
 
 #include "glview/VertexState.h"
+#include "geometry/linalg.h"
 #include "glview/Renderer.h"
 #include "core/CSGNode.h"
 

--- a/src/gui/Measurement.cc
+++ b/src/gui/Measurement.cc
@@ -24,6 +24,7 @@
  *
  */
 
+#include "geometry/linalg.h"
 #include "gui/Measurement.h"
 
 #include <QPoint>

--- a/src/gui/Measurement.h
+++ b/src/gui/Measurement.h
@@ -3,6 +3,7 @@
 
 #include <QPoint>
 #include <QString>
+#include "geometry/linalg.h"
 #include "gui/QGLView.h"
 
 enum { MEASURE_IDLE, MEASURE_DIST1, MEASURE_DIST2, MEASURE_ANG1, MEASURE_ANG2, MEASURE_ANG3 };

--- a/src/gui/QGLView.cc
+++ b/src/gui/QGLView.cc
@@ -26,6 +26,7 @@
 
 #include "gui/QGLView.h"
 
+#include "geometry/linalg.h"
 #include "gui/qtgettext.h"
 #include "gui/Preferences.h"
 #include "glview/Renderer.h"

--- a/src/io/DxfData.cc
+++ b/src/io/DxfData.cc
@@ -30,6 +30,7 @@
 #include <memory>
 #include <cmath>
 
+#include "geometry/linalg.h"
 #include "geometry/Grid.h"
 #include "utils/printutils.h"
 #include "utils/calc.h"

--- a/src/io/export.cc
+++ b/src/io/export.cc
@@ -25,6 +25,7 @@
  */
 
 #include "io/export.h"
+#include "geometry/linalg.h"
 #include "glview/ColorMap.h"
 #include "core/ColorUtil.h"
 #include "export_enums.h"

--- a/src/io/export_3mf_v1.cc
+++ b/src/io/export_3mf_v1.cc
@@ -25,6 +25,7 @@
  */
 
 #include "export_enums.h"
+#include "geometry/linalg.h"
 #include "io/export.h"
 
 #include <cassert>

--- a/src/io/export_dxf.cc
+++ b/src/io/export_dxf.cc
@@ -29,6 +29,7 @@
 #include <ostream>
 #include <memory>
 #include "io/export.h"
+#include "geometry/linalg.h"
 #include "geometry/Polygon2d.h"
 #include "geometry/PolySet.h"
 

--- a/src/io/export_pdf.cc
+++ b/src/io/export_pdf.cc
@@ -1,4 +1,5 @@
 #include "io/export.h"
+#include "geometry/linalg.h"
 #include "geometry/Polygon2d.h"
 #include "geometry/PolySet.h"
 #include "utils/printutils.h"

--- a/src/io/export_png.cc
+++ b/src/io/export_png.cc
@@ -1,4 +1,5 @@
 #include "io/export.h"
+#include "geometry/linalg.h"
 #include "utils/printutils.h"
 #include "glview/OffscreenView.h"
 #include "glview/CsgInfo.h"

--- a/src/io/export_stl.cc
+++ b/src/io/export_stl.cc
@@ -25,6 +25,7 @@
  */
 
 #include "io/export.h"
+#include "geometry/linalg.h"
 #include "geometry/PolySet.h"
 #include "geometry/PolySetUtils.h"
 #include <sstream>

--- a/src/io/export_svg.cc
+++ b/src/io/export_svg.cc
@@ -28,6 +28,7 @@
 #include <ostream>
 #include <memory>
 #include "io/export.h"
+#include "geometry/linalg.h"
 #include "geometry/Polygon2d.h"
 #include "geometry/PolySet.h"
 

--- a/src/io/import_3mf_v2.cc
+++ b/src/io/import_3mf_v2.cc
@@ -25,6 +25,7 @@
  */
 
 #include "geometry/PolySet.h"
+#include "geometry/linalg.h"
 #include "geometry/PolySetBuilder.h"
 #include "geometry/PolySetUtils.h"
 #include "geometry/Geometry.h"

--- a/src/io/import_obj.cc
+++ b/src/io/import_obj.cc
@@ -1,4 +1,5 @@
 #include "io/import.h"
+#include "geometry/linalg.h"
 #include "core/AST.h"
 #include "geometry/PolySet.h"
 #include "geometry/PolySetBuilder.h"

--- a/src/io/import_off.cc
+++ b/src/io/import_off.cc
@@ -1,4 +1,5 @@
 #include "io/import.h"
+#include "geometry/linalg.h"
 #include "Feature.h"
 #include "geometry/PolySet.h"
 #include "utils/printutils.h"

--- a/src/utils/degree_trig.cc
+++ b/src/utils/degree_trig.cc
@@ -23,6 +23,7 @@
  *  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
  *
  */
+#include "geometry/linalg.h"
 #include "utils/degree_trig.h"
 
 //

--- a/src/utils/hash.cc
+++ b/src/utils/hash.cc
@@ -1,3 +1,4 @@
+#include "geometry/linalg.h"
 #include "utils/hash.h"
 #include <cstdint>
 #include <boost/functional/hash.hpp>


### PR DESCRIPTION
Semi-automatically created from clang-tidy report

```
../dev-tools/insert-header "geometry/linalg.h" $(awk -F: '/^src.*no header providing.*"(BoundingBox|Matrix3f|Matrix3d|Matrix4d|Color4f|Vector2d|Vector3d|Vector4d|Vector3f|Vector3i)"/ {print $1}' OpenSCAD_clang-tidy.out | uniq)
```