### PR TITLE
ValueIterator (generic iterator for types to return to CMM)

### DIFF
--- a/src/core/Value.cc
+++ b/src/core/Value.cc
@@ -644,18 +644,18 @@ VectorType::embeddedValues() const
   public:
     VectorValueIterator(VectorType::iterator i) : it(i) {};
 
-    void inc() { ++it; };
-    const Value& operator*() const { return *it; }
-    bool operator==(const VirtualValueIterator& other) const { return it == dynamic_cast<const VectorValueIterator *>(&other)->it; }
-    bool operator!=(const VirtualValueIterator& other) const { return it != dynamic_cast<const VectorValueIterator *>(&other)->it; }
+    VectorValueIterator& operator++() override { ++it; return *this; }
+    const Value& operator*() const override { return *it; }
+    bool operator==(const VirtualValueIterator& other) const override { return it == dynamic_cast<const VectorValueIterator *>(&other)->it; }
+    bool operator!=(const VirtualValueIterator& other) const override { return it != dynamic_cast<const VectorValueIterator *>(&other)->it; }
   };
 
   class VectorValues : public Values {
   public:
     VectorValues(const VectorType *v) : vector(v) { };
 
-    const ValueIterator begin() const { return ValueIterator(std::make_shared<VectorValueIterator>(vector->begin())); };
-    const ValueIterator end() const { return ValueIterator(std::make_shared<VectorValueIterator>(vector->end())); };
+    const ValueIterator begin() const override { return ValueIterator(std::make_shared<VectorValueIterator>(vector->begin())); };
+    const ValueIterator end() const override { return ValueIterator(std::make_shared<VectorValueIterator>(vector->end())); };
   private:
     const VectorType *vector;
   };
@@ -669,10 +669,10 @@ ObjectType::embeddedValues() const
   public:
     ObjectValueIterator(std::vector<std::string>::const_iterator i, const ObjectType *o) : it(i), obj(o) {};
 
-    void inc() { ++it; };
-    const Value& operator*() const { return obj->get(*it); }
-    bool operator==(const VirtualValueIterator& other) const { return it == dynamic_cast<const ObjectValueIterator *>(&other)->it; }
-    bool operator!=(const VirtualValueIterator& other) const { return it != dynamic_cast<const ObjectValueIterator *>(&other)->it; }
+    ObjectValueIterator& operator++() override { ++it; return *this; }
+    const Value& operator*() const override { return obj->get(*it); }
+    bool operator==(const VirtualValueIterator& other) const override { return it == dynamic_cast<const ObjectValueIterator *>(&other)->it; }
+    bool operator!=(const VirtualValueIterator& other) const override { return it != dynamic_cast<const ObjectValueIterator *>(&other)->it; }
   private:
     std::vector<std::string>::const_iterator it;
     const ObjectType *obj;
@@ -682,8 +682,8 @@ ObjectType::embeddedValues() const
   public:
     ObjectValues(const ObjectType *o) : obj(o) { };
 
-    const ValueIterator begin() const { return ValueIterator(std::make_shared<ObjectValueIterator>(obj->keys().begin(), obj)); };
-    const ValueIterator end() const { return ValueIterator(std::make_shared<ObjectValueIterator>(obj->keys().end(), obj)); };
+    const ValueIterator begin() const override { return ValueIterator(std::make_shared<ObjectValueIterator>(obj->keys().begin(), obj)); };
+    const ValueIterator end() const override { return ValueIterator(std::make_shared<ObjectValueIterator>(obj->keys().end(), obj)); };
   private:
     const ObjectType *obj;
   };

--- a/src/core/Value.h
+++ b/src/core/Value.h
@@ -470,10 +470,10 @@ class VirtualValueIterator
 public:
   // These need to know how the particular iterator works, and so must be implemented in
   // a subclass.
-  virtual void inc();
-  virtual const Value& operator*() const;
-  virtual bool operator==(const VirtualValueIterator& other) const;
-  virtual bool operator!=(const VirtualValueIterator& other) const;
+  virtual VirtualValueIterator& operator++() = 0;
+  virtual const Value& operator*() const = 0;
+  virtual bool operator==(const VirtualValueIterator& other) const = 0;
+  virtual bool operator!=(const VirtualValueIterator& other) const = 0;
   // This one can be generically built on top of the others.
   const Value *operator->() const { return &**this; }
 };
@@ -484,7 +484,7 @@ private:
 public:
   ValueIterator(std::shared_ptr<VirtualValueIterator> i) : vi(i) { };
 
-  ValueIterator& operator++() { vi->inc(); return *this; }
+  ValueIterator& operator++() { ++(*vi); return *this; }
   const Value& operator*() const { return (**vi); }
   bool operator==(const ValueIterator& other) const { return *vi == *other.vi; }
   bool operator!=(const ValueIterator& other) const { return *vi != *other.vi; }
@@ -494,6 +494,6 @@ public:
 class Values
 {
 public:
-    [[nodiscard]] virtual const ValueIterator begin() const;
-    [[nodiscard]] virtual const ValueIterator   end() const;
+    [[nodiscard]] virtual const ValueIterator begin() const = 0;
+    [[nodiscard]] virtual const ValueIterator   end() const = 0;
 };


### PR DESCRIPTION
This is very much a draft; it is playing in C++ areas that I only dimly understand, and took a lot of trial and error.  Comments solicited.

The goal is to make it so that an aggregate type (ObjectType and VectorType, primarily, but perhaps others in the future) can implement a generic iterator and return it to ContextMemoryManager, so that they don't have to store their Values in a std::vector if they don't want to.

There are two class hierarchies that are more or less obvious:

Values (subclasses VectorValues and ObjectValues) is an object that has begin() and end() methods for traversing the aggregate.  This needs to be a separate class, not just part of VectorType/VectorObject and ObjectType/ObjectObject, because there may be multiple ways to traverse the aggregate.  (For instance, for Object you might traverse by keys, by values, or by {key, value} pairs.)  The begin() and end() methods return ValueIterator.

The iterators that do the work (VectorValueIterator and ObjectValueIterator) are subclasses of VirtualValueIterator.  They implement the standard iterator methods, but one runs on top of a vector and the other on top of an object.

And then there's the relationship between ValueIterator and VirtualValueIterator.  It appears (and I am too tired right now to double check a reference) that `for (v : aggregate)` expands into something that starts with `auto it = aggregate.begin();`.  That doesn't work so good, if aggregate.begin() is defined to return the superclass and hide the actual subclass involved, because the compiler can't know how much memory to allocate for `it`.  ValueIterator is a proxy that holds a pointer to the underlying per-aggregate iterator.  It's constant-size and known to the caller, while allowing the underlying iterator to be opaque.


A cleaner mechanism might be to use a lambda and a forEach() style mechanism, where the lambda is called once for each Value.