### PR TITLE
Fix issue #5695

### DIFF
--- a/src/gui/MainWindow.h
+++ b/src/gui/MainWindow.h
@@ -31,6 +31,7 @@
 #include <QSoundEffect>
 #include <QTime>
 #include <QSignalMapper>
+#include <QShortcut>
 
 #include "RubberBandManager.h"
 #include "gui/Editor.h"
@@ -99,6 +100,8 @@ public:
   QString lastCompiledDoc;
 
   QAction *actionRecentFile[UIUtils::maxRecentFiles];
+  QShortcut *shortcutNextWindow{nullptr};
+  QShortcut *shortcutPreviousWindow{nullptr};
   QMap<QString, QString> knownFileExtensions;
 
   QLabel *versionLabel;
@@ -176,7 +179,9 @@ private:
   void show_examples();
   void addKeyboardShortCut(const QList<QAction *>& actions);
   void updateStatusBar(ProgressWidget *progressWidget);
-  void activateWindow(int);
+  void activateDock(Dock *);
+  Dock *findVisibleDockToActivate(int offset) const;
+  Dock *getNextDockFromSender(QObject *sender);
 
   LibraryInfoDialog *libraryInfoDialog{nullptr};
   FontListDialog *fontListDialog{nullptr};
@@ -233,14 +238,15 @@ private slots:
   void showFontList();
   void hideFontList();
   void onwindowActionSelectEditor();
+  void onWindowActionNextPrevHovered();
+  void onWindowActionNextPrevTriggered();
+  void onWindowShortcutNextPrevActivated();
   void on_windowActionSelectConsole_triggered();
   void on_windowActionSelectCustomizer_triggered();
   void on_windowActionSelectErrorLog_triggered();
   void on_windowActionSelectAnimate_triggered();
   void on_windowActionSelectFontList_triggered();
   void on_windowActionSelectViewportControl_triggered();
-  void on_windowActionNextWindow_triggered();
-  void on_windowActionPreviousWindow_triggered();
   void on_editActionInsertTemplate_triggered();
   void on_editActionFoldAll_triggered();
 

--- a/src/gui/MainWindow.ui
+++ b/src/gui/MainWindow.ui
@@ -1683,18 +1683,12 @@
   </action>
   <action name="windowActionNextWindow">
    <property name="text">
-    <string>&amp;Next Window</string>
-   </property>
-   <property name="shortcut">
-    <string>Ctrl+K</string>
+    <string>&amp;Next Window	Ctrl+K</string>
    </property>
   </action>
   <action name="windowActionPreviousWindow">
    <property name="text">
-    <string>&amp;Previous Window</string>
-   </property>
-   <property name="shortcut">
-    <string>Ctrl+H</string>
+    <string>&amp;Previous Window	Ctrl+H</string>
    </property>
   </action>
   <action name="editActionInsertTemplate">

--- a/src/gui/RubberBandManager.cc
+++ b/src/gui/RubberBandManager.cc
@@ -7,26 +7,25 @@ RubberBandManager::RubberBandManager(MainWindow *w) :
   rubberBand(QRubberBand::Rectangle)
 {
   setParent(w);
-  w->installEventFilter(this);
-}
-bool RubberBandManager::eventFilter(QObject *obj, QEvent *event) {
-  if (event->type() == QEvent::KeyRelease) {
-    auto keyEvent = static_cast<QKeyEvent *>(event);
-    if (keyEvent->key() == Qt::Key_Control && rubberBand.isVisible()) {
-      hide();
-    }
-  }
-  return false;
+  emphasizedDock = nullptr;
 }
 
 void RubberBandManager::hide(){
   rubberBand.hide();
+  emphasizedDock = nullptr;
+}
+
+bool RubberBandManager::isEmphasized(Dock* dock){
+  return rubberBand.isVisible() && emphasizedDock == dock;
+}
+
+bool RubberBandManager::isVisible(){
+  return rubberBand.isVisible();
 }
 
 void RubberBandManager::emphasize(Dock *dock){
-  parent()->removeEventFilter(this);
-  dock->installEventFilter(this);
   rubberBand.setParent(dock);
   rubberBand.setGeometry(dock->widget()->geometry());
   rubberBand.show();
+  emphasizedDock = dock;
 }

--- a/src/gui/RubberBandManager.h
+++ b/src/gui/RubberBandManager.h
@@ -18,9 +18,10 @@ public:
 
   void hide();
   void emphasize(Dock *w);
-
+  bool isEmphasized(Dock *w);
+  bool isVisible();
 
 private:
-  bool eventFilter(QObject *obj, QEvent *event) final override;
   QRubberBand rubberBand;
+  Dock* emphasizedDock;
 };


### PR DESCRIPTION
The issue #5695 was introduced in PR #5630 and reported by @kintel.
The issue is caused by inconsistent handling of the next/prev window action when triggered from menu navigation with mouse and when triggered using their Ctrl+K and Ctrl+H shortcuts. 

To fix it, I had to implement the shortcut Ctrl+K and Ctrl+H differently to differentiate the two cases. When a next/prev dock is activated/hovered because of a keyboard shortcut or because of hovering with mouse the over a menu entry.

The positive consequence is that now the rubberband states are more consistant and are the following:
- when a window menu entry (next/prev or jump to) is hovered, the rubberband is made visible and indicates which dock will be the one activated on menu entry validation/trigerreing. 
- when a window menu entry (next/prev or jump to) is triggered, the dock is ativated and the rubbedband hides.
- when a short cut is used, the rubberband is activated until CTRL is released
