### PR TITLE
Refactor Preferences to extract the static part in a singleton

### DIFF
--- a/src/gui/Console.cc
+++ b/src/gui/Console.cc
@@ -127,7 +127,7 @@ void Console::update()
   }
   msgBuffer.clear();
   this->setTextCursor(appendCursor);
-  this->setMaximumBlockCount(Preferences::inst()->getValue("advanced/consoleMaxLines").toUInt());
+  this->setMaximumBlockCount(GlobalPreferences::inst()->getValue("advanced/consoleMaxLines").toUInt());
 }
 
 void Console::actionClearConsole_triggered()

--- a/src/gui/Editor.cc
+++ b/src/gui/Editor.cc
@@ -7,7 +7,7 @@
 void EditorInterface::wheelEvent(QWheelEvent *event)
 {
   QSettingsCached settings;
-  bool wheelzoom_enabled = Preferences::inst()->getValue("editor/ctrlmousewheelzoom").toBool();
+  bool wheelzoom_enabled = GlobalPreferences::inst()->getValue("editor/ctrlmousewheelzoom").toBool();
   if ((event->modifiers() == Qt::ControlModifier) && wheelzoom_enabled) {
     if (event->angleDelta().y() > 0) zoomIn();
     else if (event->angleDelta().y() < 0) zoomOut();

--- a/src/gui/InitConfigurator.cc
+++ b/src/gui/InitConfigurator.cc
@@ -55,22 +55,22 @@ void InitConfigurator::initListBox(QListWidget *listBox, const Settings::Setting
   listBox->clear();
   for (const auto& listitem : list.value()) {
     if (listitem.type == Settings::LocalAppParameterType::string) {
-      const auto item = Preferences::inst()->createListItem(Settings::LocalAppParameterType(Settings::LocalAppParameterType::string), QString::fromStdString(listitem.value));
+      const auto item = GlobalPreferences::inst()->createListItem(Settings::LocalAppParameterType(Settings::LocalAppParameterType::string), QString::fromStdString(listitem.value));
       listBox->insertItem(listBox->count(), item);
     } else if (listitem.type == Settings::LocalAppParameterType::file) {
-      const auto item = Preferences::inst()->createListItem(Settings::LocalAppParameterType(Settings::LocalAppParameterType::file));
+      const auto item = GlobalPreferences::inst()->createListItem(Settings::LocalAppParameterType(Settings::LocalAppParameterType::file));
       listBox->insertItem(listBox->count(), item);
     } else if (listitem.type == Settings::LocalAppParameterType::dir) {
-      const auto item = Preferences::inst()->createListItem(Settings::LocalAppParameterType(Settings::LocalAppParameterType::dir));
+      const auto item = GlobalPreferences::inst()->createListItem(Settings::LocalAppParameterType(Settings::LocalAppParameterType::dir));
       listBox->insertItem(listBox->count(), item);
     } else if (listitem.type == Settings::LocalAppParameterType::extension) {
-      const auto item = Preferences::inst()->createListItem(Settings::LocalAppParameterType(Settings::LocalAppParameterType::extension));
+      const auto item = GlobalPreferences::inst()->createListItem(Settings::LocalAppParameterType(Settings::LocalAppParameterType::extension));
       listBox->insertItem(listBox->count(), item);
     } else if (listitem.type == Settings::LocalAppParameterType::source) {
-      const auto item = Preferences::inst()->createListItem(Settings::LocalAppParameterType(Settings::LocalAppParameterType::source));
+      const auto item = GlobalPreferences::inst()->createListItem(Settings::LocalAppParameterType(Settings::LocalAppParameterType::source));
       listBox->insertItem(listBox->count(), item);
     } else if (listitem.type == Settings::LocalAppParameterType::sourcedir) {
-      const auto item = Preferences::inst()->createListItem(Settings::LocalAppParameterType(Settings::LocalAppParameterType::sourcedir));
+      const auto item = GlobalPreferences::inst()->createListItem(Settings::LocalAppParameterType(Settings::LocalAppParameterType::sourcedir));
       listBox->insertItem(listBox->count(), item);
     }
   }

--- a/src/gui/MainWindow.cc
+++ b/src/gui/MainWindow.cc
@@ -805,7 +805,12 @@ MainWindow::MainWindow(const QStringList& filenames) :
   updateExportActions();
 
   activeEditor->setFocus();
-  GlobalPreferences::inst()->addColorSchemes(activeEditor->colorSchemes());   // needs to be done only once, however handled
+
+  // Configure the highlighting color scheme from the active editor one.
+  // This is done only one time at creation of the first MainWindow instance
+  auto preferences = GlobalPreferences::inst();
+  if(!preferences->hasHighlightingColorScheme())
+    preferences->setHighlightingColorSchemes(activeEditor->colorSchemes());
 
   onTabManagerEditorChanged(activeEditor);
 }

--- a/src/gui/MainWindow.cc
+++ b/src/gui/MainWindow.cc
@@ -381,13 +381,13 @@ MainWindow::MainWindow(const QStringList& filenames) :
 
   connect(tabManager, &TabManager::currentEditorChanged, this, &MainWindow::onTabManagerEditorChanged);
 
-  connect(Preferences::inst(), &Preferences::consoleFontChanged, this->console, &Console::setFont);
+  connect(GlobalPreferences::inst(), &Preferences::consoleFontChanged, this->console, &Console::setFont);
 
   const QString version = QString("<b>OpenSCAD %1</b>").arg(QString::fromStdString(openscad_versionnumber));
   const QString weblink = "<a href=\"https://www.openscad.org/\">https://www.openscad.org/</a><br>";
   this->console->setFont(
-    Preferences::inst()->getValue("advanced/consoleFontFamily").toString(),
-    Preferences::inst()->getValue("advanced/consoleFontSize").toUInt()
+    GlobalPreferences::inst()->getValue("advanced/consoleFontFamily").toString(),
+    GlobalPreferences::inst()->getValue("advanced/consoleFontSize").toUInt()
     );
 
   consoleOutputRaw(version);
@@ -398,10 +398,10 @@ MainWindow::MainWindow(const QStringList& filenames) :
   connect(this->errorLogWidget, &ErrorLog::openFile, this, &MainWindow::openFileFromPath);
   connect(this->console, &Console::openFile, this, &MainWindow::openFileFromPath);
 
-  connect(Preferences::inst()->ButtonConfig, &ButtonConfigWidget::inputMappingChanged, InputDriverManager::instance(), &InputDriverManager::onInputMappingUpdated, Qt::UniqueConnection);
-  connect(Preferences::inst()->AxisConfig, &AxisConfigWidget::inputMappingChanged, InputDriverManager::instance(), &InputDriverManager::onInputMappingUpdated, Qt::UniqueConnection);
-  connect(Preferences::inst()->AxisConfig, &AxisConfigWidget::inputCalibrationChanged, InputDriverManager::instance(), &InputDriverManager::onInputCalibrationUpdated, Qt::UniqueConnection);
-  connect(Preferences::inst()->AxisConfig, &AxisConfigWidget::inputGainChanged, InputDriverManager::instance(), &InputDriverManager::onInputGainUpdated, Qt::UniqueConnection);
+  connect(GlobalPreferences::inst()->ButtonConfig, &ButtonConfigWidget::inputMappingChanged, InputDriverManager::instance(), &InputDriverManager::onInputMappingUpdated, Qt::UniqueConnection);
+  connect(GlobalPreferences::inst()->AxisConfig, &AxisConfigWidget::inputMappingChanged, InputDriverManager::instance(), &InputDriverManager::onInputMappingUpdated, Qt::UniqueConnection);
+  connect(GlobalPreferences::inst()->AxisConfig, &AxisConfigWidget::inputCalibrationChanged, InputDriverManager::instance(), &InputDriverManager::onInputCalibrationUpdated, Qt::UniqueConnection);
+  connect(GlobalPreferences::inst()->AxisConfig, &AxisConfigWidget::inputGainChanged, InputDriverManager::instance(), &InputDriverManager::onInputGainUpdated, Qt::UniqueConnection);
 
   setCorner(Qt::TopLeftCorner, Qt::LeftDockWidgetArea);
   setCorner(Qt::TopRightCorner, Qt::RightDockWidgetArea);
@@ -444,7 +444,7 @@ MainWindow::MainWindow(const QStringList& filenames) :
   waitAfterReloadTimer->setSingleShot(true);
   waitAfterReloadTimer->setInterval(autoReloadPollingPeriodMS);
   connect(waitAfterReloadTimer, &QTimer::timeout, this, &MainWindow::waitAfterReload);
-  connect(Preferences::inst(), &Preferences::ExperimentalChanged, this, &MainWindow::changeParameterWidget);
+  connect(GlobalPreferences::inst(), &Preferences::ExperimentalChanged, this, &MainWindow::changeParameterWidget);
 
   progressThrottle->start();
 
@@ -623,18 +623,18 @@ MainWindow::MainWindow(const QStringList& filenames) :
   connect(this->qglview, &QGLView::doRightClick, this, &MainWindow::rightClick);
   connect(this->qglview, &QGLView::doLeftClick, this, &MainWindow::leftClick);
 
-  connect(Preferences::inst(), &Preferences::requestRedraw, this->qglview, QOverload<>::of(&QGLView::update));
-  connect(Preferences::inst(), &Preferences::updateMouseCentricZoom, this->qglview, &QGLView::setMouseCentricZoom);
-  connect(Preferences::inst(), &Preferences::updateMouseSwapButtons, this->qglview, &QGLView::setMouseSwapButtons);
-  connect(Preferences::inst(), &Preferences::updateReorderMode, this, &MainWindow::updateReorderMode);
-  connect(Preferences::inst(), &Preferences::updateUndockMode, this, &MainWindow::updateUndockMode);
-  connect(Preferences::inst(), &Preferences::openCSGSettingsChanged, this, &MainWindow::openCSGSettingsChanged);
-  connect(Preferences::inst(), &Preferences::colorSchemeChanged, this, &MainWindow::setColorScheme);
-  connect(Preferences::inst(), &Preferences::toolbarExportChanged, this, &MainWindow::updateExportActions);
+  connect(GlobalPreferences::inst(), &Preferences::requestRedraw, this->qglview, QOverload<>::of(&QGLView::update));
+  connect(GlobalPreferences::inst(), &Preferences::updateMouseCentricZoom, this->qglview, &QGLView::setMouseCentricZoom);
+  connect(GlobalPreferences::inst(), &Preferences::updateMouseSwapButtons, this->qglview, &QGLView::setMouseSwapButtons);
+  connect(GlobalPreferences::inst(), &Preferences::updateReorderMode, this, &MainWindow::updateReorderMode);
+  connect(GlobalPreferences::inst(), &Preferences::updateUndockMode, this, &MainWindow::updateUndockMode);
+  connect(GlobalPreferences::inst(), &Preferences::openCSGSettingsChanged, this, &MainWindow::openCSGSettingsChanged);
+  connect(GlobalPreferences::inst(), &Preferences::colorSchemeChanged, this, &MainWindow::setColorScheme);
+  connect(GlobalPreferences::inst(), &Preferences::toolbarExportChanged, this, &MainWindow::updateExportActions);
 
-  Preferences::inst()->apply_win();   // not sure if to be commented, checked must not be commented(done some changes in apply())
+  GlobalPreferences::inst()->apply_win();   // not sure if to be commented, checked must not be commented(done some changes in apply())
 
-  const QString cs = Preferences::inst()->getValue("3dview/colorscheme").toString();
+  const QString cs = GlobalPreferences::inst()->getValue("3dview/colorscheme").toString();
   this->setColorScheme(cs);
 
   //find and replace panel
@@ -659,7 +659,7 @@ MainWindow::MainWindow(const QStringList& filenames) :
   addKeyboardShortCut(this->viewerToolBar->actions());
   addKeyboardShortCut(this->editortoolbar->actions());
 
-  Preferences *instance = Preferences::inst();
+  Preferences *instance = GlobalPreferences::inst();
 
   InputDriverManager::instance()->registerActions(this->menuBar()->actions(), "", "");
   InputDriverManager::instance()->registerActions(this->animateWidget->actions(), "animation", "animate");
@@ -805,6 +805,8 @@ MainWindow::MainWindow(const QStringList& filenames) :
   updateExportActions();
 
   activeEditor->setFocus();
+  GlobalPreferences::inst()->addColorSchemes(activeEditor->colorSchemes());   // needs to be done only once, however handled
+
   onTabManagerEditorChanged(activeEditor);
 }
 
@@ -997,8 +999,8 @@ void MainWindow::loadViewSettings(){
     viewPerspective();
   }
 
-  updateUndockMode(Preferences::inst()->getValue("advanced/undockableWindows").toBool());
-  updateReorderMode(Preferences::inst()->getValue("advanced/reorderWindows").toBool());
+  updateUndockMode(GlobalPreferences::inst()->getValue("advanced/undockableWindows").toBool());
+  updateReorderMode(GlobalPreferences::inst()->getValue("advanced/reorderWindows").toBool());
 }
 
 void MainWindow::loadDesignSettings()
