### PR TITLE
Fix crash in lib3mf-v2 object verify by just disabling the call.

### DIFF
--- a/src/io/import_3mf_v2.cc
+++ b/src/io/import_3mf_v2.cc
@@ -111,10 +111,15 @@ std::string collect_mesh_objects(const Lib3MF::PModel& model, MeshObjectList& ob
   bool hasuuid = false;
   const auto uuid = object->GetUUID(hasuuid);
 
+#if 0
+  // Validation disabled for now, this crashes in some cases. One example
+  // is the MicroscopeMainBody.3mf from the blog post
+  // https://axotron.se/blog/microscope-adapter-for-mobile-phone-camera/
   const auto is_valid_object = object->IsValid();
   if (!is_valid_object) {
     LOG(message_group::Warning, "Object '%1$s' with UUID '%2$s' is not valid, import() at line %3$d", name, uuid, loc.firstLine());
   }
+#endif
 
   if (is_mesh_object) {
     const auto meshobject = model->GetMeshObjectByID(object->GetUniqueResourceID());


### PR DESCRIPTION
3MF import crashes in build-item 4 of the file MicroscopeMainBody.3mf from https://axotron.se/blog/microscope-adapter-for-mobile-phone-camera/

The crash happens in object->Verify() so for now we just disable that call and optimistically assume import will work.

Without the verify call, the import seems to run fine.

```
Parsing design (AST generation)...
Compiling design (CSG Tree generation)...
Compiling design (CSG Products generation)...
import_3mf_v2: METADATA[0]: http://schemas.slic3r.org/3mf/2017/06:Version3mf = '1'
import_3mf_v2: METADATA[1]: Title = 'MicroscopeMainBody'
import_3mf_v2: METADATA[2]: Designer = ''
import_3mf_v2: METADATA[3]: Description = 'MicroscopeMainBody'
import_3mf_v2: METADATA[4]: Copyright = ''
import_3mf_v2: METADATA[5]: LicenseTerms = ''
import_3mf_v2: METADATA[6]: Rating = ''
import_3mf_v2: METADATA[7]: CreationDate = '2022-09-14'
import_3mf_v2: METADATA[8]: ModificationDate = '2022-09-14'
import_3mf_v2: METADATA[9]: Application = 'PrusaSlicer-2.5.0+win64'
Reading 3MF with title 'MicroscopeMainBody'
import_3mf_v2: build item 1, part number = '' (fc5dfebd-c032-4967-afd6-09cee47e30e7)
import_3mf_v2: build item transform matrix
           1            0            0       142.35
           0           -1 -1.22465e-16      113.363
           0  1.22465e-16           -1         42.5
           0            0            0            1
import_3mf_v2:   mesh type = Model, number = '', name = '' (c976ec31-38a9-4e6b-ce42-5db7979206e3)
import_3mf_v2: /home/tp/projects/o/debug-files/MicroscopeMainBody.3mf: mesh 0, type: Model, vertex count: 2192, triangle count: 4404
import_3mf_v2: build item 2, part number = '' (c6e4a557-e32d-43a1-b27c-053dde2f229e)
import_3mf_v2: build item transform matrix
           1            0            0      109.628
           0           -1 -1.22465e-16      79.2407
           0  1.22465e-16           -1           32
           0            0            0            1
import_3mf_v2:   mesh type = Model, number = '', name = '' (ff9bfaca-ea91-40eb-c4d2-8347e6f7d5d5)
import_3mf_v2: /home/tp/projects/o/debug-files/MicroscopeMainBody.3mf: mesh 1, type: Model, vertex count: 1825, triangle count: 3650
import_3mf_v2: build item 3, part number = '' (b1937de0-0a7c-4ef9-cd25-866cb2f07a80)
import_3mf_v2: build item transform matrix
         -1 1.22465e-16 1.49976e-32      65.075
1.22465e-16           1 1.22465e-16     79.0273
          0 1.22465e-16          -1        50.5
          0           0           0           1
import_3mf_v2:   mesh type = Model, number = '', name = '' (83f79dd8-23d9-4c28-896b-9d24d447d5c6)
import_3mf_v2: /home/tp/projects/o/debug-files/MicroscopeMainBody.3mf: mesh 2, type: Model, vertex count: 324, triangle count: 648
import_3mf_v2: build item 4, part number = '' (c3bdfa36-00f0-428b-9aa5-ea541f6d5e74)
import_3mf_v2: build item transform matrix
           1            0            0      192.364
           0           -1 -1.22465e-16      113.611
           0  1.22465e-16           -1         50.5
           0            0            0            1
import_3mf_v2:   object (1 components) type = Model, number = '', name = '' (6b04f9c0-77c9-4d9d-8476-75f1686d5fe5)
import_3mf_v2:     mesh type = Model, number = '', name = '' (83f79dd8-23d9-4c28-896b-9d24d447d5c6)
import_3mf_v2: /home/tp/projects/o/debug-files/MicroscopeMainBody.3mf: mesh 3, type: Model, vertex count: 324, triangle count: 648
import_3mf_v2: build item 5, part number = '' (a2147060-8f06-4325-c648-517c61256b94)
import_3mf_v2: build item transform matrix
           1            0            0       154.26
           0           -1 -1.22465e-16      79.2626
           0  1.22465e-16           -1         50.5
           0            0            0            1
import_3mf_v2:   object (1 components) type = Model, number = '', name = '' (879961dd-0ea9-495a-ba0d-dbb74b8a912b)
import_3mf_v2:     mesh type = Model, number = '', name = '' (83f79dd8-23d9-4c28-896b-9d24d447d5c6)
import_3mf_v2: /home/tp/projects/o/debug-files/MicroscopeMainBody.3mf: mesh 4, type: Model, vertex count: 324, triangle count: 648
Geometries in cache: 1
Geometry cache size in bytes: 458336
CGAL Polyhedrons in cache: 0
CGAL cache size in bytes: 0
Compiling design (CSG Products normalization)...
Normalized tree has 1 elements!
Compile and preview finished.
Total rendering time: 0:00:10.479
```
