### PR TITLE
Correct the message upon getting assigned an issue

### DIFF
--- a/.github/workflows/assign.yml
+++ b/.github/workflows/assign.yml
@@ -21,3 +21,17 @@ jobs:
           block_assignment: false
           reminder_days: 7
           max_assignments: 12
+          assigned_comment: |
+            ### 🎉 Issue Assignment Confirmation
+
+            Hey @{{ handle }}, thanks for taking on this issue!
+
+            This issue will be automatically unassigned if idle for **{{ total_days }} days**.
+
+            <details>
+            <summary>ℹ️ Important information</summary>
+
+            - To prevent automatic unassignment, a maintainer can add the **{{{ pin_label }}}** label
+            - You can unassign yourself at any time by commenting with `/unassign-me`
+            - Updates and status reports are encouraged to show progress
+            </details>


### PR DESCRIPTION
Once this is fixed, I will send out an announcement email.

The existing message is incorrect. I'm going to send PR to the action's repo to fix it also.

Original message: https://github.com/takanome-dev/assign-issue-action/blob/5cd840e7e688c10cdc933155c3289514d32879fa/action.yml#L64

On my example PR: https://github.com/openscad/openscad/issues/4246#issuecomment-3193001559