### PR TITLE
Fix WRL export spec violation

### DIFF
--- a/src/io/export_wrl.cc
+++ b/src/io/export_wrl.cc
@@ -74,9 +74,9 @@ void export_wrl(const std::shared_ptr<const Geometry>& geom, std::ostream& outpu
     const auto &poly=ps->indices[i];
     for(size_t j=0;j<poly.size();j++) {
       output << poly[j];
-        if (j < poly.size() - 1) output << ",";
-      output << "\n";
+      output << ",";
     }
+    output << "-1\n";
   }
   output << "]\n\n";
 


### PR DESCRIPTION
Fixes #5998 according to my testing with an online viewer and KiCAD!

So I did some digging in the VRML97 spec and found that each face in the coordIndex list needs to be terminated with `-1` according to https://tecfa.unige.ch/guides/vrml/vrml97/spec/part1/nodesRef.html#IndexedFaceSet

`An index of "-1" indicates that the current face has ended and the next one begins. The last face may be (but does not have to be) followed by a "-1" index.`

I also checked the legal separators to make sure they are also correctly used in the list.
It looks like there is a lot of freedom defined for separator usage, so I changed the output per face in coordIndex to be in one line for improved visual grouping.

From https://tecfa.unige.ch/guides/vrml/vrml97/spec/part1/concepts.html#4.3.1

`Commas, spaces, tabs, linefeeds, and carriage-returns are separator characters wherever they appear outside of string fields. Separator characters and comments are collectively termed whitespace.`

From https://tecfa.unige.ch/guides/vrml/vrml97/spec/part1/grammar.html#A.1.2

`The carriage return (0x0d), linefeed (0x0a), space (0x20), tab (0x09), and comma (0x2c) characters are whitespace characters wherever they appear outside of quoted SFString or MFString fields. Any number of whitespace characters and comments may be used to separate the syntactic entities of a VRML file. All reserved keywords are displayed in boldface type.`


A simple cube(10) was also broken before my fix and exports to the following now:
```
#VRML V2.0 utf8

Shape {

appearance Appearance { material Material {
ambientIntensity 0.3
diffuseColor 0.97647 0.843137 0.172549
specularColor 0.2 0.2 0.2
shininess 0.3
} }

geometry IndexedFaceSet {

creaseAngle 0.5

coord Coordinate { point [
0 0 0,
10 0 0,
0 10 0,
10 10 0,
0 0 10,
10 0 10,
0 10 10,
10 10 10
] }

coordIndex [
4,5,7,6,-1
2,3,1,0,-1
0,1,5,4,-1
1,3,7,5,-1
3,2,6,7,-1
2,0,4,6,-1
]

}

}

```