### PR TITLE
Fix: Prevent auto-preview on startup when auto-reload is disabled

### DIFF
--- a/src/gui/MainWindow.cc
+++ b/src/gui/MainWindow.cc
@@ -3420,8 +3420,9 @@ void MainWindow::onTabManagerEditorChanged(EditorInterface *newEditor)
   fontListDock->setNameSuffix(name);
   viewportControlDock->setNameSuffix(name);
 
-  // If there is no renderedEditor we request for a new preview.
-  if (renderedEditor == nullptr) {
+  // If there is no renderedEditor we request for a new preview if the
+  // auto-reload is enabled.
+  if (renderedEditor == nullptr && designActionAutoReload->isChecked()) {
     actionRenderPreview();
   }
 }


### PR DESCRIPTION
This commit fixes an issue where OpenSCAD would automatically preview a .scad file on startup, even if the 'Automatic Reload and Preview' setting was disabled.

The fix checks if auto-reload is enabled before triggering a preview when a new editor is opened.

Fixes #6107