### PR TITLE
Allow the public to assign issues to themselves

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -36,3 +36,5 @@ If applicable, add the content of the Help->Library Info window, or the output o
 
 **Additional context**
 Add any other context about the problem here.
+
+<!-- If you want to assign this issue to yourself, write /assign-me on its own line -->

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -18,3 +18,5 @@ A clear and concise description of any alternative solutions or features you've 
 
 **Additional context**
 Add any other context or screenshots about the feature request here.
+
+<!-- If you want to assign this issue to yourself, write /assign-me on its own line -->

--- a/.github/ISSUE_TEMPLATE/other-development-issue.md
+++ b/.github/ISSUE_TEMPLATE/other-development-issue.md
@@ -14,3 +14,5 @@ Which environment is the issue about, e.g. Compiling with MSYS2 on Windows
 
 **Issue**
 Explain what the issue is, add code, logs, screenshots as needed
+
+<!-- If you want to assign this issue to yourself, write /assign-me on its own line -->

--- a/.github/workflows/assign.yml
+++ b/.github/workflows/assign.yml
@@ -16,7 +16,6 @@ jobs:
       - name: Assign the user or unassign stale assignments
         uses: takanome-dev/assign-issue-action@v2.2
         with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
           maintainers: 'abshk-jr,amarjeetkapoor1,brad,cliffordwolf,donbright,gsohler,justbuchanan,kintel,MichaelAtOz,MichaelPFrey,minad,nophead,pca006132,rcolyer,shaina7837,Sharma-Hrishabh,t-paul,tbharathchandra,thehans'
           days_until_unassign: 30
           block_assignment: false

--- a/.github/workflows/assign.yml
+++ b/.github/workflows/assign.yml
@@ -1,0 +1,24 @@
+name: Assign Issue
+
+on:
+  schedule:
+    - cron: 0 0 * * *
+  issue_comment:
+    types: [created]
+  workflow_dispatch:
+
+jobs:
+  assign:
+    permissions:
+      issues: write
+    runs-on: ubuntu-latest
+    steps:
+      - name: Assign the user or unassign stale assignments
+        uses: takanome-dev/assign-issue-action@v2.2
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          maintainers: 'abshk-jr,amarjeetkapoor1,brad,cliffordwolf,donbright,gsohler,justbuchanan,kintel,MichaelAtOz,MichaelPFrey,minad,nophead,pca006132,rcolyer,shaina7837,Sharma-Hrishabh,t-paul,tbharathchandra,thehans'
+          days_until_unassign: 30
+          block_assignment: false
+          reminder_days: 7
+          max_assignments: 12

--- a/README.md
+++ b/README.md
@@ -140,6 +140,16 @@ To pull the various submodules (incl. the [MCAD library](https://github.com/open
     cd openscad
     git submodule update --init --recursive
 
+### Contributing Changes
+
+You can create an issue to plan and discuss your change by visiting https://github.com/openscad/openscad/issues.
+
+If you want to work on an existing issue and plan to contribute changes via a PR later, you can assign the issue to yourself by commenting:
+
+`/assign-me`
+
+in a comment on the issue.
+
 ### Building for macOS
 
 Prerequisites:


### PR DESCRIPTION
Openscad has 893 open issues. 886 of them are not assigned.

I started work on #4246 but I can't mark myself as assigned since I am not a collaborator, but I am marked as "Contributor" so maybe there's an existing permission that allows that, but I don't think that's possible i.e. https://github.com/orgs/community/discussions/13692

Maintainers list was taken from
https://api.github.com/orgs/openscad/members?role=admin and not intended to be authoritative (and also everyone in this list can just edit assignments directly, no?).

I just tested this for OrcaSlicer at
https://github.com/coryrc/OrcaSlicer/issues/4 if you want to see it working.