### PR TITLE
Disable Qt5 build for macOS

### DIFF
--- a/.github/workflows/macos-tests.yml
+++ b/.github/workflows/macos-tests.yml
@@ -22,6 +22,9 @@ jobs:
         exclude:
           # macos-latest runs on arm64, which has a broken SW renderer
           - os: macos-latest
+          # QScintilla for qt5 is not longer available on Homebrew, and
+          # it's too much work to keep that running.
+          - qt: qt5
     runs-on:  ${{ matrix.os }}
     name: ${{ matrix.os }} ${{ matrix.qt }}
     # If it's not done in 60 minutes, something is wrong.


### PR DESCRIPTION
QScintilla for qt5 is not longer available on Homebrew, and it's too much work to keep that running.
Until that's fixed upstream, we're disabling the Qt5 build on macOS.

Qt5 Scintilla Broke in https://github.com/Homebrew/homebrew-core/pull/166414