### PR TITLE
beautify files before svg export changes

### DIFF
--- a/src/core/Settings.cc
+++ b/src/core/Settings.cc
@@ -30,9 +30,9 @@ std::vector<SettingsEntryEnum<std::string>::Item> createFileFormatItems(std::vec
   std::vector<SettingsEntryEnum<std::string>::Item> items;
   std::transform(formats.begin(), formats.end(), std::back_inserter(items),
                  [](const FileFormat& format){
-    const FileFormatInfo &info = fileformat::info(format);
-    return SettingsEntryEnum<std::string>::Item{info.identifier, info.identifier, info.description};
-    });
+        const FileFormatInfo& info = fileformat::info(format);
+        return SettingsEntryEnum<std::string>::Item{info.identifier, info.identifier, info.description};
+      });
   return items;
 }
 
@@ -149,90 +149,90 @@ SettingsEntryBool Settings::mouseSwapButtons("3dview", "mouseSwapButtons", false
 SettingsEntryInt Settings::indentationWidth("editor", "indentationWidth", 1, 16, 4);
 SettingsEntryInt Settings::tabWidth("editor", "tabWidth", 1, 16, 4);
 SettingsEntryEnum<std::string> Settings::lineWrap("editor", "lineWrap", {
-  {"None", "none", _("None")},
-  {"Char", "char", _("Wrap at character boundaries")},
-  {"Word", "word", _("Wrap at word boundaries")}
-}, "Word");
+    {"None", "none", _("None")},
+    {"Char", "char", _("Wrap at character boundaries")},
+    {"Word", "word", _("Wrap at word boundaries")}
+  }, "Word");
 SettingsEntryEnum<std::string> Settings::lineWrapIndentationStyle("editor", "lineWrapIndentationStyle", {
-  {"Fixed",    "fixed",    _("Fixed")},
-  {"Same",     "same",     _("Same")},
-  {"Indented", "indented", _("Indented")}
-}, "Fixed");
+    {"Fixed",    "fixed",    _("Fixed")},
+    {"Same",     "same",     _("Same")},
+    {"Indented", "indented", _("Indented")}
+  }, "Fixed");
 SettingsEntryInt Settings::lineWrapIndentation("editor", "lineWrapIndentation", 0, 999, 4);
 SettingsEntryEnum<std::string> Settings::lineWrapVisualizationBegin("editor", "lineWrapVisualizationBegin", {
-  {"None",   "none",   _("None")},
-  {"Text",   "text"  , _("Text")},
-  {"Border", "border", _("Border")},
-  {"Margin", "margin", _("Margin")}
-}, "None");
+    {"None",   "none",   _("None")},
+    {"Text",   "text", _("Text")},
+    {"Border", "border", _("Border")},
+    {"Margin", "margin", _("Margin")}
+  }, "None");
 SettingsEntryEnum<std::string> Settings::lineWrapVisualizationEnd("editor", "lineWrapVisualizationEnd", {
-  {"None",   "none",   _("None")},
-  {"Text",   "text",   _("Text")},
-  {"Border", "border", _("Border")},
-  {"Margin", "margin", _("Margin")}
-}, "Border");
+    {"None",   "none",   _("None")},
+    {"Text",   "text",   _("Text")},
+    {"Border", "border", _("Border")},
+    {"Margin", "margin", _("Margin")}
+  }, "Border");
 SettingsEntryEnum<std::string> Settings::showWhitespace("editor", "showWhitespaces", {
-  {"Never",            "never",        _("Never")},
-  {"Always",           "always",       _("Always")},
-  {"AfterIndentation", "after-indent", _("After indentation")}
-}, "Never");
+    {"Never",            "never",        _("Never")},
+    {"Always",           "always",       _("Always")},
+    {"AfterIndentation", "after-indent", _("After indentation")}
+  }, "Never");
 SettingsEntryInt Settings::showWhitespaceSize("editor", "showWhitespacesSize", 1, 16, 2);
 SettingsEntryBool Settings::autoIndent("editor", "autoIndent", true);
 SettingsEntryBool Settings::backspaceUnindents("editor", "backspaceUnindents", false);
 SettingsEntryEnum<std::string> Settings::indentStyle("editor", "indentStyle", {
-  {"Spaces", "spaces", _("Spaces")},
-  {"Tabs",   "tabs",   _("Tabs")}
-}, "spaces");
+    {"Spaces", "spaces", _("Spaces")},
+    {"Tabs",   "tabs",   _("Tabs")}
+  }, "spaces");
 SettingsEntryEnum<std::string> Settings::tabKeyFunction("editor", "tabKeyFunction", {
-  {"Indent",    "indent", _("Indent")},
-  {"InsertTab", "tab",    _("Insert Tab")}
-}, "Indent");
+    {"Indent",    "indent", _("Indent")},
+    {"InsertTab", "tab",    _("Insert Tab")}
+  }, "Indent");
 SettingsEntryBool Settings::highlightCurrentLine("editor", "highlightCurrentLine", true);
 SettingsEntryBool Settings::enableBraceMatching("editor", "enableBraceMatching", true);
 SettingsEntryBool Settings::enableLineNumbers("editor", "enableLineNumbers", true);
 SettingsEntryBool Settings::enableNumberScrollWheel("editor", "enableNumberScrollWheel", true);
 SettingsEntryEnum<std::string> Settings::modifierNumberScrollWheel("editor", "modifierNumberScrollWheel", {
-  {"Alt",               "alt",               _("Alt")},
-  {"Left Mouse Button", "left-mouse-button", _("Left Mouse Button")},
-  {"Either",            "either",            _("Either")}
-}, "Alt");
+    {"Alt",               "alt",               _("Alt")},
+    {"Left Mouse Button", "left-mouse-button", _("Left Mouse Button")},
+    {"Either",            "either",            _("Either")}
+  }, "Alt");
 
 SettingsEntryString Settings::defaultPrintService("printing", "printService", "NONE");
 SettingsEntryBool Settings::enableRemotePrintServices("printing", "enableRemotePrintServices", false);
 SettingsEntryBool Settings::printServiceAlwaysShowDialog("printing", "always-show-dialog", false);
 SettingsEntryString Settings::printServiceName("printing", "printServiceName", "");
 SettingsEntryEnum<std::string> Settings::printServiceFileFormat(
-    "printing", "printServiceFileFormat", createFileFormatItems(fileformat::all3D()),
-    fileformat::info(FileFormat::ASCII_STL).description);
+  "printing", "printServiceFileFormat", createFileFormatItems(fileformat::all3D()),
+  fileformat::info(FileFormat::ASCII_STL).description);
 
 SettingsEntryString Settings::octoPrintUrl("printing", "octoPrintUrl", "");
 SettingsEntryString Settings::octoPrintApiKey("printing", "octoPrintApiKey", "");
 SettingsEntryEnum<std::string> Settings::octoPrintAction("printing", "octoPrintAction", {
-  {"upload", "upload", _("Upload only")},
-  {"slice",  "slice",  _("Upload & Slice")},
-  {"select", "select", _("Upload, Slice & Select for printing")},
-  {"print",  "print",  _("Upload, Slice & Start printing")}
-}, "upload");
+    {"upload", "upload", _("Upload only")},
+    {"slice",  "slice",  _("Upload & Slice")},
+    {"select", "select", _("Upload, Slice & Select for printing")},
+    {"print",  "print",  _("Upload, Slice & Start printing")}
+  }, "upload");
 SettingsEntryString Settings::octoPrintSlicerEngine("printing", "octoPrintSlicerEngine", "");
 SettingsEntryString Settings::octoPrintSlicerEngineDesc("printing", "octoPrintSlicerEngineDesc", "");
 SettingsEntryString Settings::octoPrintSlicerProfile("printing", "octoPrintSlicerProfile", "");
 SettingsEntryString Settings::octoPrintSlicerProfileDesc("printing", "octoPrintSlicerProfileDesc", "");
 SettingsEntryEnum<std::string> Settings::octoPrintFileFormat(
-    "printing", "octoPrintFileFormat",
-    createFileFormatItems({FileFormat::ASCII_STL, FileFormat::BINARY_STL, FileFormat::_3MF, FileFormat::OFF}),
-    fileformat::info(FileFormat::ASCII_STL).description);
+  "printing", "octoPrintFileFormat",
+  createFileFormatItems({FileFormat::ASCII_STL, FileFormat::BINARY_STL, FileFormat::_3MF, FileFormat::OFF}),
+  fileformat::info(FileFormat::ASCII_STL).description);
 
 SettingsEntryString Settings::localAppExecutable("printing", "localAppExecutable", "");
 SettingsEntryString Settings::localAppTempDir("printing", "localAppTempDir", "");
 SettingsEntryEnum<std::string> Settings::localAppFileFormat(
-    "printing", "localAppFileFormat", createFileFormatItems(fileformat::all3D()),
-    fileformat::info(FileFormat::ASCII_STL).description);
+  "printing", "localAppFileFormat", createFileFormatItems(fileformat::all3D()),
+  fileformat::info(FileFormat::ASCII_STL).description);
 SettingsEntryList<LocalAppParameter> Settings::localAppParameterList("printing", "localAppParameterList");
 
 SettingsEntryEnum<std::string> Settings::renderBackend3D("advanced", "renderBackend3D", {
-  {"CGAL",     "cgal",     "CGAL (old/slow)"},
-  {"Manifold", "manifold", "Manifold (new/fast)"}
-}, "CGAL");
+    {"CGAL",     "cgal",     "CGAL (old/slow)"},
+    {"Manifold", "manifold", "Manifold (new/fast)"}
+  }, "CGAL");
 SettingsEntryEnum<std::string> Settings::toolbarExport3D("advanced", "toolbarExport3D", createFileFormatItems(fileformat::all3D()), fileformat::info(FileFormat::ASCII_STL).description);
 SettingsEntryEnum<std::string> Settings::toolbarExport2D("advanced", "toolbarExport2D", createFileFormatItems(fileformat::all2D()), fileformat::info(FileFormat::DXF).description);
 
