### PR TITLE
Renamed CGAL_Nef_Polyhedron to CGALNefGeometry

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -936,7 +936,7 @@ set(CGAL_SOURCES
   src/geometry/cgal/cgalutils-project.cc
   src/geometry/cgal/cgalutils-tess.cc
   src/geometry/cgal/cgalutils-triangulate.cc
-  src/geometry/cgal/CGAL_Nef_polyhedron.cc
+  src/geometry/cgal/CGALNefGeometry.cc
   src/geometry/cgal/CGALCache.cc
   src/io/export_nef.cc
   src/io/import_nef.cc

--- a/locale/cs.po
+++ b/locale/cs.po
@@ -2763,8 +2763,8 @@ msgstr ""
 #~ msgid "WARNING: minkowski() could not get any points from object 2!"
 #~ msgstr "VAROVÁNÍ: minkowski() nenalezl žádné body v objektu 2!"
 
-#~ msgid "CGAL error in CGAL_Nef_polyhedron's %s operator: %s"
-#~ msgstr "CGAL chyba v CGAL_Nef_polyhedron operátoru %s: %s"
+#~ msgid "CGAL error in CGALNefGeometry's %s operator: %s"
+#~ msgstr "CGAL chyba v CGALNefGeometry operátoru %s: %s"
 
 #~ msgid "WARNING: hull() does not support mixing 2D and 3D objects."
 #~ msgstr "VAROVÁNÍ: hull() neumožňuje kombinovat 2D a 3D objekty."

--- a/src/RenderStatistic.cc
+++ b/src/RenderStatistic.cc
@@ -48,7 +48,7 @@
 #include "glview/Camera.h"
 #include "utils/printutils.h"
 #ifdef ENABLE_CGAL
-#include "geometry/cgal/CGAL_Nef_polyhedron.h"
+#include "geometry/cgal/CGALNefGeometry.h"
 #include "geometry/cgal/CGALCache.h"
 #endif // ENABLE_CGAL
 #ifdef ENABLE_MANIFOLD
@@ -86,7 +86,7 @@ struct LogVisitor : public StatisticVisitor
   void visit(const PolySet& node) override;
   void visit(const Polygon2d& node) override;
 #ifdef ENABLE_CGAL
-  void visit(const CGAL_Nef_polyhedron& node) override;
+  void visit(const CGALNefGeometry& node) override;
 #endif // ENABLE_CGAL
 #ifdef ENABLE_MANIFOLD
   void visit(const ManifoldGeometry& node) override;
@@ -110,7 +110,7 @@ struct StreamVisitor : public StatisticVisitor
   void visit(const PolySet& node) override;
   void visit(const Polygon2d& node) override;
 #ifdef ENABLE_CGAL
-  void visit(const CGAL_Nef_polyhedron& node) override;
+  void visit(const CGALNefGeometry& node) override;
 #endif // ENABLE_CGAL
 #ifdef ENABLE_MANIFOLD
   void visit(const ManifoldGeometry& node) override;
@@ -261,7 +261,7 @@ void LogVisitor::visit(const PolySet& ps)
 }
 
 #ifdef ENABLE_CGAL
