### PR TITLE
OEP8a:  object literals and object comprehensions

### DIFF
--- a/src/core/Expression.cc
+++ b/src/core/Expression.cc
@@ -338,6 +338,88 @@ void Vector::print(std::ostream& stream, const std::string&) const
   stream << "]";
 }
 
+Object::Object(const Location& loc) : Expression(loc), literal_flag(unknown)
+{
+}
+
+bool Object::isLiteral() const {
+  if (unknown(literal_flag)) {
+    for (const auto& v : this->values) {
+      if (!v->isLiteral()) {
+        literal_flag = false;
+        return false;
+      }
+    }
+    literal_flag = true;
+    return true;
+  } else {
+    return bool(literal_flag);
+  }
+}
+
+void Object::addSetOp(std::shared_ptr<Expression> key, std::shared_ptr<Expression> expr)
+{
+  this->keys.emplace_back(key);
+  this->values.emplace_back(expr);
+}
+
+void Object::addSetOp(Expression *key, Expression *expr)
+{
+  this->keys.emplace_back(key);
+  this->values.emplace_back(expr);
+}
+
+void Object::addIncludeOp(Object *obj)
+{
+  this->keys.emplace_back(nullptr);
+  this->values.emplace_back(obj);
+}
+
+// NEEDSWORK this should probably record the location of the keys and values being merged,
+// so that if there is a problem evaluating them it can point at the right place.
+// NEEDSWORK unused?
+void Object::mergeSetOps(Object *obj)
+{
+  for (size_t i = 0; i < obj->keys.size(); i++) {
+    this->addSetOp(obj->keys[i], obj->values[i]);
+  }
+}
+
+Value Object::evaluate(const std::shared_ptr<const Context>& context) const
+{
+  ObjectType obj(context->session());
+  for (size_t i = 0; i < this->keys.size(); i++) {
+    std::shared_ptr<Expression> keyExpr = this->keys[i];
+    if (keyExpr) {
+      Value key = this->keys[i]->evaluate(context);
+      if (key.type() == Value::Type::STRING) {
+        obj.set(key.toString(), this->values[i]->evaluate(context));
+      } else {
+        std::stringstream message;
+        message << "Key is " << key.typeName() << ", must be string.";
+        LOG(message_group::Warning, loc, context->documentRoot(), "%1$s", message.str());
+      }
+    } else {
+      obj.merge(this->values[i]->evaluate(context), loc);
+    }
+  }
+  return std::move(obj);
+}
+
+// This is used to print an object literal in the AST.
+void Object::print(std::ostream& stream, const std::string&) const
+{
+  stream << "{";
+  bool first = true;
+  for (size_t i = 0; i < this->keys.size(); i++) {
+    if (first) first = false;
+    else stream << ", ";
+    // NEEDSWORK does not handle special characters in the key
+    stream << *this->keys[i] << ":" << *this->values[i];
+  }
+  stream << "}";
+}
+
 Lookup::Lookup(std::string name, const Location& loc) : Expression(loc), name(std::move(name))
 {
 }
@@ -977,6 +1059,143 @@ Value LcLet::evaluate(const std::shared_ptr<const Context>& context) const
 }
 
 void LcLet::print(std::ostream& stream, const std::string&) const
