### PR TITLE
Add an struct type to OpenSCAD using the let() syntax

### DIFF
--- a/src/core/Expression.cc
+++ b/src/core/Expression.cc
@@ -726,8 +726,24 @@ const Expression *Let::evaluateStep(ContextHandle<Context>& targetContext) const
 
 Value Let::evaluate(const std::shared_ptr<const Context>& context) const
 {
-  ContextHandle<Context> letContext{Context::create<Context>(context)};
-  return evaluateStep(letContext)->evaluate(*letContext);
+    ContextHandle<Context> letContext { 
+        Context::create<Context>(context)
+    };
+
+    if ( !expr) {
+      ObjectType obj(context->session());
+
+      for (auto & assignment : this->arguments) {
+        auto && name = assignment->getName();
+        Value && value = assignment->getExpr()->evaluate(*letContext);
+        letContext->set_variable(name, value.clone());
+        obj.set(name, std::move(value));
+      }
+      return std::move(obj);
+
+    } else {
+        return evaluateStep(letContext)->evaluate(*letContext);
+    }
 }
 
 void Let::print(std::ostream& stream, const std::string&) const

--- a/src/core/Value.cc
+++ b/src/core/Value.cc
@@ -1268,15 +1268,18 @@ ObjectType::ObjectType(EvaluationSession *session) :
 
 const Value& ObjectType::get(const std::string& key) const
 {
-  auto result = ptr->map.find(key);
-  // NEEDSWORK it would be nice to have a "cause" for the undef, but Value::undef(...)
-  // does not appear compatible with Value&.
-  return result == ptr->map.end() ? Value::undefined : result->second;
+    auto it = std::find(ptr->keys.begin(), ptr->keys.end(), key);
+    if ( it != ptr->keys.end()){
+        size_t index = std::distance(ptr->keys.begin(), it);
+        if (index < ptr->values.size()) {
+            return ptr->values[index];
+        }
+    }
+    return Value::undefined;
 }
 
 void ObjectType::set(const std::string& key, Value&& value)
 {
-  ptr->map.emplace(key, value.clone());
   ptr->keys.emplace_back(key);
   ptr->values.emplace_back(std::move(value));
 }

--- a/src/core/Value.h
+++ b/src/core/Value.h
@@ -388,8 +388,6 @@ private:
 
 // The object type which ObjectType's shared_ptr points to.
 struct Value::ObjectType::ObjectObject {
-  using obj_t = std::unordered_map<std::string, Value>;
-  obj_t map;
   class EvaluationSession *evaluation_session = nullptr;
   std::vector<std::string> keys;
   std::vector<Value> values;

--- a/src/core/parser.y
+++ b/src/core/parser.y
@@ -342,7 +342,7 @@ expr
             {
               $$ = new TernaryOp($1, $3, $5, LOCD("ternary", @$));
             }
-        | TOK_LET '(' arguments ')' expr
+        | TOK_LET '(' arguments ')' expr_or_empty
             {
               $$ = FunctionCall::create("let", *$3, $5, LOCD("let", @$));
               delete $3;


### PR DESCRIPTION
I like OpenSCAD but there is one thing that is almost impossible for me to overcome and that is the lack of a structure type. The use of arrays is very hard because you need then to define the index constants and that takes a toll on the namespace.

I noticed that OpenSCAD already had an object type, it only lacked the proper syntax and construction from the program text. To minimize the changes in the language, I used the syntax for `let` since it already defines a structure. If the let is used without a final expression, its value is a structure.
```
extend = let( width = 100, height=200, area = function() width*height );
```
As you can see, the changes to get to this are absolutely minimal because it stays so close to the existing language. However, I had to modify the ObjectType. The  current implementation stores the Value's twice. Once in a map and once in a values vector. This wreaked havoc in the garbage collection because the garbage collector assumed the ObjectType had one of its values but it was counted as twice .... hard problem to diagnose.

I now store the values once and use a function to lookup the index of the key and get the value at that position. More efficient as well.

Curious how I should start advocating for this. I am leaving the code here to get feedback of its implementation and if this could become part of OpenSCAD.