### PR TITLE
Change package libfreetype6-dev to libfreetype-dev in initial setup

### DIFF
--- a/scripts/uni-get-dependencies.sh
+++ b/scripts/uni-get-dependencies.sh
@@ -108,7 +108,7 @@ get_debian_deps()
   libboost-program-options-dev libboost-regex-dev libboost-system-dev \
   libmpfr-dev libglew-dev libcairo2-dev libharfbuzz-dev \
   libeigen3-dev libcgal-dev libopencsg-dev libgmp-dev \
-  imagemagick libfreetype6-dev libdouble-conversion-dev libxml2-dev \
+  imagemagick libfreetype-dev libdouble-conversion-dev libxml2-dev \
   gtk-doc-tools libglib2.0-dev gettext xvfb pkg-config ragel libtbb-dev \
   libgl1-mesa-dev libxi-dev libxmu-dev libfontconfig-dev libzip-dev \
   python3-venv


### PR DESCRIPTION
In Debian, it has been a rename for this package since at least the current stable: https://packages.debian.org/stable/libfreetype6-dev

In Ubuntu, in the oldest LTS release it's also a transition: https://launchpad.net/ubuntu/focal/+package/libfreetype6-dev and it doesn't even exist in the newest: https://launchpad.net/ubuntu/noble/+package/libfreetype6-dev

`/scripts/check-dependencies.sh` was all green and install worked after this; I run Debian Sid.