### PR TITLE
Add support for per-polygon colour in WRL exports.

### DIFF
--- a/src/io/export_wrl.cc
+++ b/src/io/export_wrl.cc
@@ -80,6 +80,28 @@ void export_wrl(const std::shared_ptr<const Geometry>& geom, std::ostream& outpu
   }
   output << "]\n\n";
 
+  if (!ps->color_indices.empty()) {
+    output << "colorPerVertex FALSE\n\n";
+    output << "color Color { color [\n";
+    for (size_t i = 0; i < ps->colors.size(); ++i) {
+      auto color = ps->colors[i];
+      float r, g, b, a;
+      if (!color.getRgba(r, g, b, a)) {
+        LOG(message_group::Warning, "Invalid color in WRL export");
+      }
+      // Alpha channel ignored as WRL colours are RGB not RGBA
+      output << " " << r << " " << g << " " << b << ",\n";
+    }
+    output << " 0.976471 0.843137 0.172549, # default colour\n";
+    output << "] }\n\n";
+    output << "colorIndex [\n";
+    for (size_t i = 0; i < ps->indices.size(); ++i) {
+      auto color_index = ps->color_indices[i];
+      output << ((color_index >= 0) ? color_index : ps->colors.size()) << " ";
+    }
+    output << "]\n\n";
+  }
+
   output << "}\n\n";
 
   output << "}\n";


### PR DESCRIPTION
Adds Color and ColorIndex fields to IndexedFaceSet.

RGB only, alpha is not supported in WRL file.