@@ -318,19 +318,19 @@ SettingsEntryString SettingsPython::pythonVirtualEnv(SECTION_PYTHON, "virtual-en
 
 SettingsEntryBool SettingsExportPdf::exportPdfAlwaysShowDialog(SECTION_EXPORT_PDF, "always-show-dialog", true);
 SettingsEntryEnum<ExportPdfPaperSize> SettingsExportPdf::exportPdfPaperSize(SECTION_EXPORT_PDF, "paper-size", {
-  {ExportPdfPaperSize::A6,      "a6",      _("A6 (105 x 148 mm)")},
-  {ExportPdfPaperSize::A5,      "a5",      _("A5 (148 x 210 mm)")},
-  {ExportPdfPaperSize::A4,      "a4",      _("A4 (210x297 mm)")},
-  {ExportPdfPaperSize::A3,      "a3",      _("A3 (297x420 mm)")},
-  {ExportPdfPaperSize::LETTER,  "letter",  _("Letter (8.5x11 in)")},
-  {ExportPdfPaperSize::LEGAL,   "legal",   _("Legal (8.5x14 in)")},
-  {ExportPdfPaperSize::TABLOID, "tabloid", _("Tabloid (11x17 in)")}
-}, ExportPdfPaperSize::A4);
+    {ExportPdfPaperSize::A6,      "a6",      _("A6 (105 x 148 mm)")},
+    {ExportPdfPaperSize::A5,      "a5",      _("A5 (148 x 210 mm)")},
+    {ExportPdfPaperSize::A4,      "a4",      _("A4 (210x297 mm)")},
+    {ExportPdfPaperSize::A3,      "a3",      _("A3 (297x420 mm)")},
+    {ExportPdfPaperSize::LETTER,  "letter",  _("Letter (8.5x11 in)")},
+    {ExportPdfPaperSize::LEGAL,   "legal",   _("Legal (8.5x14 in)")},
+    {ExportPdfPaperSize::TABLOID, "tabloid", _("Tabloid (11x17 in)")}
+  }, ExportPdfPaperSize::A4);
 SettingsEntryEnum<ExportPdfPaperOrientation> SettingsExportPdf::exportPdfOrientation(SECTION_EXPORT_PDF, "orientation", {
-  {ExportPdfPaperOrientation::PORTRAIT,  "portrait",  _("Portrait (Vertical)")},
-  {ExportPdfPaperOrientation::LANDSCAPE, "landscape", _("Landscape (Horizontal)")},
-  {ExportPdfPaperOrientation::AUTO,      "auto",      _("Auto")}
-}, ExportPdfPaperOrientation::PORTRAIT);
+    {ExportPdfPaperOrientation::PORTRAIT,  "portrait",  _("Portrait (Vertical)")},
+    {ExportPdfPaperOrientation::LANDSCAPE, "landscape", _("Landscape (Horizontal)")},
+    {ExportPdfPaperOrientation::AUTO,      "auto",      _("Auto")}
+  }, ExportPdfPaperOrientation::PORTRAIT);
 SettingsEntryBool SettingsExportPdf::exportPdfShowFilename(SECTION_EXPORT_PDF, "show-filename", false);
 SettingsEntryBool SettingsExportPdf::exportPdfShowScale(SECTION_EXPORT_PDF, "show-scale", true);
 SettingsEntryBool SettingsExportPdf::exportPdfShowScaleMessage(SECTION_EXPORT_PDF, "show-scale-message", true);
@@ -352,23 +352,23 @@ SettingsEntryDouble SettingsExportPdf::exportPdfStrokeWidth(SECTION_EXPORT_PDF, 
 
 SettingsEntryBool SettingsExport3mf::export3mfAlwaysShowDialog(SECTION_EXPORT_3MF, "always-show-dialog", true);
 SettingsEntryEnum<Export3mfColorMode> SettingsExport3mf::export3mfColorMode(SECTION_EXPORT_3MF, "color-mode", {
-  {Export3mfColorMode::model,               "model",               _("Use colors from model")},
-  {Export3mfColorMode::none,                "none",                _("No colors")},
-  {Export3mfColorMode::selected_only,       "selected-only",       _("Use selected color only")},
-}, Export3mfColorMode::model);
+    {Export3mfColorMode::model,               "model",               _("Use colors from model")},
+    {Export3mfColorMode::none,                "none",                _("No colors")},
+    {Export3mfColorMode::selected_only,       "selected-only",       _("Use selected color only")},
+  }, Export3mfColorMode::model);
 SettingsEntryEnum<Export3mfUnit> SettingsExport3mf::export3mfUnit(SECTION_EXPORT_3MF, "unit", {
-  {Export3mfUnit::micron,     "micron",     _("Micron")},
-  {Export3mfUnit::millimeter, "millimeter", _("Millimeter")},
-  {Export3mfUnit::centimeter, "centimeter", _("Centimeter")},
-  {Export3mfUnit::meter,      "meter",      _("Meter")},
-  {Export3mfUnit::inch,       "inch",       _("Inch")},
-  {Export3mfUnit::foot,       "foot",       _("Feet")},
-}, Export3mfUnit::millimeter);
+    {Export3mfUnit::micron,     "micron",     _("Micron")},
+    {Export3mfUnit::millimeter, "millimeter", _("Millimeter")},
+    {Export3mfUnit::centimeter, "centimeter", _("Centimeter")},
+    {Export3mfUnit::meter,      "meter",      _("Meter")},
+    {Export3mfUnit::inch,       "inch",       _("Inch")},
+    {Export3mfUnit::foot,       "foot",       _("Feet")},
+  }, Export3mfUnit::millimeter);
 SettingsEntryString SettingsExport3mf::export3mfColor(SECTION_EXPORT_3MF, "color", "#f9d72c"); // Cornfield: CGAL_FACE_FRONT_COLOR
 SettingsEntryEnum<Export3mfMaterialType> SettingsExport3mf::export3mfMaterialType(SECTION_EXPORT_3MF, "material-type", {
-  {Export3mfMaterialType::color,        "color",        _("Color")},
-  {Export3mfMaterialType::basematerial, "basematerial", _("Base Material")},
-}, Export3mfMaterialType::basematerial);
+    {Export3mfMaterialType::color,        "color",        _("Color")},
+    {Export3mfMaterialType::basematerial, "basematerial", _("Base Material")},
+  }, Export3mfMaterialType::basematerial);
 SettingsEntryInt SettingsExport3mf::export3mfDecimalPrecision(SECTION_EXPORT_3MF, "decimal-precision", 1, 16, 6);
 SettingsEntryBool SettingsExport3mf::export3mfAddMetaData(SECTION_EXPORT_3MF, "add-meta-data", true);
 SettingsEntryBool SettingsExport3mf::export3mfAddMetaDataDesigner(SECTION_EXPORT_3MF, "add-meta-data-designer", false);

