### PR TITLE
clang-tidy fixes: src/glview

### DIFF
--- a/src/glview/CsgInfo.h
+++ b/src/glview/CsgInfo.h
@@ -1,15 +1,16 @@
 #pragma once
 
+#include <memory>
+#include <vector>
+
 #include "core/CSGNode.h"
+#include "core/CSGTreeEvaluator.h"
 #include "core/Tree.h"
 #include "geometry/GeometryEvaluator.h"
-#include "core/CSGTreeEvaluator.h"
 #include "glview/preview/CSGTreeNormalizer.h"
 #include "glview/RenderSettings.h"
 #include "utils/printutils.h"
 
-#include <memory>
-#include <vector>
 
 /*
    Small helper class for compiling and normalizing node trees into CSG products
@@ -26,16 +27,16 @@ public:
     auto& root_node = tree.root();
     GeometryEvaluator geomevaluator(tree);
     CSGTreeEvaluator evaluator(tree, &geomevaluator);
-    std::shared_ptr<CSGNode> csgRoot = evaluator.buildCSGTree(*root_node);
+    const std::shared_ptr<CSGNode> csgRoot = evaluator.buildCSGTree(*root_node);
     std::vector<std::shared_ptr<CSGNode>> highlightNodes = evaluator.getHighlightNodes();
     std::vector<std::shared_ptr<CSGNode>> backgroundNodes = evaluator.getBackgroundNodes();
 
     LOG("Compiling design (CSG Products normalization)...");
     CSGTreeNormalizer normalizer(RenderSettings::inst()->openCSGTermLimit);
     if (csgRoot) {
-      std::shared_ptr<CSGNode> normalizedRoot = normalizer.normalize(csgRoot);
+      const std::shared_ptr<CSGNode> normalizedRoot = normalizer.normalize(csgRoot);
       if (normalizedRoot) {
-        this->root_products.reset(new CSGProducts());
+        this->root_products = std::make_shared<CSGProducts>();
         this->root_products->import(normalizedRoot);
         LOG("Normalized CSG tree has %1$d elements", int(this->root_products->size()));
       } else {
@@ -46,7 +47,7 @@ public:
 
     if (highlightNodes.size() > 0) {
       LOG("Compiling highlights (%1$i CSG Trees)...", highlightNodes.size());
-      this->highlights_products.reset(new CSGProducts());
+      this->highlights_products = std::make_shared<CSGProducts>();
       for (auto& highlightNode : highlightNodes) {
         highlightNode = normalizer.normalize(highlightNode);
         this->highlights_products->import(highlightNode);
@@ -55,7 +56,7 @@ public:
 
     if (backgroundNodes.size() > 0) {
       LOG("Compiling background (%1$i CSG Trees)...", backgroundNodes.size());
-      this->background_products.reset(new CSGProducts());
+      this->background_products = std::make_shared<CSGProducts>();
       for (auto& backgroundNode : backgroundNodes) {
         backgroundNode = normalizer.normalize(backgroundNode);
         this->background_products->import(backgroundNode);

--- a/src/glview/NULLGL.cc
+++ b/src/glview/NULLGL.cc
@@ -1,41 +1,37 @@
-#include "glview/GLView.h"
-
 #include <cassert>
+#include <cstddef>
 #include <cstdint>
 #include <memory>
-#include <cstddef>
 #include <string>
 #include <vector>
 
-GLView::GLView() {}
-GLView::~GLView() {}
-void GLView::setRenderer(std::shared_ptr<Renderer>) {}
-void GLView::initializeGL() {}
-void GLView::resizeGL(int w, int h) {}
-void GLView::setCamera(const Camera& cam) {assert(false && "not implemented");}
-void GLView::paintGL() {}
-void GLView::showSmallaxes(const Color4f& col) {}
-void GLView::showAxes(const Color4f& col) {}
-void GLView::showCrosshairs(const Color4f& col) {}
-void GLView::setColorScheme(const ColorScheme& cs){assert(false && "not implemented");}
-void GLView::setColorScheme(const std::string& cs) {assert(false && "not implemented");}
-
 #include "geometry/linalg.h"
+#include "glview/Camera.h"
+#include "glview/ColorMap.h"
+#include "glview/Renderer.h"
+#include "glview/fbo.h"
+#include "glview/GLView.h"
+#include "glview/OpenGLContext.h"
 #include "glview/system-gl.h"
 
-double gl_version() { return -1; }
+bool FBO::resize(size_t, size_t) { return false; }
+FBO::FBO(int, int, bool ) {}
+GLuint FBO::bind() { return 0; }
+GLView::~GLView() = default;
+GLView::GLView() = default;
 std::string gl_dump() { return {"GL Renderer: NULLGL\n"}; }
 std::string gl_extensions_dump() { return {"NULLGL Extensions"}; }
-bool report_glerror(const char *function) { return false; }
-
-#include "glview/OpenGLContext.h"
-std::vector<uint8_t> OpenGLContext::getFramebuffer() const { return {}; }
-
-#include "glview/fbo.h"
-
-FBO::FBO(int, int, bool ) {}
-bool FBO::resize(size_t, size_t) { return false; }
-GLuint FBO::bind() { return 0; }
-void FBO::unbind() {}
-void FBO::destroy() {}
 std::unique_ptr<FBO> createFBO(int, int) {return nullptr;}
+std::vector<uint8_t> OpenGLContext::getFramebuffer() const { return {}; }
+void FBO::destroy() {}
+void FBO::unbind() {}
+void GLView::initializeGL() {}
+void GLView::paintGL() {}
+void GLView::resizeGL(int w, int h) {}
+void GLView::setCamera(const Camera& /*cam*/) {assert(false && "not implemented");}
+void GLView::setColorScheme(const ColorScheme&  /*cs*/){assert(false && "not implemented");}
+void GLView::setColorScheme(const std::string&  /*cs*/) {assert(false && "not implemented");}
+void GLView::setRenderer(std::shared_ptr<Renderer>) {}
+void GLView::showAxes(const Color4f& col) {}
+void GLView::showCrosshairs(const Color4f& col) {}
+void GLView::showSmallaxes(const Color4f& col) {}

