### PR TITLE
Add stale issue bot

### DIFF
--- a/.github/workflows/stale_bot.yml
+++ b/.github/workflows/stale_bot.yml
@@ -35,8 +35,8 @@ jobs:
           stale-issue-label: "Stalled"
           close-issue-label: "Idle-Closed"
           remove-issue-stale-when-updated: true
-          stale-issue-message: "Openscad bot: this issue is stale because it has been open for 360 days with no activity."
-          close-issue-message: "Openscad bot: This issue was closed because it has been inactive for 60 days since being marked as Stalled."
+          stale-issue-message: "OpenSCAD bot: this issue is stale because it has been inactive for 360 days. It will be closed if no further activity occurs within 60 days."
+          close-issue-message: "OpenSCAD bot: This issue was closed because it has been inactive for 60 days since being marked as Stalled."
 
           # PRs
           # Do not auto-close a PR if it is assigned to a milestone
@@ -49,5 +49,5 @@ jobs:
           stale-pr-label: "Stalled"
           close-pr-label: "Idle-Closed"
           remove-pr-stale-when-updated: true
-          stale-pr-message: "Openscad bot: this PR is stale because it has been open for 60 days with no activity."
-          close-pr-message: "Openscad bot: This PR was closed because it has been inactive for 60 days since being marked as Stalled."
+          stale-pr-message: "OpenSCAD bot: this PR is stale because it has been open for 60 days with no activity. It will be closed if no further activity occurs within 60 days."
+          close-pr-message: "OpenSCAD bot: This PR was closed because it has been inactive for 60 days since being marked as Stalled."


### PR DESCRIPTION
It's not helping anything to have abandoned PRs from 2015 still open: https://github.com/openscad/openscad/pull/1401

It's not helping anything to have issues which haven't been touched since 2014: https://github.com/openscad/openscad/issues/568

There's an infinite amount of things not being worked on and I think Issues should focus on things which could conceivably have someone taking action on them; and, even then, 104 days without a single update is still pretty generous. And it exempts enhancement proposals.