### PR TITLE
Removes the recursive calling to Preferences.

### DIFF
--- a/src/gui/InitConfigurator.cc
+++ b/src/gui/InitConfigurator.cc
@@ -13,7 +13,6 @@
 #include <QGroupBox>
 
 #include "core/Settings.h"
-#include "gui/Preferences.h"
 #include "gui/SettingsWriter.h"
 
 #include <string>
@@ -55,22 +54,22 @@ void InitConfigurator::initListBox(QListWidget *listBox, const Settings::Setting
   listBox->clear();
   for (const auto& listitem : list.value()) {
     if (listitem.type == Settings::LocalAppParameterType::string) {
-      const auto item = GlobalPreferences::inst()->createListItem(Settings::LocalAppParameterType(Settings::LocalAppParameterType::string), QString::fromStdString(listitem.value));
+      const auto item = createListItem(Settings::LocalAppParameterType(Settings::LocalAppParameterType::string), QString::fromStdString(listitem.value));
       listBox->insertItem(listBox->count(), item);
     } else if (listitem.type == Settings::LocalAppParameterType::file) {
-      const auto item = GlobalPreferences::inst()->createListItem(Settings::LocalAppParameterType(Settings::LocalAppParameterType::file));
+      const auto item = createListItem(Settings::LocalAppParameterType(Settings::LocalAppParameterType::file));
       listBox->insertItem(listBox->count(), item);
     } else if (listitem.type == Settings::LocalAppParameterType::dir) {
-      const auto item = GlobalPreferences::inst()->createListItem(Settings::LocalAppParameterType(Settings::LocalAppParameterType::dir));
+      const auto item = createListItem(Settings::LocalAppParameterType(Settings::LocalAppParameterType::dir));
       listBox->insertItem(listBox->count(), item);
     } else if (listitem.type == Settings::LocalAppParameterType::extension) {
-      const auto item = GlobalPreferences::inst()->createListItem(Settings::LocalAppParameterType(Settings::LocalAppParameterType::extension));
+      const auto item = createListItem(Settings::LocalAppParameterType(Settings::LocalAppParameterType::extension));
       listBox->insertItem(listBox->count(), item);
     } else if (listitem.type == Settings::LocalAppParameterType::source) {
-      const auto item = GlobalPreferences::inst()->createListItem(Settings::LocalAppParameterType(Settings::LocalAppParameterType::source));
+      const auto item = createListItem(Settings::LocalAppParameterType(Settings::LocalAppParameterType::source));
       listBox->insertItem(listBox->count(), item);
     } else if (listitem.type == Settings::LocalAppParameterType::sourcedir) {
-      const auto item = GlobalPreferences::inst()->createListItem(Settings::LocalAppParameterType(Settings::LocalAppParameterType::sourcedir));
+      const auto item = createListItem(Settings::LocalAppParameterType(Settings::LocalAppParameterType::sourcedir));
       listBox->insertItem(listBox->count(), item);
     }
   }

--- a/src/gui/InitConfigurator.h
+++ b/src/gui/InitConfigurator.h
@@ -58,6 +58,20 @@ protected:
 
   void initMetaData(QCheckBox *, QLineEdit *, Settings::SettingsEntryBool *, Settings::SettingsEntryString&);
   void applyMetaData(const QCheckBox *, const QLineEdit *, Settings::SettingsEntryBool *, Settings::SettingsEntryString&);
+
+  template<typename item_type>
+  QListWidgetItem * createListItem(const item_type& itemType, const QString& text = "", bool editable = false) {
+    const auto icon = QIcon::fromTheme(QString::fromStdString(itemType.icon()));
+    std::string description = itemType.description();
+    const auto itemText = description.empty() ? text : QString::fromStdString(description);
+    const auto listItem = new QListWidgetItem(icon, itemText,
+      nullptr,
+      static_cast<int>(QListWidgetItem::UserType) + static_cast<int>(itemType));
+    if (editable) {
+      listItem->setFlags(listItem->flags() | Qt::ItemIsEditable);
+    }
+    return listItem;
+  }
 };
 
 template<typename enum_type>

--- a/src/gui/Preferences.h
+++ b/src/gui/Preferences.h
@@ -45,20 +45,6 @@ public:
   // Set a new colorScheme.
   void setHighlightingColorSchemes(const QStringList& colorSchemes);
 
-  template<typename item_type>
-  QListWidgetItem * createListItem(const item_type& itemType, const QString& text = "", bool editable = false) {
-    const auto icon = QIcon::fromTheme(QString::fromStdString(itemType.icon()));
-    std::string description = itemType.description();
-    const auto itemText = description.empty() ? text : QString::fromStdString(description);
-    const auto listItem = new QListWidgetItem(icon, itemText,
-      nullptr,
-      static_cast<int>(QListWidgetItem::UserType) + static_cast<int>(itemType));
-    if (editable) {
-      listItem->setFlags(listItem->flags() | Qt::ItemIsEditable);
-    }
-    return listItem;
-  }
-
 public slots:
   void actionTriggered(class QAction *);
   void featuresCheckBoxToggled(bool);


### PR DESCRIPTION
This PR is for fixing the recursive call in static initialization that resulted from the merge of #5779

I have no way to test if the fix is enough..
I did the following to see if there is remaining recursion:
```cpp
Preferences* GlobalPreferences::inst()
{
    std::cout << "ENTERING INST" << std::endl;
    {
        static auto* instance = new Preferences();
        std::cout << "LEAVING ENTERING INST" << std::endl;
        return instance;
    }
};
```

But it would be better if tested on someone's where the segfault happens. 