--- a/src/glview/OffscreenContextNULL.cc
+++ b/src/glview/OffscreenContextNULL.cc
@@ -7,10 +7,13 @@
 #include <memory>
 #include <string>
 
+#include "glview/OffscreenContext.h"
+
 class OffscreenContextNULL : public OffscreenContext {
 public:
   OffscreenContextNULL() : OffscreenContext(0, 0) {}
-  ~OffscreenContextNULL() {}
+  ~OffscreenContextNULL() override = default;
+  
   std::string getInfo() const override {
     return "GL context creator: NULLGL";
   }

--- a/src/glview/cgal/VBOPolyhedron.h
+++ b/src/glview/cgal/VBOPolyhedron.h
@@ -26,19 +26,21 @@
 
 #pragma once
 
-#include "CGAL/OGL_helper.h"
-
-#include "glview/ColorMap.h"
-#include "glview/VertexState.h"
-#include "glview/system-gl.h"
-#include "glview/VBOBuilder.h"
-#include "glview/ColorMap.h"
-
 #include <cassert>
 #include <utility>
 #include <memory>
 #include <cstdlib>
 #include <vector>
+
+#include <CGAL/IO/Color.h>
+
+#include "CGAL/OGL_helper.h"
+#include "glview/ColorMap.h"
+#include "glview/VertexState.h"
+#include "glview/system-gl.h"
+#include "glview/VBOBuilder.h"
+#include "glview/ColorMap.h"
+#include "utils/printutils.h"
 
 class VBOPolyhedron : public CGAL::OGL::Polyhedron
 {
@@ -63,8 +65,7 @@ public:
     setColor(CGALColorIndex::UNMARKED_EDGE_COLOR, ColorMap::getColor(cs, RenderColor::CGAL_EDGE_FRONT_COLOR));
   }
 
-  ~VBOPolyhedron() override {
-  }
+  ~VBOPolyhedron() override = default;
 
   void draw(Vertex_iterator v, VBOBuilder& vbo_builder) const {
     PRINTD("draw(Vertex_iterator)");
@@ -79,9 +80,9 @@ public:
   void draw(Edge_iterator e, VBOBuilder& vbo_builder) const {
     PRINTD("draw(Edge_iterator)");
 
-    Double_point p = e->source(), q = e->target();
-    CGAL::Color c = getEdgeColor(e);
-    Color4f color(c.red(), c.green(), c.blue());
+    const Double_point p = e->source(), q = e->target();
+    const CGAL::Color c = getEdgeColor(e);
+    const Color4f color(c.red(), c.green(), c.blue());
 
     vbo_builder.createVertex({Vector3d(p.x(), p.y(), p.z())},
                               {},
@@ -230,7 +231,7 @@ public:
     size_t last_size = 0;
     size_t elements_offset = 0;
 
-    size_t num_vertices = vertices_.size() + edges_.size() * 2, elements_size = 0;
+    const size_t num_vertices = vertices_.size() + edges_.size() * 2, elements_size = 0;
     points_edges_builder.allocateBuffers(num_vertices);
 
     // Points
@@ -338,9 +339,9 @@ public:
     PRINTDB("VBO draw(showedges = %d)", showedges);
     // grab current state to restore after
     GLfloat current_point_size, current_line_width;
-    GLboolean origVertexArrayState = glIsEnabled(GL_VERTEX_ARRAY);
-    GLboolean origNormalArrayState = glIsEnabled(GL_NORMAL_ARRAY);
-    GLboolean origColorArrayState = glIsEnabled(GL_COLOR_ARRAY);
+    const GLboolean origVertexArrayState = glIsEnabled(GL_VERTEX_ARRAY);
+    const GLboolean origNormalArrayState = glIsEnabled(GL_NORMAL_ARRAY);
+    const GLboolean origColorArrayState = glIsEnabled(GL_COLOR_ARRAY);
 
     GL_CHECKD(glGetFloatv(GL_POINT_SIZE, &current_point_size));
     GL_CHECKD(glGetFloatv(GL_LINE_WIDTH, &current_line_width));

--- a/src/glview/preview/ThrownTogetherRenderer.cc
+++ b/src/glview/preview/ThrownTogetherRenderer.cc
@@ -26,17 +26,22 @@
 
 #include "glview/preview/ThrownTogetherRenderer.h"
 
-#include <memory>
 #include <cstddef>
+#include <memory>
 #include <utility>
-#include "geometry/linalg.h"
-#include "Feature.h"
-#include "glview/VertexState.h"
-#include "geometry/PolySet.h"
-#include "core/enums.h"
-#include "utils/printutils.h"
 
+#include <Eigen/Geometry>
+
+#include "core/enums.h"
+#include "geometry/linalg.h"
 #include "glview/system-gl.h"
+#include "glview/VertexState.h"
+#include "glview/Renderer.h"
+#include "utils/printutils.h"
+#include "core/CSGNode.h"
+#include "glview/ShaderUtils.h"
+#include "glview/VBOBuilder.h"
+#include "glview/VBORenderer.h"
 
 namespace {
 
@@ -78,10 +83,6 @@ ThrownTogetherRenderer::ThrownTogetherRenderer(std::shared_ptr<CSGProducts> root
 {
 }
 
-ThrownTogetherRenderer::~ThrownTogetherRenderer()
-{
-}
-
 void ThrownTogetherRenderer::prepare(const ShaderUtils::ShaderInfo *shaderinfo)
 {
   PRINTD("Thrown prepare");
@@ -111,7 +112,7 @@ void ThrownTogetherRenderer::prepare(const ShaderUtils::ShaderInfo *shaderinfo)
 void ThrownTogetherRenderer::draw(bool showedges, const ShaderUtils::ShaderInfo *shaderinfo) const
 {
   // Only use shader if select rendering or showedges
-  bool enable_shader = shaderinfo && (
+  const bool enable_shader = shaderinfo && (
     shaderinfo->type == ShaderUtils::ShaderType::EDGE_RENDERING && showedges || 
     shaderinfo->type == ShaderUtils::ShaderType::SELECT_RENDERING);
   if (enable_shader) {
@@ -160,10 +161,9 @@ void ThrownTogetherRenderer::createChainObject(VertexStateContainer& container, 
     return;
   }
 
-  bool enable_barycentric = true;
+  const bool enable_barycentric = true;
 
   const auto& leaf_color = csgobj.leaf->color;
-  const auto csgmode = RendererUtils::getCsgMode(highlight_mode, background_mode, type);
 
   vbo_builder.writeSurface();
 

--- a/src/glview/preview/ThrownTogetherRenderer.h
+++ b/src/glview/preview/ThrownTogetherRenderer.h
@@ -1,15 +1,17 @@
 #pragma once
 
-#include <memory>
 #include <cstddef>
+#include <memory>
 #include <vector>
 
-#include "glview/VertexState.h"
-#include "geometry/linalg.h"
-#include "glview/Renderer.h"
 #include "core/CSGNode.h"
-
+#include "core/enums.h"
+#include "geometry/linalg.h"
+#include "glview/system-gl.h"
 #include "glview/VBORenderer.h"
+#include "glview/VertexState.h"
+#include "glview/ShaderUtils.h"
+#include "glview/VBOBuilder.h"
 
 class CSGProducts;
 class CSGChainObject;
@@ -50,7 +52,7 @@ public:
   ThrownTogetherRenderer(std::shared_ptr<CSGProducts> root_products,
                          std::shared_ptr<CSGProducts> highlight_products,
                          std::shared_ptr<CSGProducts> background_products);
-  ~ThrownTogetherRenderer() override;
+  ~ThrownTogetherRenderer() override = default;
   void prepare(const ShaderUtils::ShaderInfo *shaderinfo = nullptr) override;
   void draw(bool showedges, const ShaderUtils::ShaderInfo *shaderinfo = nullptr) const override;
 

--- a/src/glview/system-gl.cc
+++ b/src/glview/system-gl.cc
@@ -20,9 +20,7 @@
 #include <boost/algorithm/string.hpp>
 #include <boost/format.hpp>
 
-#include "utils/printutils.h"
-
-double gl_version()
+static double gl_version()
 {
   std::string tmp((const char *)glGetString(GL_VERSION));
   std::vector<std::string> strs;

--- a/src/glview/system-gl.h
+++ b/src/glview/system-gl.h
@@ -14,7 +14,7 @@
 #endif
 
 #ifdef __APPLE__
- #include <OpenGL/glu.h>
+ #include <OpenGL/glu.h>  // IWYU pragma: export
 #else
  #include <GL/glu.h>
 #endif


### PR DESCRIPTION
```
[clang-analyzer-deadcode.DeadStores]    -1
      [misc-const-correctness]   -10
        [misc-include-cleaner]   -25
      [misc-unused-parameters]    -4
[misc-use-anonymous-namespace]    +1
[modernize-use-equals-default]    -5
      [modernize-use-override]    -1
```