### PR TITLE
Missing space in "No xxxto dump.  Please try compiling first..." message

### DIFF
--- a/src/gui/MainWindow.cc
+++ b/src/gui/MainWindow.cc
@@ -2692,7 +2692,7 @@ void MainWindow::showTextInWindow(const QString& type, const QString& content)
     e->setTabStopDistance(tabStopWidth);
     e->setWindowTitle(type+" Dump");
     if(content.isEmpty())
-        e->setPlainText("No "+type+"to dump. Please try compiling first...");
+        e->setPlainText("No "+type+" to dump. Please try compiling first...");
     else
         e->setPlainText(content);
 


### PR DESCRIPTION
Like the title says.
```
No ASTto dump. Please try compiling first...
```
should be
```
No AST to dump. Please try compiling first...
```