### PR TITLE
Add export options to manpage

### DIFF
--- a/doc/openscad.1
+++ b/doc/openscad.1
@@ -56,6 +56,11 @@ If a nonexisting file is accessed during OpenSCAD's operation, it will try to
 invoke \fImake_command missing_file\fP to create the missing file, and then
 read it again.
 .TP
+\fB-O\fP \fIsection/key=val\fP
+Pass settings value to the file export using the format section/key=value, e.g 
+export-pdf/paper-size=a3. Use --help-export to list all available settings.
+More than one \fB-O\fP option can be given.
+.TP
 \fB-D\fP \fIvar=val\fP
 This option can be used to assign constant values to OpenSCAD variables. The
 variable's value is an expression, so if this mechanism is used to assign

--- a/doc/openscad.1
+++ b/doc/openscad.1
@@ -73,6 +73,12 @@ Customizer parameter file.
 .B \-P [ \-\-P ] arg
 Customizer parameter set.
 .TP
+.B \-h [ \-\-help ]
+Print basic program usage.
+.TP
+.B \-\-help\-export
+Print list of export parameters and values that can be set via -O
+.TP
 .B \-v
 Print version.
 .TP


### PR DESCRIPTION
Add the following options listed in `--help` that are missing in the manpage:
* -O
* --help
* --help-export

I copied help messages where possible and kept the arguments in the same order.

Screenshot of relevant section of manpage:

![openscad_manpage](https://github.com/user-attachments/assets/d6034f2c-61a8-4ed2-be10-0365a042929c)
