### PR TITLE
FIX issue #5749

### DIFF
--- a/src/gui/TabManager.cc
+++ b/src/gui/TabManager.cc
@@ -44,6 +44,10 @@ TabManager::TabManager(MainWindow *o, const QString& filename)
   connect(tabWidget, &QTabWidget::currentChanged, this, &TabManager::tabSwitched);
 
   createTab(filename);
+
+  // Disable the closing button for the first tabbar
+  QWidget *button = tabWidget->tabBar()->tabButton(0, QTabBar::RightSide);
+  button->setVisible(false);
 }
 
 QWidget *TabManager::getTabContent()
@@ -58,11 +62,12 @@ void TabManager::tabSwitched(int x)
 
   editor = (EditorInterface *)tabWidget->widget(x);
 
+  auto numberOfOpenTabs = tabWidget->count();
   // Hides all the closing button except the one on the currently focused editor
-  for (int idx = 0; idx < tabWidget->count(); ++idx) {
+  for (int idx = 0; idx < numberOfOpenTabs; ++idx) {
     QWidget *button = tabWidget->tabBar()->tabButton(idx, QTabBar::RightSide);
     if (button) {
-      button->setVisible(idx == x);
+      button->setVisible(idx == x && numberOfOpenTabs > 1);
     }
   }
 
@@ -391,6 +396,9 @@ void TabManager::showTabHeaderContextMenu(const QPoint& pos)
   closeAction->setData(idx);
   closeAction->setText(_("Close Tab"));
   connect(closeAction, &QAction::triggered, this, &TabManager::closeTab);
+
+  // Don't allow to close the last tab.
+  if (tabWidget->count() <= 1) closeAction->setDisabled(true);
 
   menu.addAction(copyFileNameAction);
   menu.addAction(copyFilePathAction);

--- a/src/gui/TabManager.cc
+++ b/src/gui/TabManager.cc
@@ -47,7 +47,8 @@ TabManager::TabManager(MainWindow *o, const QString& filename)
 
   // Disable the closing button for the first tabbar
   QWidget *button = tabWidget->tabBar()->tabButton(0, QTabBar::RightSide);
-  button->setVisible(false);
+  if(button)
+      button->setVisible(false);
 }
 
 QWidget *TabManager::getTabContent()

--- a/src/gui/TabManager.cc
+++ b/src/gui/TabManager.cc
@@ -46,9 +46,22 @@ TabManager::TabManager(MainWindow *o, const QString& filename)
   createTab(filename);
 
   // Disable the closing button for the first tabbar
-  QWidget *button = tabWidget->tabBar()->tabButton(0, QTabBar::RightSide);
-  if(button)
-      button->setVisible(false);
+  setTabsCloseButtonVisibility(0, false);
+}
+
+QTabBar::ButtonPosition TabManager::getClosingButtonPosition()
+{
+  auto bar = tabWidget->tabBar();
+  return (QTabBar::ButtonPosition)bar->style()->styleHint(QStyle::SH_TabBar_CloseButtonPosition, nullptr, bar);
+}
+
+void TabManager::setTabsCloseButtonVisibility(int indice, bool isVisible)
+{
+    // Depending on the system the closing button can be on the right or left side
+    // of the tab header.
+    auto button = tabWidget->tabBar()->tabButton(indice, getClosingButtonPosition());
+    if(button)
+        button->setVisible(isVisible);
 }
 
 QWidget *TabManager::getTabContent()
@@ -66,10 +79,8 @@ void TabManager::tabSwitched(int x)
   auto numberOfOpenTabs = tabWidget->count();
   // Hides all the closing button except the one on the currently focused editor
   for (int idx = 0; idx < numberOfOpenTabs; ++idx) {
-    QWidget *button = tabWidget->tabBar()->tabButton(idx, QTabBar::RightSide);
-    if (button) {
-      button->setVisible(idx == x && numberOfOpenTabs > 1);
-    }
+    bool isVisible = idx == x && numberOfOpenTabs > 1;
+    setTabsCloseButtonVisibility(idx, isVisible);
   }
 
   emit currentEditorChanged(editor);

--- a/src/gui/TabManager.h
+++ b/src/gui/TabManager.h
@@ -50,6 +50,9 @@ private:
   bool save(EditorInterface *edt, const QString& path);
   void saveError(const QIODevice& file, const std::string& msg, const QString& filepath);
   void applyAction(QObject *object, const std::function<void(int, EditorInterface *)>& func);
+  void setTabsCloseButtonVisibility(int tabIndice, bool isVisible);
+
+  QTabBar::ButtonPosition getClosingButtonPosition();
 
 private slots:
   void tabSwitched(int);


### PR DESCRIPTION
Issue #5749 is about segfault on closing the last tab open. 

The issue appears recently because of PR refactoring ux (eg: #5609)

To fix the issue it was suggested to remove the different UI possibilities to do so. 
This is what the PR is actually doing. 

Actually one path remains (but it don't lead to a crash) which goes through the general menu [File] then [Close].

This one goes through TabManager::closeCurrentTab() which, when there is only one tab and the close requested, close the whole application. 

