### PR TITLE
clang-tidy fixes: src/io/

### DIFF
--- a/src/LibraryInfo.cc
+++ b/src/LibraryInfo.cc
@@ -9,6 +9,7 @@
 #include <Eigen/Core>
 #include <glib.h>
 
+#include "io/lib3mf_utils.h"
 
 #ifndef OPENSCAD_NOGUI
 #include <QtGlobal>
@@ -68,7 +69,6 @@
 extern std::vector<std::string> librarypath;
 extern std::vector<std::string> fontpath;
 extern const std::string get_cairo_version();
-extern const std::string get_lib3mf_version();
 extern const char *LODEPNG_VERSION_STRING;
 
 std::string LibraryInfo::info()

--- a/src/geometry/cgal/cgal.h
+++ b/src/geometry/cgal/cgal.h
@@ -14,8 +14,9 @@
  #endif
    //*/
 
-#include "CGAL/CGAL_workaround_Mark_bounded_volumes.h" // This file must be included prior to CGAL/Nef_polyhedron_3.h
 #include <vector>
+   
+#include "CGAL/CGAL_workaround_Mark_bounded_volumes.h" // This file must be included prior to CGAL/Nef_polyhedron_3.h
 #include <CGAL/Gmpq.h>
 #include <CGAL/Extended_cartesian.h>
 #include <CGAL/Nef_polyhedron_2.h>
@@ -24,6 +25,7 @@
 #include <CGAL/Nef_polyhedron_3.h>
 #include <CGAL/Surface_mesh.h>
 #include <CGAL/IO/Polyhedron_iostream.h>
+#include <CGAL/IO/Nef_polyhedron_iostream_3.h> // for dumping .nef3
 #include <CGAL/Exact_predicates_exact_constructions_kernel.h>
 #include <CGAL/Polygon_2.h>
 #include <CGAL/Polygon_with_holes_2.h>

--- a/src/gui/Export3mfDialog.cc
+++ b/src/gui/Export3mfDialog.cc
@@ -35,6 +35,7 @@
 #include <QLineEdit>
 
 #include "io/export.h"
+#include "io/lib3mf_utils.h"
 #include "core/Settings.h"
 #include "gui/UIUtils.h"
 #include "gui/SettingsWriter.h"
@@ -42,8 +43,6 @@
 using S = Settings::SettingsExport3mf;
 using SEBool = Settings::SettingsEntryBool;
 using SEString = Settings::SettingsEntryString;