+{
+  stream << "let(" << this->arguments << ") (" << *this->expr << ")";
+}
+
+
+ObjectComprehension::ObjectComprehension(const Location& loc) : Object(loc)
+{
+}
+
+OcIf::OcIf(Expression *cond, Expression *ifexpr, Expression *elseexpr, const Location& loc)
+  : ObjectComprehension(loc), cond(cond), ifexpr(ifexpr), elseexpr(elseexpr)
+{
+}
+
+Value OcIf::evaluate(const std::shared_ptr<const Context>& context) const
+{
+  const std::shared_ptr<Expression>& expr = this->cond->evaluate(context).toBool() ? this->ifexpr : this->elseexpr;
+  if (expr) {
+    return expr->evaluate(context);
+  } else {
+    return ObjectType(nullptr); // NEEDSWORK should have ObjectType::Empty();
+  }
+}
+
+void OcIf::print(std::ostream& stream, const std::string&) const
+{
+  stream << "if(" << *this->cond << ") (" << *this->ifexpr << ")";
+  if (this->elseexpr) {
+    stream << " else (" << *this->elseexpr << ")";
+  }
+}
+
+OcEach::OcEach(Expression *expr, const Location& loc) : ObjectComprehension(loc), expr(expr)
+{
+}
+
+Value OcEach::evaluate(const std::shared_ptr<const Context>& context) const
+{
+  Value v = this->expr->evaluate(context);
+  if (v.type() == Value::Type::OBJECT) {
+    ObjectType obj = v.toObject();
+    return {std::move(obj)};
+  }
+  return Value::undefined.clone();
+}
+
+void OcEach::print(std::ostream& stream, const std::string&) const
+{
+  stream << "each (" << *this->expr << ")";
+}
+
+OcFor::OcFor(AssignmentList args, Expression *expr, const Location& loc)
+  : ObjectComprehension(loc), arguments(std::move(args)), expr(expr)
+{
+}
+
+void OcFor::forEach(const AssignmentList& assignments, const Location& loc, const std::shared_ptr<const Context>& context, const std::function<void(const std::shared_ptr<const Context>&)>& operation)
+{
+  doForEach(assignments, loc, operation, 0, context);
+}
+
+Value OcFor::evaluate(const std::shared_ptr<const Context>& context) const
+{
+  ObjectType obj(context->session());
+  forEach(this->arguments, this->loc, context,
+    [this, &obj, expression = expr.get()]
+      (const std::shared_ptr<const Context>& iterationContext) {
+        obj.merge(expression->evaluate(iterationContext), loc);
+      }
+  );
+  return {std::move(obj)};
+}
+
+void OcFor::print(std::ostream& stream, const std::string&) const
+{
+  stream << "for(" << this->arguments << ") (" << *this->expr << ")";
+}
+
+OcForC::OcForC(AssignmentList args, AssignmentList incrargs, Expression *cond, Expression *expr, const Location& loc)
+  : ObjectComprehension(loc), arguments(std::move(args)), incr_arguments(std::move(incrargs)), cond(cond), expr(expr)
+{
+}
+
+Value OcForC::evaluate(const std::shared_ptr<const Context>& context) const
+{
+  ObjectType output(context->session());
+
+  ContextHandle<Context> initialContext{Let::sequentialAssignmentContext(this->arguments, this->location(), context)};
+  ContextHandle<Context> currentContext{Context::create<Context>(*initialContext)};
+
+  unsigned int counter = 0;
+  while (this->cond->evaluate(*currentContext).toBool()) {
+    output.merge(this->expr->evaluate(*currentContext), loc);
+
+    if (counter++ == 1000000) {
+      LOG(message_group::Error, loc, context->documentRoot(), "For loop counter exceeded limit");
+      throw LoopCntException::create("for", loc);
+    }
+
+    /*
+     * The next context should be evaluated in the current context,
+     * and replace the current context; but there is no reason for
+     * it to _parent_ the current context, for the next context
+     * replaces every variable in it. Keeping the next context
+     * parented to the current context would keep the current in
+     * memory unnecessarily, and greatly slow down variable lookup.
+     * However, we can't just use apply_variables(), as this breaks
+     * captured context references in lambda functions.
+     * So, we reparent the next context to the initial context.
+     */
+    ContextHandle<Context> nextContext{Let::sequentialAssignmentContext(this->incr_arguments, this->location(), *currentContext)};
+    currentContext = std::move(nextContext);
+    currentContext->setParent(*initialContext);
+  }
+  return {std::move(output)};
+}
+
+void OcForC::print(std::ostream& stream, const std::string&) const
+{
+  stream
+    << "for(" << this->arguments
+    << ";" << *this->cond
+    << ";" << this->incr_arguments
+    << ") " << *this->expr;
+}
+
+OcLet::OcLet(AssignmentList args, Expression *expr, const Location& loc)
+  : ObjectComprehension(loc), arguments(std::move(args)), expr(expr)
+{
+}
+
+Value OcLet::evaluate(const std::shared_ptr<const Context>& context) const
+{
+  return this->expr->evaluate(*Let::sequentialAssignmentContext(this->arguments, this->location(), context));
+}
+
+void OcLet::print(std::ostream& stream, const std::string&) const
 {
   stream << "let(" << this->arguments << ") (" << *this->expr << ")";
 }