--- a/src/core/Settings.h
+++ b/src/core/Settings.h
@@ -13,9 +13,9 @@
 
 namespace Settings {
 
-  // Note that those 2 values also relate to the currently
-  // static list of fields in the preferences GUI, so updating
-  // here needs a change in the UI definition!
+// Note that those 2 values also relate to the currently
+// static list of fields in the preferences GUI, so updating
+// here needs a change in the UI definition!
 constexpr inline size_t max_axis = 9;
 constexpr inline size_t max_buttons = 24;
 
@@ -49,7 +49,7 @@ private:
   std::string _name;
 };
 
-template<typename entry_type>
+template <typename entry_type>
 class SettingsEntry : public SettingsEntryBase
 {
 public:
@@ -77,10 +77,10 @@ public:
   bool isDefault() const override { return _value == _defaultValue; }
   std::string encode() const override;
   const bool decode(const std::string& encoded) const override;
-  void set(const std::string& encoded) override { setValue(decode(encoded)); };
+  void set(const std::string& encoded) override { setValue(decode(encoded)); }
   const std::tuple<std::string, std::string> help() const override {
     return {"bool", defaultValue() ? "<true>/false" : "true/<false>"};
-  };
+  }
 
 private:
   bool _value;
@@ -106,10 +106,10 @@ public:
   bool isDefault() const override { return _value == _defaultValue; }
   std::string encode() const override;
   const int decode(const std::string& encoded) const override;
-  void set(const std::string& encoded) override { setValue(decode(encoded)); };
+  void set(const std::string& encoded) override { setValue(decode(encoded)); }
   const std::tuple<std::string, std::string> help() const override {
     return {"int", std::to_string(_minimum) + " : <" + std::to_string(defaultValue()) + "> : " + std::to_string(maximum())};
-  };
+  }
 
 private:
   int _value;
@@ -139,10 +139,10 @@ public:
   bool isDefault() const override { return _value == _defaultValue; }
   std::string encode() const override;
   const double decode(const std::string& encoded) const override;
-  void set(const std::string& encoded) override { setValue(decode(encoded)); };
+  void set(const std::string& encoded) override { setValue(decode(encoded)); }
   const std::tuple<std::string, std::string> help() const override {
     return {"double", std::to_string(_minimum) + " : <" + std::to_string(defaultValue()) + "> : " + std::to_string(maximum())};
-  };
+  }
 
 private:
   double _value;
@@ -167,20 +167,21 @@ public:
   bool isDefault() const override { return _value == _defaultValue; }
   std::string encode() const override { return value(); }
   const std::string decode(const std::string& encoded) const override { return encoded; }
-  void set(const std::string& encoded) override { setValue(decode(encoded)); };
-  const std::tuple<std::string, std::string> help() const override { return {"string", "\"" + encode() + "\""}; };
+  void set(const std::string& encoded) override { setValue(decode(encoded)); }
+  const std::tuple<std::string, std::string> help() const override { return {"string", "\"" + encode() + "\""}; }
 
 private:
   std::string _value;
   std::string _defaultValue;
 };
 
-template<typename enum_type>
+template <typename enum_type>
 class SettingsEntryEnum : public SettingsEntry<enum_type>
 {
 public:
   struct Item {
-    Item(enum_type value, std::string name, std::string description) : value(value), name(std::move(name)), description(std::move(description)) {}
+    Item(enum_type value, std::string name, std::string description) : value(value), name(std::move(name)), description(std::move(description)) {
+    }
     enum_type value;
     std::string name;
     std::string description;
@@ -216,7 +217,7 @@ public:
     }
     list += "]";
     return {"enum", list};
-  };
+  }
 
 private:
   std::vector<Item> _items;
@@ -224,7 +225,7 @@ private:
   enum_type _defaultValue;
 };
 
-template<typename enum_type>
+template <typename enum_type>
 void SettingsEntryEnum<enum_type>::setValue(const enum_type& value)
 {
   for (size_t i = 0; i < _items.size(); ++i) {
@@ -235,10 +236,10 @@ void SettingsEntryEnum<enum_type>::setValue(const enum_type& value)
   }
 }
 
-template<typename enum_type>
+template <typename enum_type>
 std::string SettingsEntryEnum<enum_type>::encode() const { return item().name; }
 
-template<typename enum_type>
+template <typename enum_type>
 const enum_type SettingsEntryEnum<enum_type>::decode(const std::string& encoded) const {
   for (const Item& item : items()) {
     if (item.name == encoded) {
@@ -248,10 +249,10 @@ const enum_type SettingsEntryEnum<enum_type>::decode(const std::string& encoded)
   return defaultValue();
 }
 
-template<>
+template <>
 inline std::string SettingsEntryEnum<std::string>::encode() const { return value(); }
 
-template<>
+template <>
 inline const std::string SettingsEntryEnum<std::string>::decode(const std::string& encoded) const { return encoded; }
 
 class LocalAppParameterType
@@ -270,30 +271,32 @@ public:
 
   LocalAppParameterType() = default;
   constexpr LocalAppParameterType(Value v) : value(v) { }
-  constexpr operator Value() const { return value; }
+  constexpr operator Value() const {
+    return value;
+  }
   explicit operator bool() const = delete;
 
   std::string icon() const {
     switch (value) {
-      case string: return "chokusen-parameter";
-      case file: return "chokusen-orthogonal";
-      case dir: return "chokusen-folder";
-      case extension: return "chokusen-parameter";
-      case source: return "chokusen-file";
-      case sourcedir: return "chokusen-folder";
-      default: return "*invalid*";
+    case string: return "chokusen-parameter";
+    case file: return "chokusen-orthogonal";
+    case dir: return "chokusen-folder";
+    case extension: return "chokusen-parameter";
+    case source: return "chokusen-file";
+    case sourcedir: return "chokusen-folder";
+    default: return "*invalid*";
     }
   }
 
   std::string description() const {
     switch (value) {
-      case string: return "";
-      case file: return "<full path to the output file>";
-      case dir: return "<directory of the output file>";
-      case extension: return "<extension of the output file without leading dot>";
-      case source: return "<full path to the main source file>";
-      case sourcedir: return "<directory of the main source file>";
-      default: return "*invalid*";
+    case string: return "";
+    case file: return "<full path to the output file>";
+    case dir: return "<directory of the output file>";
+    case extension: return "<extension of the output file without leading dot>";
+    case source: return "<full path to the main source file>";
+    case sourcedir: return "<directory of the main source file>";
+    default: return "*invalid*";
     }
   }
 
@@ -305,12 +308,16 @@ struct LocalAppParameter {
   LocalAppParameterType type;
   std::string value;
 
-  LocalAppParameter() : type(LocalAppParameterType::string), value("") {}
-  LocalAppParameter(const LocalAppParameterType t, std::string v) : type(t), value(std::move(v)) {}
-  operator bool() const { return type != LocalAppParameterType::invalid; }
+  LocalAppParameter() : type(LocalAppParameterType::string), value("") {
+  }
+  LocalAppParameter(const LocalAppParameterType t, std::string v) : type(t), value(std::move(v)) {
+  }
+  operator bool() const {
+    return type != LocalAppParameterType::invalid;
+  }
 };
 
-template<typename item_type>
+template <typename item_type>
 class SettingsEntryList : public SettingsEntry<std::vector<item_type>>
 {
 public:
@@ -342,9 +349,10 @@ public:
     }
     return items;
   }
-  void set(const std::string& encoded) override { setValue(decode(encoded)); };
-  const std::tuple<std::string, std::string> help() const override { return {"list", ""};
-  };
+  void set(const std::string& encoded) override { setValue(decode(encoded)); }
+  const std::tuple<std::string, std::string> help() const override {
+    return {"list", ""};
+  }
 
 private:
   list_type_t _items;
@@ -479,13 +487,15 @@ public:
   static void visit(const SettingsVisitor& visitor);
 };
 
