### PR TITLE
Fix QKeySequence for Find and Replace

### DIFF
--- a/src/gui/MainWindow.cc
+++ b/src/gui/MainWindow.cc
@@ -506,7 +506,7 @@ MainWindow::MainWindow(const QStringList& filenames) :
   connect(this->editActionFind, &QAction::triggered, this, &MainWindow::showFind);
   connect(this->editActionFindAndReplace, &QAction::triggered, this, &MainWindow::showFindAndReplace);
 #ifdef Q_OS_WIN
-  this->editActionFindAndReplace->setShortcut(QKeySequence(Qt::CTRL, Qt::SHIFT, Qt::Key_F));
+  this->editActionFindAndReplace->setShortcut(QKeySequence(Qt::CTRL + Qt::SHIFT + Qt::Key_F));
 #endif
   connect(this->editActionFindNext, &QAction::triggered, this, &MainWindow::findNext);
   connect(this->editActionFindPrevious, &QAction::triggered, this, &MainWindow::findPrev);


### PR DESCRIPTION
Fixes #5760 

Seems like the only issue is not adding each key action, which is how it's used elsewhere in the file. I've built it locally with MSYS2 to confirm the changes work, also on Windows 11.