### PR TITLE
faster syntax highlighting

### DIFF
--- a/src/gui/ScadLexer.h
+++ b/src/gui/ScadLexer.h
@@ -50,7 +50,7 @@ private:
 class LexInterface
 {
 public:
-  virtual void highlighting(int start, const std::string& input, lexertl::smatch results) = 0;
+  virtual void highlightingMultiple(int start, int length, char* styles) = 0;
   virtual int getStyleAt(int position) = 0;
 };
 
@@ -118,7 +118,7 @@ public:
 
   QColor defaultColor(int style) const override;
 
-  void highlighting(int start, const std::string& input, lexertl::smatch results) override;
+  void highlightingMultiple(int start, int length, char* styles) override;
   QString description(int style) const override;
   QStringList autoCompletionWordSeparators() const override;
 


### PR DESCRIPTION
Closes #5991.

This performs batch highlighting by using the `SCI_SETSTYLINGEX` event. Previously, we were using one event per token for highlighting, which triggers rendering after every single token (apparently, from gdb stepping) and was very slow for large files. With the batch API, this is much faster and can open the 33MB file in less than 10s (most of the time is probably not in highlighting).