### PR TITLE
Fix checking whether Dock widgets are floating

### DIFF
--- a/src/gui/Dock.cc
+++ b/src/gui/Dock.cc
@@ -43,7 +43,7 @@ void Dock::setConfigKey(const QString& configKey)
 
 void Dock::updateTitle(){
   QString title(name);
-  if (isTopLevel() && !namesuffix.isEmpty()) {
+  if (isFloating() && !namesuffix.isEmpty()) {
     title += " (" + namesuffix + ")";
   }
   setWindowTitle(title);

--- a/src/gui/MainWindow.cc
+++ b/src/gui/MainWindow.cc
@@ -3449,7 +3449,7 @@ void MainWindow::activateDock(Dock *dock)
   if (dock == nullptr) return;
 
   // We always need to activate the window.
-  if (dock->isTopLevel()) dock->activateWindow();
+  if (dock->isFloating()) dock->activateWindow();
   else QMainWindow::activateWindow();
 
   dock->raise();


### PR DESCRIPTION
The QDockWidget::topLevelChanged() signal and its topLevel parameter are reporting changes of the floating property.

Fortunately QWidget::isTopLevel() is now deprecated.