-class SettingsPython {
+class SettingsPython
+{
 public:
   static SettingsEntryString pythonTrustedFiles;
   static SettingsEntryString pythonVirtualEnv;
 };
 
-class SettingsExportPdf {
+class SettingsExportPdf
+{
 public:
   static SettingsEntryBool exportPdfAlwaysShowDialog;
   static SettingsEntryEnum<ExportPdfPaperSize> exportPdfPaperSize;
@@ -530,7 +540,8 @@ public:
   };
 };
 
-class SettingsExport3mf {
+class SettingsExport3mf
+{
 public:
   static SettingsEntryBool export3mfAlwaysShowDialog;
   static SettingsEntryEnum<Export3mfColorMode> export3mfColorMode;

--- a/src/gui/MainWindow.cc
+++ b/src/gui/MainWindow.cc
@@ -797,8 +797,7 @@ MainWindow::MainWindow(const QStringList& filenames) :
   // Configure the highlighting color scheme from the active editor one.
   // This is done only one time at creation of the first MainWindow instance
   auto preferences = GlobalPreferences::inst();
-  if(!preferences->hasHighlightingColorScheme())
-    preferences->setHighlightingColorSchemes(activeEditor->colorSchemes());
+  if (!preferences->hasHighlightingColorScheme())preferences->setHighlightingColorSchemes(activeEditor->colorSchemes());
 
   onTabManagerEditorChanged(activeEditor);
 
@@ -1320,18 +1319,18 @@ void MainWindow::compileEnded()
 }
 
 #ifdef ENABLE_GUI_TESTS
-std::shared_ptr<AbstractNode> MainWindow::instantiateRootFromSource(SourceFile* file)
+std::shared_ptr<AbstractNode> MainWindow::instantiateRootFromSource(SourceFile *file)
 {
-    EvaluationSession session{file->getFullpath()};
-    ContextHandle<BuiltinContext> builtin_context{Context::create<BuiltinContext>(&session)};
-    setRenderVariables(builtin_context);
+  EvaluationSession session{file->getFullpath()};
+  ContextHandle<BuiltinContext> builtin_context{Context::create<BuiltinContext>(&session)};
+  setRenderVariables(builtin_context);
 
-    std::shared_ptr<const FileContext> file_context;
-    std::shared_ptr<AbstractNode> node = this->rootFile->instantiate(*builtin_context, &file_context);
+  std::shared_ptr<const FileContext> file_context;
+  std::shared_ptr<AbstractNode> node = this->rootFile->instantiate(*builtin_context, &file_context);
 
-    return node;
+  return node;
 }
-#endif
+#endif // ifdef ENABLE_GUI_TESTS
 
 void MainWindow::instantiateRoot()
 {
@@ -1837,36 +1836,36 @@ void MainWindow::hideFind()
 // activeEditor to appropriate search mode.
 void MainWindow::showFind(bool doFindAndReplace)
 {
-    findInputField->setFindCount(activeEditor->updateFindIndicators(findInputField->text()));
-    processEvents();
+  findInputField->setFindCount(activeEditor->updateFindIndicators(findInputField->text()));
+  processEvents();
 
-    if(doFindAndReplace){
-        findTypeComboBox->setCurrentIndex(1);
-        replaceInputField->show();
-        replaceButton->show();
-        replaceAllButton->show();
-        activeEditor->findState = TabManager::FIND_REPLACE_VISIBLE;
-    }else{
-        findTypeComboBox->setCurrentIndex(0);
-        replaceInputField->hide();
-        replaceButton->hide();
-        replaceAllButton->hide();
-        activeEditor->findState = TabManager::FIND_VISIBLE;
-    }
+  if (doFindAndReplace){
+    findTypeComboBox->setCurrentIndex(1);
+    replaceInputField->show();
+    replaceButton->show();
+    replaceAllButton->show();
+    activeEditor->findState = TabManager::FIND_REPLACE_VISIBLE;
+  } else {
+    findTypeComboBox->setCurrentIndex(0);
+    replaceInputField->hide();
+    replaceButton->hide();
+    replaceAllButton->hide();
+    activeEditor->findState = TabManager::FIND_VISIBLE;
+  }
 
-    find_panel->show();
-    editActionFindNext->setEnabled(true);
-    editActionFindPrevious->setEnabled(true);
-    if (!activeEditor->selectedText().isEmpty()) {
-      findInputField->setText(activeEditor->selectedText());
-    }
-    findInputField->setFocus();
-    findInputField->selectAll();
+  find_panel->show();
+  editActionFindNext->setEnabled(true);
+  editActionFindPrevious->setEnabled(true);
+  if (!activeEditor->selectedText().isEmpty()) {
+    findInputField->setText(activeEditor->selectedText());
+  }
+  findInputField->setFocus();
+  findInputField->selectAll();
 }
 
 void MainWindow::actionShowFind()
 {
-    showFind(false);
+  showFind(false);
 }
 
 void MainWindow::findString(const QString& textToFind)
@@ -1878,7 +1877,7 @@ void MainWindow::findString(const QString& textToFind)
 
 void MainWindow::actionShowFindAndReplace()
 {
-    showFind(true);
+  showFind(true);
 }
 
 void MainWindow::actionSelectFind(int type)
@@ -2538,7 +2537,7 @@ void MainWindow::rightClick(QPoint position)
 
 void MainWindow::measureFinished()
 {
-    meas.stopMeasure();
+  meas.stopMeasure();
 }
 
 void MainWindow::clearAllSelectionIndicators()
@@ -2702,19 +2701,17 @@ void MainWindow::UnknownExceptionCleanup(std::string msg){
 
 void MainWindow::showTextInWindow(const QString& type, const QString& content)
 {
-    auto e = new QTextEdit(this);
-    e->setAttribute(Qt::WA_DeleteOnClose);
-    e->setWindowFlags(Qt::Window);
-    e->setTabStopDistance(tabStopWidth);
-    e->setWindowTitle(type+" Dump");
-    if(content.isEmpty())
-        e->setPlainText("No "+type+" to dump. Please try compiling first...");
-    else
-        e->setPlainText(content);
+  auto e = new QTextEdit(this);
+  e->setAttribute(Qt::WA_DeleteOnClose);
+  e->setWindowFlags(Qt::Window);
+  e->setTabStopDistance(tabStopWidth);
+  e->setWindowTitle(type + " Dump");
+  if (content.isEmpty())e->setPlainText("No " + type + " to dump. Please try compiling first...");
+  else e->setPlainText(content);
 
-    e->setReadOnly(true);
-    e->resize(600, 400);
-    e->show();
+  e->setReadOnly(true);
+  e->resize(600, 400);
+  e->show();
 }
 
 void MainWindow::actionDisplayAST()
@@ -2737,9 +2734,11 @@ void MainWindow::actionDisplayCSGProducts()
 {
   setCurrentOutput();
   // a small lambda to avoid code duplication
-  auto constexpr dump = [](auto node){ return QString::fromStdString(node? node->dump() : "N/A"); };
+  auto constexpr dump = [](auto node){
+      return QString::fromStdString(node? node->dump() : "N/A");
+    };
   auto text = QString("\nCSG before normalization:\n%1\n\n\nCSG after normalization:\n%2\n\n\nCSG rendering chain:\n%3\n\n\nHighlights CSG rendering chain:\n%4\n\n\nBackground CSG rendering chain:\n%5\n")
-                  .arg(dump(csgRoot), dump(normalizedRoot), dump(rootProduct), dump(highlightsProducts), dump(backgroundProducts));
+    .arg(dump(csgRoot), dump(normalizedRoot), dump(rootProduct), dump(highlightsProducts), dump(backgroundProducts));
   showTextInWindow("CSG Products Dump", text);
   clearCurrentOutput();
 }
@@ -3134,23 +3133,23 @@ void MainWindow::viewCenter()
 
 void MainWindow::setProjectionType(ProjectionType mode)
 {
-    bool isOrthogonal = ProjectionType::ORTHOGONAL == mode;
-    QSettingsCached settings;
-    settings.setValue("view/orthogonalProjection", isOrthogonal);
-    viewActionPerspective->setChecked(!isOrthogonal);
-    viewActionOrthogonal->setChecked(isOrthogonal);
-    qglview->setOrthoMode(isOrthogonal);
-    qglview->update();
+  bool isOrthogonal = ProjectionType::ORTHOGONAL == mode;
+  QSettingsCached settings;
+  settings.setValue("view/orthogonalProjection", isOrthogonal);
+  viewActionPerspective->setChecked(!isOrthogonal);
+  viewActionOrthogonal->setChecked(isOrthogonal);
+  qglview->setOrthoMode(isOrthogonal);
+  qglview->update();
 }
 
 void MainWindow::viewPerspective()
 {
-    setProjectionType(ProjectionType::PERSPECTIVE);
+  setProjectionType(ProjectionType::PERSPECTIVE);
 }
 
 void MainWindow::viewOrthogonal()
 {
-    setProjectionType(ProjectionType::ORTHOGONAL);
+  setProjectionType(ProjectionType::ORTHOGONAL);
 }
 
 void MainWindow::viewTogglePerspective()

--- a/src/io/export.cc
+++ b/src/io/export.cc
@@ -73,34 +73,34 @@ void add_item(Containers& containers, const FileFormatInfo& info) {
   containers.fileFormatToInfo[info.format] = info;
 }
 
-Containers &containers() {
+Containers& containers() {
   static std::unique_ptr<Containers> containers = [](){
-    auto containers = std::make_unique<Containers>();
+      auto containers = std::make_unique<Containers>();
 
-    add_item(*containers, {FileFormat::ASCII_STL, "asciistl", "stl", "STL (ascii)"});
-    add_item(*containers, {FileFormat::BINARY_STL, "binstl", "stl", "STL (binary)"});
-    add_item(*containers, {FileFormat::OBJ, "obj", "obj", "OBJ"});
-    add_item(*containers, {FileFormat::OFF, "off", "off", "OFF"});
-    add_item(*containers, {FileFormat::WRL, "wrl", "wrl", "VRML"});
-    add_item(*containers, {FileFormat::AMF, "amf", "amf", "AMF"});
-    add_item(*containers, {FileFormat::_3MF, "3mf", "3mf", "3MF"});
-    add_item(*containers, {FileFormat::DXF, "dxf", "dxf", "DXF"});
-    add_item(*containers, {FileFormat::SVG, "svg", "svg", "SVG"});
-    add_item(*containers, {FileFormat::NEFDBG, "nefdbg", "nefdbg", "nefdbg"});
-    add_item(*containers, {FileFormat::NEF3, "nef3", "nef3", "nef3"});
-    add_item(*containers, {FileFormat::CSG, "csg", "csg", "CSG"});
-    add_item(*containers, {FileFormat::PARAM, "param", "param", "param"});
-    add_item(*containers, {FileFormat::AST, "ast", "ast", "AST"});
-    add_item(*containers, {FileFormat::TERM, "term", "term", "term"});
-    add_item(*containers, {FileFormat::ECHO, "echo", "echo", "echo"});
-    add_item(*containers, {FileFormat::PNG, "png", "png", "PNG"});
-    add_item(*containers, {FileFormat::PDF, "pdf", "pdf", "PDF"});
-    add_item(*containers, {FileFormat::POV, "pov", "pov", "POV"});
+      add_item(*containers, {FileFormat::ASCII_STL, "asciistl", "stl", "STL (ascii)"});
+      add_item(*containers, {FileFormat::BINARY_STL, "binstl", "stl", "STL (binary)"});
+      add_item(*containers, {FileFormat::OBJ, "obj", "obj", "OBJ"});
+      add_item(*containers, {FileFormat::OFF, "off", "off", "OFF"});
+      add_item(*containers, {FileFormat::WRL, "wrl", "wrl", "VRML"});
+      add_item(*containers, {FileFormat::AMF, "amf", "amf", "AMF"});
+      add_item(*containers, {FileFormat::_3MF, "3mf", "3mf", "3MF"});
+      add_item(*containers, {FileFormat::DXF, "dxf", "dxf", "DXF"});
+      add_item(*containers, {FileFormat::SVG, "svg", "svg", "SVG"});
+      add_item(*containers, {FileFormat::NEFDBG, "nefdbg", "nefdbg", "nefdbg"});
+      add_item(*containers, {FileFormat::NEF3, "nef3", "nef3", "nef3"});
+      add_item(*containers, {FileFormat::CSG, "csg", "csg", "CSG"});
+      add_item(*containers, {FileFormat::PARAM, "param", "param", "param"});
+      add_item(*containers, {FileFormat::AST, "ast", "ast", "AST"});
+      add_item(*containers, {FileFormat::TERM, "term", "term", "term"});
+      add_item(*containers, {FileFormat::ECHO, "echo", "echo", "echo"});
+      add_item(*containers, {FileFormat::PNG, "png", "png", "PNG"});
+      add_item(*containers, {FileFormat::PDF, "pdf", "pdf", "PDF"});
+      add_item(*containers, {FileFormat::POV, "pov", "pov", "POV"});
 
-    // Alias
-    containers->identifierToInfo["stl"] = containers->identifierToInfo["asciistl"];  
-    return containers;
-  }();
+      // Alias
+      containers->identifierToInfo["stl"] = containers->identifierToInfo["asciistl"];
+      return containers;
+    }();
   return *containers;
 }
 
@@ -167,22 +167,22 @@ bool canPreview(FileFormat format) {
 }
 
 bool is3D(FileFormat format) {
-return format == FileFormat::ASCII_STL ||
-  format == FileFormat::BINARY_STL ||
-  format == FileFormat::OBJ ||
-  format == FileFormat::OFF ||
-  format == FileFormat::WRL ||
-  format == FileFormat::AMF ||
-  format == FileFormat::_3MF ||
-  format == FileFormat::NEFDBG ||
-  format == FileFormat::NEF3 ||
-  format == FileFormat::POV;
+  return format == FileFormat::ASCII_STL ||
+         format == FileFormat::BINARY_STL ||
+         format == FileFormat::OBJ ||
+         format == FileFormat::OFF ||
+         format == FileFormat::WRL ||
+         format == FileFormat::AMF ||
+         format == FileFormat::_3MF ||
+         format == FileFormat::NEFDBG ||
+         format == FileFormat::NEF3 ||
+         format == FileFormat::POV;
 }
 
 bool is2D(FileFormat format) {
   return format == FileFormat::DXF ||
-    format == FileFormat::SVG ||
-    format == FileFormat::PDF;
+         format == FileFormat::SVG ||
+         format == FileFormat::PDF;
 }
 
 }  // namespace FileFormat
@@ -312,22 +312,22 @@ Vector3d remove_negative_zero(const Vector3d& pt) {
   };
 }
 
-#if EIGEN_VERSION_AT_LEAST(3,4,0)
+#if EIGEN_VERSION_AT_LEAST(3, 4, 0)
 // Eigen 3.4.0 added begin()/end()
 struct LexographicLess {
-  template<class T>
+  template <class T>
   bool operator()(T const& lhs, T const& rhs) const {
     return std::lexicographical_compare(lhs.begin(), lhs.end(), rhs.begin(), rhs.end(), std::less{});
   }
 };
 #else
 struct LexographicLess {
-  template<class T>
+  template <class T>
   bool operator()(T const& lhs, T const& rhs) const {
     return std::lexicographical_compare(lhs.data(), lhs.data() + lhs.size(), rhs.data(), rhs.data() + rhs.size(), std::less{});
   }
 };
-#endif
+#endif // if EIGEN_VERSION_AT_LEAST(3, 4, 0)
 
 } // namespace
 
@@ -359,7 +359,7 @@ std::unique_ptr<PolySet> createSortedPolySet(const PolySet& ps)
   std::vector<int> indexTranslationMap(vertexMap.size());
   out->vertices.reserve(vertexMap.size());
 
-  for (const auto& [v,i] : vertexMap) {
+  for (const auto& [v, i] : vertexMap) {
     indexTranslationMap[i] = out->vertices.size();
     out->vertices.push_back(v);
   }
@@ -388,7 +388,7 @@ std::unique_ptr<PolySet> createSortedPolySet(const PolySet& ps)
       return a.face < b.face;
     });
     for (size_t i = 0, n = faces.size(); i < n; i++) {
-      auto & face = faces[i];
+      auto& face = faces[i];
       out->indices[i] = face.face;
       out->color_indices[i] = face.color_index;
     }

