### PR TITLE
Cleanup application exit code

### DIFF
--- a/src/gui/MainWindow.cc
+++ b/src/gui/MainWindow.cc
@@ -433,7 +433,7 @@ MainWindow::MainWindow(const QStringList& filenames)
   connect(this->fileActionReload, SIGNAL(triggered()), this, SLOT(actionReload()));
   connect(this->fileActionRevoke, SIGNAL(triggered()), this, SLOT(actionRevokeTrustedFiles()));
   connect(this->fileActionClose, SIGNAL(triggered()), tabManager, SLOT(closeCurrentTab()));
-  connect(this->fileActionQuit, SIGNAL(triggered()), this, SLOT(quit()));
+  connect(this->fileActionQuit, SIGNAL(triggered()), scadApp, SLOT(quit()), Qt::QueuedConnection);
   connect(this->fileShowLibraryFolder, SIGNAL(triggered()), this, SLOT(actionShowLibraryFolder()));
 #ifndef __APPLE__
   auto shortcuts = this->fileActionSave->shortcuts();
@@ -960,10 +960,10 @@ MainWindow::~MainWindow()
   // so no need to delete it.
   delete parsedFile;
   scadApp->windowManager.remove(this);
-  if (scadApp->windowManager.getWindows().size() == 0) {
+  if (scadApp->windowManager.getWindows().empty()) {
     // Quit application even in case some other windows like
     // Preferences are still open.
-    this->quit();
+    scadApp->quit(); 
   }
 }
 
@@ -3523,17 +3523,6 @@ void MainWindow::setFont(const QString& family, uint size)
   if (size > 0) font.setPointSize(size);
   font.setStyleHint(QFont::TypeWriter);
   activeEditor->setFont(font);
-}
-
-void MainWindow::quit()
-{
-  QCloseEvent ev;
-  QApplication::sendEvent(QApplication::instance(), &ev);
-  if (ev.isAccepted()) QApplication::instance()->quit();
-  // FIXME: Cancel any CGAL calculations
-#ifdef Q_OS_MACOS
-  CocoaUtils::endApplication();
-#endif
 }
 
 void MainWindow::consoleOutput(const Message& msgObj, void *userdata)

--- a/src/gui/MainWindow.h
+++ b/src/gui/MainWindow.h
@@ -362,7 +362,6 @@ public slots:
   void helpOfflineCheatSheet();
   void helpLibrary();
   void helpFontInfo();
-  void quit();
   void checkAutoReload();
   void waitAfterReload();
   void autoReloadSet(bool);

--- a/src/gui/OpenSCADApp.cc
+++ b/src/gui/OpenSCADApp.cc
@@ -77,8 +77,3 @@ void OpenSCADApp::hideFontCacheDialog()
   assert(this->fontCacheDialog);
   this->fontCacheDialog->reset();
 }
-
-
-void OpenSCADApp::releaseQSettingsCached() {
-  QSettingsCached{}.release();
-}

--- a/src/gui/OpenSCADApp.h
+++ b/src/gui/OpenSCADApp.h
@@ -22,7 +22,6 @@ public:
 public slots:
   void showFontCacheDialog();
   void hideFontCacheDialog();
-  void releaseQSettingsCached();
 
 public:
   WindowManager windowManager;


### PR DESCRIPTION
This cleans up the exit code:
* Try to drive everything using QCoreApplication::quit()
* Remove duplicate "quit on last window closed"
* Removes MainWindow::quit()
* Use QCoreApplication::aboutToQuit to perform cleanup
* Use Qt::QueuedConnection when calling QCoreApplication::quit()