### PR TITLE
Fix python shebangs

### DIFF
--- a/tests/export_import_pngtest.py
+++ b/tests/export_import_pngtest.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 # Export-import test
 #

--- a/tests/export_pngtest.py
+++ b/tests/export_pngtest.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 # Export test
 #

--- a/tests/mingw_convert_ctest.py
+++ b/tests/mingw_convert_ctest.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 #
 # Mingw_x_testfile - convert paths in CTestTestfile.cmake so they work 

--- a/tests/shouldfail.py
+++ b/tests/shouldfail.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 # Test expected failure
 #

--- a/tests/stlexportsanitytest.py
+++ b/tests/stlexportsanitytest.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 # STL sanity checker
 #

--- a/tests/test_cmdline_tool.py
+++ b/tests/test_cmdline_tool.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+/usr/bin/env python3
 #
 # Regression test driver for cmd-line tools
 #

--- a/tests/test_cmdline_tool.py
+++ b/tests/test_cmdline_tool.py
@@ -1,4 +1,4 @@
-/usr/bin/env python3
+#!/usr/bin/env python3
 #
 # Regression test driver for cmd-line tools
 #

--- a/tests/test_pretty_print.py
+++ b/tests/test_pretty_print.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+/usr/bin/env python3
 
 # test_pretty_print by don bright 2012. Copyright assigned to Marius Kintel and
 # Clifford Wolf 2012. Released under the GPL 2, or later, as described in

--- a/tests/test_pretty_print.py
+++ b/tests/test_pretty_print.py
@@ -1,4 +1,4 @@
-/usr/bin/env python3
+#!/usr/bin/env python3
 
 # test_pretty_print by don bright 2012. Copyright assigned to Marius Kintel and
 # Clifford Wolf 2012. Released under the GPL 2, or later, as described in


### PR DESCRIPTION
The shebangs in a few of the python scripts are wrong.
They should refer to `python3` and not `python`, as that's usually python2 which is end of life and probably not what's intended.

And two of the scripts even refer directly to `/usr/bin/python`. All scripts should use `/usr/bin/env python3` so that the correct python binary is selected.

This is causing almost all tests to fail when building for GNU guix, which doesn't follow the traditional FHS, so `/usr/bin/` doesn't even exist.

Should be an easy one to merge though.