### PR TITLE
Use QFileSystemWatcher instead of QTimer to implement automatic reload

### DIFF
--- a/src/gui/MainWindow.h
+++ b/src/gui/MainWindow.h
@@ -7,6 +7,7 @@
 #include <string>
 #include <vector>
 
+#include <QFileSystemWatcher>
 #include <QAction>
 #include <QCloseEvent>
 #include <QDragEnterEvent>
@@ -79,8 +80,6 @@ public:
 
   bool isPreview;
 
-  QTimer *autoReloadTimer;
-  QTimer *waitAfterReloadTimer;
   RenderStatistic renderStatistic;
 
   SourceFile *rootFile; // Result of parsing
@@ -154,6 +153,7 @@ private slots:
   void onNavigationCloseContextMenu();
   void onNavigationHoveredContextMenuEntry();
   void onNavigationTriggerContextMenuEntry();
+  void onFileChanged(const QString& path);
 
   // implement the different actions needed when
   // the tab manager editor is changed.
@@ -189,6 +189,7 @@ private:
 
   void setRenderVariables(ContextHandle<BuiltinContext>& context);
   void updateCompileResult();
+  void rawCompile(bool reload, bool forcedone = false);
   void compile(bool reload, bool forcedone = false);
   void compileCSG();
   bool checkEditorModified();
@@ -210,6 +211,7 @@ private:
   LibraryInfoDialog *libraryInfoDialog{nullptr};
   FontListDialog *fontListDialog{nullptr};
   QSignalMapper *exportFormatMapper;
+  QFileSystemWatcher fileSystemWatcher;
 
 public slots:
   void updateExportActions();
@@ -240,7 +242,6 @@ private slots:
   void compileEnded();
   void changeParameterWidget();
 
-private slots:
   void copyViewportTranslation();
   void copyViewportRotation();
   void copyViewportDistance();
@@ -321,6 +322,7 @@ public:
   void clearCurrentOutput();
   void hideCurrentOutput();
   bool isEmpty();
+  bool autoReloadEnabled();
 
   void onAxisChanged(InputEventAxisChanged *event) override;
   void onButtonChanged(InputEventButtonChanged *event) override;


### PR DESCRIPTION
This PR will be about fixing the bug described in issue https://github.com/openscad/openscad/issues/5795

This will be done by refactoring the reload code so it use QFileSystemWatcher instead of QTimer to detect file change to make the code path more simple to understand.