-void LogVisitor::visit(const CGAL_Nef_polyhedron& nef)
+void LogVisitor::visit(const CGALNefGeometry& nef)
 {
   if (nef.getDimension() == 3) {
     const bool simple = nef.p3->is_simple();
@@ -364,7 +364,7 @@ void StreamVisitor::visit(const PolySet& ps)
 }
 
 #ifdef ENABLE_CGAL
-void StreamVisitor::visit(const CGAL_Nef_polyhedron& nef)
+void StreamVisitor::visit(const CGALNefGeometry& nef)
 {
   if (is_enabled(RenderStatistic::GEOMETRY)) {
     nlohmann::json geometryJson;

--- a/src/core/ImportNode.cc
+++ b/src/core/ImportNode.cc
@@ -33,7 +33,7 @@
 #include "core/ModuleInstantiation.h"
 #include "geometry/PolySet.h"
 #ifdef ENABLE_CGAL
-#include "geometry/cgal/CGAL_Nef_polyhedron.h"
+#include "geometry/cgal/CGALNefGeometry.h"
 #endif
 #include "geometry/Polygon2d.h"
 #include "core/Builtins.h"

--- a/src/geometry/Geometry.h
+++ b/src/geometry/Geometry.h
@@ -10,7 +10,7 @@
 #include "geometry/linalg.h"
 
 class AbstractNode;
-class CGAL_Nef_polyhedron;
+class CGALNefGeometry;
 class GeometryList;
 class GeometryVisitor;
 class Polygon2d;
@@ -63,7 +63,7 @@ public:
   virtual void visit(const PolySet& node) = 0;
   virtual void visit(const Polygon2d& node) = 0;
 #ifdef ENABLE_CGAL
-  virtual void visit(const CGAL_Nef_polyhedron& node) = 0;
+  virtual void visit(const CGALNefGeometry& node) = 0;
 #endif
 #ifdef ENABLE_MANIFOLD
   virtual void visit(const ManifoldGeometry& node) = 0;

--- a/src/geometry/GeometryCache.cc
+++ b/src/geometry/GeometryCache.cc
@@ -7,7 +7,7 @@
 #include <string>
 
 #ifdef ENABLE_CGAL
-#include "geometry/cgal/CGAL_Nef_polyhedron.h"
+#include "geometry/cgal/CGALNefGeometry.h"
 #endif
 
 GeometryCache *GeometryCache::inst = nullptr;
@@ -25,7 +25,7 @@ bool GeometryCache::insert(const std::string& id, const std::shared_ptr<const Ge
 {
   auto inserted = this->cache.insert(id, new cache_entry(geom), geom ? geom->memsize() : 0);
 #if defined(ENABLE_CGAL) && defined(DEBUG)
-  assert(!dynamic_cast<const CGAL_Nef_polyhedron *>(geom.get()));
+  assert(!dynamic_cast<const CGALNefGeometry *>(geom.get()));
   if (inserted) PRINTDB("Geometry Cache insert: %s (%d bytes)",
                         id.substr(0, 40) % (geom ? geom->memsize() : 0));
   else PRINTDB("Geometry Cache insert failed: %s (%d bytes)",

--- a/src/geometry/GeometryEvaluator.h
+++ b/src/geometry/GeometryEvaluator.h
@@ -11,7 +11,7 @@
 #include <vector>
 #include <map>
 
-class CGAL_Nef_polyhedron;
+class CGALNefGeometry;
 class Polygon2d;
 class Tree;
 
@@ -91,7 +91,7 @@ private:
   std::unique_ptr<Polygon2d> applyHull2D(const AbstractNode& node);
   std::unique_ptr<Polygon2d> applyFill2D(const AbstractNode& node);
   std::unique_ptr<Geometry> applyHull3D(const AbstractNode& node);
-  void applyResize3D(CGAL_Nef_polyhedron& N, const Vector3d& newsize, const Eigen::Matrix<bool, 3, 1>& autosize);
+  void applyResize3D(CGALNefGeometry& N, const Vector3d& newsize, const Eigen::Matrix<bool, 3, 1>& autosize);
   std::unique_ptr<Polygon2d> applyToChildren2D(const AbstractNode& node, OpenSCADOperator op);
   ResultObject applyToChildren3D(const AbstractNode& node, OpenSCADOperator op);
   ResultObject applyToChildren(const AbstractNode& node, OpenSCADOperator op);

--- a/src/geometry/GeometryUtils.cc
+++ b/src/geometry/GeometryUtils.cc
@@ -540,7 +540,7 @@ std::shared_ptr<const Geometry> GeometryUtils::getBackendSpecificGeometry(const 
 #if ENABLE_CGAL
   if (auto ps = std::dynamic_pointer_cast<const PolySet>(geom)) {
     return CGALUtils::createNefPolyhedronFromPolySet(*ps);
-  } else if (auto poly = std::dynamic_pointer_cast<const CGAL_Nef_polyhedron>(geom)) {
+  } else if (auto poly = std::dynamic_pointer_cast<const CGALNefGeometry>(geom)) {
     return geom;
   } else {
     assert(false && "Unexpected geometry");

--- a/src/geometry/PolySetBuilder.cc
+++ b/src/geometry/PolySetBuilder.cc
@@ -31,7 +31,7 @@
 
 #ifdef ENABLE_CGAL
 #include "geometry/cgal/cgalutils.h"
-#include "geometry/cgal/CGAL_Nef_polyhedron.h"
+#include "geometry/cgal/CGALNefGeometry.h"
 #endif
 #ifdef ENABLE_MANIFOLD
 #include "geometry/manifold/ManifoldGeometry.h"
@@ -96,7 +96,7 @@ void PolySetBuilder::appendGeometry(const std::shared_ptr<const Geometry>& geom)
   } else if (const auto ps = std::dynamic_pointer_cast<const PolySet>(geom)) {
     appendPolySet(*ps);
 #ifdef ENABLE_CGAL
-  } else if (const auto N = std::dynamic_pointer_cast<const CGAL_Nef_polyhedron>(geom)) {
+  } else if (const auto N = std::dynamic_pointer_cast<const CGALNefGeometry>(geom)) {
     if (const auto ps = CGALUtils::createPolySetFromNefPolyhedron3(*(N->p3))) {
       appendPolySet(*ps);
     }

--- a/src/geometry/PolySetUtils.cc
+++ b/src/geometry/PolySetUtils.cc
@@ -185,7 +185,7 @@ std::shared_ptr<const PolySet> getGeometryAsPolySet(const std::shared_ptr<const 
     return ps;
   }
 #ifdef ENABLE_CGAL
-  if (auto N = std::dynamic_pointer_cast<const CGAL_Nef_polyhedron>(geom)) {
+  if (auto N = std::dynamic_pointer_cast<const CGALNefGeometry>(geom)) {
     if (!N->isEmpty()) {
       if (auto ps = CGALUtils::createPolySetFromNefPolyhedron3(*N->p3)) {
         ps->setConvexity(N->getConvexity());

--- a/src/geometry/boolean_utils.cc
+++ b/src/geometry/boolean_utils.cc
@@ -11,7 +11,7 @@
 #ifdef ENABLE_CGAL
 #include "geometry/Geometry.h"
 #include "geometry/cgal/cgal.h"
-#include "geometry/cgal/CGAL_Nef_polyhedron.h"
+#include "geometry/cgal/CGALNefGeometry.h"
 #include <CGAL/Exact_predicates_inexact_constructions_kernel.h>
 #include <CGAL/normal_vector_newell_3.h>
 #include <CGAL/Handle_hash_function.h>
@@ -53,7 +53,7 @@ std::unique_ptr<PolySet> applyHull(const Geometry::Geometries& children)
   for (const auto& item : children) {
     auto& chgeom = item.second;
 #ifdef ENABLE_CGAL
-    if (const auto *N = dynamic_cast<const CGAL_Nef_polyhedron*>(chgeom.get())) {
+    if (const auto *N = dynamic_cast<const CGALNefGeometry*>(chgeom.get())) {
       if (!N->isEmpty()) {
         addCapacity(N->p3->number_of_vertices());
         for (CGAL_Nef_polyhedron3::Vertex_const_iterator i = N->p3->vertices_begin(); i != N->p3->vertices_end(); ++i) {
@@ -131,7 +131,7 @@ std::shared_ptr<const Geometry> applyMinkowski(const Geometry::Geometries& child
         CGAL_Polyhedron poly;
 
         auto ps = std::dynamic_pointer_cast<const PolySet>(operands[i]);
-        auto nef = std::dynamic_pointer_cast<const CGAL_Nef_polyhedron>(operands[i]);
+        auto nef = std::dynamic_pointer_cast<const CGALNefGeometry>(operands[i]);
 
         if (!nef) {
           nef = CGALUtils::getNefPolyhedronFromGeometry(operands[i]);
@@ -297,7 +297,7 @@ std::shared_ptr<const Geometry> applyMinkowski(const Geometry::Geometries& child
         t.reset();
         operands[0] = std::move(N);
       } else {
-        operands[0] = std::make_shared<CGAL_Nef_polyhedron>();
+        operands[0] = std::make_shared<CGALNefGeometry>();
       }
     }
 

--- a/src/geometry/cgal/CGALCache.cc
+++ b/src/geometry/cgal/CGALCache.cc
@@ -8,7 +8,7 @@
 #include "geometry/Geometry.h"
 #include "utils/printutils.h"
 #ifdef ENABLE_CGAL
-#include "geometry/cgal/CGAL_Nef_polyhedron.h"
+#include "geometry/cgal/CGALNefGeometry.h"
 #endif
 #ifdef ENABLE_MANIFOLD
 #include "geometry/manifold/ManifoldGeometry.h"
@@ -32,7 +32,7 @@ std::shared_ptr<const Geometry> CGALCache::get(const std::string& id) const
 bool CGALCache::acceptsGeometry(const std::shared_ptr<const Geometry>& geom) {
   return 0 
 #ifdef ENABLE_CGAL	  
-    || std::dynamic_pointer_cast<const CGAL_Nef_polyhedron>(geom) != nullptr
+    || std::dynamic_pointer_cast<const CGALNefGeometry>(geom) != nullptr
 #endif    
 #ifdef ENABLE_MANIFOLD
     || std::dynamic_pointer_cast<const ManifoldGeometry>(geom) != nullptr

--- a/src/geometry/cgal/CGALNefGeometry.cc
+++ b/src/geometry/cgal/CGALNefGeometry.cc
@@ -1,4 +1,4 @@
-#include "geometry/cgal/CGAL_Nef_polyhedron.h"
+#include "geometry/cgal/CGALNefGeometry.h"
 
 #include <memory>
 #include <cstddef>
@@ -14,41 +14,41 @@
 // Copy constructor only performs shallow copies, so all modifying functions
 // must reset p3 with a new CGAL_Nef_polyhedron3 object, to prevent cache corruption.
 // This is also partly enforced by p3 pointing to a const object.
-CGAL_Nef_polyhedron::CGAL_Nef_polyhedron(const CGAL_Nef_polyhedron& src) : Geometry(src)
+CGALNefGeometry::CGALNefGeometry(const CGALNefGeometry& src) : Geometry(src)
 {
   if (src.p3) this->p3 = src.p3;
 }
 
-std::unique_ptr<Geometry> CGAL_Nef_polyhedron::copy() const
+std::unique_ptr<Geometry> CGALNefGeometry::copy() const
 {
-  return std::make_unique<CGAL_Nef_polyhedron>(*this);
+  return std::make_unique<CGALNefGeometry>(*this);
 }
 
-CGAL_Nef_polyhedron CGAL_Nef_polyhedron::operator+(const CGAL_Nef_polyhedron& other) const
+CGALNefGeometry CGALNefGeometry::operator+(const CGALNefGeometry& other) const
 {
   return {std::make_shared<CGAL_Nef_polyhedron3>((*this->p3) + (*other.p3))};
 }
 
-CGAL_Nef_polyhedron& CGAL_Nef_polyhedron::operator+=(const CGAL_Nef_polyhedron& other)
+CGALNefGeometry& CGALNefGeometry::operator+=(const CGALNefGeometry& other)
 {
   this->p3 = std::make_shared<CGAL_Nef_polyhedron3>((*this->p3) + (*other.p3));
   return *this;
 }
 
-CGAL_Nef_polyhedron& CGAL_Nef_polyhedron::operator*=(const CGAL_Nef_polyhedron& other)
+CGALNefGeometry& CGALNefGeometry::operator*=(const CGALNefGeometry& other)
 {
   this->p3 = std::make_shared<CGAL_Nef_polyhedron3>((*this->p3) * (*other.p3));
   return *this;
 }
 
-CGAL_Nef_polyhedron& CGAL_Nef_polyhedron::operator-=(const CGAL_Nef_polyhedron& other)
+CGALNefGeometry& CGALNefGeometry::operator-=(const CGALNefGeometry& other)
 {
   this->p3 = std::make_shared<CGAL_Nef_polyhedron3>((*this->p3) - (*other.p3));
   return *this;
 }
 
 // Note: this is only the fallback method in case of failure in CGALUtils::applyMinkowski (see: cgalutils-applyops.cc)
-CGAL_Nef_polyhedron& CGAL_Nef_polyhedron::minkowski(const CGAL_Nef_polyhedron& other)
+CGALNefGeometry& CGALNefGeometry::minkowski(const CGALNefGeometry& other)
 {
   // It is required to construct copies of our const input operands here.
   // "Postcondition: If either of the input polyhedra is non-convex, it is modified during the computation,
@@ -60,21 +60,21 @@ CGAL_Nef_polyhedron& CGAL_Nef_polyhedron::minkowski(const CGAL_Nef_polyhedron& o
   return *this;
 }
 
-size_t CGAL_Nef_polyhedron::memsize() const
+size_t CGALNefGeometry::memsize() const
 {
   if (this->isEmpty()) return 0;
 
-  auto memsize = sizeof(CGAL_Nef_polyhedron);
+  auto memsize = sizeof(CGALNefGeometry);
   memsize += const_cast<CGAL_Nef_polyhedron3&>(*this->p3).bytes();
   return memsize;
 }
 
-bool CGAL_Nef_polyhedron::isEmpty() const
+bool CGALNefGeometry::isEmpty() const
 {
   return !this->p3 || this->p3->is_empty();
 }
 
-BoundingBox CGAL_Nef_polyhedron::getBoundingBox() const
+BoundingBox CGALNefGeometry::getBoundingBox() const
 {
   if (isEmpty()) {
     return {};
@@ -87,7 +87,7 @@ BoundingBox CGAL_Nef_polyhedron::getBoundingBox() const
   return result;
 }
 
-void CGAL_Nef_polyhedron::resize(const Vector3d& newsize,
+void CGALNefGeometry::resize(const Vector3d& newsize,
                                  const Eigen::Matrix<bool, 3, 1>& autosize)
 {
   // Based on resize() in Giles Bathgate's RapCAD (but not exactly)
@@ -99,12 +99,12 @@ void CGAL_Nef_polyhedron::resize(const Vector3d& newsize,
       getDimension(), newsize, autosize));
 }
 
-std::string CGAL_Nef_polyhedron::dump() const
+std::string CGALNefGeometry::dump() const
 {
   return OpenSCAD::dump_svg(*this->p3);
 }
 
-void CGAL_Nef_polyhedron::transform(const Transform3d& matrix)
+void CGALNefGeometry::transform(const Transform3d& matrix)
 {
   if (!this->isEmpty()) {
     if (matrix.matrix().determinant() == 0) {

--- a/src/geometry/cgal/CGALNefGeometry.h
+++ b/src/geometry/cgal/CGALNefGeometry.h
@@ -8,17 +8,17 @@
 #include <utility>
 #include "geometry/linalg.h"
 
-class CGAL_Nef_polyhedron : public Geometry
+class CGALNefGeometry : public Geometry
 {
 public:
   VISITABLE_GEOMETRY();
-  CGAL_Nef_polyhedron() = default;
-  CGAL_Nef_polyhedron(std::shared_ptr<const CGAL_Nef_polyhedron3> p) : p3(std::move(p)) {}
-  CGAL_Nef_polyhedron(const CGAL_Nef_polyhedron& src);
-  CGAL_Nef_polyhedron& operator=(const CGAL_Nef_polyhedron&) = default;
-  CGAL_Nef_polyhedron(CGAL_Nef_polyhedron&&) = default;
-  CGAL_Nef_polyhedron& operator=(CGAL_Nef_polyhedron&&) = default;
-  ~CGAL_Nef_polyhedron() override = default;
+  CGALNefGeometry() = default;
+  CGALNefGeometry(std::shared_ptr<const CGAL_Nef_polyhedron3> p) : p3(std::move(p)) {}
+  CGALNefGeometry(const CGALNefGeometry& src);
+  CGALNefGeometry& operator=(const CGALNefGeometry&) = default;
+  CGALNefGeometry(CGALNefGeometry&&) = default;
+  CGALNefGeometry& operator=(CGALNefGeometry&&) = default;
+  ~CGALNefGeometry() override = default;
 
   [[nodiscard]] size_t memsize() const override;
   // FIXME: Implement, but we probably want a high-resolution BBox..
@@ -31,11 +31,11 @@ public:
   [[nodiscard]] size_t numFacets() const override { return p3->number_of_facets(); }
 
   void reset() { p3.reset(); }
-  CGAL_Nef_polyhedron operator+(const CGAL_Nef_polyhedron& other) const;
-  CGAL_Nef_polyhedron& operator+=(const CGAL_Nef_polyhedron& other);
-  CGAL_Nef_polyhedron& operator*=(const CGAL_Nef_polyhedron& other);
-  CGAL_Nef_polyhedron& operator-=(const CGAL_Nef_polyhedron& other);
-  CGAL_Nef_polyhedron& minkowski(const CGAL_Nef_polyhedron& other);
+  CGALNefGeometry operator+(const CGALNefGeometry& other) const;
+  CGALNefGeometry& operator+=(const CGALNefGeometry& other);
+  CGALNefGeometry& operator*=(const CGALNefGeometry& other);
+  CGALNefGeometry& operator-=(const CGALNefGeometry& other);
+  CGALNefGeometry& minkowski(const CGALNefGeometry& other);
   void transform(const Transform3d& matrix) override;
   void resize(const Vector3d& newsize, const Eigen::Matrix<bool, 3, 1>& autosize) override;
 

--- a/src/geometry/cgal/Polygon2d-CGAL.h
+++ b/src/geometry/cgal/Polygon2d-CGAL.h
@@ -1,7 +1,7 @@
 #pragma once
 
-#include "geometry/cgal/CGAL_Nef_polyhedron.h"
+#include "geometry/cgal/CGALNefGeometry.h"
 
 namespace Polygon2DCGAL {
-CGAL_Nef_polyhedron toNefPolyhedron();
+CGALNefGeometry toNefPolyhedron();
 }

--- a/src/geometry/cgal/cgalutils-applyops.cc
+++ b/src/geometry/cgal/cgalutils-applyops.cc
@@ -41,7 +41,7 @@ namespace CGALUtils {
 std::unique_ptr<const Geometry> applyUnion3D(
 Geometry::Geometries::iterator chbegin, Geometry::Geometries::iterator chend)
 {
-  using QueueConstItem = std::pair<std::shared_ptr<const CGAL_Nef_polyhedron>, int>;
+  using QueueConstItem = std::pair<std::shared_ptr<const CGALNefGeometry>, int>;
   struct QueueItemGreater {
     // stable sort for priority_queue by facets, then progress mark
     bool operator()(const QueueConstItem& lhs, const QueueConstItem& rhs) const
@@ -72,12 +72,12 @@ Geometry::Geometries::iterator chbegin, Geometry::Geometries::iterator chend)
       q.pop();
       auto p2 = q.top();
       q.pop();
-      q.emplace(std::make_unique<const CGAL_Nef_polyhedron>(*p1.first + *p2.first), -1);
+      q.emplace(std::make_unique<const CGALNefGeometry>(*p1.first + *p2.first), -1);
       progress_tick();
     }
 
     if (q.size() == 1) {
-      return std::make_unique<CGAL_Nef_polyhedron>(q.top().first->p3);
+      return std::make_unique<CGALNefGeometry>(q.top().first->p3);
     } else {
       return nullptr;
     }
@@ -93,7 +93,7 @@ Geometry::Geometries::iterator chbegin, Geometry::Geometries::iterator chend)
  */
 std::shared_ptr<const Geometry> applyOperator3D(const Geometry::Geometries& children, OpenSCADOperator op)
 {
-  std::shared_ptr<CGAL_Nef_polyhedron> N;
+  std::shared_ptr<CGALNefGeometry> N;
 
   assert(op != OpenSCADOperator::UNION && "use applyUnion3D() instead of applyOperator3D()");
   bool foundFirst = false;
@@ -107,7 +107,7 @@ std::shared_ptr<const Geometry> applyOperator3D(const Geometry::Geometries& chil
       if (!foundFirst) {
         if (chN) {
 	  // FIXME: Do we need to make a copy here?
-          N = std::make_shared<CGAL_Nef_polyhedron>(*chN);
+          N = std::make_shared<CGALNefGeometry>(*chN);
         } else { // first child geometry might be empty/null
           N = nullptr;
         }

--- a/src/geometry/cgal/cgalutils-project.cc
+++ b/src/geometry/cgal/cgalutils-project.cc
@@ -172,12 +172,12 @@ void ZRemover::visit(CGAL_Nef_polyhedron3::Halffacet_const_handle hfacet)
 
 namespace CGALUtils {
 
-std::unique_ptr<Polygon2d> project(const CGAL_Nef_polyhedron& N, bool cut)
+std::unique_ptr<Polygon2d> project(const CGALNefGeometry& N, bool cut)
 {
   std::unique_ptr<Polygon2d> poly;
   if (N.getDimension() != 3) return poly;
 
-  CGAL_Nef_polyhedron newN;
+  CGALNefGeometry newN;
   if (cut) {
     try {
       CGAL_Nef_polyhedron3::Plane_3 xy_plane = CGAL_Nef_polyhedron3::Plane_3(0, 0, 1, 0);

--- a/src/geometry/cgal/cgalutils.h
+++ b/src/geometry/cgal/cgalutils.h
@@ -14,7 +14,7 @@
 #ifdef ENABLE_CGAL
 #include "geometry/cgal/cgal.h"
 #include <CGAL/Exact_predicates_inexact_constructions_kernel.h>
-#include "geometry/cgal/CGAL_Nef_polyhedron.h"
+#include "geometry/cgal/CGALNefGeometry.h"
 using K = CGAL::Epick;
 using Vertex3K = CGAL::Point_3<K>;
 using PolygonK = std::vector<Vertex3K>;
@@ -29,7 +29,7 @@ Result vector_convert(V const& v) {
   return Result(CGAL::to_double(v[0]), CGAL::to_double(v[1]), CGAL::to_double(v[2]));
 }
 
-std::unique_ptr<CGAL_Nef_polyhedron> createNefPolyhedronFromPolySet(const PolySet& ps);
+std::unique_ptr<CGALNefGeometry> createNefPolyhedronFromPolySet(const PolySet& ps);
 template <typename K>
 bool is_weakly_convex(const CGAL::Polyhedron_3<K>& p);
 template <typename K>
@@ -37,8 +37,8 @@ bool is_weakly_convex(const CGAL::Surface_mesh<CGAL::Point_3<K>>& m);
 std::shared_ptr<const Geometry> applyOperator3D(const Geometry::Geometries& children, OpenSCADOperator op);
 std::unique_ptr<const Geometry> applyUnion3D(Geometry::Geometries::iterator chbegin, Geometry::Geometries::iterator chend);
 //FIXME: Old, can be removed:
-//void applyBinaryOperator(CGAL_Nef_polyhedron &target, const CGAL_Nef_polyhedron &src, OpenSCADOperator op);
-std::unique_ptr<Polygon2d> project(const CGAL_Nef_polyhedron& N, bool cut);
+//void applyBinaryOperator(CGALNefGeometry &target, const CGALNefGeometry &src, OpenSCADOperator op);
+std::unique_ptr<Polygon2d> project(const CGALNefGeometry& N, bool cut);
 template <typename K>
 CGAL::Iso_cuboid_3<K> boundingBox(const CGAL::Nef_polyhedron_3<K>& N);
 template <typename K>
@@ -61,8 +61,8 @@ bool createMeshFromPolySet(const PolySet& ps, TriangleMesh& mesh);
 
 template <typename K>
 std::unique_ptr<PolySet> createPolySetFromNefPolyhedron3(const CGAL::Nef_polyhedron_3<K>& N);
-std::shared_ptr<const CGAL_Nef_polyhedron> getNefPolyhedronFromGeometry(const std::shared_ptr<const Geometry>& geom);
-std::shared_ptr<const CGAL_Nef_polyhedron> getGeometryAsNefPolyhedron(const std::shared_ptr<const Geometry>&);
+std::shared_ptr<const CGALNefGeometry> getNefPolyhedronFromGeometry(const std::shared_ptr<const Geometry>& geom);
+std::shared_ptr<const CGALNefGeometry> getGeometryAsNefPolyhedron(const std::shared_ptr<const Geometry>&);
 
 template <typename K>
 CGAL::Aff_transformation_3<K> createAffineTransformFromMatrix(const Transform3d& matrix);

--- a/src/geometry/manifold/ManifoldGeometry.cc
+++ b/src/geometry/manifold/ManifoldGeometry.cc
@@ -270,8 +270,8 @@ ManifoldGeometry ManifoldGeometry::binOp(const ManifoldGeometry& lhs, const Mani
 std::shared_ptr<ManifoldGeometry> minkowskiOp(const ManifoldGeometry& lhs, const ManifoldGeometry& rhs) {
 // FIXME: How to deal with operation not supported?
 #ifdef ENABLE_CGAL
-  auto lhs_nef = std::shared_ptr<CGAL_Nef_polyhedron>(CGALUtils::createNefPolyhedronFromPolySet(*lhs.toPolySet()));
-  auto rhs_nef = std::shared_ptr<CGAL_Nef_polyhedron>(CGALUtils::createNefPolyhedronFromPolySet(*rhs.toPolySet()));
+  auto lhs_nef = std::shared_ptr<CGALNefGeometry>(CGALUtils::createNefPolyhedronFromPolySet(*lhs.toPolySet()));
+  auto rhs_nef = std::shared_ptr<CGALNefGeometry>(CGALUtils::createNefPolyhedronFromPolySet(*rhs.toPolySet()));
   if (lhs_nef->isEmpty() || rhs_nef->isEmpty()) {
     return {};
   }

--- a/src/glview/PolySetRenderer.cc
+++ b/src/glview/PolySetRenderer.cc
@@ -53,7 +53,7 @@
 #include "glview/VertexState.h"
 
 #ifdef ENABLE_CGAL
-#include "geometry/cgal/CGAL_Nef_polyhedron.h"
+#include "geometry/cgal/CGALNefGeometry.h"
 #endif
 #ifdef ENABLE_MANIFOLD
 #include "geometry/manifold/ManifoldGeometry.h"
@@ -85,7 +85,7 @@ void PolySetRenderer::addGeometry(const std::shared_ptr<const Geometry>& geom)
     this->polysets_.push_back(mani->toPolySet());
 #endif
 #ifdef ENABLE_CGAL
-  } else if (const auto N = std::dynamic_pointer_cast<const CGAL_Nef_polyhedron>(geom)) {
+  } else if (const auto N = std::dynamic_pointer_cast<const CGALNefGeometry>(geom)) {
     // Note: It's rare, but possible for Nef polyhedrons to exist among geometries in Manifold mode.
     // One way is through import("file.nef3")
     assert(N->getDimension() == 3);

--- a/src/glview/cgal/CGALRenderer.cc
+++ b/src/glview/cgal/CGALRenderer.cc
@@ -87,7 +87,7 @@ void CGALRenderer::addGeometry(const std::shared_ptr<const Geometry> &geom) {
         poly, std::shared_ptr<const PolySet>(poly->tessellate()));
 #ifdef ENABLE_CGAL
   } else if (const auto new_N =
-                 std::dynamic_pointer_cast<const CGAL_Nef_polyhedron>(geom)) {
+                 std::dynamic_pointer_cast<const CGALNefGeometry>(geom)) {
     assert(new_N->getDimension() == 3);
     if (!new_N->isEmpty()) {
       this->nefPolyhedrons_.push_back(new_N);

--- a/src/glview/cgal/CGALRenderer.h
+++ b/src/glview/cgal/CGALRenderer.h
@@ -12,7 +12,7 @@
 #include "glview/ColorMap.h"
 #include "glview/VertexState.h"
 #ifdef ENABLE_CGAL
-#include "geometry/cgal/CGAL_Nef_polyhedron.h"
+#include "geometry/cgal/CGALNefGeometry.h"
 #endif
 
 class CGALRenderer : public VBORenderer
@@ -43,7 +43,7 @@ private:
   std::vector<std::pair<std::shared_ptr<const Polygon2d>, std::shared_ptr<const PolySet>>> polygons_;
 #ifdef ENABLE_CGAL
   std::vector<std::shared_ptr<class VBOPolyhedron>> polyhedrons_;
-  std::vector<std::shared_ptr<const CGAL_Nef_polyhedron>> nefPolyhedrons_;
+  std::vector<std::shared_ptr<const CGALNefGeometry>> nefPolyhedrons_;
 #endif
 
   std::vector<VertexStateContainer> vertex_state_containers_;

--- a/src/gui/MainWindow.cc
+++ b/src/gui/MainWindow.cc
@@ -149,7 +149,7 @@
 #ifdef ENABLE_CGAL
 #include "geometry/cgal/cgal.h"
 #include "geometry/cgal/CGALCache.h"
-#include "geometry/cgal/CGAL_Nef_polyhedron.h"
+#include "geometry/cgal/CGALNefGeometry.h"
 #endif // ENABLE_CGAL
 #ifdef ENABLE_MANIFOLD
 #include "geometry/manifold/manifoldutils.h"
@@ -2748,7 +2748,7 @@ void MainWindow::actionCheckValidity()
 
   bool valid = true;
 #ifdef ENABLE_CGAL
-  if (auto N = std::dynamic_pointer_cast<const CGAL_Nef_polyhedron>(rootGeom)) {
+  if (auto N = std::dynamic_pointer_cast<const CGALNefGeometry>(rootGeom)) {
     valid = N->p3 ? const_cast<CGAL_Nef_polyhedron3&>(*N->p3).is_valid() : false;
   } else
 #endif
@@ -2806,7 +2806,7 @@ bool MainWindow::canExport(unsigned int dim)
   }
 
 #ifdef ENABLE_CGAL
-  auto N = dynamic_cast<const CGAL_Nef_polyhedron *>(rootGeom.get());
+  auto N = dynamic_cast<const CGALNefGeometry *>(rootGeom.get());
   if (N && !N->p3->is_simple()) {
     LOG(message_group::UI_Warning, "Object may not be a valid 2-manifold and may need repair! See https://en.wikibooks.org/wiki/OpenSCAD_User_Manual/STL_Import_and_Export");
   }

--- a/src/io/export_3mf_v1.cc
+++ b/src/io/export_3mf_v1.cc
@@ -50,7 +50,7 @@
 
 #ifdef ENABLE_CGAL
 #include "geometry/cgal/cgalutils.h"
-#include "geometry/cgal/CGAL_Nef_polyhedron.h"
+#include "geometry/cgal/CGALNefGeometry.h"
 #endif
 
 #undef BOOL
@@ -298,7 +298,7 @@ bool append_polyset(const std::shared_ptr<const PolySet>& ps, ExportContext& ctx
 }
 
 #ifdef ENABLE_CGAL
-bool append_nef(const CGAL_Nef_polyhedron& root_N, ExportContext& ctx)
+bool append_nef(const CGALNefGeometry& root_N, ExportContext& ctx)
 {
   if (!root_N.p3) {
     LOG(message_group::Export_Error, "Export failed, empty geometry.");
@@ -327,7 +327,7 @@ static bool append_3mf(const std::shared_ptr<const Geometry>& geom, ExportContex
       if (!append_3mf(item.second, ctx)) return false;
     }
 #ifdef ENABLE_CGAL
-  } else if (const auto N = std::dynamic_pointer_cast<const CGAL_Nef_polyhedron>(geom)) {
+  } else if (const auto N = std::dynamic_pointer_cast<const CGALNefGeometry>(geom)) {
     return append_nef(*N, ctx);
 #endif
 #ifdef ENABLE_MANIFOLD

--- a/src/io/export_3mf_v2.cc
+++ b/src/io/export_3mf_v2.cc
@@ -49,7 +49,7 @@
 
 #ifdef ENABLE_CGAL
 #include "geometry/cgal/cgalutils.h"
-#include "geometry/cgal/CGAL_Nef_polyhedron.h"
+#include "geometry/cgal/CGALNefGeometry.h"
 #endif
 #ifdef ENABLE_MANIFOLD
 #include "geometry/manifold/ManifoldGeometry.h"
@@ -237,7 +237,7 @@ bool append_polyset(const std::shared_ptr<const PolySet>& ps, ExportContext& ctx
 }
 
 #ifdef ENABLE_CGAL
-bool append_nef(const CGAL_Nef_polyhedron& root_N, ExportContext& ctx)
+bool append_nef(const CGALNefGeometry& root_N, ExportContext& ctx)
 {
   if (!root_N.p3) {
     LOG(message_group::Export_Error, "Export failed, empty geometry.");
@@ -264,7 +264,7 @@ bool append_3mf(const std::shared_ptr<const Geometry>& geom, ExportContext& ctx)
       if (!append_3mf(item.second, ctx)) return false;
     }
 #ifdef ENABLE_CGAL
-  } else if (const auto N = std::dynamic_pointer_cast<const CGAL_Nef_polyhedron>(geom)) {
+  } else if (const auto N = std::dynamic_pointer_cast<const CGALNefGeometry>(geom)) {
     return append_nef(*N, ctx);
 #endif
 #ifdef ENABLE_MANIFOLD

--- a/src/io/export_amf.cc
+++ b/src/io/export_amf.cc
@@ -31,7 +31,7 @@
 #ifdef ENABLE_CGAL
 #include "geometry/cgal/cgal.h"
 #include "geometry/cgal/cgalutils.h"
-#include "geometry/cgal/CGAL_Nef_polyhedron.h"
+#include "geometry/cgal/CGALNefGeometry.h"
 #endif
 
 #include <algorithm>
@@ -88,7 +88,7 @@ static size_t add_vertex(std::vector<vertex_str>& vertices, const Point& p) {
     Saves the current 3D CGAL Nef polyhedron as AMF to the given file.
     The file must be open.
  */
-static void append_amf(const CGAL_Nef_polyhedron& root_N, std::ostream& output)
+static void append_amf(const CGALNefGeometry& root_N, std::ostream& output)
 {
   if (!root_N.p3->is_simple()) {
     LOG(message_group::Export_Warning, "Export failed, the object isn't a valid 2-manifold.");

--- a/src/io/export_stl.cc
+++ b/src/io/export_stl.cc
@@ -51,7 +51,7 @@
 #include "geometry/manifold/ManifoldGeometry.h"
 #endif
 #ifdef ENABLE_CGAL
-#include "geometry/cgal/CGAL_Nef_polyhedron.h"
+#include "geometry/cgal/CGALNefGeometry.h"
 #include "geometry/cgal/cgalutils.h"
 #endif
 
@@ -195,7 +195,7 @@ uint64_t append_stl(const std::shared_ptr<const PolySet>& polyset, std::ostream&
     Saves the current 3D CGAL Nef polyhedron as STL to the given file.
     The file must be open.
  */
-uint64_t append_stl(const CGAL_Nef_polyhedron& root_N, std::ostream& output,
+uint64_t append_stl(const CGALNefGeometry& root_N, std::ostream& output,
                     bool binary)
 {
   uint64_t triangle_count = 0;
@@ -250,7 +250,7 @@ uint64_t append_stl(const std::shared_ptr<const Geometry>& geom, std::ostream& o
   } else if (const auto ps = std::dynamic_pointer_cast<const PolySet>(geom)) {
     triangle_count += append_stl(ps, output, binary);
 #ifdef ENABLE_CGAL
-  } else if (const auto N = std::dynamic_pointer_cast<const CGAL_Nef_polyhedron>(geom)) {
+  } else if (const auto N = std::dynamic_pointer_cast<const CGALNefGeometry>(geom)) {
     triangle_count += append_stl(*N, output, binary);
 #endif
 #ifdef ENABLE_MANIFOLD

--- a/src/io/import.h
+++ b/src/io/import.h
@@ -19,7 +19,7 @@ std::unique_ptr<class Polygon2d> import_svg(double fn, double fs, double fa,
 					  const double dpi, const bool center, const Location& loc);
 
 #ifdef ENABLE_CGAL
-std::unique_ptr<class CGAL_Nef_polyhedron> import_nef3(const std::string& filename, const Location& loc);
+std::unique_ptr<class CGALNefGeometry> import_nef3(const std::string& filename, const Location& loc);
 #endif
 
 class Value import_json(const std::string& filename, class EvaluationSession *session, const Location& loc);

--- a/src/io/import_nef.cc
+++ b/src/io/import_nef.cc
@@ -10,26 +10,26 @@
 
 #ifdef ENABLE_CGAL
 #include "geometry/cgal/cgal.h"
-#include "geometry/cgal/CGAL_Nef_polyhedron.h"
+#include "geometry/cgal/CGALNefGeometry.h"
 #include <CGAL/IO/Nef_polyhedron_iostream_3.h>
 
-std::unique_ptr<CGAL_Nef_polyhedron> import_nef3(const std::string& filename, const Location& loc)
+std::unique_ptr<CGALNefGeometry> import_nef3(const std::string& filename, const Location& loc)
 {
   // Open file and position at the end
   std::ifstream f(filename.c_str(), std::ios::in | std::ios::binary);
   if (!f.good()) {
     LOG(message_group::Warning, "Can't open import file '%1$s', import() at line %2$d", filename, loc.firstLine());
-    return std::make_unique<CGAL_Nef_polyhedron>();
+    return std::make_unique<CGALNefGeometry>();
   }
 
   try {
     auto nef = std::make_shared<CGAL_Nef_polyhedron3>();
     f >> *nef;
-    return std::make_unique<CGAL_Nef_polyhedron>(nef);
+    return std::make_unique<CGALNefGeometry>(nef);
   } catch (const CGAL::Failure_exception& e) {
     LOG(message_group::Warning, "Failure trying to import '%1$s', import() at line %2$d", filename, loc.firstLine());
     LOG(e.what());
-    return std::make_unique<CGAL_Nef_polyhedron>();
+    return std::make_unique<CGALNefGeometry>();
   }
 }
 


### PR DESCRIPTION
Our Geometry subtype CGAL_Nef_Polyhedron was too easy to mistake for the type alias CGAL_Nef_Polyhedron3. Renaming to make it more clear it's actually an OpenSCAD Geometry.