### PR TITLE
Add format() function based on the fmt library.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -343,6 +343,11 @@ if (MSVC)
   target_include_directories(OpenSCAD SYSTEM PRIVATE ${HARFBUZZ_INCLUDE_DIRS}/harfbuzz)
   target_link_libraries(OpenSCAD PRIVATE harfbuzz::harfbuzz)
 
+  find_package(fmt REQUIRED)
+  message(STATUS "fmt: ${fmt_VERSION}")
+  target_include_directories(OpenSCAD SYSTEM PRIVATE ${fmt_INCLUDE_DIRS})
+  target_link_libraries(OpenSCAD PRIVATE fmt::fmt)
+
   find_package(unofficial-fontconfig CONFIG REQUIRED)
   target_link_libraries(OpenSCAD PRIVATE unofficial::fontconfig::fontconfig)
 
@@ -394,6 +399,11 @@ else()
   find_package(FontConfig 2.8.0 REQUIRED QUIET)
   message(STATUS "Fontconfig: ${FONTCONFIG_VERSION}")
   target_link_libraries(OpenSCAD PRIVATE ${FONTCONFIG_LIBRARIES})
+
+  find_package(fmt 7.1.3 REQUIRED)
+  message(STATUS "fmt: ${fmt_VERSION}")
+  target_include_directories(OpenSCAD SYSTEM PRIVATE ${fmt_INCLUDE_DIRS})
+  target_link_libraries(OpenSCAD PRIVATE fmt::fmt)
 
   find_package(GLIB2 2.26 REQUIRED QUIET)
   message(STATUS "Glib: ${GLIB2_VERSION}")

--- a/src/Feature.cc
+++ b/src/Feature.cc
@@ -32,6 +32,7 @@ const Feature Feature::ExperimentalLazyUnion("lazy-union", "Enable lazy unions."
 const Feature Feature::ExperimentalVxORenderersIndexing("vertex-object-renderers-indexing", "Enable indexing in vertex object renderers");
 const Feature Feature::ExperimentalTextMetricsFunctions("textmetrics", "Enable the <code>textmetrics()</code> and <code>fontmetrics()</code> functions.");
 const Feature Feature::ExperimentalImportFunction("import-function", "Enable import function returning data instead of geometry.");
+const Feature Feature::ExperimentalFormatFunction("format-function", "Enable format function for string formatting.");
 const Feature Feature::ExperimentalPredictibleOutput("predictible-output", "Attempt to produce predictible, diffable outputs (e.g. sorting the STL, or remeshing in a determined order)");
 #ifdef ENABLE_PYTHON
 const Feature Feature::ExperimentalPythonEngine("python-engine", "Enable experimental Python Engine (implies risk of malicious scripts downloaded).");

--- a/src/Feature.h
+++ b/src/Feature.h
@@ -18,6 +18,7 @@ public:
   static const Feature ExperimentalVxORenderersIndexing;
   static const Feature ExperimentalTextMetricsFunctions;
   static const Feature ExperimentalImportFunction;
+  static const Feature ExperimentalFormatFunction;
   static const Feature ExperimentalPredictibleOutput;
 #ifdef ENABLE_PYTHON
   static const Feature ExperimentalPythonEngine;

--- a/src/core/Format.h
+++ b/src/core/Format.h
@@ -1,0 +1,113 @@
+/*
+ *  OpenSCAD (www.openscad.org)
+ *  Copyright (C) 2009-2025 Clifford Wolf <clifford@clifford.at> and
+ *                          Marius Kintel <marius@kintel.net>
+ *
+ *  This program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  As a special exception, you have permission to link this program
+ *  with the CGAL library and distribute executables, as long as you
+ *  follow the requirements of the GNU GPL in regard to all of the
+ *  software in the executable aside from CGAL.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program; if not, write to the Free Software
+ *  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ *
+ */
+
+#pragma once
+
+#include <fmt/args.h>
+#include <fmt/core.h>
+#include <fmt/format.h>
+
+#include "core/Value.h"
+#include "utils/printutils.h"
+
+template <>
+struct fmt::formatter<RangeType> : public fmt::formatter<double> {
+  template <typename FmtContext>
+  constexpr auto format(RangeType const& r, FmtContext& ctx) const {
+    format_to(ctx.out(), "[");
+    fmt::formatter<double>::format(r.begin_value(), ctx);
+    if (r.step_value() != 1) {
+      format_to(ctx.out(), ":");
+      fmt::formatter<double>::format(r.step_value(), ctx);
+    }
+    format_to(ctx.out(), ":");
+    fmt::formatter<double>::format(r.end_value(), ctx);
+    format_to(ctx.out(), "]");
+    return ctx.out();
+  }
+};
+
+template <>
+class fmt::formatter<VectorType> : public fmt::formatter<std::string> {
+public:
+  template <typename FmtContext>
+  auto format(VectorType const& v, FmtContext& ctx) const {
+    if (!v.empty()) {
+      fmt::format_to(ctx.out(), "[");
+      auto it = v.begin();
+      while (true) {
+        fmt::format_to(ctx.out(), "{}", *it);
+        if (++it == v.end()) {
+            break;
+        }
+        fmt::format_to(ctx.out(), ", ");
+      }
+      fmt::format_to(ctx.out(), "]");
+    }
+    return ctx.out();
+  }
+};
+
+template <>
+class fmt::formatter<Value> {
+private:
+  std::string spec;
+public:
+  auto parse(format_parse_context& ctx) {
+      spec = "";
+      auto i = ctx.begin(), end = ctx.end();
+      while (i != end && *i != '}') {
+        char c = *i++;
+        spec.push_back(c);
+      };
+      spec = spec.empty() ? "{}" : "{:" + spec + "}";
+      return i;
+  }
+
+  template <typename FmtContext>
+  constexpr auto format(Value const& v, FmtContext& ctx) const {
+      switch (v.type()) {
+        case Value::Type::UNDEFINED:
+          return fmt::format_to(ctx.out(), fmt::format_string<>(spec), v.toUndefString());
+        case Value::Type::BOOL:
+          return fmt::format_to(ctx.out(), fmt::format_string<>(spec), v.toBool());
+        case Value::Type::NUMBER:
+          return fmt::format_to(ctx.out(), fmt::format_string<>(spec), v.toDouble());
+        case Value::Type::STRING:
+          return fmt::format_to(ctx.out(), fmt::format_string<>(spec), v.toString());
+        case Value::Type::RANGE:
+          return fmt::format_to(ctx.out(), fmt::format_string<>(spec), v.toRange());
+        case Value::Type::VECTOR:
+          return fmt::format_to(ctx.out(), fmt::format_string<>(spec), v.toVector());
+        case Value::Type::FUNCTION:
+          return fmt::format_to(ctx.out(), fmt::format_string<>(spec), STR(v.toFunction()));
+        case Value::Type::OBJECT:
+          return fmt::format_to(ctx.out(), fmt::format_string<>(spec), STR(v.toObject()));
+        default:
+          return ctx.out();
+      }
+  }
+};


### PR DESCRIPTION
```openscad
echo(format("hallo {name:*>8}! {r} {n} {3}",
    name = "welt",
    n = 42,
    r = [1:0.5:6],
    [2,2.4, "blah"]
));

// ECHO: "hallo ****welt! [1:0.5:6] 42 [2, 2.4, blah]"
```