### PR TITLE
Bump QT6 to 6.5.5 for macosx-build-dependencies.sh

### DIFF
--- a/scripts/macosx-build-dependencies.sh
+++ b/scripts/macosx-build-dependencies.sh
@@ -57,7 +57,7 @@ PACKAGES=(
     "cgal 6.0.1"
     # Using Qt6 going forward, leaving Qt5 config just in case
     # "qt5 5.15.16"
-    "qt6 6.5.3"
+    "qt6 6.5.5"
     "opencsg 1.7.0"
     "qscintilla 2.14.1"
     "onetbb 2021.12.0"
@@ -255,9 +255,9 @@ build_qt6()
   v=(${version//./ }) # Split into array
   rm -rf qt-everywhere-src-$version
   if [ ! -f qt-everywhere-src-$version.tar.xz ]; then
-    curl -LO --insecure https://download.qt.io/official_releases/qt/${v[0]}.${v[1]}/$version/single/qt-everywhere-src-$version.tar.xz
+    curl -LO --insecure https://download.qt.io/official_releases/qt/${v[0]}.${v[1]}/$version/src/single/qt-everywhere-opensource-src-$version.tar.xz
   fi
-  tar xjf qt-everywhere-src-$version.tar.xz
+  tar xjf qt-everywhere-opensource-src-$version.tar.xz
   cd qt-everywhere-src-$version
 
   mkdir build


### PR DESCRIPTION
Bump QT6 to 6.5.5 

Because of following error (macOS 15.4.1 + Xcode 16.3)

```
-- Build files have been written to: /Users/sskaje/Work/openscad/libraries/src/qt-everywhere-src-6.5.3/build
[474/3591] Building C object qtbase/src/3rdparty/libpng/CMakeFiles/BundledLibpng.dir/pngerror.c.o
FAILED: qtbase/src/3rdparty/libpng/CMakeFiles/BundledLibpng.dir/pngerror.c.o 
/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/cc -DGL_SILENCE_DEPRECATION -DPNG_ARM_NEON_OPT=0 -DPNG_IMPEXP="" -DPNG_POWERPC_VSX_OPT=0 -DQT_EXPLICIT_QFILE_CONSTRUCTION_FROM_PATH -DQT_NO_DEBUG -DQT_NO_EXCEPTIONS -DQT_NO_JAVA_STYLE_ITERATORS -DQT_NO_NARROWING_CONVERSIONS_IN_CONNECT -D_CRT_SECURE_NO_DEPRECATE -D_LARGEFILE64_SOURCE -D_LARGEFILE_SOURCE -I/Users/sskaje/Work/openscad/libraries/src/qt-everywhere-src-6.5.3/qtbase/src/3rdparty/libpng -I/Users/sskaje/Work/openscad/libraries/src/qt-everywhere-src-6.5.3/qtbase/mkspecs/macx-clang -I/Users/sskaje/Work/openscad/libraries/src/qt-everywhere-src-6.5.3/build/qtbase/include -DNDEBUG -O2 -std=c11 -arch arm64 -isysroot /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX15.4.sdk -mmacosx-version-min=11.0 -fPIC -fvisibility=hidden -w -fno-exceptions -fapplication-extension -MD -MT qtbase/src/3rdparty/libpng/CMakeFiles/BundledLibpng.dir/pngerror.c.o -MF qtbase/src/3rdparty/libpng/CMakeFiles/BundledLibpng.dir/pngerror.c.o.d -o qtbase/src/3rdparty/libpng/CMakeFiles/BundledLibpng.dir/pngerror.c.o -c /Users/sskaje/Work/openscad/libraries/src/qt-everywhere-src-6.5.3/qtbase/src/3rdparty/libpng/pngerror.c
In file included from /Users/sskaje/Work/openscad/libraries/src/qt-everywhere-src-6.5.3/qtbase/src/3rdparty/libpng/pngerror.c:19:
/Users/sskaje/Work/openscad/libraries/src/qt-everywhere-src-6.5.3/qtbase/src/3rdparty/libpng/pngpriv.h:524:16: fatal error: 'fp.h' file not found
  524 | #      include <fp.h>
      |                ^~~~~~
1 error generated.
[475/3591] Building C object qtbase/src/3rdparty/libpng/CMakeFiles/BundledLibpng.dir/pngmem.c.o
FAILED: qtbase/src/3rdparty/libpng/CMakeFiles/BundledLibpng.dir/pngmem.c.o 
/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/cc -DGL_SILENCE_DEPRECATION -DPNG_ARM_NEON_OPT=0 -DPNG_IMPEXP="" -DPNG_POWERPC_VSX_OPT=0 -DQT_EXPLICIT_QFILE_CONSTRUCTION_FROM_PATH -DQT_NO_DEBUG -DQT_NO_EXCEPTIONS -DQT_NO_JAVA_STYLE_ITERATORS -DQT_NO_NARROWING_CONVERSIONS_IN_CONNECT -D_CRT_SECURE_NO_DEPRECATE -D_LARGEFILE64_SOURCE -D_LARGEFILE_SOURCE -I/Users/sskaje/Work/openscad/libraries/src/qt-everywhere-src-6.5.3/qtbase/src/3rdparty/libpng -I/Users/sskaje/Work/openscad/libraries/src/qt-everywhere-src-6.5.3/qtbase/mkspecs/macx-clang -I/Users/sskaje/Work/openscad/libraries/src/qt-everywhere-src-6.5.3/build/qtbase/include -DNDEBUG -O2 -std=c11 -arch arm64 -isysroot /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX15.4.sdk -mmacosx-version-min=11.0 -fPIC -fvisibility=hidden -w -fno-exceptions -fapplication-extension -MD -MT qtbase/src/3rdparty/libpng/CMakeFiles/BundledLibpng.dir/pngmem.c.o -MF qtbase/src/3rdparty/libpng/CMakeFiles/BundledLibpng.dir/pngmem.c.o.d -o qtbase/src/3rdparty/libpng/CMakeFiles/BundledLibpng.dir/pngmem.c.o -c /Users/sskaje/Work/openscad/libraries/src/qt-everywhere-src-6.5.3/qtbase/src/3rdparty/libpng/pngmem.c
In file included from /Users/sskaje/Work/openscad/libraries/src/qt-everywhere-src-6.5.3/qtbase/src/3rdparty/libpng/pngmem.c:20:
/Users/sskaje/Work/openscad/libraries/src/qt-everywhere-src-6.5.3/qtbase/src/3rdparty/libpng/pngpriv.h:524:16: fatal error: 'fp.h' file not found
  524 | #      include <fp.h>
      |                ^~~~~~
1 error generated.
```


