### PR TITLE
Refactor activeEditor

### DIFF
--- a/src/gui/Animate.cc
+++ b/src/gui/Animate.cc
@@ -140,7 +140,7 @@ void Animate::incrementTVal()
   if (this->animNumSteps == 0) return;
 
   if (mainWindow->parameterDock->isVisible()) {
-    if (mainWindow->activeEditor->parameterWidget->childHasFocus()) return;
+    if (mainWindow->activeEditor()->parameterWidget->childHasFocus()) return;
   }
 
   if (this->animNumSteps > 1) {

--- a/src/gui/MainWindow.cc
+++ b/src/gui/MainWindow.cc
@@ -287,8 +287,8 @@ std::unique_ptr<ExternalToolInterface> createExternalToolService(
 EditorInterface* MainWindow::activeEditor() const
 {
     assert(tabManager != nullptr);
-    assert(tabManager->editor != nullptr);
-    return tabManager->editor;
+    assert(tabManager->editor() != nullptr);
+    return tabManager->editor();
 }
 
 MainWindow::MainWindow(const QStringList& filenames) :

--- a/src/gui/MainWindow.h
+++ b/src/gui/MainWindow.h
@@ -94,8 +94,8 @@ public:
   bool trust_python_file(const std::string& file, const std::string& content);
 #endif
   Tree tree;
-  EditorInterface *activeEditor;
-  TabManager *tabManager;
+  EditorInterface* activeEditor() const;
+  TabManager *tabManager {nullptr};
 
   std::shared_ptr<const Geometry> rootGeom;
   std::shared_ptr<Renderer> geomRenderer;

--- a/src/gui/Preferences.cc
+++ b/src/gui/Preferences.cc
@@ -1401,6 +1401,8 @@ void Preferences::updateGUIFontSize(QComboBox *fsSelector, const QString &settin
 
 Preferences* GlobalPreferences::inst()
 {
-    static auto* instance = new Preferences();
-    return instance;
+    {
+        static auto* instance = new Preferences();
+        return instance;
+    }
 };

--- a/src/gui/TabManager.h
+++ b/src/gui/TabManager.h
@@ -14,7 +14,7 @@ class TabManager : public QObject
   Q_OBJECT
 
 public:
-  TabManager(MainWindow *o, const QString& filename);
+  TabManager(MainWindow *o);
   QWidget *getTabContent();
   EditorInterface *editor;
   QSet<EditorInterface *> editorList;
@@ -53,6 +53,10 @@ private:
   void setTabsCloseButtonVisibility(int tabIndice, bool isVisible);
 
   QTabBar::ButtonPosition getClosingButtonPosition();
+
+  // Internal function to factorize the building of menu actions.
+  template<class Function>
+  QAction* buildMenuAction(const QString& actionText, int idx, bool isEnabled, Function onTriggeredFunction);
 
 private slots:
   void tabSwitched(int);

--- a/src/gui/TabManager.h
+++ b/src/gui/TabManager.h
@@ -16,7 +16,6 @@ class TabManager : public QObject
 public:
   TabManager(MainWindow *o);
   QWidget *getTabContent();
-  EditorInterface *editor;
   QSet<EditorInterface *> editorList;
 
   void createTab(const QString& filename);
@@ -29,6 +28,7 @@ public:
   bool saveACopy(EditorInterface *edt);
   void open(const QString& filename);
   size_t count();
+  EditorInterface* editor() const;
 
 public:
   static constexpr const int FIND_HIDDEN = 0;
@@ -51,6 +51,7 @@ private:
   void saveError(const QIODevice& file, const std::string& msg, const QString& filepath);
   void applyAction(QObject *object, const std::function<void(int, EditorInterface *)>& func);
   void setTabsCloseButtonVisibility(int tabIndice, bool isVisible);
+  void setCloseButtonForAllTabsExcept(int indice);
 
   QTabBar::ButtonPosition getClosingButtonPosition();
 


### PR DESCRIPTION
Having a lot of variable storing/caching a pointer to the "active" editor increase the difficulty to keep track which part of the code is changing/controlling. 

This PR is a quick test on if it would be easy to move both MainWindow::activeEditor and TabManager::editor as methods so we have better control on the data flow and it simplifiy the internal logic of the application as it removes the need to manually handle the updates of the different version.  
