### PR TITLE
Fix: Set CMP0167 policy in CMakeLists.txt

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,6 +25,9 @@ endif()
 if(POLICY CMP0077) # Let parent project set child project options (used to skip python lookup from manifold & force TBB)
   cmake_policy(SET CMP0079 NEW)
 endif()
+if(POLICY CMP0167) # Use upstream's FindBoost.cmake to find Boost libraries.
+  cmake_policy(SET CMP0167 NEW) # Use upstream's FindBoost.cmake to find Boost libraries.
+endif()
 
 include("cmake/Modules/openscad_version.cmake")
 


### PR DESCRIPTION
Fixes #5932.

A similar warning is still printed during building, but this is coming from CGAL.
I've filed a [bug ticket](https://github.com/CGAL/cgal/issues/8914) there as well.