### PR TITLE
Force upgrade of cgal and boost in CI

### DIFF
--- a/.github/workflows/macos-tests.yml
+++ b/.github/workflows/macos-tests.yml
@@ -59,6 +59,8 @@ jobs:
       run: |
         export HOMEBREW_NO_INSTALLED_DEPENDENTS_CHECK=1
         ./scripts/macosx-build-homebrew.sh ${{ matrix.qt }}
+    - name: List installed Homebrew packages
+      run: brew list --versions
     - name: Build OpenSCAD
       run: |
         mkdir build

--- a/.github/workflows/macos-tests.yml
+++ b/.github/workflows/macos-tests.yml
@@ -51,6 +51,8 @@ jobs:
       run: |
         brew unlink python3
         brew link --overwrite python3
+    - name: Upgrade Homebrew packages
+      run: brew upgrade cgal boost
     - name: Install Homebrew packages
       env:
         HOMEBREW_NO_AUTO_UPDATE: 1

--- a/.github/workflows/macos-tests.yml
+++ b/.github/workflows/macos-tests.yml
@@ -51,8 +51,8 @@ jobs:
       run: |
         brew unlink python3
         brew link --overwrite python3
-    - name: Upgrade Homebrew packages
-      run: brew upgrade cgal boost
+    - name: Install latest Homebrew packages
+      run: brew install cgal boost
     - name: Install Homebrew packages
       env:
         HOMEBREW_NO_AUTO_UPDATE: 1

--- a/.github/workflows/macos-tests.yml
+++ b/.github/workflows/macos-tests.yml
@@ -17,8 +17,14 @@ jobs:
   build_and_test:
     strategy:
       matrix:
-        os: [macos-14]
-        qt: [qt6]
+        os: [macos-13, macos-latest]
+        qt: [qt5, qt6]
+        exclude:
+          # macos-latest runs on arm64, which has a broken SW renderer
+          - os: macos-latest
+          # QScintilla for qt5 is not longer available on Homebrew, and
+          # it's too much work to keep that running.
+          - qt: qt5
     runs-on:  ${{ matrix.os }}
     name: ${{ matrix.os }} ${{ matrix.qt }}
     # If it's not done in 60 minutes, something is wrong.

--- a/.github/workflows/macos-tests.yml
+++ b/.github/workflows/macos-tests.yml
@@ -17,14 +17,8 @@ jobs:
   build_and_test:
     strategy:
       matrix:
-        os: [macos-13, macos-latest]
-        qt: [qt5, qt6]
-        exclude:
-          # macos-latest runs on arm64, which has a broken SW renderer
-          - os: macos-latest
-          # QScintilla for qt5 is not longer available on Homebrew, and
-          # it's too much work to keep that running.
-          - qt: qt5
+        os: [macos-14]
+        qt: [qt6]
     runs-on:  ${{ matrix.os }}
     name: ${{ matrix.os }} ${{ matrix.qt }}
     # If it's not done in 60 minutes, something is wrong.


### PR DESCRIPTION
This PR forces an upgrade of cgal and boost in the macOS CI workflow. This is to confirm that a recent change in one of these libraries is the cause of the failing test export-svg_spec-paths-arcs01.