### PR TITLE
Add a `name` parameter to `group(…) {}` that is used to name objects in exported `.3mf` files (when using `lazy-union`)

### DIFF
--- a/src/core/GroupModule.cc
+++ b/src/core/GroupModule.cc
@@ -37,8 +37,14 @@
 std::shared_ptr<AbstractNode> builtin_group(const ModuleInstantiation *inst, Arguments arguments,
                                             const Children& children)
 {
-  Parameters parameters = Parameters::parse(std::move(arguments), inst->location(), {});
-  return children.instantiate(std::make_shared<GroupNode>(inst));
+  Parameters parameters = Parameters::parse(std::move(arguments), inst->location(), {}, {"name"});
+
+  std::string group_name = "";
+  if (parameters["name"].type() == Value::Type::STRING) {
+    group_name = parameters["name"].toString();
+  }
+
+  return children.instantiate(std::make_shared<GroupNode>(inst, "", group_name));
 }
 
 void register_builtin_group()
@@ -46,5 +52,7 @@ void register_builtin_group()
   Builtins::init("group", new BuiltinModule(builtin_group),
                  {
                    "group",
+                   "group()",
+                   "group(name)",
                  });
 }

--- a/src/core/node.cc
+++ b/src/core/node.cc
@@ -135,6 +135,11 @@ std::string GroupNode::verbose_name() const
   return this->_name;
 }
 
+std::string GroupNode::model_name() const
+{
+  return this->_model_name;
+}
+
 std::string ListNode::name() const
 {
   return "list";

--- a/src/core/node.h
+++ b/src/core/node.h
@@ -48,6 +48,8 @@ public:
       the verbose name shall be overloaded. */
   virtual std::string verbose_name() const { return this->name(); }
 
+  virtual std::string model_name() const { return ""; }
+
   const std::vector<std::shared_ptr<AbstractNode>>& getChildren() const { return this->children; }
   int index() const { return this->idx; }
 
@@ -116,15 +118,17 @@ class GroupNode : public AbstractNode
 {
 public:
   VISITABLE();
-  GroupNode(const ModuleInstantiation *mi, std::string name = "")
-    : AbstractNode(mi), _name(std::move(name))
+  GroupNode(const ModuleInstantiation *mi, std::string name = "", std::string model_name = "")
+    : AbstractNode(mi), _name(std::move(name)), _model_name(std::move(model_name))
   {
   }
   std::string name() const override;
   std::string verbose_name() const override;
+  std::string model_name() const override;
 
 private:
   const std::string _name;
+  const std::string _model_name;
 };
 
 /*!

--- a/src/geometry/Geometry.h
+++ b/src/geometry/Geometry.h
@@ -41,6 +41,8 @@ public:
   [[nodiscard]] virtual size_t numFacets() const = 0;
   [[nodiscard]] unsigned int getConvexity() const { return convexity; }
   void setConvexity(int c) { this->convexity = c; }
+  [[nodiscard]] std::string getModelName() const { return model_name; }
+  void setModelName(std::string model_name) { this->model_name = model_name; }
   virtual void setColor(const Color4f& c) {}
 
   virtual void transform(const Transform3d& /*mat*/) { assert(!"transform not implemented!"); }
@@ -53,6 +55,7 @@ public:
 
 protected:
   int convexity{1};
