### PR TITLE
Manifold minkowski: Convert via Surface_mesh instead of Polyhedron for convex decomposition

### DIFF
--- a/src/geometry/cgal/cgalutils-convex.cc
+++ b/src/geometry/cgal/cgalutils-convex.cc
@@ -49,7 +49,6 @@ bool is_weakly_convex(const CGAL::Polyhedron_3<K>& p) {
 
 template bool is_weakly_convex(const CGAL::Polyhedron_3<CGAL_Kernel3>& p);
 
-
 template <typename K>
 bool is_weakly_convex(const CGAL::Surface_mesh<CGAL::Point_3<K>>& m) {
   using Mesh = typename CGAL::Surface_mesh<CGAL::Point_3<K>>;
@@ -90,6 +89,8 @@ bool is_weakly_convex(const CGAL::Surface_mesh<CGAL::Point_3<K>>& m) {
 
   return visited.size() == m.number_of_faces();
 }
+
+template bool is_weakly_convex(const CGAL::Surface_mesh<CGAL_Point_3>& m);
 
 }  // namespace CGALUtils
 

--- a/src/geometry/cgal/cgalutils-polyhedron.cc
+++ b/src/geometry/cgal/cgalutils-polyhedron.cc
@@ -1,3 +1,4 @@
+#include "geometry/cgal/cgal.h"
 #include "geometry/cgal/cgalutils.h"
 
 #include <algorithm>
@@ -273,7 +274,7 @@ void convertNefToSurfaceMesh(const CGAL_Nef_polyhedron3& nef, SurfaceMesh& mesh)
   CGAL::convert_nef_polyhedron_to_polygon_mesh(nef, mesh, triangulate);
 }
 
-void converSurfaceMeshToNef(const CGAL_Kernel3Mesh& mesh, CGAL_Nef_polyhedron3& nef)
+void convertSurfaceMeshToNef(const CGAL_Kernel3Mesh& mesh, CGAL_Nef_polyhedron3& nef)
 {
   nef = CGAL_Nef_polyhedron3(mesh);
 }

--- a/src/geometry/cgal/cgalutils.h
+++ b/src/geometry/cgal/cgalutils.h
@@ -113,7 +113,7 @@ template <typename K>
 void convertNefToPolyhedron(const CGAL::Nef_polyhedron_3<K>& nef, CGAL::Polyhedron_3<K>& polyhedron);
 
 void convertNefToSurfaceMesh(const CGAL_Nef_polyhedron3& nef, CGAL_Kernel3Mesh& mesh);
-void converSurfaceMeshToNef(const CGAL_Kernel3Mesh& mesh, CGAL_Nef_polyhedron3& nef);
+void convertSurfaceMeshToNef(const CGAL_Kernel3Mesh& mesh, CGAL_Nef_polyhedron3& nef);
 
 #endif
 std::unique_ptr<PolySet> createTriangulatedPolySetFromPolygon2d(const Polygon2d& polygon2d);


### PR DESCRIPTION
This should be green refactoring. The goal is to avoid using CGAL::Polyhedron due to its inability to express corner-case manifold geometry.

Keeping an internal `#define USE_SURFACE_MESH`, to allow for quick rollback if we discover any issues.