### PR TITLE
FindNettle: Prefer pkg-config Nettle version

### DIFF
--- a/cmake/Modules/FindNettle.cmake
+++ b/cmake/Modules/FindNettle.cmake
@@ -82,10 +82,12 @@ find_library(Nettle_LIBRARY
   PATHS ${PC_Nettle_LIBRARY_DIRS}
 )
 
-# Extract version information from the header file
 if(Nettle_INCLUDE_DIR)
-  # This file only exists in nettle>=3.0
-  if(EXISTS ${Nettle_INCLUDE_DIR}/nettle/version.h)
+  if(PC_Nettle_VERSION)
+    set(Nettle_VERSION ${PC_Nettle_VERSION})
+  elseif(EXISTS ${Nettle_INCLUDE_DIR}/nettle/version.h)
+    # Extract version information from the header file
+    # This file only exists in nettle>=3.0
     file(STRINGS ${Nettle_INCLUDE_DIR}/nettle/version.h _ver_major_line
          REGEX "^#define NETTLE_VERSION_MAJOR  *[0-9]+"
          LIMIT_COUNT 1)
@@ -100,11 +102,7 @@ if(Nettle_INCLUDE_DIR)
     unset(_ver_major_line)
     unset(_ver_minor_line)
   else()
-    if(PC_Nettle_VERSION)
-      set(Nettle_VERSION ${PC_Nettle_VERSION})
-    else()
-      set(Nettle_VERSION "1.0")
-    endif()
+    set(Nettle_VERSION "1.0")
   endif()
 endif()
 


### PR DESCRIPTION
Gentoo Linux rewrites /usr/include/nettle/version.h to support multiple ABIs.

Even with Nettle 3.10 installed this results in:
-- Could NOT find Nettle: Found unsuitable version ".", but required is at least "3.0" (found /usr/lib64/libnettle.so)

---

This is from libzip: https://github.com/nih-at/libzip/commit/135bd6dc0523da4d8d2315189e12cebeb7568f9e.

Needed to enable OpenSCAD Python support on Gentoo.


