### PR TITLE
Clean MainWindow show/hide action

### DIFF
--- a/src/gui/Animate.cc
+++ b/src/gui/Animate.cc
@@ -139,7 +139,7 @@ void Animate::incrementTVal()
 {
     if (this->animNumSteps == 0) return;
 
-  if (mainWindow->windowActionHideCustomizer->isVisible()) {
+  if (mainWindow->parameterDock->isVisible()) {
     if (mainWindow->activeEditor->parameterWidget->childHasFocus()) return;
   }
 

--- a/src/gui/Animate.cc
+++ b/src/gui/Animate.cc
@@ -28,23 +28,23 @@ Animate::Animate(QWidget *parent) : QWidget(parent)
   const auto scrollMargins = scrollAreaWidgetContents->layout()->contentsMargins();
   const auto parameterMargins = groupBoxParameter->layout()->contentsMargins();
   initMinWidth = width + margins.left() + margins.right() + scrollMargins.left() + scrollMargins.right()
-  +parameterMargins.left() + parameterMargins.right();
+    + parameterMargins.left() + parameterMargins.right();
 }
 
 void Animate::initGUI()
 {
-    this->animStep = 0;
-    this->animNumSteps = 0;
+  this->animStep = 0;
+  this->animNumSteps = 0;
   this->animTVal = 0.0;
-    this->animDumping = false;
+  this->animDumping = false;
   this->animDumpStartStep = 0;
 
   this->iconRun = QIcon::fromTheme("chokusen-animate-play");
   this->iconPause = QIcon::fromTheme("chokusen-animate-pause");
   this->iconDisabled = QIcon::fromTheme("chokusen-animate-disabled");
 
-    animateTimer = new QTimer(this);
-    connect(animateTimer, SIGNAL(timeout()), this, SLOT(incrementTVal()));
+  animateTimer = new QTimer(this);
+  connect(animateTimer, SIGNAL(timeout()), this, SLOT(incrementTVal()));
 
   connect(this->e_tval, SIGNAL(textChanged(QString)), this, SLOT(updatedAnimTval()));
   connect(this->e_fps, SIGNAL(textChanged(QString)), this, SLOT(updatedAnimFpsAndAnimSteps()));
@@ -72,9 +72,9 @@ void Animate::connectAction(QAction *action, QPushButton *button)
 
 void Animate::updatedAnimTval()
 {
-    double t = this->e_tval->text().toDouble(&this->tOK);
+  double t = this->e_tval->text().toDouble(&this->tOK);
   // Clamp t to 0-1
-    if (this->tOK) {
+  if (this->tOK) {
     t = t < 0 ? 0.0 : ((t > 1.0) ? 1.0 : t);
   } else {
     t = 0.0;
@@ -88,23 +88,23 @@ void Animate::updatedAnimTval()
 
 void Animate::updatedAnimFpsAndAnimSteps()
 {
-    animateTimer->stop();
+  animateTimer->stop();
 
   int numsteps = this->e_fsteps->text().toInt(&this->steps_ok);
   if (this->steps_ok) {
-      this->animNumSteps = numsteps;
+    this->animNumSteps = numsteps;
   } else {
-      this->animNumSteps = 0;
+    this->animNumSteps = 0;
   }
   this->animDumping = false;
 
   double fps = this->e_fps->text().toDouble(&this->fpsOK);
   animateTimer->stop();
   if (this->fpsOK && fps > 0 && this->animNumSteps > 0) {
-      this->animStep = int(this->animTVal * this->animNumSteps) % this->animNumSteps;
-      animateTimer->setSingleShot(false);
-      animateTimer->setInterval(int(1000 / fps));
-      animateTimer->start();
+    this->animStep = int(this->animTVal * this->animNumSteps) % this->animNumSteps;
+    animateTimer->setSingleShot(false);
+    animateTimer->setInterval(int(1000 / fps));
+    animateTimer->start();
   }
 
   QPalette defaultPalette;
@@ -129,7 +129,7 @@ void Animate::updatedAnimFpsAndAnimSteps()
 
 void Animate::updatedAnimDump(bool checked)
 {
-    if (!checked) this->animDumping = false;
+  if (!checked) this->animDumping = false;
 
   updatePauseButtonIcon();
 }
@@ -137,17 +137,17 @@ void Animate::updatedAnimDump(bool checked)
 // Only called from animate_timer
 void Animate::incrementTVal()
 {
-    if (this->animNumSteps == 0) return;
+  if (this->animNumSteps == 0) return;
 
   if (mainWindow->parameterDock->isVisible()) {
     if (mainWindow->activeEditor->parameterWidget->childHasFocus()) return;
   }
 
   if (this->animNumSteps > 1) {
-      this->animStep = (this->animStep + 1) % this->animNumSteps;
-      this->animTVal = 1.0 * this->animStep / this->animNumSteps;
+    this->animStep = (this->animStep + 1) % this->animNumSteps;
+    this->animTVal = 1.0 * this->animStep / this->animNumSteps;
   } else if (this->animNumSteps > 0) {
-      this->animStep = 0;
+    this->animStep = 0;
     this->animTVal = 0.0;
   }
 
@@ -159,17 +159,17 @@ void Animate::incrementTVal()
 
 void Animate::updateTVal()
 {
-    if (this->animNumSteps == 0) return;
+  if (this->animNumSteps == 0) return;
 
   if (this->animStep < 0) {
-      this->animStep = this->animNumSteps - this->animStep - 2;
+    this->animStep = this->animNumSteps - this->animStep - 2;
   }
 
   if (this->animNumSteps > 1) {
-      this->animStep = (this->animStep) % this->animNumSteps;
-      this->animTVal = 1.0 * this->animStep / this->animNumSteps;
+    this->animStep = (this->animStep) % this->animNumSteps;
+    this->animTVal = 1.0 * this->animStep / this->animNumSteps;
   } else if (this->animNumSteps > 0) {
-      this->animStep = 0;
+    this->animStep = 0;
     this->animTVal = 0.0;
   }
 
@@ -180,14 +180,14 @@ void Animate::updateTVal()
 }
 
 void Animate::pauseAnimation(){
-    animateTimer->stop();
+  animateTimer->stop();
   updatePauseButtonIcon();
 }
 
 void Animate::on_pauseButton_pressed()
 {
-    if (animateTimer->isActive()) {
-        animateTimer->stop();
+  if (animateTimer->isActive()) {
+    animateTimer->stop();
     updatePauseButtonIcon();
   } else {
     this->updatedAnimFpsAndAnimSteps();
@@ -196,7 +196,7 @@ void Animate::on_pauseButton_pressed()
 
 void Animate::updatePauseButtonIcon()
 {
-    if (animateTimer->isActive()) {
+  if (animateTimer->isActive()) {
     pauseButton->setIcon(this->iconPause);
     pauseButton->setToolTip(_("press to pause animation") );
   } else {
@@ -223,29 +223,29 @@ void Animate::animateUpdate()
   if (mainWindow->animateDockContents->isVisible()) {
     double fps = this->e_fps->text().toDouble(&this->fpsOK);
     if (this->fpsOK && fps <= 0 && !animateTimer->isActive()) {
-        animateTimer->stop();
-        animateTimer->setSingleShot(true);
-        animateTimer->setInterval(50);
-        animateTimer->start();
+      animateTimer->stop();
+      animateTimer->setSingleShot(true);
+      animateTimer->setInterval(50);
+      animateTimer->start();
     }
   }
 }
 
 bool Animate::dumpPictures(){
-    return this->e_dump->isChecked() && this->animateTimer->isActive();
+  return this->e_dump->isChecked() && this->animateTimer->isActive();
 }
 
 int Animate::nextFrame(){
-    if (animDumping && animDumpStartStep == animStep) {
-        animDumping = false;
+  if (animDumping && animDumpStartStep == animStep) {
+    animDumping = false;
     e_dump->setChecked(false);
   } else {
-        if (!animDumping) {
-            animDumping = true;
-            animDumpStartStep = animStep;
+    if (!animDumping) {
+      animDumping = true;
+      animDumpStartStep = animStep;
     }
   }
-    return animStep;
+  return animStep;
 }
 
 void Animate::resizeEvent(QResizeEvent *event)

--- a/src/gui/Dock.cc
+++ b/src/gui/Dock.cc
@@ -27,9 +27,6 @@ void Dock::setVisible(bool visible)
     QSettingsCached settings;
     settings.setValue(configKey, !visible);
   }
-  if (action != nullptr) {
-    action->setChecked(!visible);
-  }
   QDockWidget::setVisible(visible);
 }
 
@@ -41,11 +38,6 @@ void Dock::setTitleBarVisibility(bool isVisible)
 void Dock::setConfigKey(const QString& configKey)
 {
   this->configKey = configKey;
-}
-
-void Dock::setAction(QAction *action)
-{
-  this->action = action;
 }
 
 void Dock::updateTitle(){

--- a/src/gui/Dock.cc
+++ b/src/gui/Dock.cc
@@ -8,6 +8,8 @@
 Dock::Dock(QWidget *parent) : QDockWidget(parent)
 {
   connect(this, &QDockWidget::topLevelChanged, this, &Dock::onTopLevelStatusChanged);
+  connect(this, &QDockWidget::visibilityChanged, this, &Dock::onVisibilityChanged);
+
   dockTitleWidget = new QWidget();
 }
 
@@ -21,13 +23,12 @@ void Dock::disableSettingsUpdate()
   updateSettings = false;
 }
 
-void Dock::setVisible(bool visible)
+void Dock::onVisibilityChanged(bool isDockVisible)
 {
   if (updateSettings) {
     QSettingsCached settings;
-    settings.setValue(configKey, !visible);
+    settings.setValue(configKey, !isVisible());
   }
-  QDockWidget::setVisible(visible);
 }
 
 void Dock::setTitleBarVisibility(bool isVisible)

--- a/src/gui/Dock.h
+++ b/src/gui/Dock.h
@@ -13,7 +13,6 @@ public:
   virtual ~Dock();
 
   void setConfigKey(const QString& configKey);
-  void setAction(QAction *action);
   void disableSettingsUpdate();
 
   void setName(const QString& name_);
@@ -23,7 +22,6 @@ public:
   void setTitleBarVisibility(bool isVisible);
   void updateTitle();
 
-
 public slots:
   void setVisible(bool visible) override;
   void onTopLevelStatusChanged(bool);
@@ -32,7 +30,6 @@ private:
   QString name;
   QString namesuffix;
   QString configKey;
-  QAction *action{nullptr};
   bool updateSettings{true};
   QWidget *dockTitleWidget;
 };

--- a/src/gui/Dock.h
+++ b/src/gui/Dock.h
@@ -23,7 +23,7 @@ public:
   void updateTitle();
 
 public slots:
-  void setVisible(bool visible) override;
+  void onVisibilityChanged(bool visible);
   void onTopLevelStatusChanged(bool);
 
 private:

--- a/src/gui/MainWindow.cc
+++ b/src/gui/MainWindow.cc
@@ -294,21 +294,12 @@ MainWindow::MainWindow(const QStringList& filenames) :
   };
 
   this->editorDock->setConfigKey("view/hideEditor");
-  this->editorDock->setAction(this->windowActionHideEditor);
-  this->editorDock->setWindowTitle("Editor");
-
   this->consoleDock->setConfigKey("view/hideConsole");
-  this->consoleDock->setAction(this->windowActionHideConsole);
   this->parameterDock->setConfigKey("view/hideCustomizer");
-  this->parameterDock->setAction(this->windowActionHideCustomizer);
   this->errorLogDock->setConfigKey("view/hideErrorLog");
-  this->errorLogDock->setAction(this->windowActionHideErrorLog);
   this->animateDock->setConfigKey("view/hideAnimate");
-  this->animateDock->setAction(this->windowActionHideAnimate);
   this->fontListDock->setConfigKey("view/hideFontList");
-  this->fontListDock->setAction(this->windowActionHideFontList);
   this->viewportControlDock->setConfigKey("view/hideViewportControl");
-  this->viewportControlDock->setAction(this->windowActionHideViewportControl);
 
   this->versionLabel = nullptr; // must be initialized before calling updateStatusBar()
   updateStatusBar(nullptr);
@@ -3277,7 +3268,6 @@ void MainWindow::hideViewportControl()
   }
 }
 
-
 void MainWindow::showParameters()
 {
   windowActionHideCustomizer->setChecked(false);
@@ -3293,11 +3283,6 @@ void MainWindow::hideParameters()
   } else {
     parameterDock->show();
   }
-}
-
-void MainWindow::onWindowActionSelectEditor()
-{
-  showEditor();
 }
 
 void MainWindow::on_windowActionSelectConsole_triggered()

--- a/src/gui/MainWindow.cc
+++ b/src/gui/MainWindow.cc
@@ -245,7 +245,7 @@ void removeExportActions(QToolBar *toolbar, QAction *action) {
   int idx = toolbar->actions().indexOf(action);
   while (idx > 0) {
     QAction *a = toolbar->actions().at(idx - 1);
-    if (a->objectName().isEmpty()) // separator
+    if (a->objectName().isEmpty())     // separator
       break;
     toolbar->removeAction(a);
     idx--;
@@ -301,7 +301,7 @@ MainWindow::MainWindow(const QStringList& filenames) :
   this->fontListDock->setConfigKey("view/hideFontList");
   this->viewportControlDock->setConfigKey("view/hideViewportControl");
 
-  this->versionLabel = nullptr; // must be initialized before calling updateStatusBar()
+  this->versionLabel = nullptr;   // must be initialized before calling updateStatusBar()
   updateStatusBar(nullptr);
 
   renderCompleteSoundEffect = new QSoundEffect();
@@ -377,7 +377,7 @@ MainWindow::MainWindow(const QStringList& filenames) :
   consoleOutputRaw(version);
   consoleOutputRaw(weblink);
   consoleOutputRaw(copyrighttext);
-  this->consoleUpdater->start(0); // Show "Loaded Design" message from TabManager
+  this->consoleUpdater->start(0);   // Show "Loaded Design" message from TabManager
 
   connect(this->errorLogWidget, SIGNAL(openFile(QString,int)), this, SLOT(openFileFromPath(QString,int)));
   connect(this->console, SIGNAL(openFile(QString,int)), this, SLOT(openFileFromPath(QString,int)));
@@ -577,14 +577,6 @@ MainWindow::MainWindow(const QStringList& filenames) :
     menuWindow->addAction(dock->toggleViewAction());
   }
 
-  connect(this->windowActionHideEditor, SIGNAL(triggered()), this, SLOT(hideEditor()));
-  connect(this->windowActionHideConsole, SIGNAL(triggered()), this, SLOT(hideConsole()));
-  connect(this->windowActionHideCustomizer, SIGNAL(triggered()), this, SLOT(hideParameters()));
-  connect(this->windowActionHideErrorLog, SIGNAL(triggered()), this, SLOT(hideErrorLog()));
-  connect(this->windowActionHideAnimate, SIGNAL(triggered()), this, SLOT(hideAnimate()));
-  connect(this->windowActionHideFontList, SIGNAL(triggered()), this, SLOT(hideFontList()));
-  connect(this->windowActionHideViewportControl, SIGNAL(triggered()), this, SLOT(hideViewportControl()));
-
   // Help menu
   connect(this->helpActionAbout, SIGNAL(triggered()), this, SLOT(helpAbout()));
   connect(this->helpActionHomepage, SIGNAL(triggered()), this, SLOT(helpHomepage()));
@@ -623,7 +615,7 @@ MainWindow::MainWindow(const QStringList& filenames) :
   connect(Preferences::inst(), SIGNAL(colorSchemeChanged(const QString&)), this, SLOT(setColorScheme(const QString&)));
   connect(Preferences::inst(), SIGNAL(toolbarExportChanged()), this, SLOT(updateExportActions()));
 
-  Preferences::inst()->apply_win(); // not sure if to be commented, checked must not be commented(done some changes in apply())
+  Preferences::inst()->apply_win();   // not sure if to be commented, checked must not be commented(done some changes in apply())
 
   QString cs = Preferences::inst()->getValue("3dview/colorscheme").toString();
   this->setColorScheme(cs);
@@ -657,15 +649,15 @@ MainWindow::MainWindow(const QStringList& filenames) :
   instance->ButtonConfig->init();
 
   // fetch window states to be restored after restoreState() call
-  bool hideConsole = settings.value("view/hideConsole").toBool();
-  bool hideEditor = settings.value("view/hideEditor").toBool();
-  bool hideCustomizer = settings.value("view/hideCustomizer").toBool();
-  bool hideErrorLog = settings.value("view/hideErrorLog").toBool();
-  bool hideAnimate = settings.value("view/hideAnimate").toBool();
-  bool hideFontList = settings.value("view/hideFontList").toBool();
-  bool hideViewportControl = settings.value("view/hideViewportControl").toBool();
-  bool hideEditorToolbar = settings.value("view/hideEditorToolbar").toBool();
-  bool hide3DViewToolbar = settings.value("view/hide3DViewToolbar").toBool();
+  bool isConsoldDockVisible = !settings.value("view/hideConsole").toBool();
+  bool isEditorDockVisible = !settings.value("view/hideEditor").toBool();
+  bool isCustomizerDockVisible = !settings.value("view/hideCustomizer").toBool();
+  bool isErrorLogVisible = !settings.value("view/hideErrorLog").toBool();
+  bool isAnimateDockVisible = !settings.value("view/hideAnimate").toBool();
+  bool isFontListDockVisible = !settings.value("view/hideFontList").toBool();
+  bool isViewportControlVisible = !settings.value("view/hideViewportControl").toBool();
+  bool isEditorToolbarVisible = !settings.value("view/hideEditorToolbar").toBool();
+  bool is3DViewToolbarVisible = !settings.value("view/hide3DViewToolbar").toBool();
 
   // make sure it looks nice..
   const auto windowState = settings.value("window/state", QByteArray()).toByteArray();
@@ -698,9 +690,9 @@ MainWindow::MainWindow(const QStringList& filenames) :
     tabifyDockWidget(consoleDock, errorLogDock);
     tabifyDockWidget(errorLogDock, fontListDock);
     tabifyDockWidget(fontListDock, animateDock);
-    showConsole();
-    hideCustomizer = true;
-    hideViewportControl = true;
+    consoleDock->show();
+    isCustomizerDockVisible = true;
+    isViewportControlVisible = true;
   } else {
 #ifdef Q_OS_WIN
     // Try moving the main window into the display range, this
@@ -721,7 +713,7 @@ MainWindow::MainWindow(const QStringList& filenames) :
 #endif // ifdef Q_OS_WIN
   }
 
-  updateWindowSettings(hideConsole, hideEditor, hideCustomizer, hideErrorLog, hideEditorToolbar, hide3DViewToolbar, hideAnimate, hideFontList, hideViewportControl);
+  updateWindowSettings(isConsoldDockVisible, isEditorDockVisible, isCustomizerDockVisible, isErrorLogVisible, isEditorToolbarVisible, is3DViewToolbarVisible, isAnimateDockVisible, isFontListDockVisible, isViewportControlVisible);
 
   // Connect the menu "Windows/Navigation" to slot that process it by opening in a pop menu
   // the navigationMenu.
@@ -744,7 +736,7 @@ MainWindow::MainWindow(const QStringList& filenames) :
   // activation of the corresponding dock.
   std::vector<QAction *> actions = {windowActionNextWindow, windowActionPreviousWindow};
   for (auto& action : actions) {
-      connect(action, &QAction::hovered, this, &MainWindow::onWindowActionNextPrevHovered);
+    connect(action, &QAction::hovered, this, &MainWindow::onWindowActionNextPrevHovered);
     connect(action, &QAction::triggered, this, &MainWindow::onWindowActionNextPrevTriggered);
   }
 
@@ -755,6 +747,22 @@ MainWindow::MainWindow(const QStringList& filenames) :
   shortcutPreviousWindow = new QShortcut(QKeySequence(Qt::CTRL + Qt::Key_H), this);
   QObject::connect(shortcutPreviousWindow,    &QShortcut::activated,
                    this,        &MainWindow::onWindowShortcutNextPrevActivated);
+
+  // Adds dock specific behavior on visibility change
+  QObject::connect(editorDock,  &Dock::visibilityChanged,
+                   this,        &MainWindow::onEditorDockVisibilityChanged);
+  QObject::connect(consoleDock,  &Dock::visibilityChanged,
+                   this,        &MainWindow::onConsoleDockVisibilityChanged);
+  QObject::connect(errorLogDock,  &Dock::visibilityChanged,
+                   this,        &MainWindow::onErrorLogDockVisibilityChanged);
+  QObject::connect(animateDock,  &Dock::visibilityChanged,
+                   this,        &MainWindow::onAnimateDockVisibilityChanged);
+  QObject::connect(fontListDock,  &Dock::visibilityChanged,
+                   this,        &MainWindow::onFontListDockVisibilityChanged);
+  QObject::connect(viewportControlDock,  &Dock::visibilityChanged,
+                   this,        &MainWindow::onViewportControlDockVisibilityChanged);
+  QObject::connect(parameterDock,  &Dock::visibilityChanged,
+                   this,        &MainWindow::onParametersDockVisibilityChanged);
 
   connect(this->activeEditor, SIGNAL(escapePressed()), this, SLOT(measureFinished()));
   // display this window and check for OpenGL 2.0 (OpenCSG) support
@@ -817,7 +825,7 @@ void MainWindow::onNavigationHoveredContextMenuEntry(){
 
   // Hover signal is emitted at each mouse move, to avoid excessive
   // load we only raise/emphasize if it is not yet done.
-  if(rubberBandManager.isEmphasized(dock)) return;
+  if (rubberBandManager.isEmphasized(dock)) return;
 
   dock->raise();
   rubberBandManager.emphasize(dock);
@@ -867,26 +875,27 @@ void MainWindow::addKeyboardShortCut(const QList<QAction *>& actions)
  * Qt call. So the values are loaded before the call and restored here
  * regardless of the (potential outdated) serialized state.
  */
-void MainWindow::updateWindowSettings(bool console, bool editor, bool customizer, bool errorLog, bool editorToolbar, bool viewToolbar, bool animate, bool fontList, bool viewportControl)
+void MainWindow::updateWindowSettings(bool isConsoleVisible,
+                                      bool isEditorVisible,
+                                      bool isCustomizerVisible,
+                                      bool isErrorLogVisible,
+                                      bool isEditorToolbarVisible,
+                                      bool isViewToolbarVisible,
+                                      bool isAnimateVisible,
+                                      bool isFontListVisible,
+                                      bool isViewportControlVisible)
 {
-  windowActionHideEditor->setChecked(editor);
-  hideEditor();
-  windowActionHideConsole->setChecked(console);
-  hideConsole();
-  windowActionHideErrorLog->setChecked(errorLog);
-  hideErrorLog();
-  windowActionHideCustomizer->setChecked(customizer);
-  hideParameters();
-  windowActionHideAnimate->setChecked(animate);
-  hideAnimate();
-  windowActionHideFontList->setChecked(fontList);
-  hideFontList();
-  windowActionHideViewportControl->setChecked(viewportControl);
-  hideViewportControl();
+  editorDock->setVisible(isEditorVisible);
+  consoleDock->setVisible(isConsoleVisible);
+  errorLogDock->setVisible(isErrorLogVisible);
+  parameterDock->setVisible(isCustomizerVisible);
+  animateDock->setVisible(isAnimateVisible);
+  fontListDock->setVisible(isFontListVisible);
+  viewportControlDock->setVisible(isViewportControlVisible);
 
-  viewActionHideEditorToolBar->setChecked(editorToolbar);
+  viewActionHideEditorToolBar->setChecked(!isEditorToolbarVisible);
   hideEditorToolbar();
-  viewActionHide3DViewToolBar->setChecked(viewToolbar);
+  viewActionHide3DViewToolBar->setChecked(!isViewToolbarVisible);
   hide3DViewToolbar();
 }
 
@@ -1095,7 +1104,7 @@ void MainWindow::updateRecentFiles(const QString& FileSavedOrOpened)
 {
   // Check that the canonical file path exists - only update recent files
   // if it does. Should prevent empty list items on initial open etc.
-  QSettingsCached settings; // already set up properly via main.cpp
+  QSettingsCached settings;   // already set up properly via main.cpp
   auto files = settings.value("recentFileList").toStringList();
   files.removeAll(FileSavedOrOpened);
   files.prepend(FileSavedOrOpened);
@@ -1134,7 +1143,7 @@ void MainWindow::compile(bool reload, bool forcedone)
     if (reload) {
       // Refresh files if it has changed on disk
       if (fileChangedOnDisk() && checkEditorModified()) {
-        shouldcompiletoplevel = tabManager->refreshDocument(); // don't compile if we couldn't open the file
+        shouldcompiletoplevel = tabManager->refreshDocument();         // don't compile if we couldn't open the file
         if (shouldcompiletoplevel && Preferences::inst()->getValue("advanced/autoReloadRaise").toBool()) {
           // reloading the 'same' document brings the 'old' one to front.
           this->raise();
@@ -1217,7 +1226,7 @@ void MainWindow::waitAfterReload()
   auto stop = would_have_thrown();
   if (mtime > this->depsMTime) this->depsMTime = mtime;
   else if (!stop) {
-    compile(true, true); // In case file itself or top-level includes changed during dependency updates
+    compile(true, true);     // In case file itself or top-level includes changed during dependency updates
     return;
   }
   this->waitAfterReloadTimer->start();
@@ -1512,7 +1521,7 @@ void MainWindow::actionOpenRecent()
 
 void MainWindow::clearRecentFiles()
 {
-  QSettingsCached settings; // already set up properly via main.cpp
+  QSettingsCached settings;   // already set up properly via main.cpp
   QStringList files;
   settings.setValue("recentFileList", files);
 
@@ -1655,8 +1664,8 @@ void MainWindow::actionShowLibraryFolder()
 void MainWindow::actionReload()
 {
   if (checkEditorModified()) {
-    fileChangedOnDisk(); // force cached autoReloadId to update
-    (void)tabManager->refreshDocument(); // ignore errors opening the file
+    fileChangedOnDisk();     // force cached autoReloadId to update
+    (void)tabManager->refreshDocument();     // ignore errors opening the file
   }
 }
 
@@ -1927,11 +1936,11 @@ bool MainWindow::trust_python_file(const std::string& file,  const std::string& 
     return true;
   }
 
-  if (content.size() <= 1) { // 1st character already typed
+  if (content.size() <= 1) {   // 1st character already typed
     this->trusted_edit_document_name = file;
     return true;
   }
-  if (content.rfind("from openscad import", 0) == 0) { // 1st character already typed
+  if (content.rfind("from openscad import", 0) == 0) {   // 1st character already typed
     this->trusted_edit_document_name = file;
     return true;
   }
@@ -2003,8 +2012,8 @@ void MainWindow::parseTopLevelDocument()
     fulltext = "\n";
   }
 #endif // ifdef ENABLE_PYTHON
-  this->parsedFile = nullptr; // because the parse() call can throw and we don't want a stale pointer!
-  this->rootFile = nullptr;  // ditto
+  this->parsedFile = nullptr;   // because the parse() call can throw and we don't want a stale pointer!
+  this->rootFile = nullptr;    // ditto
   this->rootFile = parse(this->parsedFile, fulltext, fname, fname, false) ? this->parsedFile : nullptr;
 
   this->activeEditor->resetHighlighting();
@@ -2022,7 +2031,7 @@ void MainWindow::parseTopLevelDocument()
 
 void MainWindow::changeParameterWidget()
 {
-  windowActionHideCustomizer->setVisible(true);
+  parameterDock->setVisible(true);
 }
 
 void MainWindow::checkAutoReload()
@@ -2111,7 +2120,7 @@ void MainWindow::actionRenderPreview()
   this->designActionMeasureDist->setEnabled(false);
   this->designActionMeasureAngle->setEnabled(false);
 
-  prepareCompile("csgRender", windowActionHideAnimate->isChecked(), true);
+  prepareCompile("csgRender", !animateDock->isVisible(), true);
   compile(false, false);
   if (preview_requested) {
     // if the action was called when the gui was locked, we must request it one more time
@@ -2614,7 +2623,7 @@ void MainWindow::exceptionCleanup(){
 }
 
 void MainWindow::UnknownExceptionCleanup(std::string msg){
-  setCurrentOutput(); // we need to show this error
+  setCurrentOutput();   // we need to show this error
   if (msg.size() == 0) {
     LOG(message_group::Error, "Compilation aborted by unknown exception");
   } else {
@@ -3112,11 +3121,6 @@ void MainWindow::viewAll()
   this->qglview->update();
 }
 
-void MainWindow::on_editorDock_visibilityChanged(bool)
-{
-  updateExportActions();
-}
-
 void MainWindow::hideEditorToolbar()
 {
   QSettingsCached settings;
@@ -3146,24 +3150,21 @@ void MainWindow::hide3DViewToolbar()
 void MainWindow::showLink(const QString& link)
 {
   if (link == "#console") {
-    showConsole();
+    consoleDock->show();
   } else if (link == "#errorlog") {
-    showErrorLog();
+    errorLogDock->show();
   }
 }
 
-void MainWindow::showEditor()
-{
-  windowActionHideEditor->setChecked(false);
-  hideEditor();
-  editorDock->raise();
-  tabManager->setFocus();
-}
-
-void MainWindow::hideEditor()
+void MainWindow::onEditorDockVisibilityChanged(bool isVisible)
 {
   auto e = (ScintillaEditor *) this->activeEditor;
-  if (windowActionHideEditor->isChecked()) {
+  if (isVisible) {
+    e->qsci->setReadOnly(false);
+    e->setupAutoComplete(false);
+    editorDock->raise();
+    tabManager->setFocus();
+  } else {
     // Workaround manually disabling interactions with editor by setting it
     // to read-only when not being shown.  This is an upstream bug from Qt
     // (tracking ticket: https://bugreports.qt.io/browse/QTBUG-82939) and
@@ -3171,148 +3172,59 @@ void MainWindow::hideEditor()
     // the else should be removed. Currently known to affect 5.14.1 and 5.15.0
     e->qsci->setReadOnly(true);
     e->setupAutoComplete(true);
-    editorDock->close();
-  } else {
-    e->qsci->setReadOnly(false);
-    e->setupAutoComplete(false);
-    editorDock->show();
+  }
+  updateExportActions();
+}
+
+void MainWindow::onConsoleDockVisibilityChanged(bool isVisible)
+{
+  if (isVisible) {
+    frameCompileResult->hide();
+    consoleDock->raise();
+    console->setFocus();
   }
 }
 
-void MainWindow::showConsole()
+void MainWindow::onErrorLogDockVisibilityChanged(bool isVisible)
 {
-  windowActionHideConsole->setChecked(false);
-  frameCompileResult->hide();
-  consoleDock->show();
-  consoleDock->raise();
-  console->setFocus();
-}
-
-void MainWindow::hideConsole()
-{
-  if (windowActionHideConsole->isChecked()) {
-    consoleDock->hide();
-  } else {
-    consoleDock->show();
+  if (isVisible) {
+    frameCompileResult->hide();
+    errorLogDock->raise();
+    errorLogWidget->logTable->setFocus();
   }
 }
 
-void MainWindow::showErrorLog()
+void MainWindow::onAnimateDockVisibilityChanged(bool isVisible)
 {
-  windowActionHideErrorLog->setChecked(false);
-  frameCompileResult->hide();
-  errorLogDock->show();
-  errorLogDock->raise();
-  errorLogWidget->logTable->setFocus();
-}
-
-void MainWindow::hideErrorLog()
-{
-  if (windowActionHideErrorLog->isChecked()) {
-    errorLogDock->hide();
-  } else {
-    errorLogDock->show();
+  if (isVisible) {
+    animateDock->raise();
+    animateWidget->setFocus();
   }
 }
 
-void MainWindow::showAnimate()
+void MainWindow::onFontListDockVisibilityChanged(bool isVisible)
 {
-  windowActionHideAnimate->setChecked(false);
-  animateDock->show();
-  animateDock->raise();
-  animateWidget->setFocus();
-}
-
-void MainWindow::hideAnimate()
-{
-  if (windowActionHideAnimate->isChecked()) {
-    animateDock->hide();
-  } else {
-    animateDock->show();
-  }
-}
-
-void MainWindow::showFontList()
-{
-  windowActionHideFontList->setChecked(false);
-  fontListWidget->update_font_list();
-  fontListDock->show();
-  fontListDock->raise();
-  fontListWidget->setFocus();
-}
-
-void MainWindow::hideFontList()
-{
-  if (windowActionHideFontList->isChecked()) {
-    fontListDock->hide();
-  } else {
+  if (isVisible) {
     fontListWidget->update_font_list();
-    fontListDock->show();
+    fontListWidget->setFocus();
+    fontListDock->raise();
   }
 }
 
-void MainWindow::showViewportControl()
+void MainWindow::onViewportControlDockVisibilityChanged(bool isVisible)
 {
-  windowActionHideViewportControl->setChecked(false);
-  viewportControlDock->show();
-  viewportControlDock->raise();
-  viewportControlWidget->setFocus();
-}
-
-void MainWindow::hideViewportControl()
-{
-  if (windowActionHideViewportControl->isChecked()) {
-    viewportControlDock->hide();
-  } else {
-    viewportControlDock->show();
+  if (isVisible) {
+    viewportControlDock->raise();
+    viewportControlWidget->setFocus();
   }
 }
 
-void MainWindow::showParameters()
+void MainWindow::onParametersDockVisibilityChanged(bool isVisible)
 {
-  windowActionHideCustomizer->setChecked(false);
-  parameterDock->show();
-  parameterDock->raise();
-  activeEditor->parameterWidget->scrollArea->setFocus();
-}
-
-void MainWindow::hideParameters()
-{
-  if (windowActionHideCustomizer->isChecked()) {
-    parameterDock->hide();
-  } else {
-    parameterDock->show();
+  if (isVisible) {
+    parameterDock->raise();
+    activeEditor->parameterWidget->scrollArea->setFocus();
   }
-}
-
-void MainWindow::on_windowActionSelectConsole_triggered()
-{
-  showConsole();
-}
-
-void MainWindow::on_windowActionSelectErrorLog_triggered()
-{
-  showErrorLog();
-}
-
-void MainWindow::on_windowActionSelectAnimate_triggered()
-{
-  showAnimate();
-}
-
-void MainWindow::on_windowActionSelectFontList_triggered()
-{
-  showFontList();
-}
-
-void MainWindow::on_windowActionSelectViewportControl_triggered()
-{
-  showViewportControl();
-}
-
-void MainWindow::on_windowActionSelectCustomizer_triggered()
-{
-  showParameters();
 }
 
 // Use the sender's to detect if we are moving forward/backward in docks
@@ -3337,9 +3249,12 @@ void MainWindow::onWindowActionNextPrevHovered()
 {
   auto dock = getNextDockFromSender(sender());
 
+  // This can happens if there is no visible dock at all
+  if (dock == nullptr) return;
+
   // Hover signal is emitted at each mouse move, to avoid excessive
   // load we only raise/emphasize if it is not yet done.
-  if(rubberBandManager.isEmphasized(dock)) return;
+  if (rubberBandManager.isEmphasized(dock)) return;
 
   dock->raise();
   rubberBandManager.emphasize(dock);
@@ -3348,12 +3263,20 @@ void MainWindow::onWindowActionNextPrevHovered()
 void MainWindow::onWindowActionNextPrevTriggered()
 {
   auto dock = getNextDockFromSender(sender());
+
+  // This can happens if there is no visible dock at all
+  if (dock == nullptr) return;
+
   activateDock(dock);
 }
 
 void MainWindow::onWindowShortcutNextPrevActivated()
 {
   auto dock = getNextDockFromSender(sender());
+
+  // This can happens if there is no visible dock at all
+  if (dock == nullptr) return;
+
   activateDock(dock);
   rubberBandManager.emphasize(dock);
 }
@@ -3600,7 +3523,7 @@ void MainWindow::consoleOutput(const Message& msgObj)
   // Then processEvents should no longer be needed here.
   this->processEvents();
   if (consoleUpdater && !consoleUpdater->isActive()) {
-    consoleUpdater->start(50); // Limit console updates to 20 FPS
+    consoleUpdater->start(50);     // Limit console updates to 20 FPS
   }
 }
 

--- a/src/gui/MainWindow.cc
+++ b/src/gui/MainWindow.cc
@@ -3295,7 +3295,7 @@ void MainWindow::hideParameters()
   }
 }
 
-void MainWindow::onwindowActionSelectEditor()
+void MainWindow::onWindowActionSelectEditor()
 {
   showEditor();
 }

--- a/src/gui/MainWindow.h
+++ b/src/gui/MainWindow.h
@@ -238,9 +238,18 @@ private slots:
   void showFontList();
   void hideFontList();
   void onWindowActionSelectEditor();
+
+  // Handle the Next/Prev dock menu action when the is hovered, currently this activate the rubberband
   void onWindowActionNextPrevHovered();
+
+  // Handle the Next/Prev dock menu action when the is validatee, currently switch to the targetted dock
+  // and remove the rubberband
   void onWindowActionNextPrevTriggered();
+
+  // Handle the Next/Prev shortcut, currently switch to the targetted dock
+  // and adds the rubberband, the rubbreband is removed on shortcut key release.
   void onWindowShortcutNextPrevActivated();
+
   void on_windowActionSelectConsole_triggered();
   void on_windowActionSelectCustomizer_triggered();
   void on_windowActionSelectErrorLog_triggered();

--- a/src/gui/MainWindow.h
+++ b/src/gui/MainWindow.h
@@ -237,7 +237,7 @@ private slots:
   void hideAnimate();
   void showFontList();
   void hideFontList();
-  void onwindowActionSelectEditor();
+  void onWindowActionSelectEditor();
   void onWindowActionNextPrevHovered();
   void onWindowActionNextPrevTriggered();
   void onWindowShortcutNextPrevActivated();

--- a/src/gui/MainWindow.h
+++ b/src/gui/MainWindow.h
@@ -223,20 +223,6 @@ private slots:
   void hideEditorToolbar();
   void hide3DViewToolbar();
   void showLink(const QString&);
-  void showEditor();
-  void hideEditor();
-  void showConsole();
-  void hideConsole();
-  void showErrorLog();
-  void hideErrorLog();
-  void showViewportControl();
-  void hideViewportControl();
-  void showParameters();
-  void hideParameters();
-  void showAnimate();
-  void hideAnimate();
-  void showFontList();
-  void hideFontList();
 
   // Handle the Next/Prev dock menu action when the is hovered, currently this activate the rubberband
   void onWindowActionNextPrevHovered();
@@ -249,12 +235,14 @@ private slots:
   // and adds the rubberband, the rubbreband is removed on shortcut key release.
   void onWindowShortcutNextPrevActivated();
 
-  void on_windowActionSelectConsole_triggered();
-  void on_windowActionSelectCustomizer_triggered();
-  void on_windowActionSelectErrorLog_triggered();
-  void on_windowActionSelectAnimate_triggered();
-  void on_windowActionSelectFontList_triggered();
-  void on_windowActionSelectViewportControl_triggered();
+  void onEditorDockVisibilityChanged(bool isVisible);
+  void onConsoleDockVisibilityChanged(bool isVisible);
+  void onErrorLogDockVisibilityChanged(bool isVisible);
+  void onAnimateDockVisibilityChanged(bool isVisible);
+  void onFontListDockVisibilityChanged(bool isVisible);
+  void onViewportControlDockVisibilityChanged(bool isVisible);
+  void onParametersDockVisibilityChanged(bool isVisible);
+
   void on_editActionInsertTemplate_triggered();
   void on_editActionFoldAll_triggered();
 
@@ -323,7 +311,6 @@ public:
 
 public slots:
   void actionReloadRenderPreview();
-  void on_editorDock_visibilityChanged(bool);
   void on_toolButtonCompileResultClose_clicked();
   void processEvents();
   void jumpToLine(int, int);

--- a/src/gui/MainWindow.h
+++ b/src/gui/MainWindow.h
@@ -237,7 +237,6 @@ private slots:
   void hideAnimate();
   void showFontList();
   void hideFontList();
-  void onWindowActionSelectEditor();
 
   // Handle the Next/Prev dock menu action when the is hovered, currently this activate the rubberband
   void onWindowActionNextPrevHovered();

--- a/src/gui/MainWindow.ui
+++ b/src/gui/MainWindow.ui
@@ -935,14 +935,6 @@
     <string>Ctrl+-</string>
    </property>
   </action>
-  <action name="windowActionHideEditor">
-   <property name="checkable">
-    <bool>true</bool>
-   </property>
-   <property name="text">
-    <string>Hide Editor</string>
-   </property>
-  </action>
   <action name="designActionReloadAndPreview">
    <property name="text">
     <string>&amp;Reload and Preview</string>
@@ -1287,14 +1279,6 @@
     <string>&amp;Orthogonal</string>
    </property>
   </action>
-  <action name="windowActionHideConsole">
-   <property name="checkable">
-    <bool>true</bool>
-   </property>
-   <property name="text">
-    <string>Hide Console</string>
-   </property>
-  </action>
   <action name="helpActionAbout">
    <property name="enabled">
     <bool>true</bool>
@@ -1581,17 +1565,6 @@
     <string>&amp;Cheat Sheet</string>
    </property>
   </action>
-  <action name="windowActionHideCustomizer">
-   <property name="checkable">
-    <bool>true</bool>
-   </property>
-   <property name="checked">
-    <bool>true</bool>
-   </property>
-   <property name="text">
-    <string>Hide Customizer</string>
-   </property>
-  </action>
   <action name="fileActionExportPDF">
    <property name="icon">
     <iconset theme="chokusen-export-pdf">
@@ -1607,78 +1580,6 @@
    </property>
    <property name="text">
     <string>Hide 3D View toolbar</string>
-   </property>
-  </action>
-  <action name="windowActionHideErrorLog">
-   <property name="checkable">
-    <bool>true</bool>
-   </property>
-   <property name="checked">
-    <bool>true</bool>
-   </property>
-   <property name="text">
-    <string>Hide Error Log</string>
-   </property>
-   <property name="toolTip">
-    <string>Hide ErrorLog</string>
-   </property>
-  </action>
-  <action name="windowActionHideAnimate">
-   <property name="checkable">
-    <bool>true</bool>
-   </property>
-   <property name="checked">
-    <bool>true</bool>
-   </property>
-   <property name="text">
-    <string>Hide Animation Toolbar/Window</string>
-   </property>
-   <property name="toolTip">
-    <string>Hide Animation Toolbar/Window</string>
-   </property>
-  </action>
-  <action name="windowActionHideViewportControl">
-   <property name="checkable">
-    <bool>true</bool>
-   </property>
-   <property name="checked">
-    <bool>true</bool>
-   </property>
-   <property name="text">
-    <string>Hide Viewport-Control</string>
-   </property>
-   <property name="toolTip">
-    <string>Hide Viewport-Control</string>
-   </property>
-  </action>
-  <action name="windowActionSelectEditor">
-   <property name="text">
-    <string>&amp;Editor</string>
-   </property>
-  </action>
-  <action name="windowActionSelectConsole">
-   <property name="text">
-    <string>&amp;Console</string>
-   </property>
-  </action>
-  <action name="windowActionSelectCustomizer">
-   <property name="text">
-    <string>C&amp;ustomizer</string>
-   </property>
-  </action>
-  <action name="windowActionSelectErrorLog">
-   <property name="text">
-    <string>Error &amp;Log</string>
-   </property>
-  </action>
-  <action name="windowActionSelectAnimate">
-   <property name="text">
-    <string>&amp;Animate</string>
-   </property>
-  </action>
-  <action name="windowActionSelectViewportControl">
-   <property name="text">
-    <string>Viewport-Control</string>
    </property>
   </action>
   <action name="windowActionNextWindow">
@@ -1702,22 +1603,6 @@
   <action name="editActionFoldAll">
    <property name="text">
     <string>Fold/Unfoll All</string>
-   </property>
-  </action>
-  <action name="windowActionHideFontList">
-   <property name="checkable">
-    <bool>true</bool>
-   </property>
-   <property name="checked">
-    <bool>true</bool>
-   </property>
-   <property name="text">
-    <string>Hide Font List</string>
-   </property>
-  </action>
-  <action name="windowActionSelectFontList">
-   <property name="text">
-    <string>Font List</string>
    </property>
   </action>
   <action name="windowActionJumpTo">

--- a/src/gui/TabManager.cc
+++ b/src/gui/TabManager.cc
@@ -108,7 +108,7 @@ void TabManager::prevTab()
 
 void TabManager::actionNew()
 {
-  if (par->windowActionHideEditor->isChecked()) par->windowActionHideEditor->trigger();   //if editor hidden, make it visible
+  if (!par->editorDock->isVisible()) par->editorDock->setVisible(true);   //if editor hidden, make it visible
   createTab("");
 }
 

--- a/src/gui/TabManager.cc
+++ b/src/gui/TabManager.cc
@@ -448,10 +448,10 @@ void TabManager::openTabFile(const QString& filename)
 {
   par->setCurrentOutput();
 #ifdef ENABLE_PYTHON
-  if(boost::algorithm::ends_with(filename, ".py")) {
-    std::string templ="from openscad import *\n";	  
+  if (boost::algorithm::ends_with(filename, ".py")) {
+    std::string templ = "from openscad import *\n";
   } else
-#endif  
+#endif
   editor->setPlainText("");
 
   QFileInfo fileinfo(filename);


### PR DESCRIPTION
We have recently start using using https://doc.qt.io/qt-6/qdockwidget.html#toggleViewAction to handle the dock visibility as well as the checkboxes in the menuWindows, 
We also have recently replace the windowActionSelectXXXDock with the"Jump-To" one.  

The consequence of these two is that the show/hide/select/triggered docks methods/slot are not needed anymore. 

So in the PR is remove them and update the connected code. 
The hard part was that the show/hide method were used to handle the visibility, the checkbox states but also to implement "dock" specific behavior when the visibility change. 
This behavior has been preserved  and moved in dedicated slots named onXXXDockVisibilityChanged(bool). 

Normally this PR shouldn't break/change anything. If it does, please report. 