### PR TITLE
Add vcpkg manifest and fix repeated import in ScintillaEditor header

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -62,6 +62,7 @@ object_script.openscad.Release
 /locale/*.mo
 /locale/POTFILES
 /tmp
+/vcpkg_installed
 /nbproject
 /mingw32.*
 /mingw64.*

--- a/src/gui/ScintillaEditor.h
+++ b/src/gui/ScintillaEditor.h
@@ -16,7 +16,6 @@
 #include <QString>
 #include <QWidget>
 #include <QVBoxLayout>
-#include <QVBoxLayout>
 #include <Qsci/qsciscintilla.h>
 
 #include "gui/Editor.h"

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -1,0 +1,19 @@
+{
+  "name": "openscad",
+  "version-string": "1.0.0",
+  "dependencies": [
+    "boost",
+    "eigen3",
+    "cgal",
+    "harfbuzz",
+    "fontconfig",
+    "double-conversion",
+    "opencsg",
+    "libxml2",
+    "libzip",
+    "glib",
+    "gperf",
+    "qscintilla",
+    "tbb"
+  ]
+}


### PR DESCRIPTION
Initial files for installing vcpkg via manifest mode. However, as I haven't tested a full manifest build it may not work/install if the portfile issues still exist. Also add vcpkg_installed to gitignore as it is installed in the main project directory/folder. Currently these dependencies will only build up to headless, for a full gui build I would need to figure out whats missing in the QScintilla and Qt vcpkg ports.

Works towards a headless build, #5984 