### PR TITLE
Improve scalability of Launching Screen.

### DIFF
--- a/src/gui/LaunchingScreen.ui
+++ b/src/gui/LaunchingScreen.ui
@@ -2,19 +2,12 @@
 <ui version="4.0">
  <class>LaunchingScreen</class>
  <widget class="QDialog" name="LaunchingScreen">
-  <property name="geometry">
-   <rect>
-    <x>0</x>
-    <y>0</y>
-    <width>620</width>
-    <height>418</height>
-   </rect>
-  </property>
-  <property name="minimumSize">
-   <size>
-    <width>600</width>
-    <height>0</height>
-   </size>
+  <property name="styleSheet">
+   <string notr="true">
+    QLabel { font-size: 9pt; }
+    QPushButton { font-size: 9pt; }
+    QCheckBox { font-size: 9pt; }
+   </string>
   </property>
   <property name="windowTitle">
    <string>Welcome to OpenSCAD</string>


### PR DESCRIPTION
Adds style sheet entries for labels, pushbuttons, and check boxes that are defined in terms of points, rather than left unspecified.  These seem to yield about the same size (at least on my Windows 11 system), but scale with Settings>System>Display>Scale.

Remove the size hints for the dialog box, which were allowing it to be the wrong size for its contents.  Qt seems to do the right thing by default.

Notes:
- You don't get good results from dynamically changing the scale; you need to restart the application.  It looks like the text resizes but the boxes containing it don't.
- This change doesn't change the behavior of the setting at Settings > Accessibility > Text Size.  I think that may be intended to change the point size of the text.
- Further research and experimentation is needed on both of those points, but this seems like an improvement.

Tested only on Windows 11.

Here's the original and new at 100%:
![image](https://github.com/user-attachments/assets/38adc6c8-18ac-4c33-92b7-75e87bbea7d2)
![image](https://github.com/user-attachments/assets/d9b70064-a3be-40e7-8e16-9f4ec90ea29c)

Here's both of them, resized down as far as it will let us:
![image](https://github.com/user-attachments/assets/1cb96db4-7bd1-4a05-b457-0da3ff385f7e)
![image](https://github.com/user-attachments/assets/7da466c2-05ab-4349-bc8c-1ed9fa581e4b)

Here they are at 200%:
![image](https://github.com/user-attachments/assets/74c63fb4-c295-4fd0-b678-6ec25ebfef71)
![image](https://github.com/user-attachments/assets/e1b4f8c7-031f-4453-9689-0ad0fd7b3dc0)

And then resized down as far as it will let us:
![image](https://github.com/user-attachments/assets/2fd8a505-41a0-4f93-a342-626d7c589769)
![image](https://github.com/user-attachments/assets/4f2d5c8e-9ab5-4eff-8520-b5d14c7efb36)

Here's the effect from starting at 100% and dynamically switching to 200% without restarting the app.
![image](https://github.com/user-attachments/assets/816798f0-ae58-4643-adcc-2ee5f7fe69bd)
![image](https://github.com/user-attachments/assets/a8b8c950-e2c7-4c2c-b64b-e5940724f6ee)