@@ -1007,11 +1009,11 @@ void MainWindow::loadDesignSettings()
   if (settings.value("design/autoReload", false).toBool()) {
     designActionAutoReload->setChecked(true);
   }
-  auto polySetCacheSizeMB = Preferences::inst()->getValue("advanced/polysetCacheSizeMB").toUInt();
+  auto polySetCacheSizeMB = GlobalPreferences::inst()->getValue("advanced/polysetCacheSizeMB").toUInt();
   GeometryCache::instance()->setMaxSizeMB(polySetCacheSizeMB);
-  auto cgalCacheSizeMB = Preferences::inst()->getValue("advanced/cgalCacheSizeMB").toUInt();
+  auto cgalCacheSizeMB = GlobalPreferences::inst()->getValue("advanced/cgalCacheSizeMB").toUInt();
   CGALCache::instance()->setMaxSizeMB(cgalCacheSizeMB);
-  auto backend3D = Preferences::inst()->getValue("advanced/renderBackend3D").toString().toStdString();
+  auto backend3D = GlobalPreferences::inst()->getValue("advanced/renderBackend3D").toString().toStdString();
   RenderSettings::inst()->backend3D = renderBackend3DFromString(backend3D);
 }
 
@@ -1141,11 +1143,11 @@ void MainWindow::updateRecentFiles(const QString& FileSavedOrOpened)
  */
 void MainWindow::compile(bool reload, bool forcedone)
 {
-  OpenSCAD::hardwarnings = Preferences::inst()->getValue("advanced/enableHardwarnings").toBool();
-  OpenSCAD::traceDepth = Preferences::inst()->getValue("advanced/traceDepth").toUInt();
-  OpenSCAD::traceUsermoduleParameters = Preferences::inst()->getValue("advanced/enableTraceUsermoduleParameters").toBool();
-  OpenSCAD::parameterCheck = Preferences::inst()->getValue("advanced/enableParameterCheck").toBool();
-  OpenSCAD::rangeCheck = Preferences::inst()->getValue("advanced/enableParameterRangeCheck").toBool();
+  OpenSCAD::hardwarnings = GlobalPreferences::inst()->getValue("advanced/enableHardwarnings").toBool();
+  OpenSCAD::traceDepth = GlobalPreferences::inst()->getValue("advanced/traceDepth").toUInt();
+  OpenSCAD::traceUsermoduleParameters = GlobalPreferences::inst()->getValue("advanced/enableTraceUsermoduleParameters").toBool();
+  OpenSCAD::parameterCheck = GlobalPreferences::inst()->getValue("advanced/enableParameterCheck").toBool();
+  OpenSCAD::rangeCheck = GlobalPreferences::inst()->getValue("advanced/enableParameterRangeCheck").toBool();
 
   try{
     bool shouldcompiletoplevel = false;
@@ -1161,7 +1163,7 @@ void MainWindow::compile(bool reload, bool forcedone)
       // Refresh files if it has changed on disk
       if (fileChangedOnDisk() && checkEditorModified()) {
         shouldcompiletoplevel = tabManager->refreshDocument();         // don't compile if we couldn't open the file
-        if (shouldcompiletoplevel && Preferences::inst()->getValue("advanced/autoReloadRaise").toBool()) {
+        if (shouldcompiletoplevel && GlobalPreferences::inst()->getValue("advanced/autoReloadRaise").toBool()) {
           // reloading the 'same' document brings the 'old' one to front.
           this->raise();
         }
@@ -1191,7 +1193,7 @@ void MainWindow::compile(bool reload, bool forcedone)
     if (shouldcompiletoplevel) {
       initialize_rng();
       this->errorLogWidget->clearModel();
-      if (Preferences::inst()->getValue("advanced/consoleAutoClear").toBool()) {
+      if (GlobalPreferences::inst()->getValue("advanced/consoleAutoClear").toBool()) {
         this->console->actionClearConsole_triggered();
       }
       if (activeEditor->isContentModified()) saveBackup();
@@ -1292,7 +1294,7 @@ void MainWindow::updateCompileResult()
 
 void MainWindow::compileDone(bool didchange)
 {
-  OpenSCAD::hardwarnings = Preferences::inst()->getValue("advanced/enableHardwarnings").toBool();
+  OpenSCAD::hardwarnings = GlobalPreferences::inst()->getValue("advanced/enableHardwarnings").toBool();
   try{
     const char *callslot;
     if (didchange) {
@@ -1395,7 +1397,7 @@ void MainWindow::instantiateRoot()
  */
 void MainWindow::compileCSG()
 {
-  OpenSCAD::hardwarnings = Preferences::inst()->getValue("advanced/enableHardwarnings").toBool();
+  OpenSCAD::hardwarnings = GlobalPreferences::inst()->getValue("advanced/enableHardwarnings").toBool();
   try{
     assert(this->rootNode);
     LOG("Compiling design (CSG Products generation)...");
@@ -1430,7 +1432,7 @@ void MainWindow::compileCSG()
     LOG("Compiling design (CSG Products normalization)...");
     this->processEvents();
 
-    const size_t normalizelimit = 2ul * Preferences::inst()->getValue("advanced/openCSGLimit").toUInt();
+    const size_t normalizelimit = 2ul * GlobalPreferences::inst()->getValue("advanced/openCSGLimit").toUInt();
     CSGTreeNormalizer normalizer(normalizelimit);
 
     if (this->csgRoot) {
@@ -1479,7 +1481,7 @@ void MainWindow::compileCSG()
 
     if (this->rootProduct &&
         (this->rootProduct->size() >
-         Preferences::inst()->getValue("advanced/openCSGLimit").toUInt())) {
+         GlobalPreferences::inst()->getValue("advanced/openCSGLimit").toUInt())) {
       LOG(message_group::UI_Warning, "Normalized tree has %1$d elements!", this->rootProduct->size());
       LOG(message_group::UI_Warning, "OpenCSG rendering has been disabled.");
     }
@@ -2295,7 +2297,7 @@ void MainWindow::action3DPrint()
 
     LOG("Selected File format: %1$s", fileformat::info(fileFormat).description);
 
-    Preferences::Preferences::inst()->updateGUI();
+    GlobalPreferences::inst()->updateGUI();
     const auto externalToolService = createExternalToolService(serviceType, serviceName, fileFormat);
     if (!externalToolService) {
       LOG("Error: Unable to create service: %1$d %2$s %3$d", static_cast<int>(serviceType), serviceName.toStdString(), static_cast<int>(fileFormat));
@@ -2380,8 +2382,8 @@ void MainWindow::actionRenderDone(const std::shared_ptr<const Geometry>& root_ge
 
   updateStatusBar(nullptr);
 
-  const bool renderSoundEnabled = Preferences::inst()->getValue("advanced/enableSoundNotification").toBool();
-  const uint soundThreshold = Preferences::inst()->getValue("advanced/timeThresholdOnRenderCompleteSound").toUInt();
+  const bool renderSoundEnabled = GlobalPreferences::inst()->getValue("advanced/enableSoundNotification").toBool();
+  const uint soundThreshold = GlobalPreferences::inst()->getValue("advanced/timeThresholdOnRenderCompleteSound").toUInt();
   if (renderSoundEnabled && soundThreshold <= renderStatistic.ms().count() / 1000) {
     renderCompleteSoundEffect->play();
   }
@@ -3554,10 +3556,10 @@ void MainWindow::closeEvent(QCloseEvent *event)
 
 void MainWindow::preferences()
 {
-  Preferences::inst()->update();
-  Preferences::inst()->show();
-  Preferences::inst()->activateWindow();
-  Preferences::inst()->raise();
+  GlobalPreferences::inst()->update();
+  GlobalPreferences::inst()->show();
+  GlobalPreferences::inst()->activateWindow();
+  GlobalPreferences::inst()->raise();
 }
 
 void MainWindow::setColorScheme(const QString& scheme)
@@ -3636,7 +3638,7 @@ void MainWindow::clearCurrentOutput()
 void MainWindow::openCSGSettingsChanged()
 {
 #ifdef ENABLE_OPENCSG
-  OpenCSG::setOption(OpenCSG::AlgorithmSetting, Preferences::inst()->getValue("advanced/forceGoldfeather").toBool() ?
+  OpenCSG::setOption(OpenCSG::AlgorithmSetting, GlobalPreferences::inst()->getValue("advanced/forceGoldfeather").toBool() ?
                      OpenCSG::Goldfeather : OpenCSG::Automatic);
 #endif
 }

--- a/src/gui/OpenCSGWarningDialog.cc
+++ b/src/gui/OpenCSGWarningDialog.cc
@@ -8,9 +8,9 @@ OpenCSGWarningDialog::OpenCSGWarningDialog(QWidget *)
   setupUi(this);
 
   connect(this->showBox, &QCheckBox::toggled,
-          Preferences::inst()->openCSGWarningBox, &QCheckBox::setChecked);
+          GlobalPreferences::inst()->openCSGWarningBox, &QCheckBox::setChecked);
   connect(this->showBox, &QCheckBox::toggled,
-          Preferences::inst(), &Preferences::on_openCSGWarningBox_toggled);
+          GlobalPreferences::inst(), &Preferences::on_openCSGWarningBox_toggled);
 }
 
 void OpenCSGWarningDialog::setText(const QString& text)

--- a/src/gui/Preferences.cc
+++ b/src/gui/Preferences.cc
@@ -1401,9 +1401,6 @@ void Preferences::updateGUIFontSize(QComboBox *fsSelector, const QString &settin
 
 Preferences* GlobalPreferences::inst()
 {
-    static Preferences* instance {nullptr};
-    if(instance==nullptr){
-        instance = new Preferences();
-    }
+    static auto* instance = new Preferences();
     return instance;
 };

--- a/src/gui/Preferences.cc
+++ b/src/gui/Preferences.cc
@@ -74,6 +74,9 @@
 
 #include <string>
 
+
+static const char* featurePropertyName="FeatureProperty";
+
 using S = Settings::Settings;
 
 Q_DECLARE_METATYPE(Feature *);
@@ -92,10 +95,8 @@ class SettingsReader : public Settings::SettingsVisitor
   }
 };
 
-Preferences::Preferences(const char* propertyName, QWidget *parent) : QMainWindow(parent)
+Preferences::Preferences(QWidget *parent) : QMainWindow(parent)
 {
-  featurePropertyName = propertyName;
-
   setupUi(this);
 
   std::list<std::string> names = ColorMap::inst()->colorSchemeNames(true);
@@ -1402,7 +1403,7 @@ Preferences* GlobalPreferences::inst()
 {
     static Preferences* instance {nullptr};
     if(instance==nullptr){
-        instance = new Preferences("FeatureProperty");
+        instance = new Preferences();
     }
     return instance;
 };

--- a/src/gui/Preferences.cc
+++ b/src/gui/Preferences.cc
@@ -76,8 +76,6 @@
 
 using S = Settings::Settings;
 
-Preferences *GlobalPreferences::instance = nullptr;
-
 Q_DECLARE_METATYPE(Feature *);
 
 class SettingsReader : public Settings::SettingsVisitor
@@ -1353,9 +1351,16 @@ void Preferences::apply_win() const
   emit openCSGSettingsChanged();
 }
 
-void Preferences::addColorSchemes(const QStringList& colorSchemes)
+bool Preferences::hasHighlightingColorScheme() const
 {
-    BlockSignals<QComboBox *>(syntaxHighlight)->addItems(colorSchemes);
+    return BlockSignals<QComboBox *>(syntaxHighlight)->count() != 0;
+}
+
+void Preferences::setHighlightingColorSchemes(const QStringList& colorSchemes)
+{
+    auto combobox = BlockSignals<QComboBox *>(syntaxHighlight);
+    combobox->clear();
+    combobox->addItems(colorSchemes);
 }
 
 void Preferences::createFontSizeMenu(QComboBox *boxarg, const QString &setting)
@@ -1395,6 +1400,7 @@ void Preferences::updateGUIFontSize(QComboBox *fsSelector, const QString &settin
 
 Preferences* GlobalPreferences::inst()
 {
+    static Preferences* instance {nullptr};
     if(instance==nullptr){
         instance = new Preferences("FeatureProperty");
     }

--- a/src/gui/Preferences.cc
+++ b/src/gui/Preferences.cc
@@ -76,9 +76,8 @@
 
 using S = Settings::Settings;
 
-Preferences *Preferences::instance = nullptr;
+Preferences *GlobalPreferences::instance = nullptr;
 
-const char *Preferences::featurePropertyName = "FeatureProperty";
 Q_DECLARE_METATYPE(Feature *);
 
 class SettingsReader : public Settings::SettingsVisitor
@@ -95,9 +94,24 @@ class SettingsReader : public Settings::SettingsVisitor
   }
 };
 
-Preferences::Preferences(QWidget *parent) : QMainWindow(parent)
+Preferences::Preferences(const char* propertyName, QWidget *parent) : QMainWindow(parent)
 {
+  featurePropertyName = propertyName;
+
   setupUi(this);
+
+  std::list<std::string> names = ColorMap::inst()->colorSchemeNames(true);
+  QStringList renderColorSchemes;
+  for (const auto& name : names) renderColorSchemes << name.c_str();
+
+  syntaxHighlight->clear();
+  colorSchemeChooser->clear();
+  colorSchemeChooser->addItems(renderColorSchemes);
+  init();
+  AxisConfig->init();
+  setupFeaturesPage();
+  setup3DPrintPage();
+  updateGUI();
 }
 
 void Preferences::init() {
@@ -265,7 +279,6 @@ void Preferences::init() {
 Preferences::~Preferences()
 {
   removeDefaultSettings();
-  instance = nullptr;
 }
 
 void Preferences::update()
@@ -393,35 +406,35 @@ void Preferences::setup3DPrintPage()
 {
   const auto& currentPrintService = Settings::Settings::defaultPrintService.value();
   const auto currentPrintServiceName = QString::fromStdString(Settings::Settings::printServiceName.value());
-  instance->checkBoxEnableRemotePrintServices->setChecked(Settings::Settings::enableRemotePrintServices.value());
-  instance->comboBoxDefaultPrintService->clear();
+  checkBoxEnableRemotePrintServices->setChecked(Settings::Settings::enableRemotePrintServices.value());
+  comboBoxDefaultPrintService->clear();
   const std::unordered_map<std::string, QString> services = {
       {"NONE", _("NONE")},
       {"OCTOPRINT", _("OctoPrint")},
       {"LOCAL_APPLICATION", _("Local Application")},
   };
 
-  instance->comboBoxDefaultPrintService->addItem(services.at("NONE"),
+  comboBoxDefaultPrintService->addItem(services.at("NONE"),
                                                  QStringList{"NONE", ""});
   for (const auto &printServiceItem : PrintService::getPrintServices()) {
     const auto &key = printServiceItem.first;
     const auto &printService = printServiceItem.second;
     const auto settingValue = QStringList{"PRINT_SERVICE", QString::fromStdString(key)};
     const auto displayName = QString(printService->getDisplayName());
-    instance->comboBoxDefaultPrintService->addItem(displayName, settingValue);
+    comboBoxDefaultPrintService->addItem(displayName, settingValue);
     if (key == currentPrintServiceName.toStdString()) {
-      instance->comboBoxDefaultPrintService->setCurrentText(
+      comboBoxDefaultPrintService->setCurrentText(
           QString(printService->getDisplayName()));
     }
   }
-  instance->comboBoxDefaultPrintService->addItem(services.at("OCTOPRINT"),
+  comboBoxDefaultPrintService->addItem(services.at("OCTOPRINT"),
                                                  QStringList{"OCTOPRINT", ""});
-  instance->comboBoxDefaultPrintService->addItem(services.at("LOCAL_APPLICATION"),
+  comboBoxDefaultPrintService->addItem(services.at("LOCAL_APPLICATION"),
                                                  QStringList{"LOCAL_APPLICATION", ""});
 
   auto it = services.find(currentPrintService);
   if (it != services.end()) {
-    instance->comboBoxDefaultPrintService->setCurrentText(it->second);
+    comboBoxDefaultPrintService->setCurrentText(it->second);
   }
 }
 
@@ -1340,34 +1353,10 @@ void Preferences::apply_win() const
   emit openCSGSettingsChanged();
 }
 
-void Preferences::create(const QStringList& colorSchemes)
+void Preferences::addColorSchemes(const QStringList& colorSchemes)
 {
-  if (instance != nullptr) {
-    return;
-  }
-
-  std::list<std::string> names = ColorMap::inst()->colorSchemeNames(true);
-  QStringList renderColorSchemes;
-  for (const auto& name : names) renderColorSchemes << name.c_str();
-
-  instance = new Preferences();
-  instance->syntaxHighlight->clear();
-  BlockSignals<QComboBox *>(instance->syntaxHighlight)->addItems(colorSchemes);
-  instance->colorSchemeChooser->clear();
-  instance->colorSchemeChooser->addItems(renderColorSchemes);
-  instance->init();
-  instance->AxisConfig->init();
-  instance->setupFeaturesPage();
-  instance->setup3DPrintPage();
-  instance->updateGUI();
+    BlockSignals<QComboBox *>(syntaxHighlight)->addItems(colorSchemes);
 }
-
-Preferences *Preferences::inst() {
-  assert(instance != nullptr);
-
-  return instance;
-}
-
 
 void Preferences::createFontSizeMenu(QComboBox *boxarg, const QString &setting)
 {
@@ -1403,3 +1392,11 @@ void Preferences::updateGUIFontSize(QComboBox *fsSelector, const QString &settin
     BlockSignals<QComboBox *>(fsSelector)->setEditText(fontsize);
   }
 }
+
+Preferences* GlobalPreferences::inst()
+{
+    if(instance==nullptr){
+        instance = new Preferences("FeatureProperty");
+    }
+    return instance;
+};

--- a/src/gui/Preferences.h
+++ b/src/gui/Preferences.h
@@ -198,7 +198,7 @@ private slots:
 
 private:
   friend GlobalPreferences;
-  Preferences(const char *propertyName, QWidget *parent = nullptr);
+  Preferences(QWidget *parent = nullptr);
   void keyPressEvent(QKeyEvent *e) override;
   void showEvent(QShowEvent *e) override;
   void closeEvent(QCloseEvent *e) override;
@@ -220,8 +220,6 @@ private:
 
   QSettings::SettingsMap defaultmap;
   QHash<const QAction *, QWidget *> prefPages;
-
-  const char* featurePropertyName=nullptr;
 };
 
 class GlobalPreferences

--- a/src/gui/Preferences.h
+++ b/src/gui/Preferences.h
@@ -23,15 +23,13 @@
 #include "core/Settings.h"
 #include "gui/InitConfigurator.h"
 
+class GlobalPreferences;
 class Preferences : public QMainWindow, public Ui::Preferences, public InitConfigurator
 {
   Q_OBJECT;
 
 public:
   ~Preferences() override;
-
-  static void create(const QStringList& colorSchemes);
-  static Preferences *inst();
 
   QVariant getValue(const QString& key) const;
   void init();
@@ -40,6 +38,7 @@ public:
   void updateGUI();
   void fireEditorConfigChanged() const;
   void insertListItem(QListWidget *listBox, QListWidgetItem *listItem);
+  void addColorSchemes(const QStringList& colorSchemes);
 
   template<typename item_type>
   QListWidgetItem * createListItem(const item_type& itemType, const QString& text = "", bool editable = false) {
@@ -193,7 +192,8 @@ private slots:
   void on_checkBoxEnableNumberScrollWheel_toggled(bool checked);
 
 private:
-  Preferences(QWidget *parent = nullptr);
+  friend GlobalPreferences;
+  Preferences(const char *propertyName, QWidget *parent = nullptr);
   void keyPressEvent(QKeyEvent *e) override;
   void showEvent(QShowEvent *e) override;
   void closeEvent(QCloseEvent *e) override;
@@ -216,6 +216,14 @@ private:
   QSettings::SettingsMap defaultmap;
   QHash<const QAction *, QWidget *> prefPages;
 
-  static Preferences *instance;
-  static const char *featurePropertyName;
+  const char* featurePropertyName=nullptr;
+};
+
+class GlobalPreferences
+{
+public:
+    static Preferences* inst();
+private:
+    static Preferences *instance;
+    static const char *featurePropertyName;
 };

--- a/src/gui/Preferences.h
+++ b/src/gui/Preferences.h
@@ -38,7 +38,12 @@ public:
   void updateGUI();
   void fireEditorConfigChanged() const;
   void insertListItem(QListWidget *listBox, QListWidgetItem *listItem);
-  void addColorSchemes(const QStringList& colorSchemes);
+
+  // Returns true if there is an higlightling color scheme configured.
+  bool hasHighlightingColorScheme() const;
+
+  // Set a new colorScheme.
+  void setHighlightingColorSchemes(const QStringList& colorSchemes);
 
   template<typename item_type>
   QListWidgetItem * createListItem(const item_type& itemType, const QString& text = "", bool editable = false) {
@@ -223,7 +228,4 @@ class GlobalPreferences
 {
 public:
     static Preferences* inst();
-private:
-    static Preferences *instance;
-    static const char *featurePropertyName;
 };

--- a/src/gui/QGLView.cc
+++ b/src/gui/QGLView.cc
@@ -148,7 +148,7 @@ std::string QGLView::getRendererInfo() const
 #ifdef ENABLE_OPENCSG
 void QGLView::display_opencsg_warning()
 {
-  if (Preferences::inst()->getValue("advanced/opencsg_show_warning").toBool()) {
+  if (GlobalPreferences::inst()->getValue("advanced/opencsg_show_warning").toBool()) {
     QTimer::singleShot(0, this, &QGLView::display_opencsg_warning_dialog);
   }
 }

--- a/src/gui/ScintillaEditor.cc
+++ b/src/gui/ScintillaEditor.cc
@@ -352,7 +352,7 @@ void ScintillaEditor::setupAutoComplete(const bool forceOff)
     qsci->SendScintilla(QsciScintilla::SCI_CALLTIPCANCEL);
   }
 
-  const bool configValue = Preferences::inst()->getValue("editor/enableAutocomplete").toBool();
+  const bool configValue = GlobalPreferences::inst()->getValue("editor/enableAutocomplete").toBool();
   const bool enable = configValue && !forceOff;
 
   if (enable) {
@@ -367,7 +367,7 @@ void ScintillaEditor::setupAutoComplete(const bool forceOff)
     qsci->setCallTipsStyle(QsciScintilla::CallTipsNone);
   }
 
-  int val = Preferences::inst()->getValue("editor/characterThreshold").toInt();
+  int val = GlobalPreferences::inst()->getValue("editor/characterThreshold").toInt();
   qsci->setAutoCompletionThreshold(val <= 0 ? 1 : val);
 }
 
@@ -1281,7 +1281,7 @@ bool ScintillaEditor::modifyNumber(int key)
   auto number = (dotpos < 0)?nr.toLongLong():(nr.left(dotpos) + nr.mid(dotpos + 1)).toLongLong();
   auto tail = nr.length() - curpos;
   auto exponent = tail - ((dotpos >= curpos)?1:0);
-  long long int step = Preferences::inst()->getValue("editor/stepSize").toInt();
+  long long int step = GlobalPreferences::inst()->getValue("editor/stepSize").toInt();
   for (int i = exponent; i > 0; i--) step *= 10;
 
   switch (key) {

--- a/src/gui/TabManager.cc
+++ b/src/gui/TabManager.cc
@@ -153,7 +153,6 @@ void TabManager::createTab(const QString& filename)
 
   auto scintillaEditor = new ScintillaEditor(tabWidget);
   editor = scintillaEditor;
-  Preferences::create(editor->colorSchemes());   // needs to be done only once, however handled
   par->activeEditor = editor;
   editor->parameterWidget = new ParameterWidget(par->parameterDock);
   connect(editor->parameterWidget, &ParameterWidget::parametersChanged, par, &MainWindow::actionRenderPreview);
@@ -173,9 +172,9 @@ void TabManager::createTab(const QString& filename)
     par->setLastFocus(editor);
   });
 
-  connect(Preferences::inst(), &Preferences::editorConfigChanged, scintillaEditor, &ScintillaEditor::applySettings);
-  connect(Preferences::inst(), &Preferences::autocompleteChanged, scintillaEditor, &ScintillaEditor::onAutocompleteChanged);
-  connect(Preferences::inst(), &Preferences::characterThresholdChanged, scintillaEditor, &ScintillaEditor::onCharacterThresholdChanged);
+  connect(GlobalPreferences::inst(), &Preferences::editorConfigChanged, scintillaEditor, &ScintillaEditor::applySettings);
+  connect(GlobalPreferences::inst(), &Preferences::autocompleteChanged, scintillaEditor, &ScintillaEditor::onAutocompleteChanged);
+  connect(GlobalPreferences::inst(), &Preferences::characterThresholdChanged, scintillaEditor, &ScintillaEditor::onCharacterThresholdChanged);
   scintillaEditor->applySettings();
   editor->addTemplate();
 
@@ -190,10 +189,10 @@ void TabManager::createTab(const QString& filename)
     setTabModified(editor);
   });
 
-  connect(Preferences::inst(), &Preferences::fontChanged, editor, &EditorInterface::initFont);
-  connect(Preferences::inst(), &Preferences::syntaxHighlightChanged, editor, &EditorInterface::setHighlightScheme);
-  editor->initFont(Preferences::inst()->getValue("editor/fontfamily").toString(), Preferences::inst()->getValue("editor/fontsize").toUInt());
-  editor->setHighlightScheme(Preferences::inst()->getValue("editor/syntaxhighlight").toString());
+  connect(GlobalPreferences::inst(), &Preferences::fontChanged, editor, &EditorInterface::initFont);
+  connect(GlobalPreferences::inst(), &Preferences::syntaxHighlightChanged, editor, &EditorInterface::setHighlightScheme);
+  editor->initFont(GlobalPreferences::inst()->getValue("editor/fontfamily").toString(), GlobalPreferences::inst()->getValue("editor/fontsize").toUInt());
+  editor->setHighlightScheme(GlobalPreferences::inst()->getValue("editor/syntaxhighlight").toString());
 
   connect(scintillaEditor, &ScintillaEditor::hyperlinkIndicatorClicked, this, &TabManager::onHyperlinkIndicatorClicked);
 

--- a/src/gui/input/InputEventMapper.cc
+++ b/src/gui/input/InputEventMapper.cc
@@ -176,11 +176,11 @@ void InputEventMapper::onTimer()
   for (size_t i = 0; i < getMaxButtons(); ++i) {
     if (button_state[i] != button_state_last[i]) {
       button_state_last[i] = button_state[i];
-      Preferences::inst()->ButtonConfig->updateButtonState(i, button_state[i]);
+      GlobalPreferences::inst()->ButtonConfig->updateButtonState(i, button_state[i]);
     }
   }
   for (size_t i = 0; i < getMaxAxis(); ++i) {
-    Preferences::inst()->AxisConfig->AxesChanged(i, axisRawValue[i] + axisTrimValue[i]);
+    GlobalPreferences::inst()->AxisConfig->AxesChanged(i, axisRawValue[i] + axisTrimValue[i]);
   }
 
   if (!generated_any_events) {

--- a/src/gui/parameter/ParameterWidget.cc
+++ b/src/gui/parameter/ParameterWidget.cc
@@ -71,11 +71,11 @@ ParameterWidget::ParameterWidget(QWidget *parent) : QWidget(parent)
   connect(addButton, &QPushButton::clicked, this, &ParameterWidget::onSetAdd);
   connect(deleteButton, &QPushButton::clicked, this, &ParameterWidget::onSetDelete);
 
-  QString fontfamily = Preferences::inst()->getValue("advanced/customizerFontFamily").toString();
-  uint fontsize = Preferences::inst()->getValue("advanced/customizerFontSize").toUInt();
+  QString fontfamily = GlobalPreferences::inst()->getValue("advanced/customizerFontFamily").toString();
+  uint fontsize = GlobalPreferences::inst()->getValue("advanced/customizerFontSize").toUInt();
   setFontFamilySize(fontfamily, fontsize);
 
-  connect(Preferences::inst(), &Preferences::customizerFontChanged, this, &ParameterWidget::setFontFamilySize);
+  connect(GlobalPreferences::inst(), &Preferences::customizerFontChanged, this, &ParameterWidget::setFontFamilySize);
 }
 
 // Can only be called before the initial setParameters().


### PR DESCRIPTION
The class Preferences is currently a mix of static behavior and non static. 

The instance is initialized by calling the method Preferences::create().
Calling it is mandatory to avoid crashing when calling inst(). 
Currently the Preferences creation is done in TabManager::createTab. But I see no rational of having the TabManager in charge of constructing a static variable for the whole application. 

To remove this I refactored the Preferences class to make a purely non static class. 
The static part has been moved into a new class only in charge of this purpose called GlobalPreferences. 

TabManager/Editor specific first initialization is now done once in MainWindow::MainWindow. 


