### PR TITLE
Ignore .idea (Intellij/CLion) setup files and .clangd/

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,8 @@
 .cache/
 .vs/
 .vscode/
+.idea/
+.clangd/
 /*.scad
 **/out*.*
 *.dmg


### PR DESCRIPTION
I am using CLion as development environment which creates .idea and .clangd files.

I would like to add them to the base setup so I do not have to be overly careful in making commits.