--- a/src/io/export.h
+++ b/src/io/export.h
@@ -74,7 +74,7 @@ bool is2D(FileFormat format);
 
 using CmdLineExportOptions = std::unordered_map<std::string, std::unordered_map<std::string, std::string>>;
 
-template<typename settings_entry_type>
+template <typename settings_entry_type>
 auto set_cmd_line_option(const CmdLineExportOptions& cmdLineOptions, const std::string& section, const settings_entry_type& se)
 {
   if (cmdLineOptions.count(section) == 0) {
@@ -92,43 +92,43 @@ auto set_cmd_line_option(const CmdLineExportOptions& cmdLineOptions, const std::
 // include defaults to use without dialog or direction.
 // Defaults match values used prior to incorporation of options.
 struct ExportPdfOptions {
-    bool showScale = true;
-    bool showScaleMsg = true;
-    bool showGrid = false;
-    double gridSize = 10.0;
-    bool showDesignFilename = false;
-    ExportPdfPaperOrientation orientation = ExportPdfPaperOrientation::PORTRAIT;
-    ExportPdfPaperSize paperSize = ExportPdfPaperSize::A4;
-    bool addMetaData = SPDF::exportPdfAddMetaData.defaultValue();
-    std::string metaDataTitle;
-    std::string metaDataAuthor;
-    std::string metaDataSubject;
-    std::string metaDataKeywords;
-    bool fill = false;
-    std::string fillColor = "black";
-    bool stroke = true;
-    std::string strokeColor = "black";
-    double strokeWidth = 1;
+  bool showScale = true;
+  bool showScaleMsg = true;
+  bool showGrid = false;
+  double gridSize = 10.0;
+  bool showDesignFilename = false;
+  ExportPdfPaperOrientation orientation = ExportPdfPaperOrientation::PORTRAIT;
+  ExportPdfPaperSize paperSize = ExportPdfPaperSize::A4;
+  bool addMetaData = SPDF::exportPdfAddMetaData.defaultValue();
+  std::string metaDataTitle;
+  std::string metaDataAuthor;
+  std::string metaDataSubject;
+  std::string metaDataKeywords;
+  bool fill = false;
+  std::string fillColor = "black";
+  bool stroke = true;
+  std::string strokeColor = "black";
+  double strokeWidth = 1;
 
   static std::shared_ptr<const ExportPdfOptions> withOptions(const CmdLineExportOptions& cmdLineOptions) {
     return std::make_shared<const ExportPdfOptions>(ExportPdfOptions{
-        .showScale = set_cmd_line_option(cmdLineOptions, Settings::SECTION_EXPORT_PDF, Settings::SettingsExportPdf::exportPdfShowScale),
-        .showScaleMsg = set_cmd_line_option(cmdLineOptions, Settings::SECTION_EXPORT_PDF, Settings::SettingsExportPdf::exportPdfShowScaleMessage),
-        .showGrid = set_cmd_line_option(cmdLineOptions, Settings::SECTION_EXPORT_PDF, Settings::SettingsExportPdf::exportPdfShowGrid),
-        .gridSize = set_cmd_line_option(cmdLineOptions, Settings::SECTION_EXPORT_PDF, Settings::SettingsExportPdf::exportPdfGridSize),
-        .showDesignFilename = set_cmd_line_option(cmdLineOptions, Settings::SECTION_EXPORT_PDF, Settings::SettingsExportPdf::exportPdfShowFilename),
-        .orientation = set_cmd_line_option(cmdLineOptions, Settings::SECTION_EXPORT_PDF, Settings::SettingsExportPdf::exportPdfOrientation),
-        .paperSize = set_cmd_line_option(cmdLineOptions, Settings::SECTION_EXPORT_PDF, Settings::SettingsExportPdf::exportPdfPaperSize),
-        .addMetaData = set_cmd_line_option(cmdLineOptions, Settings::SECTION_EXPORT_PDF, Settings::SettingsExportPdf::exportPdfAddMetaData),
-        .metaDataTitle = set_cmd_line_option(cmdLineOptions, Settings::SECTION_EXPORT_PDF, Settings::SettingsExportPdf::exportPdfMetaDataTitle),
-        .metaDataAuthor = set_cmd_line_option(cmdLineOptions, Settings::SECTION_EXPORT_PDF, Settings::SettingsExportPdf::exportPdfMetaDataAuthor),
-        .metaDataSubject = set_cmd_line_option(cmdLineOptions, Settings::SECTION_EXPORT_PDF, Settings::SettingsExportPdf::exportPdfMetaDataSubject),
-        .metaDataKeywords = set_cmd_line_option(cmdLineOptions, Settings::SECTION_EXPORT_PDF, Settings::SettingsExportPdf::exportPdfMetaDataKeywords),
-        .fill = set_cmd_line_option(cmdLineOptions, Settings::SECTION_EXPORT_PDF, Settings::SettingsExportPdf::exportPdfFill),
-        .fillColor = set_cmd_line_option(cmdLineOptions, Settings::SECTION_EXPORT_PDF, Settings::SettingsExportPdf::exportPdfFillColor),
-        .stroke = set_cmd_line_option(cmdLineOptions, Settings::SECTION_EXPORT_PDF, Settings::SettingsExportPdf::exportPdfStroke),
-        .strokeColor = set_cmd_line_option(cmdLineOptions, Settings::SECTION_EXPORT_PDF, Settings::SettingsExportPdf::exportPdfStrokeColor),
-        .strokeWidth = set_cmd_line_option(cmdLineOptions, Settings::SECTION_EXPORT_PDF, Settings::SettingsExportPdf::exportPdfStrokeWidth),
+      .showScale = set_cmd_line_option(cmdLineOptions, Settings::SECTION_EXPORT_PDF, Settings::SettingsExportPdf::exportPdfShowScale),
+      .showScaleMsg = set_cmd_line_option(cmdLineOptions, Settings::SECTION_EXPORT_PDF, Settings::SettingsExportPdf::exportPdfShowScaleMessage),
+      .showGrid = set_cmd_line_option(cmdLineOptions, Settings::SECTION_EXPORT_PDF, Settings::SettingsExportPdf::exportPdfShowGrid),
+      .gridSize = set_cmd_line_option(cmdLineOptions, Settings::SECTION_EXPORT_PDF, Settings::SettingsExportPdf::exportPdfGridSize),
+      .showDesignFilename = set_cmd_line_option(cmdLineOptions, Settings::SECTION_EXPORT_PDF, Settings::SettingsExportPdf::exportPdfShowFilename),
+      .orientation = set_cmd_line_option(cmdLineOptions, Settings::SECTION_EXPORT_PDF, Settings::SettingsExportPdf::exportPdfOrientation),
+      .paperSize = set_cmd_line_option(cmdLineOptions, Settings::SECTION_EXPORT_PDF, Settings::SettingsExportPdf::exportPdfPaperSize),
+      .addMetaData = set_cmd_line_option(cmdLineOptions, Settings::SECTION_EXPORT_PDF, Settings::SettingsExportPdf::exportPdfAddMetaData),
+      .metaDataTitle = set_cmd_line_option(cmdLineOptions, Settings::SECTION_EXPORT_PDF, Settings::SettingsExportPdf::exportPdfMetaDataTitle),
+      .metaDataAuthor = set_cmd_line_option(cmdLineOptions, Settings::SECTION_EXPORT_PDF, Settings::SettingsExportPdf::exportPdfMetaDataAuthor),
+      .metaDataSubject = set_cmd_line_option(cmdLineOptions, Settings::SECTION_EXPORT_PDF, Settings::SettingsExportPdf::exportPdfMetaDataSubject),
+      .metaDataKeywords = set_cmd_line_option(cmdLineOptions, Settings::SECTION_EXPORT_PDF, Settings::SettingsExportPdf::exportPdfMetaDataKeywords),
+      .fill = set_cmd_line_option(cmdLineOptions, Settings::SECTION_EXPORT_PDF, Settings::SettingsExportPdf::exportPdfFill),
+      .fillColor = set_cmd_line_option(cmdLineOptions, Settings::SECTION_EXPORT_PDF, Settings::SettingsExportPdf::exportPdfFillColor),
+      .stroke = set_cmd_line_option(cmdLineOptions, Settings::SECTION_EXPORT_PDF, Settings::SettingsExportPdf::exportPdfStroke),
+      .strokeColor = set_cmd_line_option(cmdLineOptions, Settings::SECTION_EXPORT_PDF, Settings::SettingsExportPdf::exportPdfStrokeColor),
+      .strokeWidth = set_cmd_line_option(cmdLineOptions, Settings::SECTION_EXPORT_PDF, Settings::SettingsExportPdf::exportPdfStrokeWidth),
     });
   }
 

--- a/src/openscad.cc
+++ b/src/openscad.cc
@@ -209,8 +209,7 @@ bool checkAndExport(const std::shared_ptr<const Geometry>& root_geom, unsigned d
 
   if (is_stdout) {
     exportFileStdOut(root_geom, exportInfo);
-  }
-  else {
+  } else {
     exportFileByName(root_geom, filename, exportInfo);
   }
   return true;
@@ -223,7 +222,7 @@ void help(const char *arg0, const po::options_description& desc, bool failure = 
   exit(failure ? 1 : 0);
 }
 
-template<std::size_t size>
+template <std::size_t size>
 void help_export(const std::array<const Settings::SettingsEntryBase *, size>& options) {
   LOG("Section '%1$s':", options.at(0)->category());
 
@@ -257,7 +256,7 @@ int info()
   try {
     OffscreenView const glview(512, 512);
     std::cout << glview.getRendererInfo() << "\n";
-  } catch (const OffscreenViewException &ex) {
+  } catch (const OffscreenViewException& ex) {
     LOG("Can't create OpenGL OffscreenView: %1$s. Exiting.\n", ex.what());
     return 1;
   }
@@ -404,14 +403,14 @@ int do_export(const CommandLine& cmd, const RenderVariables& render_variables, F
   std::shared_ptr<const FileContext> file_context;
   std::shared_ptr<AbstractNode> absolute_root_node;
 
-#ifdef ENABLE_PYTHON    
-  if(python_result_node != NULL && python_active) {
+#ifdef ENABLE_PYTHON
+  if (python_result_node != NULL && python_active) {
     absolute_root_node = python_result_node;
   } else {
-#endif	    
+#endif
   absolute_root_node = root_file->instantiate(*builtin_context, &file_context);
 #ifdef ENABLE_PYTHON
-  }
+}
 #endif
 
   Camera camera = cmd.camera;
@@ -441,29 +440,29 @@ int do_export(const CommandLine& cmd, const RenderVariables& render_variables, F
     // the output.
     fs::current_path(fparent); // Force exported filenames to be relative to document path
     with_output(cmd.is_stdout, filename_str, [&tree, root_node](std::ostream& stream) {
-      stream << tree.getString(*root_node, "\t") << "\n";
-    });
+        stream << tree.getString(*root_node, "\t") << "\n";
+      });
     fs::current_path(cmd.original_path);
   } else if (export_format == FileFormat::AST) {
     fs::current_path(fparent); // Force exported filenames to be relative to document path
     with_output(cmd.is_stdout, filename_str, [root_file](std::ostream& stream) {
-      stream << root_file->dump("");
-    });
+        stream << root_file->dump("");
+      });
     fs::current_path(cmd.original_path);
   } else if (export_format == FileFormat::PARAM) {
     with_output(cmd.is_stdout, filename_str, [&root_file, &fpath](std::ostream& stream) {
-      export_param(root_file, fpath, stream);
-    });
+        export_param(root_file, fpath, stream);
+      });
   } else if (export_format == FileFormat::TERM) {
     CSGTreeEvaluator csgRenderer(tree);
     auto root_raw_term = csgRenderer.buildCSGTree(*root_node);
     with_output(cmd.is_stdout, filename_str, [root_raw_term](std::ostream& stream) {
-      if (!root_raw_term || root_raw_term->isEmptySet()) {
-        stream << "No top-level CSG object\n";
-      } else {
-        stream << root_raw_term->dump() << "\n";
-      }
-    });
+        if (!root_raw_term || root_raw_term->isEmptySet()) {
+          stream << "No top-level CSG object\n";
+        } else {
+          stream << root_raw_term->dump() << "\n";
+        }
+      });
   } else if (export_format == FileFormat::ECHO) {
     // echo -> don't need to evaluate any geometry
   } else {
@@ -510,12 +509,12 @@ int do_export(const CommandLine& cmd, const RenderVariables& render_variables, F
     if (export_format == FileFormat::PNG) {
       bool success = true;
       bool const wrote = with_output(cmd.is_stdout, filename_str, [&success, &root_geom, &cmd, &camera, &glview](std::ostream& stream) {
-        if (cmd.viewOptions.renderer == RenderType::BACKEND_SPECIFIC || cmd.viewOptions.renderer == RenderType::GEOMETRY) {
-          success = export_png(root_geom, cmd.viewOptions, camera, stream);
-        } else {
-          success = export_png(*glview, stream);
-        }
-      }, std::ios::out | std::ios::binary);
+          if (cmd.viewOptions.renderer == RenderType::BACKEND_SPECIFIC || cmd.viewOptions.renderer == RenderType::GEOMETRY) {
+            success = export_png(root_geom, cmd.viewOptions, camera, stream);
+          } else {
+            success = export_png(*glview, stream);
+          }
+        }, std::ios::out | std::ios::binary);
       if (!success || !wrote) {
         return 1;
       }
@@ -576,23 +575,23 @@ int cmdline(const CommandLine& cmd)
     text = std::string((std::istreambuf_iterator<char>(ifs)), std::istreambuf_iterator<char>());
   }
 
