### PR TITLE
Fix macOS CI issues

### DIFF
--- a/.github/workflows/macos-tests.yml
+++ b/.github/workflows/macos-tests.yml
@@ -47,6 +47,10 @@ jobs:
       with:
         detached: true
         limit-access-to-actor: true
+    - name: Workaround for https://github.com/actions/runner-images/issues/9966
+      run: |
+        brew unlink python3
+        brew link --overwrite python3
     - name: Install Homebrew packages
       env:
         HOMEBREW_NO_AUTO_UPDATE: 1

--- a/.github/workflows/macos-tests.yml
+++ b/.github/workflows/macos-tests.yml
@@ -47,14 +47,6 @@ jobs:
       with:
         detached: true
         limit-access-to-actor: true
-    - name: Install CMake
-      uses: jwlawson/actions-setup-cmake@v2
-      with:
-        cmake-version: 3.31.6
-    - name: Set up Python
-      uses: actions/setup-python@v5
-      with:
-        python-version: 3.11
     - name: Install Homebrew packages
       env:
         HOMEBREW_NO_AUTO_UPDATE: 1


### PR DESCRIPTION
Add workaround for bad Python installation on GitHub macOS nodes.
Also removed the old workaround to avoid using CMake 4 now that CMake 4 works.