+  std::string model_name{""};
 };
 
 /**

--- a/src/geometry/GeometryEvaluator.cc
+++ b/src/geometry/GeometryEvaluator.cc
@@ -510,7 +510,14 @@ Response GeometryEvaluator::visit(State& state, const AbstractNode& node)
   if (state.isPostfix()) {
     std::shared_ptr<const Geometry> geom;
     if (!isSmartCached(node)) {
-      geom = applyToChildren(node, OpenSCADOperator::UNION).constptr();
+      std::shared_ptr<Geometry> mutableGeom = applyToChildren(node, OpenSCADOperator::UNION).asMutableGeometry();
+      if (mutableGeom != nullptr) {
+        if (!node.model_name().empty()) {
+          std::cout << "Setting model name: " << node.model_name() << std::endl;
+        }
+        mutableGeom->setModelName(node.model_name());
+      }
+      geom = std::static_pointer_cast<const Geometry>(mutableGeom);
     } else {
       geom = smartCacheGet(node, state.preferNef());
     }

--- a/src/io/export_3mf_v2.cc
+++ b/src/io/export_3mf_v2.cc
@@ -68,6 +68,7 @@ struct ExportContext {
   Color4f selectedColor;
   const ExportInfo& info;
   const std::shared_ptr<const Export3mfOptions> options;
+  std::string model_name;
 };
 
 uint32_t lib3mf_write_callback(const char *data, uint32_t bytes, std::ostream *stream)
@@ -154,8 +155,7 @@ bool append_polyset(const std::shared_ptr<const PolySet>& ps, ExportContext& ctx
     if (!mesh) return false;
 
     const int mesh_count = count_mesh_objects(ctx.model);
-    const auto modelname =
-      ctx.modelcount == 1 ? "OpenSCAD Model" : "OpenSCAD Model " + std::to_string(mesh_count);
+    const auto modelname = ctx.model_name.empty() ? (ctx.modelcount == 1 ? "OpenSCAD Model" : "OpenSCAD Model " + std::to_string(mesh_count)) : ctx.model_name;
     const auto partname = ctx.modelcount == 1 ? "" : "Part " + std::to_string(mesh_count);
     mesh->SetName(modelname);
     if (ctx.basematerialgroup) {
@@ -248,6 +248,7 @@ bool append_nef(const CGALNefGeometry& root_N, ExportContext& ctx)
 
 bool append_3mf(const std::shared_ptr<const Geometry>& geom, ExportContext& ctx)
 {
+  ctx.model_name = geom.get()->getModelName();
   if (const auto geomlist = std::dynamic_pointer_cast<const GeometryList>(geom)) {
     ctx.modelcount = geomlist->getChildren().size();
     for (const auto& item : geomlist->getChildren()) {

--- a/tests/data/scad/3D/features/group-tests.scad
+++ b/tests/data/scad/3D/features/group-tests.scad
@@ -1,0 +1,17 @@
+// Group at the top level.
+group(name="octo_dome") color("blue") {
+    difference() {
+      sphere(r=12, $fn=8);
+      translate([-500, -500, -1000]) cube(1000);
+    }
+  }
+
+// Group with one module applied to it.
+color("red") group(name="flag")
+    translate([0, 0, 12 * cos(360 / 16)]) {
+      translate([0, -0.25, 8.5]) cube([5, 0.5, 3]);
+      translate([-0.5, -0.50, 0]) cube([1, 1, 12]);
+    }
+
+// Empty
+group(){}


### PR DESCRIPTION
Partially addresses: https://github.com/openscad/openscad/issues/5089

This change adds an optional `name` parameter to the built-in `group(…)` module, which is tracked and set as the `name` attribute on objects in `.3mf` exports (when using `lazy-union`).

```scad
color("blue") group(name="octo_dome") {
    difference() {
      sphere(r=12, $fn=8);
      translate([-500, -500, -1000]) cube(1000);
    }
  }
color("red") group(name="flag")
    translate([0, 0, 12 * cos(360 / 16)]) {
      translate([0, -0.25, 8.5]) cube([5, 0.5, 3]);
      translate([-0.5, -0.50, 0]) cube([1, 1, 12]);
    }
```

This has the particularly useful benefit that these names are recognized and used as part names in common 3D printing slicers (e.g. Bambu Studio, PrusaSlicer, OrcaSlicer):

![clipboard](https://github.com/user-attachments/assets/83a0cf04-30e2-4eaf-9363-3ae4bb1df1ea)

It also allows post-processing scripts to identify and operate on these objects without making fragile assumptions about which pieces are exported in which order. (This is particularly useful if different customizer settings result in different sets of objects in the output.)

Note that:

- This is effectively a more minimal alternative to https://github.com/openscad/openscad/pull/4986 , which seems to have stalled.
- This change only has an effect with the `lazy-union` feature enabled, as otherwise OpenSCAD just creates a top-level wrapper object that obviates all the others.
- The `group(…)` built-in module was previously possible to use, it just didn't do anything useful. This adds an explicit use case to it.
- I looked at a few options, such as setting object/item IDs, but `lib3mf` doesn't seem to support this. Using the `name` field was the most natural option. Note that this allows names to appear for multiple models in an export, but I think that can be useful in some cases.
- It can be a bit unintuitive what modules can be applied to a `group(…)` that preserve the name, because braces can create an additional `group(…)` wrapper implicitly. However, I think it's reasonable to document and recommend to apply the `group(…)` call at the very top level for any names you want in a `.3mf output
- I'd really like a way to make the `.3mf` output more useful for 3D printing, such as the following. But I think that functionality can be designed separately, and just having the name transferred into the `.3mf` makes it much easier to write more robust post-processing scripts in the meantime.
  - Marking objects as different types e.g. "support blocker", "negative part", "modifier".
  - Coloring objects in a slicer-compatible way, perhaps even associating filament information from a config file.
  - Exporting multiple objects each consisting of (potentially) multiple parts, potentially across multiple plates.
  - Also see: https://github.com/openscad/openscad/issues/5120

I need help with the following:

- Is this a reasonable approach in the first place?
- Should this be placed behind an additional feature flag?
- How do I update the tests? I've tried adding one, but there isn't much documentation about adding a test and they take a long time to run.
- Should I update any documentation in this PR itself?