--- a/src/core/Value.h
+++ b/src/core/Value.h
@@ -276,10 +276,12 @@ private:
 public:
     std::shared_ptr<ObjectObject> ptr;
     ObjectType(class EvaluationSession *session);
+    // ObjectType(class EvaluationSession *session, std::shared_ptr<AbstractNode> node);
     [[nodiscard]] ObjectType clone() const;
     [[nodiscard]] const Value& get(const std::string& key) const;
     bool set(const std::string& key, Value value);
     bool del(const std::string& key); // true if was present
+    void merge(Value&& value, const Location& loc);
     bool contains(const std::string& key) const;
     bool empty() const;
     Value operator==(const ObjectType& v) const;
@@ -291,6 +293,7 @@ public:
     const Value& operator[](const str_utf8_wrapper& v) const;
     [[nodiscard]] const std::vector<std::string>& keys() const;
     [[nodiscard]] const std::vector<Value>& values() const;
+    static bool keyIsIdentifier(const std::string& k);
   };
 
 private:
@@ -436,6 +439,8 @@ struct Value::ObjectType::ObjectObject {
         }
         return index == NOINDEX;
     }
+
+    void merge(Value&& value, const Location& loc);
 
     size_t del(const std::string & key) {
         size_t index = find(key);

--- a/tests/regression/echo/import-json-expected.echo
+++ b/tests/regression/echo/import-json-expected.echo
@@ -1,4 +1,4 @@
-ECHO: { array-mixed = ["one", 1, false]; array-string = ["one", "two", "three"]; array_number = [0, 1, 2, 3, 5]; bool = true; float = 3.5e-10; number = 2; object = { name = "The object name"; nested = { value = 42; }; number = 4; }; string = "hallo world!"; }
+ECHO: { "array-mixed" : ["one", 1, false], "array-string" : ["one", "two", "three"], array_number : [0, 1, 2, 3, 5], bool : true, float : 3.5e-10, number : 2, object : { name : "The object name", nested : { value : 42 }, number : 4 }, string : "hallo world!" }
 ECHO: "hallo world!"
 ECHO: [0, 1, 2, 3, 5]
 ECHO: ["one", "two", "three"]

--- a/tests/regression/echo/import-json-relative-path-expected.echo
+++ b/tests/regression/echo/import-json-relative-path-expected.echo
@@ -1,4 +1,4 @@
-ECHO: { array-mixed = ["one", 1, false]; array-string = ["one", "two", "three"]; array_number = [0, 1, 2, 3, 5]; bool = true; float = 3.5e-10; number = 2; object = { name = "The object name"; nested = { value = 42; }; number = 4; }; string = "hallo world!"; }
+ECHO: { "array-mixed" : ["one", 1, false], "array-string" : ["one", "two", "three"], array_number : [0, 1, 2, 3, 5], bool : true, float : 3.5e-10, number : 2, object : { name : "The object name", nested : { value : 42 }, number : 4 }, string : "hallo world!" }
 ECHO: "hallo world!"
 ECHO: [0, 1, 2, 3, 5]
 ECHO: ["one", "two", "three"]

--- a/tests/regression/echo/text-metrics-test-expected.echo
+++ b/tests/regression/echo/text-metrics-test-expected.echo
@@ -1,8 +1,8 @@
 ECHO: "Normal..."
-ECHO: { position = [0.96, -0.1408]; size = [27.8024, 10.208]; ascent = 10.0672; descent = -0.1408; offset = [0, 0]; advance = [29.3443, 0]; }
-ECHO: { position = [-116.212, -10.208]; size = [98.96, 20.416]; ascent = 20.1344; descent = -0.2816; offset = [-117.377, -9.9264]; advance = [117.377, 0]; }
-ECHO: { nominal = { ascent = 12.5733; descent = -2.9433; }; max = { ascent = 13.6109; descent = -4.2114; }; interline = 15.9709; font = { family = "Liberation Sans"; style = "Regular"; }; }
-ECHO: { nominal = { ascent = 25.1466; descent = -5.8866; }; max = { ascent = 27.2218; descent = -8.4228; }; interline = 31.9418; font = { family = "Liberation Sans"; style = "Regular"; }; }
+ECHO: { position : [0.96, -0.1408], size : [27.8024, 10.208], ascent : 10.0672, descent : -0.1408, offset : [0, 0], advance : [29.3443, 0] }
+ECHO: { position : [-116.212, -10.208], size : [98.96, 20.416], ascent : 20.1344, descent : -0.2816, offset : [-117.377, -9.9264], advance : [117.377, 0] }
+ECHO: { nominal : { ascent : 12.5733, descent : -2.9433 }, max : { ascent : 13.6109, descent : -4.2114 }, interline : 15.9709, font : { family : "Liberation Sans", style : "Regular" } }
+ECHO: { nominal : { ascent : 25.1466, descent : -5.8866 }, max : { ascent : 27.2218, descent : -8.4228 }, interline : 31.9418, font : { family : "Liberation Sans", style : "Regular" } }
 ECHO: "Errors..."
 WARNING: textmetrics(..., size=[]) Invalid type: expected number, found vector in file text-metrics-test.scad, line 20
 WARNING: textmetrics(..., text=123) Invalid type: expected string, found number in file text-metrics-test.scad, line 20
@@ -13,8 +13,8 @@ WARNING: textmetrics(..., language=[0 : 1 : 10]) Invalid type: expected string, 
 WARNING: textmetrics(..., script=0) Invalid type: expected string, found number in file text-metrics-test.scad, line 20
 WARNING: textmetrics(..., halign=0) Invalid type: expected string, found number in file text-metrics-test.scad, line 20
 WARNING: textmetrics(..., valign=0) Invalid type: expected string, found number in file text-metrics-test.scad, line 20
-ECHO: { position = [0, 0]; size = [0, 0]; ascent = 0; descent = 0; offset = [0, 0]; advance = [0, 0]; }
+ECHO: { position : [0, 0], size : [0, 0], ascent : 0, descent : 0, offset : [0, 0], advance : [0, 0] }
 WARNING: variable "text" not specified as parameter in file text-metrics-test.scad, line 25
 WARNING: fontmetrics(..., size=true) Invalid type: expected number, found bool in file text-metrics-test.scad, line 25
 WARNING: fontmetrics(..., font=0) Invalid type: expected string, found number in file text-metrics-test.scad, line 25
-ECHO: { nominal = { ascent = 12.5733; descent = -2.9433; }; max = { ascent = 13.6109; descent = -4.2114; }; interline = 15.9709; font = { family = "Liberation Sans"; style = "Regular"; }; }
+ECHO: { nominal : { ascent : 12.5733, descent : -2.9433 }, max : { ascent : 13.6109, descent : -4.2114 }, interline : 15.9709, font : { family : "Liberation Sans", style : "Regular" } }


### PR DESCRIPTION
[ Not ready for merge ]

Implements the remaining "object" features from OEP8, as extracted in [OEP8a](https://github.com/openscad/openscad/wiki/OEP8a:--Objects-(dictionaries%3F)).

This adds object literals in a JavaScript-like syntax, including object comprehensions.
For a more complete writeup see OEP8a, but briefly:
* `{ name: value, ... }` - object with constant identifier-safe names
* `{ "name": value, ... }` - object with constant names not limited to identifiers
* `{ (expr): value, ... }` - object with names from expressions
* `{ for (...) (name): value, ... }` - generate several members
* `{ if (...) name: value else name: value, ... }` - conditionally generate members
* `{ let(...) ... }` - set variables and evaluate object comprehension
* `{ each object }` - split up and add each of its members
* Changes echo() and str() form to use this syntax.

This PR is not ready for merge.  I wrote it a couple of years ago as part of PR#4478, and extracted it.  I haven't reviewed it yet, but others are welcome to take a look.
