### PR TITLE
[CLEAN] Move getCodeLocation from MainWindow to Node::getCodeLocation

### DIFF
--- a/src/core/node.cc
+++ b/src/core/node.cc
@@ -67,6 +67,54 @@ std::shared_ptr<const AbstractNode> AbstractNode::getNodeByID(int idx, std::dequ
   return nullptr;
 }
 
+void AbstractNode::getCodeLocation(int currentLevel,  int includeLevel,
+                                   int *firstLine, int *firstColumn, int *lastLine, int *lastColumn,
+                                   int nestedModuleDepth) const
+{
+  auto location = modinst->location();
+  if (currentLevel >= includeLevel && nestedModuleDepth == 0) {
+    if (*firstLine < 0 || *firstLine > location.firstLine()) {
+      *firstLine = location.firstLine();
+      *firstColumn = location.firstColumn();
+    } else if (*firstLine == location.firstLine() && *firstColumn > location.firstColumn()) {
+      *firstColumn = location.firstColumn();
+    }
+
+    if (*lastLine < 0 || *lastLine < location.lastLine()) {
+      *lastLine = location.lastLine();
+      *lastColumn = location.lastColumn();
+    } else {
+      if (*firstLine < 0 || *firstLine > location.firstLine()) {
+        *firstLine = location.firstLine();
+        *firstColumn = location.firstColumn();
+      } else if (*firstLine == location.firstLine() && *firstColumn > location.firstColumn()) {
+        *firstColumn = location.firstColumn();
+      }
+      if (*lastLine < 0 || *lastLine < location.lastLine()) {
+        *lastLine = location.lastLine();
+        *lastColumn = location.lastColumn();
+      } else if (*lastLine == location.lastLine() && *lastColumn < location.lastColumn()) {
+        *lastColumn = location.lastColumn();
+      }
+    }
+  }
+
+  if (verbose_name().rfind("module", 0) == 0) {
+    nestedModuleDepth++;
+  }
+  if (modinst->name() == "children") {
+    nestedModuleDepth--;
+  }
+
+  if (nestedModuleDepth >= 0) {
+    for (const auto& node : children) {
+      node->getCodeLocation(currentLevel + 1, includeLevel, firstLine,  firstColumn, lastLine,
+                            lastColumn, nestedModuleDepth);
+    }
+  }
+}
+
+
 std::string GroupNode::name() const
 {
   return "group";

--- a/src/core/node.h
+++ b/src/core/node.h
@@ -41,6 +41,7 @@ public:
       overloaded to provide specialization for e.g. CSG nodes, primitive nodes etc.
       Used for human-readable output. */
   virtual std::string name() const = 0;
+
   /*| When a more specific name for user interaction shall be used, such as module names,
       the verbose name shall be overloaded. */
   virtual std::string verbose_name() const { return this->name(); }
@@ -65,6 +66,11 @@ public:
   int idx; // Node index (unique per tree)
 
   std::shared_ptr<const AbstractNode> getNodeByID(int idx, std::deque<std::shared_ptr<const AbstractNode>>& path) const;
+
+  // returns the precise source code location associated with the node
+  void getCodeLocation(int currentLevel,  int includeLevel, int *firstLine,
+                       int *firstColumn, int *lastLine, int *lastColumn, int nestedModuleDepth) const;
+
   std::shared_ptr<AbstractNode> clone(void);
 };
 

--- a/src/gui/MainWindow.cc
+++ b/src/gui/MainWindow.cc
@@ -2511,50 +2511,6 @@ static void findNodesWithSameMod(const std::shared_ptr<const AbstractNode>& tree
   }
 }
 
-static void getCodeLocation(const AbstractNode *self, int currentLevel,  int includeLevel, int *firstLine, int *firstColumn, int *lastLine, int *lastColumn, int nestedModuleDepth)
-{
-  auto location = self->modinst->location();
-  if (currentLevel >= includeLevel && nestedModuleDepth == 0) {
-    if (*firstLine < 0 || *firstLine > location.firstLine()) {
-      *firstLine = location.firstLine();
-      *firstColumn = location.firstColumn();
-    } else if (*firstLine == location.firstLine() && *firstColumn > location.firstColumn()) {
-      *firstColumn = location.firstColumn();
-    }
-
-    if (*lastLine < 0 || *lastLine < location.lastLine()) {
-      *lastLine = location.lastLine();
-      *lastColumn = location.lastColumn();
-    } else {
-      if (*firstLine < 0 || *firstLine > location.firstLine()) {
-        *firstLine = location.firstLine();
-        *firstColumn = location.firstColumn();
-      } else if (*firstLine == location.firstLine() && *firstColumn > location.firstColumn()) {
-        *firstColumn = location.firstColumn();
-      }
-      if (*lastLine < 0 || *lastLine < location.lastLine()) {
-        *lastLine = location.lastLine();
-        *lastColumn = location.lastColumn();
-      } else if (*lastLine == location.lastLine() && *lastColumn < location.lastColumn()) {
-        *lastColumn = location.lastColumn();
-      }
-    }
-  }
-
-  if (self->verbose_name().rfind("module", 0) == 0) {
-    nestedModuleDepth++;
-  }
-  if (self->modinst->name() == "children") {
-    nestedModuleDepth--;
-  }
-
-  if (nestedModuleDepth >= 0) {
-    for (const auto& node : self->children) {
-      getCodeLocation(node.get(), currentLevel + 1, includeLevel, firstLine,  firstColumn, lastLine, lastColumn, nestedModuleDepth);
-    }
-  }
-}
-
 void MainWindow::setSelectionIndicatorStatus(int nodeIndex, EditorSelectionIndicatorStatus status)
 {
   std::deque<std::shared_ptr<const AbstractNode>> stack;
@@ -2592,7 +2548,7 @@ void MainWindow::setSelectionIndicatorStatus(int nodeIndex, EditorSelectionIndic
   auto lastColumn = location.lastColumn();
 
   // Update the location returned by location to cover the whole section.
-  getCodeLocation(node.get(), 0, 0, &line, &column, &lastLine, &lastColumn, 0);
+  node->getCodeLocation(0, 0, &line, &column, &lastLine, &lastColumn, 0);
 
   this->activeEditor->setSelectionIndicatorStatus(status, 0, line - 1, column - 1, lastLine - 1, lastColumn - 1);
 }


### PR DESCRIPTION
The getCodeLocation is a free function in MainWindow.cpp while it may/could/should be a member of AbstractNode. 
So I made this.
The advantage is that it removes some lines in MainWindow.cpp (which is quite big:)) 