### PR TITLE
macOS: Bump lib3mf to 2.4.1

### DIFF
--- a/patches/lib3mf-macos.patch
+++ b/patches/lib3mf-macos.patch
@@ -1,7 +1,13 @@
-diff --color -ur lib3mf-2.3.0/CMakeLists.txt lib3mf-2.3.0-patched/CMakeLists.txt
---- lib3mf-2.3.0/CMakeLists.txt	2024-03-05 09:02:36
-+++ lib3mf-2.3.0-patched/CMakeLists.txt	2024-04-13 19:50:17
-@@ -170,7 +170,8 @@
+diff --color -ru lib3mf-2.4.1/CMakeLists.txt lib3mf-2.4.1-patched/CMakeLists.txt
+--- lib3mf-2.4.1/CMakeLists.txt	2025-02-26 10:59:32
++++ lib3mf-2.4.1-patched/CMakeLists.txt	2025-04-02 22:33:07
+@@ -1,4 +1,4 @@
+-cmake_minimum_required (VERSION 3.0)
++cmake_minimum_required (VERSION 3.5)
+ 
+ cmake_policy(SET CMP0054 NEW)
+ cmake_policy(SET CMP0048 NEW)
+@@ -201,7 +201,8 @@
  else()
      find_package(PkgConfig REQUIRED)
      pkg_check_modules(LIBZIP REQUIRED libzip)
@@ -9,5 +15,3 @@ diff --color -ur lib3mf-2.3.0/CMakeLists.txt lib3mf-2.3.0-patched/CMakeLists.txt
 +    target_link_libraries(${PROJECT_NAME} ${LIBZIP_LINK_LIBRARIES})
 +    target_include_directories(${PROJECT_NAME} PRIVATE ${LIBZIP_INCLUDE_DIRS})
  endif()
- 
- 

--- a/scripts/macosx-build-dependencies.sh
+++ b/scripts/macosx-build-dependencies.sh
@@ -49,7 +49,7 @@ PACKAGES=(
     "libzip 1.9.2"
     "fontconfig 2.14.1"
     "hidapi 0.12.0"
-    "lib3mf 2.3.1"
+    "lib3mf 2.4.1"
     "pcre2 10.44"
     "glib2 2.83.0"
     "pixman 0.42.2"


### PR DESCRIPTION
Before merging, we may need to wait for https://github.com/msys2/MINGW-packages/pull/23855