-#ifdef ENABLE_PYTHON  
+#ifdef ENABLE_PYTHON
   python_active = false;
-  if(cmd.filename.c_str() != NULL) {
-	  if(boost::algorithm::ends_with(cmd.filename, ".py")) {
-		  if( python_trusted == true) python_active = true;
-		  else  LOG("Python is not enabled");
-	  }
+  if (cmd.filename.c_str() != NULL) {
+    if (boost::algorithm::ends_with(cmd.filename, ".py")) {
+      if (python_trusted == true) python_active = true;
+      else LOG("Python is not enabled");
+    }
   }
 
-  if(python_active) {
+  if (python_active) {
     auto fulltext_py = text;
     initPython(PlatformUtils::applicationPath(), 0.0);
-    auto error  = evaluatePython(fulltext_py, false);
-    if(error.size() > 0) LOG(error.c_str());
-    text ="\n";
+    auto error = evaluatePython(fulltext_py, false);
+    if (error.size() > 0)LOG(error.c_str());
+    text = "\n";
   }
-#endif	  
+#endif // ifdef ENABLE_PYTHON
   text += "\n\x03\n" + commandline_commands;
 
   SourceFile *root_file = nullptr;
@@ -625,7 +624,7 @@ int cmdline(const CommandLine& cmd)
   RenderVariables render_variables = {
     .preview = fileformat::canPreview(export_format)
       ? (cmd.viewOptions.renderer == RenderType::OPENCSG
-        || cmd.viewOptions.renderer == RenderType::THROWNTOGETHER)
+         || cmd.viewOptions.renderer == RenderType::THROWNTOGETHER)
       : false,
     .camera = cmd.camera,
   };
@@ -687,8 +686,7 @@ static bool flagConvert(const std::string& str){
 static std::tuple<std::string, std::string> simple_split(const std::string& str, const char c)
 {
   const auto idx = str.find_first_of(c);
-  if (idx == std::string::npos)
-    return {};
+  if (idx == std::string::npos)return {};
   const auto first = str.substr(0, idx);
   const auto second = str.substr(idx + 1);
   return {first, second};
@@ -813,7 +811,7 @@ int main(int argc, char **argv)
   // just forward everything to the python main.
   const auto applicationName = fs::path(argv[0]).filename().generic_string();
   if (applicationName == "openscad-python") {
-      return pythonRunArgs(argc, argv);
+    return pythonRunArgs(argc, argv);
   }
 #endif
 
@@ -833,21 +831,21 @@ int main(int argc, char **argv)
   ViewOptions viewOptions{};
   po::options_description desc("Allowed options");
   desc.add_options()
-    ("export-format", po::value<std::string>(), "overrides format of exported scad file when using option '-o', arg can be any of its supported file extensions.  For ASCII stl export, specify 'asciistl', and for binary stl export, specify 'binstl'.  ASCII export is the current stl default, but binary stl is planned as the future default so asciistl should be explicitly specified in scripts when needed.\n")
-    ("o,o", po::value<std::vector<std::string>>(), "output specified file instead of running the GUI. The file extension specifies the type: stl, off, wrl, amf, 3mf, csg, dxf, svg, pdf, png, echo, ast, term, nef3, nefdbg, param, pov. May be used multiple times for different exports. Use '-' for stdout.\n")
-    ("O,O", po::value<std::vector<std::string>>(), "pass settings value to the file export using the format section/key=value, e.g export-pdf/paper-size=a3. Use --help-export to list all available settings.")
-    ("D,D", po::value<std::vector<std::string>>(), "var=val -pre-define variables")
-    ("p,p", po::value<std::string>(), "customizer parameter file")
-    ("P,P", po::value<std::string>(), "customizer parameter set")
+  ("export-format", po::value<std::string> (), "overrides format of exported scad file when using option '-o', arg can be any of its supported file extensions.  For ASCII stl export, specify 'asciistl', and for binary stl export, specify 'binstl'.  ASCII export is the current stl default, but binary stl is planned as the future default so asciistl should be explicitly specified in scripts when needed.\n")
+  ("o,o", po::value<std::vector<std::string>> (), "output specified file instead of running the GUI. The file extension specifies the type: stl, off, wrl, amf, 3mf, csg, dxf, svg, pdf, png, echo, ast, term, nef3, nefdbg, param, pov. May be used multiple times for different exports. Use '-' for stdout.\n")
+  ("O,O", po::value<std::vector<std::string>> (), "pass settings value to the file export using the format section/key=value, e.g export-pdf/paper-size=a3. Use --help-export to list all available settings.")
+  ("D,D", po::value<std::vector<std::string>> (), "var=val -pre-define variables")
+  ("p,p", po::value<std::string> (), "customizer parameter file")
+  ("P,P", po::value<std::string> (), "customizer parameter set")
 #ifdef ENABLE_EXPERIMENTAL
-  ("enable", po::value<std::vector<std::string>>(), ("enable experimental features (specify 'all' for enabling all available features): " +
-                                           str_join(boost::make_iterator_range(Feature::begin(), Feature::end()), " | ",
-                                                    [](const Feature *feature) {
+  ("enable", po::value<std::vector<std::string>> (), ("enable experimental features (specify 'all' for enabling all available features): " +
+                                                      str_join(boost::make_iterator_range(Feature::begin(), Feature::end()), " | ",
+                                                               [](const Feature *feature) {
     return feature->get_name();
   }) +
-                                           "\n").c_str())
+                                                               "\n").c_str())
 #endif
-    ("help,h", "print this help message and exit")
+  ("help,h", "print this help message and exit")
     ("help-export", "print list of export parameters and values that can be set via -O")
     ("version,v", "print the version")
     ("info", "print information about the build process\n")
@@ -867,11 +865,11 @@ int main(int argc, char **argv)
     ("summary", po::value<std::vector<std::string>>(), "enable additional render summary and statistics: all | cache | time | camera | geometry | bounding-box | area")
     ("summary-file", po::value<std::string>(), "output summary information in JSON format to the given file, using '-' outputs to stdout")
     ("colorscheme", po::value<std::string>(), ("=colorscheme: " +
-                                          str_join(ColorMap::inst()->colorSchemeNames(), " | ",
-                                                   [](const std::string& colorScheme) {
-    return (colorScheme == ColorMap::inst()->defaultColorSchemeName() ? "*" : "") + colorScheme;
-  }) +
-                                          "\n").c_str())
+                                               str_join(ColorMap::inst()->colorSchemeNames(), " | ",
+                                                        [](const std::string& colorScheme) {
+                                                        return (colorScheme == ColorMap::inst()->defaultColorSchemeName() ? "*" : "") + colorScheme;
+    }) +
+                                               "\n").c_str())
     ("d,d", po::value<std::string>(), "deps_file -generate a dependency file for make")
     ("m,m", po::value<std::string>(), "make_cmd -runs make_cmd file if file is missing")
     ("quiet,q", "quiet mode (don't print anything *except* errors)")
@@ -883,12 +881,12 @@ int main(int argc, char **argv)
     ("debug", po::value<std::string>(), "special debug info - specify 'all' or a set of source file names")
 #ifdef ENABLE_PYTHON
   ("trust-python",  "Trust python")
-  ("python-module", po::value<std::string>(), "=module Call pip python module")
+    ("python-module", po::value<std::string>(), "=module Call pip python module")
 #endif
   ;
 
 #ifdef ENABLE_GUI_TESTS
-    desc.add_options()("run-all-gui-tests", "special gui testing mode - run all the tests");
+  desc.add_options()("run-all-gui-tests", "special gui testing mode - run all the tests");
 #endif
 
   po::options_description hidden("Hidden options");
@@ -925,14 +923,14 @@ int main(int argc, char **argv)
 
   const auto pymod = "python-module";
   if (vm.count(pymod)) {
-      PRINTDB("Running Python Module %s", pymod);
-      std::vector<std::string> args;
-      if (vm.count("input-file")) {
-          args = vm["input-file"].as<std::vector<std::string>>();
-      }
-      return pythonRunModule(applicationPath, vm[pymod].as<std::string>(), args);
+    PRINTDB("Running Python Module %s", pymod);
+    std::vector<std::string> args;
+    if (vm.count("input-file")) {
+      args = vm["input-file"].as<std::vector<std::string>>();
+    }
+    return pythonRunModule(applicationPath, vm[pymod].as<std::string>(), args);
   }
-#endif
+#endif // ifdef ENABLE_PYTHON
   if (vm.count("quiet")) {
     OpenSCAD::quiet = true;
   }
@@ -1134,9 +1132,9 @@ int main(int argc, char **argv)
     if (vm.count("export-format")) {
       LOG("Ignoring --export-format option");
     }
-    std::string gui_test="none";
+    std::string gui_test = "none";
     if (vm.count("run-all-gui-tests")){
-        gui_test = "all";
+      gui_test = "all";
     }
     rc = gui(inputFiles, original_path, argc, argv, gui_test);
 #endif


### PR DESCRIPTION
This runs beautify to clean up the existing code in preparation for: https://github.com/openscad/openscad/pull/6052

Only the code that will be changed has been updated. I've cut an issue to discuss options for cleaning up more: https://github.com/openscad/openscad/issues/6055