-
-extern const std::string get_lib3mf_version();
 
 Export3mfDialog::Export3mfDialog()
 {

--- a/src/io/DxfData.cc
+++ b/src/io/DxfData.cc
@@ -26,34 +26,31 @@
 
 #include "io/DxfData.h"
 
-#include <stdexcept>
-#include <memory>
+#include <algorithm>
 #include <cmath>
-
-#include "geometry/linalg.h"
-#include "geometry/Grid.h"
-#include "utils/printutils.h"
-#include "utils/calc.h"
-
-#include <cassert>
 #include <cstddef>
+#include <filesystem>
 #include <fstream>
+#include <map>
+#include <memory>
+#include <sstream>
+#include <stdexcept>
+#include <string>
 #include <unordered_map>
 #include <vector>
-#include <boost/lexical_cast.hpp>
+
 #include <boost/algorithm/string.hpp>
-#include <filesystem>
-#include <algorithm>
-#include <sstream>
-#include <string>
-#include <map>
+#include <boost/lexical_cast.hpp>
 
 #include "core/Value.h"
+#include "geometry/Grid.h"
+#include "geometry/linalg.h"
 #include "geometry/Polygon2d.h"
 #include "io/fileutils.h"
-#include "utils/printutils.h"
+#include "utils/calc.h"
 #include "utils/degree_trig.h"
-
+#include "utils/printutils.h"
+#include "utils/printutils.h"
 
 namespace fs = std::filesystem;
 
@@ -186,7 +183,7 @@ DxfData::DxfData(double fn, double fs, double fa,
         } else if (mode == "LWPOLYLINE") {
           // assert(xverts.size() == yverts.size());
           // Get maximum to enforce managed exception if xverts.size() != yverts.size()
-          int numverts = std::max(xverts.size(), yverts.size());
+          const int numverts = std::max(xverts.size(), yverts.size());
           for (int i = 1; i < numverts; ++i) {
             ADD_LINE(xverts.at(i - 1), yverts.at(i - 1), xverts.at(i % numverts), yverts.at(i % numverts));
           }
@@ -195,11 +192,11 @@ DxfData::DxfData(double fn, double fs, double fa,
             ADD_LINE(xverts.at(numverts - 1), yverts.at(numverts - 1), xverts.at(0), yverts.at(0));
           }
         } else if (mode == "CIRCLE") {
-          int n = Calc::get_fragments_from_r(radius, fn, fs, fa);
+          const int n = Calc::get_fragments_from_r(radius, fn, fs, fa);
           Vector2d center(xverts.at(0), yverts.at(0));
           for (int i = 0; i < n; ++i) {
-            double a1 = (360.0 * i) / n;
-            double a2 = (360.0 * (i + 1)) / n;
+            const double a1 = (360.0 * i) / n;
+            const double a2 = (360.0 * (i + 1)) / n;
             ADD_LINE(cos_degrees(a1) * radius + center[0], sin_degrees(a1) * radius + center[1],
                      cos_degrees(a2) * radius + center[0], sin_degrees(a2) * radius + center[1]);
           }
@@ -209,11 +206,11 @@ DxfData::DxfData(double fn, double fs, double fa,
           while (arc_start_angle > arc_stop_angle) {
             arc_stop_angle += 360.0;
           }
-          double arc_angle = arc_stop_angle - arc_start_angle;
+          const double arc_angle = arc_stop_angle - arc_start_angle;
           n = static_cast<int>(ceil(n * arc_angle / 360));
           for (int i = 0; i < n; ++i) {
-            double a1 = arc_start_angle + arc_angle * i / n;
-            double a2 = arc_start_angle + arc_angle * (i + 1) / n;
+            const double a1 = arc_start_angle + arc_angle * i / n;
+            const double a2 = arc_start_angle + arc_angle * (i + 1) / n;
             ADD_LINE(cos_degrees(a1) * radius + center[0], sin_degrees(a1) * radius + center[1],
                      cos_degrees(a2) * radius + center[0], sin_degrees(a2) * radius + center[1]);
           }
@@ -225,12 +222,12 @@ DxfData::DxfData(double fn, double fs, double fa,
 //				Vector2d ce(xverts[1], yverts[1]);
           Vector2d ce(xverts.at(1), yverts.at(1));
 //				double r_major = ce.length();
-          double r_major = sqrt(ce[0] * ce[0] + ce[1] * ce[1]);
+          const double r_major = sqrt(ce[0] * ce[0] + ce[1] * ce[1]);
 //				double rot_angle = ce.angle();
           double rot_angle;
           {
 //					double dot = ce.dot(Vector2d(1.0, 0.0));
-            double dot = ce[0];
+            const double dot = ce[0];
             double cosval = dot / r_major;
             if (cosval > 1.0) cosval = 1.0;
             if (cosval < -1.0) cosval = -1.0;
@@ -239,14 +236,14 @@ DxfData::DxfData(double fn, double fs, double fa,
           }
 
           // the ratio stored in 'radius; due to the parser code not checking entity type
-          double r_minor = r_major * radius;
-          double sweep_angle = ellipse_stop_angle - ellipse_start_angle;
+          const double r_minor = r_major * radius;
+          const double sweep_angle = ellipse_stop_angle - ellipse_start_angle;
           int n = Calc::get_fragments_from_r(r_major, fn, fs, fa);
           n = static_cast<int>(ceil(n * sweep_angle / (2 * M_PI)));
 //				Vector2d p1;
           Vector2d p1{0.0, 0.0};
           for (int i = 0; i <= n; ++i) {
-            double a = (ellipse_start_angle + sweep_angle * i / n);
+            const double a = (ellipse_start_angle + sweep_angle * i / n);
 //					Vector2d p2(cos(a)*r_major, sin(a)*r_minor);
             Vector2d p2(cos(a) * r_major, sin(a) * r_minor);
 //					p2.rotate(rot_angle);
@@ -266,17 +263,17 @@ DxfData::DxfData(double fn, double fs, double fa,
         } else if (mode == "INSERT") {
           // scale is stored in ellipse_start|stop_angle, rotation in arc_start_angle;
           // due to the parser code not checking entity type
-          int n = blockdata[iddata].size();
+          const int n = blockdata[iddata].size();
           for (int i = 0; i < n; ++i) {
-            double a = arc_start_angle;
-            double lx1 = this->points[blockdata[iddata][i].idx[0]][0] * ellipse_start_angle;
-            double ly1 = this->points[blockdata[iddata][i].idx[0]][1] * ellipse_stop_angle;
-            double lx2 = this->points[blockdata[iddata][i].idx[1]][0] * ellipse_start_angle;
-            double ly2 = this->points[blockdata[iddata][i].idx[1]][1] * ellipse_stop_angle;
-            double px1 = (cos_degrees(a) * lx1 - sin_degrees(a) * ly1) * scale + xverts.at(0);
-            double py1 = (sin_degrees(a) * lx1 + cos_degrees(a) * ly1) * scale + yverts.at(0);
-            double px2 = (cos_degrees(a) * lx2 - sin_degrees(a) * ly2) * scale + xverts.at(0);
-            double py2 = (sin_degrees(a) * lx2 + cos_degrees(a) * ly2) * scale + yverts.at(0);
+            const double a = arc_start_angle;
+            const double lx1 = this->points[blockdata[iddata][i].idx[0]][0] * ellipse_start_angle;
+            const double ly1 = this->points[blockdata[iddata][i].idx[0]][1] * ellipse_stop_angle;
+            const double lx2 = this->points[blockdata[iddata][i].idx[1]][0] * ellipse_start_angle;
+            const double ly2 = this->points[blockdata[iddata][i].idx[1]][1] * ellipse_stop_angle;
+            const double px1 = (cos_degrees(a) * lx1 - sin_degrees(a) * ly1) * scale + xverts.at(0);
+            const double py1 = (sin_degrees(a) * lx1 + cos_degrees(a) * ly1) * scale + yverts.at(0);
+            const double px2 = (cos_degrees(a) * lx2 - sin_degrees(a) * ly2) * scale + xverts.at(0);
+            const double py2 = (sin_degrees(a) * lx2 + cos_degrees(a) * ly2) * scale + yverts.at(0);
             ADD_LINE(px1, py1, px2, py2);
           }
         } else if (mode == "DIMENSION" &&
@@ -405,10 +402,10 @@ DxfData::DxfData(double fn, double fs, double fa,
     int current_line, current_point;
 
     for (const auto& l : enabled_lines) {
-      int idx = l.second;
+      const int idx = l.second;
       for (int j = 0; j < 2; ++j) {
         auto lv = grid.data(this->points[lines[idx].idx[j]][0], this->points[lines[idx].idx[j]][1]);
-        for (int k : lv) {
+        for (const int k : lv) {
           if (k < 0 || static_cast<unsigned int>(k) >= lines.size()) {
             LOG(message_group::Warning,
                 "Bad DXF line index in %1$s.", QuotedString(fs_uncomplete(filename, fs::current_path()).generic_string()));
@@ -437,7 +434,7 @@ create_open_path:
       lines[current_line].disabled = true;
       enabled_lines.erase(current_line);
       auto lv = grid.data(ref_point[0], ref_point[1]);
-      for (int k : lv) {
+      for (const int k : lv) {
         if (k < 0 || static_cast<unsigned int>(k) >= lines.size()) {
           LOG(message_group::Warning,
               "Bad DXF line index in %1$s.", QuotedString(fs_uncomplete(filename, fs::current_path()).generic_string()));
@@ -478,7 +475,7 @@ found_next_line_in_open_path:;
       lines[current_line].disabled = true;
       enabled_lines.erase(current_line);
       auto lv = grid.data(ref_point[0], ref_point[1]);
-      for (int k : lv) {
+      for (const int k : lv) {
         if (k < 0 || static_cast<unsigned int>(k) >= lines.size()) {
           LOG(message_group::Warning,
               "Bad DXF line index in %1$s.", QuotedString(fs_uncomplete(filename, fs::current_path()).generic_string()));
@@ -535,13 +532,13 @@ void DxfData::fixup_path_direction()
       }
     }
     // rotate points if the path is in non-standard rotation
-    size_t b = min_x_point;
-    size_t a = b == 0 ? path.indices.size() - 2 : b - 1;
-    size_t c = b == path.indices.size() - 1 ? 1 : b + 1;
-    double ax = this->points[path.indices[a]][0] - this->points[path.indices[b]][0];
-    double ay = this->points[path.indices[a]][1] - this->points[path.indices[b]][1];
-    double cx = this->points[path.indices[c]][0] - this->points[path.indices[b]][0];
-    double cy = this->points[path.indices[c]][1] - this->points[path.indices[b]][1];
+    const size_t b = min_x_point;
+    const size_t a = b == 0 ? path.indices.size() - 2 : b - 1;
+    const size_t c = b == path.indices.size() - 1 ? 1 : b + 1;
+    const double ax = this->points[path.indices[a]][0] - this->points[path.indices[b]][0];
+    const double ay = this->points[path.indices[a]][1] - this->points[path.indices[b]][1];
+    const double cx = this->points[path.indices[c]][0] - this->points[path.indices[b]][0];
+    const double cy = this->points[path.indices[c]][1] - this->points[path.indices[b]][1];
 #if 0
     printf("Rotate check:\n");
     printf("  a/b/c indices = %d %d %d\n", a, b, c);

--- a/src/io/DxfData.h
+++ b/src/io/DxfData.h
@@ -3,6 +3,7 @@
 #include <memory>
 #include <string>
 #include <vector>
+
 #include "geometry/linalg.h"
 
 class DxfData

--- a/src/io/dxfdim.cc
+++ b/src/io/dxfdim.cc
@@ -25,33 +25,34 @@
  */
 
 #include "io/dxfdim.h"
-#include "core/AST.h"
-#include "core/Value.h"
-#include "core/function.h"
-#include "io/DxfData.h"
-#include "core/Builtins.h"
-#include "core/Parameters.h"
-#include "utils/printutils.h"
-#include "io/fileutils.h"
-#include "handle_dep.h"
-#include "utils/degree_trig.h"
 
+#include <cmath>
+#include <cstddef>
+#include <cstdint>
+#include <filesystem>
+#include <string>
 #include <unordered_map>
 #include <utility>
-#include <cstddef>
-#include <cmath>
-#include <cstdint>
-#include <string>
 #include <vector>
 
-#include <filesystem>
+#include "core/AST.h"
+#include "core/Builtins.h"
+#include "core/function.h"
+#include "core/Parameters.h"
+#include "core/Value.h"
+#include "handle_dep.h"
+#include "io/DxfData.h"
+#include "io/fileutils.h"
+#include "utils/degree_trig.h"
+#include "utils/printutils.h"
+
 std::unordered_map<std::string, double> dxf_dim_cache;
 std::unordered_map<std::string, std::vector<double>> dxf_cross_cache;
 namespace fs = std::filesystem;
 
-Value builtin_dxf_dim(Arguments arguments, const Location& loc)
+static Value builtin_dxf_dim(Arguments arguments, const Location& loc)
 {
-  Parameters parameters = Parameters::parse(std::move(arguments), loc, {}, {"file", "layer", "origin", "scale", "name"});
+  const Parameters parameters = Parameters::parse(std::move(arguments), loc, {}, {"file", "layer", "origin", "scale", "name"});
 
   std::string rawFilename;
   std::string filename;
@@ -69,10 +70,10 @@ Value builtin_dxf_dim(Arguments arguments, const Location& loc)
     }
   }
   std::string layername = parameters.get("layer", "");
-  double scale = parameters.get("scale", 1);
+  const double scale = parameters.get("scale", 1);
   std::string name = parameters.get("name", "");
 
-  fs::path filepath(filename);
+  const fs::path filepath(filename);
   uintmax_t filesize = -1;
   int64_t lastwritetime = -1;
   if (fs::exists(filepath)) {
@@ -84,7 +85,7 @@ Value builtin_dxf_dim(Arguments arguments, const Location& loc)
     LOG(message_group::Warning, loc, parameters.documentRoot(), "Can't open DXF file '%1$s'!", rawFilename);
     return Value::undefined.clone();
   }
-  std::string key = STR(filename, "|", layername, "|", name, "|", xorigin,
+  const std::string key = STR(filename, "|", layername, "|", name, "|", xorigin,
                         "|", yorigin, "|", scale, "|", lastwritetime,
                         "|", filesize);
   auto result = dxf_dim_cache.find(key);
@@ -96,42 +97,42 @@ Value builtin_dxf_dim(Arguments arguments, const Location& loc)
     if (!name.empty() && dim.name != name) continue;
 
     DxfData::Dim *d = &dim;
-    int type = d->type & 7;
+    const int type = d->type & 7;
 
     if (type == 0) {
       // Rotated, horizontal or vertical
-      double x = d->coords[4][0] - d->coords[3][0];
-      double y = d->coords[4][1] - d->coords[3][1];
-      double angle = d->angle;
-      double distance_projected_on_line = std::fabs(x * cos_degrees(angle) + y * sin_degrees(angle));
+      const double x = d->coords[4][0] - d->coords[3][0];
+      const double y = d->coords[4][1] - d->coords[3][1];
+      const double angle = d->angle;
+      const double distance_projected_on_line = std::fabs(x * cos_degrees(angle) + y * sin_degrees(angle));
       dxf_dim_cache.emplace(key, distance_projected_on_line);
       return {distance_projected_on_line};
     } else if (type == 1) {
       // Aligned
-      double x = d->coords[4][0] - d->coords[3][0];
-      double y = d->coords[4][1] - d->coords[3][1];
-      double value = sqrt(x * x + y * y);
+      const double x = d->coords[4][0] - d->coords[3][0];
+      const double y = d->coords[4][1] - d->coords[3][1];
+      const double value = sqrt(x * x + y * y);
       dxf_dim_cache.emplace(key, value);
       return {value};
     } else if (type == 2) {
       // Angular
-      double a1 = atan2_degrees(d->coords[0][0] - d->coords[5][0], d->coords[0][1] - d->coords[5][1]);
-      double a2 = atan2_degrees(d->coords[4][0] - d->coords[3][0], d->coords[4][1] - d->coords[3][1]);
-      double value = std::fabs(a1 - a2);
+      const double a1 = atan2_degrees(d->coords[0][0] - d->coords[5][0], d->coords[0][1] - d->coords[5][1]);
+      const double a2 = atan2_degrees(d->coords[4][0] - d->coords[3][0], d->coords[4][1] - d->coords[3][1]);
+      const double value = std::fabs(a1 - a2);
       dxf_dim_cache.emplace(key, value);
       return {value};
     } else if (type == 3 || type == 4) {
       // Diameter or Radius
-      double x = d->coords[5][0] - d->coords[0][0];
-      double y = d->coords[5][1] - d->coords[0][1];
-      double value = sqrt(x * x + y * y);
+      const double x = d->coords[5][0] - d->coords[0][0];
+      const double y = d->coords[5][1] - d->coords[0][1];
+      const double value = sqrt(x * x + y * y);
       dxf_dim_cache.emplace(key, value);
       return {value};
     } else if (type == 5) {
       // Angular 3 Point
     } else if (type == 6) {
       // Ordinate
-      double value = (d->type & 64) ? d->coords[3][0] : d->coords[3][1];
+      const double value = (d->type & 64) ? d->coords[3][0] : d->coords[3][1];
       dxf_dim_cache.emplace(key, value);
       return {value};
     }
@@ -145,10 +146,10 @@ Value builtin_dxf_dim(Arguments arguments, const Location& loc)
   return Value::undefined.clone();
 }
 
-Value builtin_dxf_cross(Arguments arguments, const Location& loc)
+static Value builtin_dxf_cross(Arguments arguments, const Location& loc)
 {
   auto *session = arguments.session();
-  Parameters parameters = Parameters::parse(std::move(arguments), loc, {}, {"file", "layer", "origin", "scale", "name"});
+  const Parameters parameters = Parameters::parse(std::move(arguments), loc, {}, {"file", "layer", "origin", "scale", "name"});
 
   std::string rawFilename;
   std::string filename;
@@ -166,9 +167,9 @@ Value builtin_dxf_cross(Arguments arguments, const Location& loc)
     }
   }
   std::string layername = parameters.get("layer", "");
-  double scale = parameters.get("scale", 1);
+  const double scale = parameters.get("scale", 1);
 
-  fs::path filepath(filename);
+  const fs::path filepath(filename);
   uintmax_t filesize = -1;
   int64_t lastwritetime = -1;
   if (fs::exists(filepath)) {
@@ -181,7 +182,7 @@ Value builtin_dxf_cross(Arguments arguments, const Location& loc)
     return Value::undefined.clone();
   }
 
-  std::string key = STR(filename, "|", layername, "|", xorigin, "|", yorigin,
+  const std::string key = STR(filename, "|", layername, "|", xorigin, "|", yorigin,
                         "|", scale, "|", lastwritetime,
                         "|", filesize);
 
@@ -207,18 +208,18 @@ Value builtin_dxf_cross(Arguments arguments, const Location& loc)
     coords[j++][1] = dxf.points[dxf.paths[i].indices[1]][1];
 
     if (j == 4) {
-      double x1 = coords[0][0], y1 = coords[0][1];
-      double x2 = coords[1][0], y2 = coords[1][1];
-      double x3 = coords[2][0], y3 = coords[2][1];
-      double x4 = coords[3][0], y4 = coords[3][1];
-      double dem = (y4 - y3) * (x2 - x1) - (x4 - x3) * (y2 - y1);
+      const double x1 = coords[0][0], y1 = coords[0][1];
+      const double x2 = coords[1][0], y2 = coords[1][1];
+      const double x3 = coords[2][0], y3 = coords[2][1];
+      const double x4 = coords[3][0], y4 = coords[3][1];
+      const double dem = (y4 - y3) * (x2 - x1) - (x4 - x3) * (y2 - y1);
       if (dem == 0) break;
-      double ua = ((x4 - x3) * (y1 - y3) - (y4 - y3) * (x1 - x3)) / dem;
+      const double ua = ((x4 - x3) * (y1 - y3) - (y4 - y3) * (x1 - x3)) / dem;
       // double ub = ((x2 - x1)*(y1 - y3) - (y2 - y1)*(x1 - x3)) / dem;
-      double x = x1 + ua * (x2 - x1);
-      double y = y1 + ua * (y2 - y1);
+      const double x = x1 + ua * (x2 - x1);
+      const double y = y1 + ua * (y2 - y1);
 
-      std::vector<double> value = {x, y};
+      const std::vector<double> value = {x, y};
       dxf_cross_cache.emplace(key, value);
       VectorType ret(session);
       ret.reserve(2);

--- a/src/io/dxfdim.h
+++ b/src/io/dxfdim.h
@@ -1,7 +1,7 @@
 #pragma once
 
-#include <unordered_map>
 #include <string>
+#include <unordered_map>
 #include <vector>
 
 extern std::unordered_map<std::string, double> dxf_dim_cache;

--- a/src/io/export.cc
+++ b/src/io/export.cc
@@ -25,33 +25,38 @@
  */
 
 #include "io/export.h"
-#include "geometry/linalg.h"
-#include "glview/ColorMap.h"
-#include "core/ColorUtil.h"
-#include "export_enums.h"
-#include "geometry/PolySet.h"
-#include "utils/printutils.h"
-#include "geometry/Geometry.h"
-#include "glview/RenderSettings.h"
 
-#include <unordered_map>
 #include <algorithm>
-#include <functional>
 #include <cassert>
-#include <map>
-#include <cstdint>
-#include <memory>
+#include <chrono>
 #include <cstddef>
-#include <fstream>
-#include <string>
-#include <vector>
+#include <cstdint>
+#include <ctime>
 #include <filesystem>
+#include <fstream>
+#include <functional>
+#include <iomanip>
 #include <iostream>
+#include <map>
+#include <memory>
+#include <string>
+#include <unordered_map>
+#include <vector>
 
 #ifdef _WIN32
 #include <io.h>
 #include <fcntl.h>
 #endif
+
+#include "geometry/Geometry.h"
+#include "geometry/GeometryUtils.h"
+#include "geometry/linalg.h"
+#include "geometry/PolySet.h"
+#include "glview/Camera.h"
+#include "glview/ColorMap.h"
+#include "glview/RenderSettings.h"
+#include "utils/printutils.h"
+
 
 #define QUOTE(x__) # x__
 #define QUOTED(x__) QUOTE(x__)
@@ -204,7 +209,7 @@ ExportInfo createExportInfo(const FileFormat& format, const FileFormatInfo& info
   return exportInfo;
 }
 
-void exportFile(const std::shared_ptr<const Geometry>& root_geom, std::ostream& output, const ExportInfo& exportInfo)
+static void exportFile(const std::shared_ptr<const Geometry>& root_geom, std::ostream& output, const ExportInfo& exportInfo)
 {
   switch (exportInfo.format) {
   case FileFormat::ASCII_STL:

--- a/src/io/export.h
+++ b/src/io/export.h
@@ -1,25 +1,24 @@
 #pragma once
 
-#include <unordered_map>
 #include <filesystem>
+#include <iostream>
 #include <iterator>
 #include <map>
-#include <iostream>
-#include <array>
 #include <memory>
 #include <string>
+#include <unordered_map>
 #include <vector>
 
 #include <boost/range/algorithm.hpp>
 #include <boost/range/adaptor/map.hpp>
 
 #include "core/Settings.h"
-#include "geometry/Geometry.h"
 #include "core/Tree.h"
+#include "core/SourceFile.h"
+#include "geometry/Geometry.h"
+#include "geometry/linalg.h"
 #include "glview/Camera.h"
 #include "glview/ColorMap.h"
-#include "geometry/linalg.h"
-
 #include "io/export_enums.h"
 
 using SPDF = Settings::SettingsExportPdf;

--- a/src/io/export_3mf_v1.cc
+++ b/src/io/export_3mf_v1.cc
@@ -24,22 +24,22 @@
  *
  */
 
-#include "export_enums.h"
-#include "geometry/Geometry.h"
-#include "geometry/linalg.h"
 #include "io/export.h"
-
+ 
+#include <algorithm>
 #include <cassert>
-#include <ostream>
 #include <cstdint>
 #include <memory>
+#include <ostream>
 #include <string>
-#include <algorithm>
+
 #include <Common/Platform/NMR_WinTypes.h>
 #include <Model/COM/NMR_DLLInterfaces.h>
 
 #include "core/ColorUtil.h"
-#include "geometry/GeometryUtils.h"
+#include "export_enums.h"
+#include "geometry/Geometry.h"
+#include "geometry/linalg.h"
 #include "geometry/PolySet.h"
 #include "geometry/PolySetUtils.h"
 #include "utils/printutils.h"
@@ -49,7 +49,6 @@
 #endif
 
 #ifdef ENABLE_CGAL
-#include "geometry/cgal/cgal.h"
 #include "geometry/cgal/cgalutils.h"
 #include "geometry/cgal/CGAL_Nef_polyhedron.h"
 #endif

--- a/src/io/export_dxf.cc
+++ b/src/io/export_dxf.cc
@@ -23,12 +23,14 @@
  *  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
  *
  */
+#include "io/export.h"
 
 #include <cassert>
+#include <clocale>
 #include <limits>
-#include <ostream>
 #include <memory>
-#include "io/export.h"
+#include <ostream>
+
 #include "geometry/Geometry.h"
 #include "geometry/linalg.h"
 #include "geometry/Polygon2d.h"
@@ -38,7 +40,7 @@
     Saves the current Polygon2d as DXF to the given absolute filename.
  */
 
-void export_dxf_header(std::ostream& output, double xMin, double yMin, double xMax, double yMax) {
+static void export_dxf_header(std::ostream& output, double xMin, double yMin, double xMax, double yMax) {
 
   // https://dxfwrite.readthedocs.io/en/latest/headervars.html
   // http://paulbourke.net/dataformats/dxf/min3d.html
@@ -159,7 +161,7 @@ void export_dxf_header(std::ostream& output, double xMin, double yMin, double xM
 
 }
 
-void export_dxf(const Polygon2d& poly, std::ostream& output)
+static void export_dxf(const Polygon2d& poly, std::ostream& output)
 {
   setlocale(LC_NUMERIC, "C"); // Ensure radix is . (not ,) in output
 

--- a/src/io/export_nef.cc
+++ b/src/io/export_nef.cc
@@ -25,16 +25,16 @@
  */
 
 #include "io/export.h"
-#include "utils/printutils.h"
+
+#include <memory>
+#include <ostream>
+
 #include "geometry/Geometry.h"
+#include "utils/printutils.h"
 
 #ifdef ENABLE_CGAL
-#include "geometry/cgal/CGAL_Nef_polyhedron.h"
 #include "geometry/cgal/cgal.h"
 #include "geometry/cgal/cgalutils.h"
-#include <ostream>
-#include <memory>
-#include <CGAL/IO/Nef_polyhedron_iostream_3.h> // for dumping .nef3
 
 void export_nefdbg(const std::shared_ptr<const Geometry>& geom, std::ostream& output)
 {

--- a/src/io/export_obj.cc
+++ b/src/io/export_obj.cc
@@ -25,9 +25,10 @@
  *
  */
 
+#include "io/export.h"
+ 
 #include <ostream>
 #include <memory>
-#include "io/export.h"
 
 #include "geometry/Geometry.h"
 #include "geometry/PolySetUtils.h"

--- a/src/io/export_off.cc
+++ b/src/io/export_off.cc
@@ -26,19 +26,18 @@
  */
 
 #include "io/export.h"
-#include "geometry/Geometry.h"
-#include "geometry/linalg.h"
-#include "Feature.h"
-#include "geometry/Reindexer.h"
-#include "geometry/PolySet.h"
-#include "geometry/PolySetUtils.h"
 
 #include <ostream>
 #include <memory>
 #include <cstddef>
 #include <cstdint>
 
-uint8_t clamp_color_channel(float value)
+#include "Feature.h"
+#include "geometry/Geometry.h"
+#include "geometry/PolySet.h"
+#include "geometry/PolySetUtils.h"
+
+static uint8_t clamp_color_channel(float value)
 {
   if (value < 0) return 0;
   if (value > 1) return 255;
@@ -52,7 +51,7 @@ void export_off(const std::shared_ptr<const Geometry>& geom, std::ostream& outpu
     ps = createSortedPolySet(*ps);
   }
   const auto& v = ps->vertices;
-  size_t numverts = v.size();
+  const size_t numverts = v.size();
 
 
   output << "OFF " << numverts << " " << ps->indices.size() << " 0\n";
@@ -63,7 +62,7 @@ void export_off(const std::shared_ptr<const Geometry>& geom, std::ostream& outpu
   auto has_color = !ps->color_indices.empty();
   
   for (size_t i = 0; i < ps->indices.size(); ++i) {
-    size_t nverts = ps->indices[i].size();
+    const size_t nverts = ps->indices[i].size();
     output << nverts;
     for (size_t n = 0; n < nverts; ++n) output << " " << ps->indices[i][n];
     if (has_color) {

--- a/src/io/export_pdf.cc
+++ b/src/io/export_pdf.cc
@@ -1,16 +1,20 @@
 #include "io/export.h"
-#include "geometry/Geometry.h"
-#include "geometry/linalg.h"
-#include "geometry/Polygon2d.h"
-#include "geometry/PolySet.h"
-#include "utils/printutils.h"
-#include "utils/version_helper.h"
 
 #include <cassert>
 #include <ostream>
 #include <memory>
 #include <string>
 #include <cmath>
+
+#include <Eigen/Core>
+
+#include "geometry/Geometry.h"
+#include "geometry/linalg.h"
+#include "geometry/Polygon2d.h"
+#include "geometry/PolySet.h"
+#include "io/export_enums.h"
+#include "utils/printutils.h"
+#include "utils/version_helper.h"
 
 #ifdef ENABLE_CAIRO
 
@@ -21,7 +25,7 @@ constexpr inline auto FONT = "Liberation Sans";
 constexpr double MARGIN = 30.0;
 constexpr double PTS_IN_MM = 2.834645656693;
 
-const std::string get_cairo_version() {
+std::string get_cairo_version() {
   return OpenSCAD::get_version(CAIRO_VERSION_STRING, cairo_version_string());
 }
 
@@ -62,16 +66,16 @@ double points_to_mm(double pts)
 void draw_grid(cairo_t *cr, double left, double right, double bottom, double top, double gridSize )
 {
   if (gridSize<1.) gridSize=2.;
-  double darkerLine=0.36;
-  double lightLine=0.24;
-  int major = (gridSize>10.? gridSize: int(10./gridSize));
+  const double darkerLine=0.36;
+  const double lightLine=0.24;
+  const int major = (gridSize>10.? gridSize: int(10./gridSize));
 
   double pts=0.;  // for iteration across page
   
   // bounds are margins in points.
   // compute Xrange in units of gridSize
-  int Xstart=ceil(points_to_mm(left)/gridSize);
-  int Xstop=floor(points_to_mm(right)/gridSize);
+  const int Xstart=ceil(points_to_mm(left)/gridSize);
+  const int Xstop=floor(points_to_mm(right)/gridSize);
   // draw Horizontal lines
    for (int i = Xstart; i < Xstop+1; i++) {
       if (i%major)  { 
@@ -88,8 +92,8 @@ void draw_grid(cairo_t *cr, double left, double right, double bottom, double top
       cairo_stroke(cr);
   };
   // compute Yrange in units of gridSize
-  int Ystart=ceil(points_to_mm(top)/gridSize);
-  int Ystop=floor(points_to_mm(bottom)/gridSize);
+  const int Ystart=ceil(points_to_mm(top)/gridSize);
+  const int Ystop=floor(points_to_mm(bottom)/gridSize);
   // draw vertical lines
    for (int i = Ystart; i < Ystop+1; i++) {
          if (i%major)  { 
@@ -109,50 +113,50 @@ void draw_grid(cairo_t *cr, double left, double right, double bottom, double top
 
 // New draw_axes (renamed from axis since it draws both).  
 void draw_axes(cairo_t *cr, double left, double right, double bottom, double top){
-  double darkerLine=0.36;
-  double offset = mm_to_points(5.);
+  const double darkerLine=0.36;
+  const double offset = mm_to_points(5.);
   double pts=0.;  // for iteration across page
   
-       	cairo_set_line_width(cr, darkerLine);
+  cairo_set_line_width(cr, darkerLine);
 	cairo_set_source_rgba(cr, 0., 0., 0., 0.6);
   
   // Axes proper
   // Left axis
-     cairo_move_to(cr, left, top);
-     cairo_line_to(cr, left, bottom);
-     cairo_stroke(cr);
+  cairo_move_to(cr, left, top);
+  cairo_line_to(cr, left, bottom);
+  cairo_stroke(cr);
   // Bottom axis
-     cairo_move_to(cr, left, bottom);
-     cairo_line_to(cr, right, bottom);
-     cairo_stroke(cr);
+  cairo_move_to(cr, left, bottom);
+  cairo_line_to(cr, right, bottom);
+  cairo_stroke(cr);
   
   // tics and labels
   // bounds are margins in points.
-  	// compute Xrange in 10mm
-  int Xstart=ceil(points_to_mm(left)/10.);
-  int Xstop=floor(points_to_mm(right)/10.);
-   for (int i = Xstart; i < Xstop+1; i++) {
-      pts=mm_to_points(i*10.);
-      cairo_move_to(cr, pts, bottom);
-      cairo_line_to(cr, pts, bottom + offset);
-      cairo_stroke(cr);
-      if (i % 2 == 0) {
-            std::string num = std::to_string(i * 10);
-            draw_text(num.c_str(), cr, pts+1, bottom+offset-2, 6.);
-      }
+  // compute Xrange in 10mm
+  const int Xstart=ceil(points_to_mm(left)/10.);
+  const int Xstop=floor(points_to_mm(right)/10.);
+  for (int i = Xstart; i < Xstop+1; i++) {
+    pts=mm_to_points(i*10.);
+    cairo_move_to(cr, pts, bottom);
+    cairo_line_to(cr, pts, bottom + offset);
+    cairo_stroke(cr);
+    if (i % 2 == 0) {
+      const std::string num = std::to_string(i * 10);
+      draw_text(num.c_str(), cr, pts+1, bottom+offset-2, 6.);
+    }
   };
-  	// compute Yrange in 10mm
-  int Ystart=ceil(points_to_mm(top)/10.);
-  int Ystop=floor(points_to_mm(bottom)/10.);
-   for (int i = Ystart; i < Ystop+1; i++) {
-      pts=mm_to_points(i*10.);
-      cairo_move_to(cr, left, pts);
-      cairo_line_to(cr, left-offset, pts);
-      cairo_stroke(cr);
-      if (i % 2 == 0) {
-            std::string num = std::to_string(-i * 10);
-            draw_text(num.c_str(), cr, left-offset, pts - 3, 6.);
-      }
+  // compute Yrange in 10mm
+  const int Ystart=ceil(points_to_mm(top)/10.);
+  const int Ystop=floor(points_to_mm(bottom)/10.);
+  for (int i = Ystart; i < Ystop+1; i++) {
+    pts=mm_to_points(i*10.);
+    cairo_move_to(cr, left, pts);
+    cairo_line_to(cr, left-offset, pts);
+    cairo_stroke(cr);
+    if (i % 2 == 0) {
+      const std::string num = std::to_string(-i * 10);
+      draw_text(num.c_str(), cr, left-offset, pts - 3, 6.);
+    }
   };
 }  
 
@@ -195,7 +199,7 @@ void draw_geom(const std::shared_ptr<const Geometry>& geom, cairo_t *cr){
 
 cairo_status_t export_pdf_write(void *closure, const unsigned char *data, unsigned int length)
 {
-  std::ostream *stream = static_cast<std::ostream *>(closure);
+  auto *stream = static_cast<std::ostream *>(closure);
   stream->write(reinterpret_cast<const char *>(data), length);
   return !(*stream) ? CAIRO_STATUS_WRITE_ERROR : CAIRO_STATUS_SUCCESS;
 }
@@ -215,7 +219,7 @@ void export_pdf(const std::shared_ptr<const Geometry>& geom, std::ostream& outpu
 {
   // Extract the options.  This will change when options becomes a variant.
   const ExportPdfOptions *options;
-  ExportPdfOptions defaultPdfOptions;
+  const ExportPdfOptions defaultPdfOptions;
   // could use short-circuit short-form, but will need to grow.
   if (exportInfo.optionsPdf) {
     options = exportInfo.optionsPdf.get();
@@ -227,15 +231,15 @@ void export_pdf(const std::shared_ptr<const Geometry>& geom, std::ostream& outpu
   // Fit geometry to page
   // Get dims in mm.
   BoundingBox bbox = geom->getBoundingBox();
-  int minx = (int)floor(bbox.min().x());
-  int maxy = (int)floor(bbox.max().y());
-  int maxx = (int)ceil(bbox.max().x());
-  int miny = (int)ceil(bbox.min().y());
+  const int minx = (int)floor(bbox.min().x());
+  const int maxy = (int)floor(bbox.max().y());
+  const int maxx = (int)ceil(bbox.max().x());
+  const int miny = (int)ceil(bbox.min().y());
   // compute page attributes in points
-  int spanX = mm_to_points(maxx-minx);
-  int spanY = mm_to_points(maxy-miny);
-  int centerX = mm_to_points(minx)+spanX/2;
-  int centerY = mm_to_points(miny)+spanY/2;
+  const int spanX = mm_to_points(maxx-minx);
+  const int spanY = mm_to_points(maxy-miny);
+  const int centerX = mm_to_points(minx)+spanX/2;
+  const int centerY = mm_to_points(miny)+spanY/2;
   
   // Set orientation and paper size
   if ((options->orientation==ExportPdfPaperOrientation::AUTO && spanX>spanY)||(options->orientation==ExportPdfPaperOrientation::LANDSCAPE)) {
@@ -247,7 +251,7 @@ void export_pdf(const std::shared_ptr<const Geometry>& geom, std::ostream& outpu
   }; 
   
   // Does it fit? (in points)	
-  bool inpaper = (spanX<=pdfX-MARGIN)&&(spanY<=pdfY-MARGIN);
+  const bool inpaper = (spanX<=pdfX-MARGIN)&&(spanY<=pdfY-MARGIN);
   if (!inpaper) {
     LOG(message_group::Export_Warning, "Geometry is too large to fit into selected size.");
   }
@@ -255,13 +259,13 @@ void export_pdf(const std::shared_ptr<const Geometry>& geom, std::ostream& outpu
   //  Center on page.  Still in points.
   // Note Cairo inverts the Y axis, with zero at the top, positive going down.
   // Compute translation and auxiliary numbers in lieu of transform matrices.
-  double tcX=pdfX/2-centerX;
-  double tcY=(pdfY/2+centerY); // Note Geometry Y will still need to be inverted.
+  const double tcX=pdfX/2-centerX;
+  const double tcY=(pdfY/2+centerY); // Note Geometry Y will still need to be inverted.
   // Shifted exact margins
-  double Mlx=centerX-pdfX/2+MARGIN;  // Left margin, X axis
-  double Mrx=centerX+pdfX/2-MARGIN;  // Right margin, X axis
-  double Mty=-(centerY-pdfY/2+MARGIN);  // INVERTED Top margin, Y axis
-  double Mby=-(centerY+pdfY/2-MARGIN);  // INVERTED Bottom margin, Y axis
+  const double Mlx=centerX-pdfX/2+MARGIN;  // Left margin, X axis
+  const double Mrx=centerX+pdfX/2-MARGIN;  // Right margin, X axis
+  const double Mty=-(centerY-pdfY/2+MARGIN);  // INVERTED Top margin, Y axis
+  const double Mby=-(centerY+pdfY/2-MARGIN);  // INVERTED Bottom margin, Y axis
   
   // Initialize Cairo Surface and PDF
   cairo_surface_t *surface = cairo_pdf_surface_create_for_stream(export_pdf_write, &output, pdfX, pdfY);
@@ -292,7 +296,7 @@ void export_pdf(const std::shared_ptr<const Geometry>& geom, std::ostream& outpu
   cairo_stroke(cr);
     
     // Set Annotations
-      std::string about = "Scale is to calibrate actual printed dimension. Check both X and Y. Measure between tick 0 and last tick";
+    const std::string about = "Scale is to calibrate actual printed dimension. Check both X and Y. Measure between tick 0 and last tick";
     cairo_set_source_rgba(cr, 0., 0., 0., 0.48);
     // Design Filename
     if (options->showDesignFilename) draw_text(exportInfo.sourceFilePath.c_str(), cr, Mlx, Mby, 10.);

--- a/src/io/export_pov.cc
+++ b/src/io/export_pov.cc
@@ -97,14 +97,14 @@ void export_pov(const std::shared_ptr<const Geometry>& geom, std::ostream& outpu
   auto & max_y = bbox.max().y();
   auto & max_z = bbox.max().z();
 
-  double dx = max_x - min_x;
-  double dy = max_y - min_y;
-  double dz = max_z - min_z;
+  const double dx = max_x - min_x;
+  const double dy = max_y - min_y;
+  const double dz = max_z - min_z;
 
   constexpr double move_away_factor = 2.;
-  std::vector<double> lx { min_x - dx * move_away_factor, bbox.center().x(), max_x + dx * move_away_factor };
-  std::vector<double> ly { min_y - dy * move_away_factor, bbox.center().y(), max_y + dy * move_away_factor };
-  std::vector<double> lz { min_z - dz * move_away_factor, bbox.center().z(), max_z + dz * move_away_factor };
+  const std::vector<double> lx { min_x - dx * move_away_factor, bbox.center().x(), max_x + dx * move_away_factor };
+  const std::vector<double> ly { min_y - dy * move_away_factor, bbox.center().y(), max_y + dy * move_away_factor };
+  const std::vector<double> lz { min_z - dz * move_away_factor, bbox.center().z(), max_z + dz * move_away_factor };
 
   constexpr float brightness = 0.2;  // 1.0 is way too bright
 

--- a/src/io/export_svg.cc
+++ b/src/io/export_svg.cc
@@ -23,11 +23,14 @@
  *  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
  *
  */
+#include "io/export.h"
 
 #include <cassert>
-#include <ostream>
+#include <clocale>
+#include <cmath>
 #include <memory>
-#include "io/export.h"
+#include <ostream>
+
 #include "geometry/Geometry.h"
 #include "geometry/linalg.h"
 #include "geometry/Polygon2d.h"
@@ -76,12 +79,12 @@ void export_svg(const std::shared_ptr<const Geometry>& geom, std::ostream& outpu
   setlocale(LC_NUMERIC, "C"); // Ensure radix is . (not ,) in output
 
   BoundingBox bbox = geom->getBoundingBox();
-  int minx = (int)floor(bbox.min().x());
-  int miny = (int)floor(-bbox.max().y());
-  int maxx = (int)ceil(bbox.max().x());
-  int maxy = (int)ceil(-bbox.min().y());
-  int width = maxx - minx;
-  int height = maxy - miny;
+  const int minx = (int)floor(bbox.min().x());
+  const int miny = (int)floor(-bbox.max().y());
+  const int maxx = (int)ceil(bbox.max().x());
+  const int maxy = (int)ceil(-bbox.min().y());
+  const int width = maxx - minx;
+  const int height = maxy - miny;
 
   output
     << "<?xml version=\"1.0\" standalone=\"no\"?>\n"

--- a/src/io/export_wrl.cc
+++ b/src/io/export_wrl.cc
@@ -25,13 +25,13 @@
 
 #include "io/export.h"
 
-#include "geometry/Geometry.h"
-#include "geometry/PolySet.h"
-#include "geometry/PolySetUtils.h"
-
 #include <ostream>
 #include <memory>
 #include <cstddef>
+
+#include "geometry/Geometry.h"
+#include "geometry/PolySet.h"
+#include "geometry/PolySetUtils.h"
 
 void export_wrl(const std::shared_ptr<const Geometry>& geom, std::ostream& output)
 {

--- a/src/io/fileutils.cc
+++ b/src/io/fileutils.cc
@@ -1,9 +1,11 @@
 #include "io/fileutils.h"
-#include "utils/printutils.h"
 
+#include <chrono>
 #include <cstdint>
 #include <filesystem>
 #include <string>
+
+#include "utils/printutils.h"
 
 namespace fs = std::filesystem;
 

--- a/src/io/imageutils-lodepng.cc
+++ b/src/io/imageutils-lodepng.cc
@@ -1,9 +1,9 @@
 #include "io/imageutils.h"
-#include "lodepng/lodepng.h"
+
 #include <iostream>
-#include <cstdio>
-#include <cstdlib>
 #include <vector>
+
+#include "lodepng/lodepng.h"
 
 bool write_png(std::ostream& output, unsigned char *pixels, int width, int height)
 {
@@ -13,7 +13,7 @@ bool write_png(std::ostream& output, unsigned char *pixels, int width, int heigh
   // some png renderers have different interpretations of alpha, so don't use it
   state.info_png.color.colortype = LCT_RGB;
   state.info_png.color.bitdepth = 8;
-  unsigned err = lodepng::encode(dataout, pixels, width, height, state);
+  const auto err = lodepng::encode(dataout, pixels, width, height, state);
   if (err) return false;
   output.write(reinterpret_cast<const char *>(&dataout[0]), dataout.size());
   if (output.bad() ) std::cerr << "Error writing to ostream\n";

--- a/src/io/imageutils-macosx.cc
+++ b/src/io/imageutils-macosx.cc
@@ -1,19 +1,21 @@
-#include <ApplicationServices/ApplicationServices.h>
-#include <iostream>
 #include "io/imageutils.h"
+
+#include <iostream>
 #include <cassert>
 #include <cstddef>
 
-CGDataConsumerCallbacks dc_callbacks;
+#include <ApplicationServices/ApplicationServices.h>
 
-size_t write_bytes_to_ostream(void *info, const void *buffer, size_t count)
+static CGDataConsumerCallbacks dc_callbacks;
+
+static size_t write_bytes_to_ostream(void *info, const void *buffer, size_t count)
 {
   assert(info && buffer);
-  std::ostream *output = (std::ostream *)info;
-  size_t startpos = output->tellp();
+  auto *output = (std::ostream *)info;
+  const size_t startpos = output->tellp();
   size_t endpos = startpos;
   try {
-    output->write( (const char *)buffer, count);
+    output->write((const char *)buffer, count);
     endpos = output->tellp();
   } catch (const std::ios_base::failure& e) {
     std::cerr << "Error writing to ostream:" << e.what() << "\n";
@@ -21,7 +23,7 @@ size_t write_bytes_to_ostream(void *info, const void *buffer, size_t count)
   return (endpos - startpos);
 }
 
-CGDataConsumerRef CGDataConsumerCreateWithOstream(std::ostream& output)
+static CGDataConsumerRef CGDataConsumerCreateWithOstream(std::ostream& output)
 {
   dc_callbacks.putBytes = write_bytes_to_ostream;
   dc_callbacks.releaseConsumer = nullptr; // ostream closed by caller of write_png
@@ -31,11 +33,11 @@ CGDataConsumerRef CGDataConsumerCreateWithOstream(std::ostream& output)
 
 bool write_png(std::ostream& output, unsigned char *pixels, int width, int height)
 {
-  size_t rowBytes = static_cast<size_t>(width) * 4;
+  const size_t rowBytes = static_cast<size_t>(width) * 4;
 //  CGColorSpaceRef colorSpace = CGColorSpaceCreateWithName(kCGColorSpaceGenericRGB);
   CGColorSpaceRef colorSpace = CGColorSpaceCreateDeviceRGB();
-  CGBitmapInfo bitmapInfo = kCGImageAlphaNoneSkipLast | kCGBitmapByteOrder32Big; // BGRA
-  int bitsPerComponent = 8;
+  const CGBitmapInfo bitmapInfo = kCGImageAlphaNoneSkipLast | kCGBitmapByteOrder32Big; // BGRA
+  const int bitsPerComponent = 8;
   CGContextRef contextRef = CGBitmapContextCreate(pixels, width, height,
                                                   bitsPerComponent, rowBytes,
                                                   colorSpace, bitmapInfo);
@@ -66,7 +68,7 @@ bool write_png(std::ostream& output, unsigned char *pixels, int width, int heigh
      CGDataConsumerRef dataconsumer = CGDataConsumerCreateWithURL(fileURL);
    */
 
-  CFIndex fileImageIndex = 1;
+  const CFIndex fileImageIndex = 1;
   CFMutableDictionaryRef fileDict = nullptr;
   CFStringRef fileUTType = kUTTypePNG;
   // Create an image destination opaque reference for authoring an image file
@@ -83,7 +85,7 @@ bool write_png(std::ostream& output, unsigned char *pixels, int width, int heigh
     return false;
   }
 
-  CFIndex capacity = 1;
+  const CFIndex capacity = 1;
   CFMutableDictionaryRef imageProps =
     CFDictionaryCreateMutable(kCFAllocatorDefault,
                               capacity,

--- a/src/io/imageutils.cc
+++ b/src/io/imageutils.cc
@@ -1,4 +1,5 @@
 #include "io/imageutils.h"
+
 #include <iostream>
 #include <cassert>
 #include <cstring>

--- a/src/io/import.h
+++ b/src/io/import.h
@@ -2,6 +2,7 @@
 
 #include <memory>
 #include <string>
+
 #include <boost/optional.hpp>
 
 #include "core/AST.h"

--- a/src/io/import_3mf_dummy.cc
+++ b/src/io/import_3mf_dummy.cc
@@ -30,8 +30,9 @@
 #include "core/AST.h"
 #include "utils/printutils.h"
 #include "geometry/PolySet.h"
+#include "io/lib3mf_utils.h"
 
-const std::string get_lib3mf_version() {
+std::string get_lib3mf_version() {
   return "(not enabled)";
 }
 

--- a/src/io/import_3mf_v1.cc
+++ b/src/io/import_3mf_v1.cc
@@ -44,6 +44,7 @@
 #include "utils/version_helper.h"
 #include "core/AST.h"
 #include "glview/RenderSettings.h"
+#include "io/lib3mf_utils.h"
 
 #ifdef ENABLE_CGAL
 #include "geometry/cgal/cgalutils.h"
@@ -55,12 +56,7 @@
 #undef BOOL
 using namespace NMR;
 
-/*
- * Provided here for reference in LibraryInfo.cc which can't include
- * both Qt and lib3mf headers due to some conflicting definitions of
- * windows types when compiling with MinGW.
- */
-static std::string get_lib3mf_version() {
+std::string get_lib3mf_version() {
   DWORD major, minor, micro;
   NMR::lib3mf_getinterfaceversion(&major, &minor, &micro);
 

--- a/src/io/import_3mf_v1.cc
+++ b/src/io/import_3mf_v1.cc
@@ -171,7 +171,7 @@ std::string collect_mesh_objects(MeshObjectList& object_list, PLib3MFModelObject
   if (lib3mf_object_gettype(object, &objecttype) != LIB3MF_OK) {
     return "Could not read object type";
   }
-  const const char number[4096] = {0, };
+  const char number[4096] = {0, };
   ULONG numberlen;
   if (lib3mf_object_getpartnumberutf8(object, &number[0], sizeof(number), &numberlen) != LIB3MF_OK) {
     return "Could not read part number of object";

--- a/src/io/import_3mf_v1.cc
+++ b/src/io/import_3mf_v1.cc
@@ -171,18 +171,18 @@ std::string collect_mesh_objects(MeshObjectList& object_list, PLib3MFModelObject
   if (lib3mf_object_gettype(object, &objecttype) != LIB3MF_OK) {
     return "Could not read object type";
   }
-  const char number[4096] = {0, };
+  char number[4096] = {0, };
   ULONG numberlen;
   if (lib3mf_object_getpartnumberutf8(object, &number[0], sizeof(number), &numberlen) != LIB3MF_OK) {
     return "Could not read part number of object";
   }
-  const char name[4096] = {0, };
+  char name[4096] = {0, };
   ULONG namelen;
   if (lib3mf_object_getnameutf8(object, &name[0], sizeof(name), &namelen) != LIB3MF_OK) {
     return "Could not read name of object";
   }
-  const BOOL hasuuid = false;
-  const char uuid[40] = {0, };
+  BOOL hasuuid = false;
+  char uuid[40] = {0, };
   if (lib3mf_object_getuuidutf8(object, &hasuuid, &uuid[0]) != LIB3MF_OK) {
     return "Could not read UUID of object";
   }

--- a/src/io/import_3mf_v2.cc
+++ b/src/io/import_3mf_v2.cc
@@ -44,6 +44,7 @@
 #include "glview/RenderSettings.h"
 #include "utils/printutils.h"
 #include "utils/version_helper.h"
+#include "io/lib3mf_utils.h"
 
 template<> struct std::hash<Color4f> {
     std::size_t operator()(Color4f const& c) const noexcept {
@@ -303,12 +304,7 @@ std::string read_metadata(const Lib3MF::PModel& model)
 
 } // namespace
 
-/*
- * Provided here for reference in LibraryInfo.cc which can't include
- * both Qt and lib3mf headers due to some conflicting definitions of
- * windows types when compiling with MinGW.
- */
-const std::string get_lib3mf_version() {
+std::string get_lib3mf_version() {
   Lib3MF_uint32 interfaceVersionMajor, interfaceVersionMinor, interfaceVersionMicro;
   Lib3MF::PWrapper wrapper;
 

--- a/src/io/import_3mf_v2.cc
+++ b/src/io/import_3mf_v2.cc
@@ -23,25 +23,27 @@
  *  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
  *
  */
+#include "io/import.h"
 
-#include "geometry/PolySet.h"
-#include "geometry/linalg.h"
-#include "geometry/PolySetBuilder.h"
-#include "geometry/PolySetUtils.h"
-#include "geometry/Geometry.h"
-#include "utils/printutils.h"
-#include "utils/version_helper.h"
-#include "core/AST.h"
-#include "glview/RenderSettings.h"
-
-#include <string>
+#include <algorithm>
 #include <cstdint>
+#include <memory>
+#include <string>
 #include <unordered_map>
 #include <utility>
-#include <memory>
 #include <vector>
-#include <algorithm>
+
 #include <lib3mf_implicit.hpp>
+ 
+#include "core/AST.h"
+#include "geometry/Geometry.h"
+#include "geometry/linalg.h"
+#include "geometry/PolySet.h"
+#include "geometry/PolySetBuilder.h"
+#include "geometry/PolySetUtils.h"
+#include "glview/RenderSettings.h"
+#include "utils/printutils.h"
+#include "utils/version_helper.h"
 
 template<> struct std::hash<Color4f> {
     std::size_t operator()(Color4f const& c) const noexcept {
@@ -98,7 +100,7 @@ Matrix4d get_matrix(Lib3MF::sTransform &transform)
     return tm;
 }
 
-std::string collect_mesh_objects(const Lib3MF::PModel model, MeshObjectList& object_list, const Lib3MF::PObject object, const Matrix4d& m, const Location& loc, int level = 1)
+std::string collect_mesh_objects(const Lib3MF::PModel& model, MeshObjectList& object_list, const Lib3MF::PObject& object, const Matrix4d& m, const Location& loc, int level = 1)
 {
   const bool is_mesh_object = object->IsMeshObject();
   const bool is_components_object = object->IsComponentsObject();

--- a/src/io/import_json.cc
+++ b/src/io/import_json.cc
@@ -23,17 +23,19 @@
  *  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
  *
  */
+#include "io/import.h"
 
 #include <exception>
-#include <utility>
 #include <fstream>
 #include <string>
+#include <utility>
+
 #include "json/json.hpp"
 
 #include "core/AST.h"
+#include "core/EvaluationSession.h"
 #include "core/Value.h"
 #include "utils/printutils.h"
-#include "core/EvaluationSession.h"
 
 using json = nlohmann::json;
 

--- a/src/io/import_nef.cc
+++ b/src/io/import_nef.cc
@@ -4,8 +4,9 @@
 #include <ios>
 #include <memory>
 #include <string>
-#include "utils/printutils.h"
+
 #include "core/AST.h"
+#include "utils/printutils.h"
 
 #ifdef ENABLE_CGAL
 #include "geometry/cgal/cgal.h"

--- a/src/io/import_obj.cc
+++ b/src/io/import_obj.cc
@@ -1,17 +1,22 @@
 #include "io/import.h"
-#include "geometry/linalg.h"
-#include "core/AST.h"
-#include "geometry/PolySet.h"
-#include "geometry/PolySetBuilder.h"
+
+#include <cstddef>
+#include <fstream>
 #include <ios>
 #include <memory>
-#include <fstream>
 #include <string>
 #include <vector>
-#include <boost/regex.hpp>
-#include <boost/lexical_cast.hpp>
+
 #include <boost/algorithm/string.hpp>
 #include <boost/algorithm/string/split.hpp>
+#include <boost/lexical_cast.hpp>
+#include <boost/regex.hpp>
+
+#include "core/AST.h"
+#include "geometry/linalg.h"
+#include "geometry/PolySet.h"
+#include "geometry/PolySetBuilder.h"
+#include "utils/printutils.h"
 
 std::unique_ptr<PolySet> import_obj(const std::string& filename, const Location& loc) {
   PolySetBuilder builder;
@@ -23,16 +28,16 @@ std::unique_ptr<PolySet> import_obj(const std::string& filename, const Location&
         filename, loc.firstLine());
     return PolySet::createEmpty();
   }
-  boost::regex ex_comment(R"(^\s*#)");
-  boost::regex ex_v( R"(^\s*v\s+([^\s]+)\s+([^\s]+)\s+([^\s]+)\s*$)");
-  boost::regex ex_f( R"(^\s*f\s+(.*)$)");
-  boost::regex ex_vt( R"(^\s*vt)");
-  boost::regex ex_vn( R"(^\s*vn)");
-  boost::regex ex_mtllib( R"(^\s*mtllib)");
-  boost::regex ex_usemtl( R"(^\s*usemtl)");
-  boost::regex ex_o( R"(^\s*o)");
-  boost::regex ex_s( R"(^\s*s)");
-  boost::regex ex_g( R"(^\s*g)");
+  const boost::regex ex_comment(R"(^\s*#)");
+  const boost::regex ex_v( R"(^\s*v\s+([^\s]+)\s+([^\s]+)\s+([^\s]+)\s*$)");
+  const boost::regex ex_f( R"(^\s*f\s+(.*)$)");
+  const boost::regex ex_vt( R"(^\s*vt)");
+  const boost::regex ex_vn( R"(^\s*vn)");
+  const boost::regex ex_mtllib( R"(^\s*mtllib)");
+  const boost::regex ex_usemtl( R"(^\s*usemtl)");
+  const boost::regex ex_o( R"(^\s*o)");
+  const boost::regex ex_s( R"(^\s*s)");
+  const boost::regex ex_g( R"(^\s*g)");
   int lineno = 1;
   std::string line;
 
@@ -72,7 +77,7 @@ std::unique_ptr<PolySet> import_obj(const std::string& filename, const Location&
         if(wordindex.size() < 1)
           LOG(message_group::Warning, "Invalid Face index in File %1$s in Line %2$d", filename, lineno);
         else {
-          size_t ind=boost::lexical_cast<int>(wordindex[0]);
+          const size_t ind=boost::lexical_cast<int>(wordindex[0]);
           if(ind >= 1 && ind  <= vertex_map.size()) {
             builder.addVertex(vertex_map[ind-1]);
           } else {

--- a/src/io/import_off.cc
+++ b/src/io/import_off.cc
@@ -1,5 +1,6 @@
 #include "io/import.h"
 
+#include <charconv>
 #include <cstddef>
 #include <cstdint>
 #include <cstdio>

--- a/src/io/import_off.cc
+++ b/src/io/import_off.cc
@@ -1,33 +1,36 @@
 #include "io/import.h"
-#include "geometry/linalg.h"
-#include "Feature.h"
-#include "geometry/PolySet.h"
-#include "utils/printutils.h"
-#include "core/AST.h"
-#include <system_error>
-#include <map>
-#include <ios>
-#include <cstdint>
-#include <memory>
-#include <charconv>
+
 #include <cstddef>
+#include <cstdint>
+#include <cstdio>
 #include <fstream>
+#include <locale>
+#include <ios>
+#include <sstream>
+#include <map>
+#include <memory>
 #include <string>
 #include <vector>
-#include <boost/regex.hpp>
-#include <boost/lexical_cast.hpp>
+
 #include <boost/algorithm/string.hpp>
 #include <boost/algorithm/string/split.hpp>
+#include <boost/lexical_cast.hpp>
+#include <boost/regex.hpp>
+
+#include "core/AST.h"
+#include "geometry/linalg.h"
+#include "geometry/PolySet.h"
+#include "utils/printutils.h"
 
 // References:
 // http://www.geomview.org/docs/html/OFF.html
 
 std::unique_ptr<PolySet> import_off(const std::string& filename, const Location& loc)
 {
-  boost::regex ex_magic(R"(^(ST)?(C)?(N)?(4)?(n)?OFF( BINARY)? *)");
+  const boost::regex ex_magic(R"(^(ST)?(C)?(N)?(4)?(n)?OFF( BINARY)? *)");
   // XXX: are ST C N always in order?
-  boost::regex ex_cr(R"(\r$)");
-  boost::regex ex_comment(R"(\s*#.*$)");
+  const boost::regex ex_cr(R"(\r$)");
+  const boost::regex ex_comment(R"(\s*#.*$)");
   boost::smatch results;
 
   std::ifstream f(filename.c_str(), std::ios::in | std::ios::binary);
@@ -240,13 +243,13 @@ std::unique_ptr<PolySet> import_off(const std::string& filename, const Location&
 
     std::map<Color4f, int32_t> color_indices;
     try {
-      unsigned long face_size=boost::lexical_cast<unsigned long>(words[0]);
+      const auto face_size=boost::lexical_cast<unsigned long>(words[0]);
       unsigned long i;
       if (words.size() - 1 < face_size) {
         AsciiError("can't parse face: missing indices");
         return PolySet::createEmpty();
       }
-      size_t face_idx = ps->indices.size();
+      const size_t face_idx = ps->indices.size();
       ps->indices.emplace_back().reserve(face_size);
       //PRINTDB("Index[%d] [%d] = { ", face % n);
       for (i = 0; i < face_size; i++) {
@@ -262,11 +265,11 @@ std::unique_ptr<PolySet> import_off(const std::string& filename, const Location&
       if (words.size() >= face_size + 4) {
         i = face_size + 1;
         // handle optional color info (r g b [a])
-        int r=getcolor(words[i++]);
-        int g=getcolor(words[i++]);
-        int b=getcolor(words[i++]);
-        int a=i < words.size() ? getcolor(words[i++]) : 255;
-        Color4f color(r, g, b, a);
+        const int r=getcolor(words[i++]);
+        const int g=getcolor(words[i++]);
+        const int b=getcolor(words[i++]);
+        const int a=i < words.size() ? getcolor(words[i++]) : 255;
+        const Color4f color(r, g, b, a);
 
         auto iter_pair = color_indices.insert_or_assign(color, ps->colors.size());
         if (iter_pair.second) ps->colors.push_back(color); // inserted

--- a/src/io/import_stl.cc
+++ b/src/io/import_stl.cc
@@ -1,20 +1,22 @@
 #include "io/import.h"
+
+#include <array>
+#include <cstddef>
+#include <cstdint>
+#include <fstream>
+#include <ios>
+#include <memory>
+#include <string>
+
+#include <boost/algorithm/string.hpp>
+#include <boost/lexical_cast.hpp>
+#include <boost/predef.h>
+#include <boost/regex.hpp>
+
+#include "core/AST.h"
 #include "geometry/PolySet.h"
 #include "geometry/PolySetBuilder.h"
 #include "utils/printutils.h"
-#include "core/AST.h"
-
-#include <array>
-#include <ios>
-#include <cstdint>
-#include <memory>
-#include <cstddef>
-#include <fstream>
-#include <string>
-#include <boost/predef.h>
-#include <boost/regex.hpp>
-#include <boost/lexical_cast.hpp>
-#include <boost/algorithm/string.hpp>
 
 #if !defined(BOOST_ENDIAN_BIG_BYTE_AVAILABLE) && !defined(BOOST_ENDIAN_LITTLE_BYTE_AVAILABLE)
 #error Byte order undefined or unknown. Currently only BOOST_ENDIAN_BIG_BYTE and BOOST_ENDIAN_LITTLE_BYTE are supported.
@@ -81,16 +83,16 @@ std::unique_ptr<PolySet> import_stl(const std::string& filename, const Location&
   }
 
   uint32_t facenum = 0;
-  boost::regex ex_sfe(R"(^\s*solid|^\s*facet|^\s*endfacet)");
-  boost::regex ex_outer("^\\s*outer loop$");
-  boost::regex ex_loopend("^\\s*endloop$");
-  boost::regex ex_vertex("^\\s*vertex");
-  boost::regex ex_vertices(
+  const boost::regex ex_sfe(R"(^\s*solid|^\s*facet|^\s*endfacet)");
+  const boost::regex ex_outer("^\\s*outer loop$");
+  const boost::regex ex_loopend("^\\s*endloop$");
+  const boost::regex ex_vertex("^\\s*vertex");
+  const boost::regex ex_vertices(
     R"(^\s*vertex\s+([^\s]+)\s+([^\s]+)\s+([^\s]+)\s*$)");
-  boost::regex ex_endsolid("^\\s*endsolid");
+  const boost::regex ex_endsolid("^\\s*endsolid");
 
   bool binary = false;
-  std::streampos file_size = f.tellg();
+  const std::streampos file_size = f.tellg();
   f.seekg(80);
   if (f.good() && !f.eof()) {
     f.read((char *)&facenum, sizeof(uint32_t));

--- a/src/io/import_svg.cc
+++ b/src/io/import_svg.cc
@@ -24,20 +24,25 @@
  *
  */
 
+#include "io/import.h"
+ 
 #include <exception>
 #include <memory>
-#include <Eigen/Core>
-#include <Eigen/Geometry>
-
 #include <string>
 #include <vector>
-#include "io/import.h"
+
+#include <Eigen/Core>
+#include <Eigen/Geometry>
+#include <clipper2/clipper.h>
+
+#include "core/AST.h"
+#include "geometry/ClipperUtils.h"
 #include "geometry/Polygon2d.h"
-#include "utils/printutils.h"
 #include "libsvg/libsvg.h"
 #include "libsvg/svgpage.h"
-#include "geometry/ClipperUtils.h"
-#include "core/AST.h"
+#include "libsvg/shape.h"
+#include "libsvg/util.h"
+#include "utils/printutils.h"
 
 namespace {
 
@@ -154,8 +159,8 @@ std::unique_ptr<Polygon2d> import_svg(double fn, double fs, double fa,
         height_mm = to_mm(h, page->get_viewbox().height, viewbox_valid, dpi);
 
         if (viewbox_valid) {
-          double px = w.unit == libsvg::unit_t::PERCENT ? w.number / 100.0 : 1.0;
-          double py = h.unit == libsvg::unit_t::PERCENT ? h.number / 100.0 : 1.0;
+          const double px = w.unit == libsvg::unit_t::PERCENT ? w.number / 100.0 : 1.0;
+          const double py = h.unit == libsvg::unit_t::PERCENT ? h.number / 100.0 : 1.0;
           viewbox << px * page->get_viewbox().x, py *page->get_viewbox().y;
 
           scale << width_mm / page->get_viewbox().width,
@@ -189,8 +194,8 @@ std::unique_ptr<Polygon2d> import_svg(double fn, double fs, double fa,
         }
       }
     }
-    double cx = center ? bbox.center().x() : -align.x();
-    double cy = center ? bbox.center().y() : height_mm - align.y();
+    const double cx = center ? bbox.center().x() : -align.x();
+    const double cy = center ? bbox.center().y() : height_mm - align.y();
 
     std::vector<std::shared_ptr<const Polygon2d>> polygons;
     for (const auto& shape_ptr : *shapes) {
@@ -200,9 +205,9 @@ std::unique_ptr<Polygon2d> import_svg(double fn, double fs, double fa,
         for (const auto& p : s.get_path_list()) {
           Outline2d outline;
           for (const auto& v : p) {
-            double x = scale.x() * (-viewbox.x() + v.x()) - cx;
-            double y = scale.y() * (-viewbox.y() - v.y()) + cy;
-            outline.vertices.push_back(Vector2d(x, y));
+            const double x = scale.x() * (-viewbox.x() + v.x()) - cx;
+            const double y = scale.y() * (-viewbox.y() - v.y()) + cy;
+            outline.vertices.emplace_back(x, y);
             outline.positive = true;
           }
           poly->addOutline(outline);

--- a/src/io/lib3mf_utils.h
+++ b/src/io/lib3mf_utils.h
@@ -1,0 +1,5 @@
+#pragma once
+
+#include <string>
+
+std::string get_lib3mf_version();


### PR DESCRIPTION
```
[clang-analyzer-cplusplus.NewDeleteLeaks]    +1
 [misc-confusable-identifiers]    -1
      [misc-const-correctness]  -178
        [misc-include-cleaner]   -43
[misc-use-anonymous-namespace]    +7
          [modernize-use-auto]    -3
       [modernize-use-emplace]    -1
[performance-unnecessary-value-param]    -1
```