### PR TITLE
Add explicit constData() assignment for a QByteArray

### DIFF
--- a/src/gui/MainWindow.cc
+++ b/src/gui/MainWindow.cc
@@ -2090,7 +2090,7 @@ SourceFile *MainWindow::parseDocument(EditorInterface *editor)
   auto fulltext = std::string(document.toUtf8().constData()) + "\n\x03\n" + commandline_commands;
   auto fnameba = editor->filepath.toLocal8Bit();
 
-  const char *fname = editor->filepath.isEmpty() ? "" : fnameba;
+  const char *fname = editor->filepath.isEmpty() ? "" : fnameba.constData();
 #ifdef ENABLE_PYTHON
   this->python_active = false;
   if (fname != NULL) {


### PR DESCRIPTION
Helps avoid compiler error and warnings. Currently, this operation would rely on implicit conversion of `fnameba` (type QByteArray) into type const char*. 

By calling `fnameba.constData()`, both parts of the ternary opn are the same, which is safer.

This PR is linked to #5984 , but merging this first could be of more general use and isnt specific to the windows/MSVC build that PR is working towards. 