### PR TITLE
Switch to clang-format and add formatting workflow

### DIFF
--- a/.github/workflows/beautify.yml
+++ b/.github/workflows/beautify.yml
@@ -1,0 +1,44 @@
+name: Code Format Check
+
+on:
+  push:
+    branches:
+    - master
+  pull_request:
+    branches:
+    - master
+
+jobs:
+  Beautify:
+    runs-on: ubuntu-latest
+    steps:
+
+    - name: Checkout code
+      uses: actions/checkout@v4
+
+    - name: Install dependencies
+      run: |
+        sudo apt update
+        sudo apt -qq -y install clang-format
+
+    - name: Run check
+      id: check
+      run: ./scripts/beautify.sh --check
+      continue-on-error: true
+
+    - name: Generate patch
+      if: steps.check.outcome == 'failure'
+      run: |
+        cp -r . ${{ runner.temp }}/a
+        cp -r . ${{ runner.temp }}/b
+        cd ${{ runner.temp }}/b
+        ./scripts/beautify.sh --all
+        cd ${{ runner.temp }}
+        diff -ruN a b | tee ${{ runner.temp }}/beautify.patch
+
+    - name: Upload patch artifact
+      if: steps.check.outcome == 'failure'
+      uses: actions/upload-artifact@v4
+      with:
+        name: beautify-patch
+        path: ${{ runner.temp }}/beautify.patch

--- a/.github/workflows/beautify.yml
+++ b/.github/workflows/beautify.yml
@@ -42,3 +42,7 @@ jobs:
       with:
         name: beautify-patch
         path: ${{ runner.temp }}/beautify.patch
+
+    - name: Raise failure
+      if: steps.check.outcome == 'failure'
+      run: exit 1

--- a/.github/workflows/beautify.yml
+++ b/.github/workflows/beautify.yml
@@ -45,4 +45,7 @@ jobs:
 
     - name: Raise failure
       if: steps.check.outcome == 'failure'
-      run: exit 1
+      run: |
+        echo "Code is improperly formatted. Check steps above and see https://github.com/openscad/openscad/blob/master/doc/hacking.md for more information."
+        clang-format --version
+        exit 1

--- a/.github/workflows/beautify.yml
+++ b/.github/workflows/beautify.yml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   Beautify:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
 
     - name: Checkout code

--- a/doc/hacking.md
+++ b/doc/hacking.md
@@ -9,18 +9,24 @@ Coding style highlights:
 
 ## Beautifying code
 
