### PR TITLE
Tag object tests as experimental

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1098,7 +1098,7 @@ add_cmdline_test(svgimport OPENSCAD ARGS --imgsize 600,600 SUFFIX png FILES
 #
 
 file(GLOB OBJECT_TEST ${TEST_SCAD_DIR}/experimental/object/*.scad)
-add_cmdline_test(echo         OPENSCAD SUFFIX echo FILES ${OBJECT_TEST} ARGS --enable object-function)
+add_cmdline_test(echo EXPERIMENTAL OPENSCAD SUFFIX echo FILES ${OBJECT_TEST} ARGS --enable object-function)
 
 
 #


### PR DESCRIPTION
Fixes non-experimental build test failure.