-Code to be committed can be beautified by installing `uncrustify`
-(https://github.com/uncrustify/uncrustify) and running
-`scripts/beautify.sh`. This will, by default, beautify all files that
+Code to be committed can be beautified by installing `clang-format` and running
+`./scripts/beautify.sh`. This will, by default, beautify all files that
 are currently changed.
 
-Alternatively, it's possible to beautify the entire codebase by running `scripts/beautify.sh --all`.
-This is not recommended except in special cases like:
-* We're upgrading uncrustify to fix rules globally
-* You're bringing an old branch to life and want to minimize conflict cause by the large coding style update
+Alternatively, it's possible to beautify the entire codebase by running `./scripts/beautify.sh --all`.
 
-Note: Uncrustify is in heavy development and tends to introduce breaking changes from time to time.
-OpenSCAD has been tested against uncrustify commit a05edf605a5b1ea69ac36918de563d4acf7f31fb (Dec 24 2017).
+All pull requests must pass `./scripts/beautify.sh --check` . In rare cases beautify may need to be run multiple times before all issues are resolved. If there is an issue with the local version of `clang-format` conflicting with the workflow version, the workflows output a patch that can be manually applied to resolve the differences. The patch can be pulled from GitHub or generated locally using `act`:
+
+    act -j Beautify --artifact-server-path build/artifacts/
+    unzip build/artifacts/1/beautify-patch/beautify-patch.zip
+    git apply beautify.patch
+
+`beautify.sh` can also be used directly as a git hook.
+
+    cd .git/hooks
+    ln -s ../../scripts/beautify.sh pre-commit
+
+After making a commit beautify will automatically run. You can then check the changes, and add them to their own commit, or amend them to the previous commit using `git commit --amend`
 
 # Regression Tests
 

--- a/doc/hacking.md
+++ b/doc/hacking.md
@@ -17,7 +17,7 @@ Alternatively, it's possible to beautify the entire codebase by running `./scrip
 
 All pull requests must pass `./scripts/beautify.sh --check` . In rare cases beautify may need to be run multiple times before all issues are resolved. If there is an issue with the local version of `clang-format` conflicting with the workflow version, the workflows output a patch that can be manually applied to resolve the differences. The patch can be pulled from GitHub or generated locally using `act`:
 
-    act -j Beautify --artifact-server-path build/artifacts/
+    act -j Beautify -P ubuntu-latest=ghcr.io/catthehacker/ubuntu:act-24.04 --artifact-server-path build/artifacts/
     unzip build/artifacts/1/beautify-patch/beautify-patch.zip
     git apply beautify.patch
 

--- a/doc/hacking.md
+++ b/doc/hacking.md
@@ -21,7 +21,9 @@ All pull requests must pass `./scripts/beautify.sh --check` . In rare cases beau
     unzip build/artifacts/1/beautify-patch/beautify-patch.zip
     git apply beautify.patch
 
-`beautify.sh` can also be used directly as a git hook.
+This can be done automatically using `./scripts/hard_beautify.sh`
+
+`beautify.sh` or `hard_beautify.sh` can also be used directly as a git hook:
 
     cd .git/hooks
     ln -s ../../scripts/beautify.sh pre-commit

--- a/doc/hacking.md
+++ b/doc/hacking.md
@@ -15,20 +15,28 @@ are currently changed.
 
 Alternatively, it's possible to beautify the entire codebase by running `./scripts/beautify.sh --all`.
 
-All pull requests must pass `./scripts/beautify.sh --check` . In rare cases beautify may need to be run multiple times before all issues are resolved. If there is an issue with the local version of `clang-format` conflicting with the workflow version, the workflows output a patch that can be manually applied to resolve the differences. The patch can be pulled from GitHub or generated locally using `act`:
+All pull requests must pass `./scripts/beautify.sh --check` . In rare cases beautify may need to be run multiple times before all issues are resolved. Different clang versions between local development environment and the workflow can cause issues.
+
+Clang-format versions:
+
+* 18: current standard used in workflow under Ubuntu 24.04
+* 19: known conflicts with version 18
+* 20: compatible with 18 so far
+
+To deal with version conflicts the workflow generates a patch that can be used to format the code. This can be pulled from GitHub after a job fails, or generated locally using `act` and `docker`:
 
     act -j Beautify -P ubuntu-latest=ghcr.io/catthehacker/ubuntu:act-24.04 --artifact-server-path build/artifacts/
     unzip build/artifacts/1/beautify-patch/beautify-patch.zip
     git apply beautify.patch
 
-This can be done automatically using `./scripts/hard_beautify.sh`
+This can be done automatically using `./scripts/hard_beautify.sh`, which also functions as a git hook. 
 
-`beautify.sh` or `hard_beautify.sh` can also be used directly as a git hook:
+To set up a git hook create a symlink for `beautify.sh` or `hard_beautify.sh`:
 
     cd .git/hooks
     ln -s ../../scripts/beautify.sh pre-commit
 
-After making a commit beautify will automatically run. You can then check the changes, and add them to their own commit, or amend them to the previous commit using `git commit --amend`
+After making a commit beautify will automatically run. You can then check the changes, and add them to their own commit, or amend them to the previous commit.
 
 # Regression Tests
 

--- a/scripts/beautify.sh
+++ b/scripts/beautify.sh
@@ -61,7 +61,7 @@ do
   fi
 
   if [ "$KEY" == "--diffbase" ]; then
-    [ -z "$var" ] && echo "script option --diffbase=BASE requires a non-empty value" && exit 1
+    [ -z "${VALUE}" ] && echo "script option --diffbase=BASE requires a non-empty value" && exit 1
     DIFFBASE="${VALUE}"
   elif [ "$PARAM" == "--check" ]; then
     CHECKALL=1

--- a/scripts/beautify.sh
+++ b/scripts/beautify.sh
@@ -86,6 +86,7 @@ function execute() {
     MESSAGE=$2
 
     echo "$MESSAGE"
+    $VERSION_CMD
     
     "$FUNCTION"
     RETURN_VALUE=$?

--- a/scripts/beautify.sh
+++ b/scripts/beautify.sh
@@ -69,12 +69,16 @@ do
     DOALL=1
   elif [ "$KEY" == "-h" ]; then
     SCRIPT=$(basename "$0")
-    echo "Runs clang-format on files which differ from diffbase, OR across the entire project (for --all)"
-    echo "If no options given, then diffbase defaults to \"origin/master\""
-    echo
-    echo "Usage:"
-    echo "    $SCRIPT [--all|--diffbase=BASE]"
-    echo
+cat << EOF
+Usage: $SCRIPT [--all|--check|--diffbase=BASE]
+
+Runs clang-format on files. Default scope is files changed from origin/master.
+
+    --all               format all files
+    --check             check files, do not make changes
+    --diffbase=BASE     format files that differ from BASE
+
+EOF
     exit
   fi
 done

--- a/scripts/beautify.sh
+++ b/scripts/beautify.sh
@@ -1,12 +1,23 @@
 #!/usr/bin/env bash
+set -euo pipefail
+# Reformat C++ code using clang-format
 
-# Reformat C++ code using uncrustify
+# This script can be set directly as a git hook:
+# cd .git/hooks/
+# ln -s ../../scripts/beautify.sh pre-commit
 
-SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
-ROOT_DIR=$SCRIPT_DIR/..
+# Resolve script's real location (follow symlinks)
+SCRIPT_DIR="$(cd "$(dirname "$(readlink -f "$0")")" && pwd)"
 
-FORMAT_CMD_UNCRUSTIFY="uncrustify -c "$ROOT_DIR/.uncrustify.cfg" --no-backup"
-FORMAT_CMD=$FORMAT_CMD_UNCRUSTIFY
+# ROOT_DIR="$(git -C "$SCRIPT_DIR" rev-parse --show-toplevel)"
+ROOT_DIR="$( cd "$SCRIPT_DIR/.." && pwd )"
+
+DOALL=0
+CHECKALL=0
+
+FORMAT_CMD="clang-format -i --style file:$ROOT_DIR/.clang-format"
+CHECK_CMD="$FORMAT_CMD --dry-run --Werror"
+VERSION_CMD="clang-format --version"
 
 # Filter out any files that shouldn't be auto-formatted.
 # note: -v flag inverts selection - this tells grep to *filter out* anything
@@ -14,22 +25,28 @@ FORMAT_CMD=$FORMAT_CMD_UNCRUSTIFY
 #       which files would have been excluded.
 FILTER_CMD="grep -v -E ext/"
 
-function reformat_all() {
+function find_all() {
     find "$ROOT_DIR/src" \( -name "*.h" -o -name "*.hpp" -o -name "*.cc" -o -name "*.cpp" \) -a -not -name findversion.h \
-        | $FILTER_CMD \
-        | xargs $FORMAT_CMD
+        | $FILTER_CMD
+}
+
+function check_all() {
+    find_all | xargs $CHECK_CMD
+}
+
+function reformat_all() {
+    find_all | xargs $FORMAT_CMD
 }
 
 # reformat files that differ from master.
 DIFFBASE="origin/master"
 function reformat_changed() {
     ANCESTOR=$(git merge-base HEAD "$DIFFBASE")
-    FILES=$(git --no-pager diff --name-only "$ANCESTOR" | grep -E "\.(h|hpp|cc|cpp)" | $FILTER_CMD)
-    if [ $? -ne 0 ]; then
-        echo "No files to format, exiting..."
-    else
+    if FILES=$(git --no-pager diff --name-only "$ANCESTOR" | grep -E "\.(h|hpp|cc|cpp)" | $FILTER_CMD); then
         echo -e "Reformatting files:\n$FILES"
         echo $FILES | xargs $FORMAT_CMD
+    else
+        echo "No files to format, exiting..."
     fi
 }
 
@@ -44,13 +61,15 @@ do
   fi
 
   if [ "$KEY" == "--diffbase" ]; then
-    [ -z "${VALUE}" ] && echo "script option --diffbase=BASE requires a non-empty value" && exit 1
+    [ -z "$var" ] && echo "script option --diffbase=BASE requires a non-empty value" && exit 1
     DIFFBASE="${VALUE}"
+  elif [ "$PARAM" == "--check" ]; then
+    CHECKALL=1
   elif [ "$PARAM" == "--all" ]; then
     DOALL=1
   elif [ "$KEY" == "-h" ]; then
     SCRIPT=$(basename "$0")
-    echo "Runs uncrustify on files which differ from diffbase, OR across the entire project (for --all)"
+    echo "Runs clang-format on files which differ from diffbase, OR across the entire project (for --all)"
     echo "If no options given, then diffbase defaults to \"origin/master\""
     echo
     echo "Usage:"
@@ -60,11 +79,26 @@ do
   fi
 done
 
+function execute() {
+    # Execute function with done message, version, and preserved return value 
+    local FUNCTION MESSAGE RETURN_VALUE
+    FUNCTION=$1
+    MESSAGE=$2
+
+    echo "$MESSAGE"
+    
+    "$FUNCTION"
+    RETURN_VALUE=$?
+
+    echo -n "Completed with "
+    $VERSION_CMD
+    return $RETURN_VALUE
+}
 
 if ((DOALL)); then
-    echo "Reformatting all files..."
-    reformat_all
+    execute reformat_all "Reformatting all files..."
+elif ((CHECKALL)); then
+    execute check_all "Checking all files..."
 else
-    echo "Reformatting files that differ from $DIFFBASE..."
-    reformat_changed
+    execute reformat_changed "Reformatting files that differ from $DIFFBASE..."
 fi

--- a/scripts/hard_beautify.sh
+++ b/scripts/hard_beautify.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+set -euo pipefail
+# Reformat C++ code using clang-format
+
+# This script can be set directly as a git hook:
+# cd .git/hooks/
+# ln -s ../../scripts/hard_beautify.sh pre-commit
+
+# Resolve script's real location (follow symlinks)
+SCRIPT_DIR="$(cd "$(dirname "$(readlink -f "$0")")" && pwd)"
+ROOT_DIR="$( cd "$SCRIPT_DIR/.." && pwd )"
+
+ARTIFACTS_DIR="$ROOT_DIR/build/artifacts"
+ZIP_FILE="$ARTIFACTS_DIR/1/beautify-patch/beautify-patch.zip"
+
+[ -d "$ARTIFACTS_DIR" ] && rm -r "$ARTIFACTS_DIR"
+
+act -j Beautify -P ubuntu-latest=ghcr.io/catthehacker/ubuntu:act-24.04 --artifact-server-path "$ROOT_DIR/build/artifacts/" || true
+
+if [ -f "$ZIP_FILE" ]; then
+  ( 
+    cd "$ARTIFACTS_DIR" 
+    unzip "$ZIP_FILE"
+  )
+  ( 
+    cd "$ROOT_DIR"
+    git apply "$ARTIFACTS_DIR/beautify.patch"
+  )
+fi

--- a/scripts/nix/shell.nix
+++ b/scripts/nix/shell.nix
@@ -49,7 +49,7 @@ pkgs.mkShell {
     imagemagick
 
     # used by scripts/beautify.sh to clean up code
-    uncrustify
+    clang-tools
   ];
 
   # avoid segfault when showing a file dialog or color picker


### PR DESCRIPTION
This change removes `uncrustify` from the codebase and documentation in favor of `clang-format`, and adds a workflow for enforcement.

* Switch to `clang-format` for code formatting
* Add a GitHub workflow to enforce formatting
  * Workflow outputs a patch that can be used to resolve issues in the worst-case scenario
* Updated documentation
  * Workflow can be run locally using `act`
  * `beautify.sh` can be used as a git hook
* Added `hard_beautify.sh` that automatically beautifies code using the git workflow. This is the most accurate method of beautifying code, and can also be used as a git hook.

After this change, the code base will need to be reformatted to allow future pull requests.

https://github.com/openscad/openscad/issues/6055