### PR TITLE
Rewrite uni get dependencies

### DIFF
--- a/scripts/deps/packages.json
+++ b/scripts/deps/packages.json
@@ -1,0 +1,151 @@
+{
+  "schema": 1,
+  "notes": "Base distro definitions (shared across profiles). Profiles add or extend packages without redefining managers.",
+  "distros": {
+    "debian": {
+      "manager": "apt",
+      "packages": [
+        "build-essential", "bison", "flex", "git", "curl", "cmake", "ninja-build",
+        "libffi-dev", "libboost-program-options-dev", "libboost-regex-dev", "libboost-system-dev",
+        "libmpfr-dev", "libglew-dev", "libcairo2-dev", "libharfbuzz-dev", "libeigen3-dev",
+        "libcgal-dev", "libopencsg-dev", "libgmp-dev", "imagemagick", "libfreetype-dev",
+        "libdouble-conversion-dev", "libxml2-dev", "gtk-doc-tools", "libglib2.0-dev", "gettext",
+        "xvfb", "pkg-config", "ragel", "libtbb-dev", "libgl1-mesa-dev", "libxi-dev", "libxmu-dev",
+        "libfontconfig-dev", "libzip-dev", "python3-venv",
+        "qtbase5-dev", "libqscintilla2-qt5-dev", "libqt5opengl5-dev", "libqt5svg5-dev",
+        "qtmultimedia5-dev", "libqt5multimedia5-plugins", "qt5-qmake"
+      ],
+      "version_overrides": {
+        "12": { "add": [], "remove": [] }
+      }
+    },
+    "ubuntu": {
+      "extends": "debian",
+      "version_overrides": { "24": { "add": [], "remove": [] } }
+    },
+    "fedora": {
+      "manager": "dnf",
+      "packages": [
+        "gcc", "gcc-c++", "qt5-qtbase-devel", "bison", "flex", "eigen3-devel", "harfbuzz-devel",
+        "fontconfig-devel", "freetype-devel", "boost-devel", "mpfr-devel", "gmp-devel", "glew-devel",
+        "CGAL-devel", "pkgconfig", "opencsg-devel", "git", "libXmu-devel", "curl", "ImageMagick",
+        "glib2-devel", "make", "xorg-x11-server-Xvfb", "gettext", "qscintilla-qt5-devel",
+        "mesa-dri-drivers", "libzip-devel", "ccache", "qt5-qtmultimedia-devel", "qt5-qtsvg-devel",
+        "double-conversion-devel", "tbb-devel", "libxml2-devel", "libffi-devel", "redhat-rpm-config",
+        "qtchooser"
+      ],
+      "version_overrides": {
+        "42": { "add": [], "remove": [] }
+      }
+    },
+    "arch": {
+      "manager": "pacman",
+      "packages": [
+        "base-devel", "gcc", "bison", "flex", "make", "libzip", "qt5", "qscintilla-qt5", "cgal",
+        "gmp", "mpfr", "boost", "opencsg", "glew", "eigen", "glib2", "fontconfig", "freetype2",
+        "harfbuzz", "double-conversion", "imagemagick", "tbb", "curl", "git", "pkgconf", "mesa",
+        "libxi", "libxmu"
+      ],
+      "version_overrides": {}
+    },
+    "gentoo": {
+      "manager": "emerge",
+      "pre_commands": ["emerge --sync"],
+      "packages": [
+        "sys-devel/gcc", "sys-devel/bison", "sys-devel/flex", "dev-vcs/git", "net-misc/curl",
+        "dev-util/cmake", "dev-util/ninja", "dev-libs/libffi", "dev-libs/boost", "dev-libs/mpfr",
+        "dev-libs/gmp", "media-libs/glew", "media-libs/freetype", "media-libs/fontconfig",
+        "media-libs/harfbuzz", "sci-libs/eigen", "sci-mathematics/cgal", "media-gfx/imagemagick",
+        "media-libs/opencsg", "x11-libs/libXmu", "dev-cpp/tbb", "dev-libs/libzip", "dev-libs/libxml2",
+        "dev-qt/qtcore", "dev-qt/qtgui", "dev-qt/qtopengl", "dev-qt/qtsvg", "dev-qt/qtmultimedia",
+        "dev-qt/linguist-tools", "dev-util/ccache", "dev-qt/qtchooser"
+      ],
+      "version_overrides": {}
+    },
+    "freebsd": {
+      "manager": "pkg",
+      "packages": [
+        "bison", "boost-libs", "cmake", "git", "bash", "eigen3", "flex", "gmake", "gmp",
+        "mpfr", "xorg", "libGLU", "libXmu", "libXi", "xorg-vfbserver", "glew",
+        "qt5-core", "qt5-gui", "qt5-buildtools", "qt5-opengl", "qt5-qmake", "opencsg", "cgal",
+        "curl", "imagemagick", "gettext", "double-conversion", "onetbb", "libzip", "libxml2"
+      ],
+      "version_overrides": {}
+    },
+    "netbsd": {
+      "manager": "pkgin",
+      "packages": [
+        "bison", "boost", "cmake", "git", "bash", "eigen3", "flex", "gmake", "gmp", "mpfr",
+        "qt5", "glew", "cgal", "opencsg", "python", "curl", "ImageMagick", "gettext",
+        "threadingbuildingblocks", "libzip", "libxml2"
+      ],
+      "version_overrides": {}
+    },
+    "macos": {
+      "manager": "brew",
+      "packages": [
+        "qt@5", "qscintilla2", "boost", "cgal", "eigen", "gmp", "mpfr", "glew", "opencsg",
+        "freetype", "fontconfig", "harfbuzz", "pkg-config", "bison", "flex", "cmake", "ninja",
+        "git", "curl", "imagemagick", "tbb", "libzip", "libffi", "libxml2", "cairo",
+        "double-conversion"
+      ],
+      "version_overrides": {}
+    },
+    "opensuse": {
+      "manager": "zypper",
+      "packages": [
+        "mpfr-devel", "gmp-devel", "boost-devel", "glew-devel", "cmake", "git", "bison", "flex", "cgal-devel", "curl",
+        "glib2-devel", "gettext", "freetype-devel", "harfbuzz-devel", "qscintilla-qt5-devel", "libqt5-qtbase-devel", "libQt5OpenGL-devel",
+        "xvfb-run", "libzip-devel", "libqt5-qtmultimedia-devel", "libqt5-qtsvg-devel", "double-conversion-devel", "tbb-devel", "libeigen3-devel",
+        "ImageMagick", "opencsg-devel"
+      ],
+      "version_overrides": {}
+    },
+    "mageia": {
+      "manager": "urpmi",
+      "packages": [
+        "task-c-devel", "task-c++-devel", "libqt5-devel", "libgmp-devel", "libmpfr-devel", "libboost-devel", "eigen3-devel", "libglew-devel",
+        "bison", "flex", "cmake", "imagemagick", "glib2-devel", "python", "curl", "git", "x11-server-xvfb", "gettext", "double-conversion-devel", "tbb"
+      ],
+      "version_overrides": {}
+    },
+    "solus": {
+      "manager": "eopkg",
+      "packages": [
+        "system.devel", "qt5-base-devel", "qt5-multimedia-devel", "qt5-svg-devel", "qscintilla-devel", "CGAL-devel", "gmp-devel", "mpfr-devel",
+        "glib2-devel", "libboost-devel", "opencsg-devel", "glew-devel", "eigen3", "fontconfig-devel", "freetype2-devel", "harfbuzz-devel",
+        "libzip-devel", "double-conversion-devel", "bison", "flex", "intel-tbb-devel", "curl", "git"
+      ],
+      "version_overrides": {}
+    },
+    "altlinux": {
+      "manager": "apt",
+      "packages": [
+        "boost-devel", "gcc4.5", "gcc4.5-c++", "boost-program_options-devel", "boost-thread-devel", "boost-system-devel", "boost-regex-devel",
+        "eigen3", "libmpfr", "libgmp", "libgmp_cxx-devel", "qt5-devel", "libcgal-devel", "git-core", "tbb-devel", "libglew-devel", "flex",
+        "bison", "curl", "imagemagick", "gettext", "glib2-devel"
+      ],
+      "version_overrides": {}
+    },
+    "qomo": {
+      "manager": "dnf",
+      "packages": [
+        "qt5-qtbase-devel", "bison", "flex", "eigen3-devel", "harfbuzz-devel", "fontconfig-devel", "freetype-devel", "boost-devel", "mpfr-devel",
+        "gmp-devel", "glew-devel", "CGAL-devel", "gcc", "gcc-c++", "pkgconfig", "opencsg-devel", "git", "libXmu-devel", "curl", "ImageMagick",
+        "glib2-devel", "make", "xorg-x11-server-Xvfb", "gettext", "qscintilla-qt5-devel", "mesa-dri-drivers", "libzip-devel", "ccache",
+        "qt5-qtmultimedia-devel", "qt5-qtsvg-devel", "double-conversion-devel", "tbb-devel", "libxml2-devel", "libffi-devel", "redhat-rpm-config",
+        "qtchooser"
+      ],
+      "version_overrides": {}
+    },
+    "nixos": {
+      "manager": "nix-env",
+      "packages": [
+        "qt5.qtbase", "qt5.qtmultimedia", "qt5.qtsvg", "qscintilla", "boost", "cgal", "eigen", "gmp", "mpfr", "glew",
+        "opencsg", "freetype", "fontconfig", "harfbuzz", "pkg-config", "bison", "flex", "cmake", "ninja", "git", "curl",
+        "imagemagick", "tbb", "libzip", "libffi", "libxml2", "cairo", "double-conversion"
+      ],
+      "version_overrides": {}
+    }
+  }
+}

--- a/scripts/deps/packages.json
+++ b/scripts/deps/packages.json
@@ -1,151 +1,487 @@
 {
-  "schema": 1,
-  "notes": "Base distro definitions (shared across profiles). Profiles add or extend packages without redefining managers.",
-  "distros": {
-    "debian": {
-      "manager": "apt",
-      "packages": [
-        "build-essential", "bison", "flex", "git", "curl", "cmake", "ninja-build",
-        "libffi-dev", "libboost-program-options-dev", "libboost-regex-dev", "libboost-system-dev",
-        "libmpfr-dev", "libglew-dev", "libcairo2-dev", "libharfbuzz-dev", "libeigen3-dev",
-        "libcgal-dev", "libopencsg-dev", "libgmp-dev", "imagemagick", "libfreetype-dev",
-        "libdouble-conversion-dev", "libxml2-dev", "gtk-doc-tools", "libglib2.0-dev", "gettext",
-        "xvfb", "pkg-config", "ragel", "libtbb-dev", "libgl1-mesa-dev", "libxi-dev", "libxmu-dev",
-        "libfontconfig-dev", "libzip-dev", "python3-venv",
-        "qtbase5-dev", "libqscintilla2-qt5-dev", "libqt5opengl5-dev", "libqt5svg5-dev",
-        "qtmultimedia5-dev", "libqt5multimedia5-plugins", "qt5-qmake"
-      ],
-      "version_overrides": {
-        "12": { "add": [], "remove": [] }
-      }
-    },
-    "ubuntu": {
-      "extends": "debian",
-      "version_overrides": { "24": { "add": [], "remove": [] } }
-    },
-    "fedora": {
-      "manager": "dnf",
-      "packages": [
-        "gcc", "gcc-c++", "qt5-qtbase-devel", "bison", "flex", "eigen3-devel", "harfbuzz-devel",
-        "fontconfig-devel", "freetype-devel", "boost-devel", "mpfr-devel", "gmp-devel", "glew-devel",
-        "CGAL-devel", "pkgconfig", "opencsg-devel", "git", "libXmu-devel", "curl", "ImageMagick",
-        "glib2-devel", "make", "xorg-x11-server-Xvfb", "gettext", "qscintilla-qt5-devel",
-        "mesa-dri-drivers", "libzip-devel", "ccache", "qt5-qtmultimedia-devel", "qt5-qtsvg-devel",
-        "double-conversion-devel", "tbb-devel", "libxml2-devel", "libffi-devel", "redhat-rpm-config",
-        "qtchooser"
-      ],
-      "version_overrides": {
-        "42": { "add": [], "remove": [] }
-      }
-    },
-    "arch": {
-      "manager": "pacman",
-      "packages": [
-        "base-devel", "gcc", "bison", "flex", "make", "libzip", "qt5", "qscintilla-qt5", "cgal",
-        "gmp", "mpfr", "boost", "opencsg", "glew", "eigen", "glib2", "fontconfig", "freetype2",
-        "harfbuzz", "double-conversion", "imagemagick", "tbb", "curl", "git", "pkgconf", "mesa",
-        "libxi", "libxmu"
-      ],
-      "version_overrides": {}
-    },
-    "gentoo": {
-      "manager": "emerge",
-      "pre_commands": ["emerge --sync"],
-      "packages": [
-        "sys-devel/gcc", "sys-devel/bison", "sys-devel/flex", "dev-vcs/git", "net-misc/curl",
-        "dev-util/cmake", "dev-util/ninja", "dev-libs/libffi", "dev-libs/boost", "dev-libs/mpfr",
-        "dev-libs/gmp", "media-libs/glew", "media-libs/freetype", "media-libs/fontconfig",
-        "media-libs/harfbuzz", "sci-libs/eigen", "sci-mathematics/cgal", "media-gfx/imagemagick",
-        "media-libs/opencsg", "x11-libs/libXmu", "dev-cpp/tbb", "dev-libs/libzip", "dev-libs/libxml2",
-        "dev-qt/qtcore", "dev-qt/qtgui", "dev-qt/qtopengl", "dev-qt/qtsvg", "dev-qt/qtmultimedia",
-        "dev-qt/linguist-tools", "dev-util/ccache", "dev-qt/qtchooser"
-      ],
-      "version_overrides": {}
-    },
-    "freebsd": {
-      "manager": "pkg",
-      "packages": [
-        "bison", "boost-libs", "cmake", "git", "bash", "eigen3", "flex", "gmake", "gmp",
-        "mpfr", "xorg", "libGLU", "libXmu", "libXi", "xorg-vfbserver", "glew",
-        "qt5-core", "qt5-gui", "qt5-buildtools", "qt5-opengl", "qt5-qmake", "opencsg", "cgal",
-        "curl", "imagemagick", "gettext", "double-conversion", "onetbb", "libzip", "libxml2"
-      ],
-      "version_overrides": {}
-    },
-    "netbsd": {
-      "manager": "pkgin",
-      "packages": [
-        "bison", "boost", "cmake", "git", "bash", "eigen3", "flex", "gmake", "gmp", "mpfr",
-        "qt5", "glew", "cgal", "opencsg", "python", "curl", "ImageMagick", "gettext",
-        "threadingbuildingblocks", "libzip", "libxml2"
-      ],
-      "version_overrides": {}
-    },
-    "macos": {
-      "manager": "brew",
-      "packages": [
-        "qt@5", "qscintilla2", "boost", "cgal", "eigen", "gmp", "mpfr", "glew", "opencsg",
-        "freetype", "fontconfig", "harfbuzz", "pkg-config", "bison", "flex", "cmake", "ninja",
-        "git", "curl", "imagemagick", "tbb", "libzip", "libffi", "libxml2", "cairo",
-        "double-conversion"
-      ],
-      "version_overrides": {}
-    },
-    "opensuse": {
-      "manager": "zypper",
-      "packages": [
-        "mpfr-devel", "gmp-devel", "boost-devel", "glew-devel", "cmake", "git", "bison", "flex", "cgal-devel", "curl",
-        "glib2-devel", "gettext", "freetype-devel", "harfbuzz-devel", "qscintilla-qt5-devel", "libqt5-qtbase-devel", "libQt5OpenGL-devel",
-        "xvfb-run", "libzip-devel", "libqt5-qtmultimedia-devel", "libqt5-qtsvg-devel", "double-conversion-devel", "tbb-devel", "libeigen3-devel",
-        "ImageMagick", "opencsg-devel"
-      ],
-      "version_overrides": {}
-    },
-    "mageia": {
-      "manager": "urpmi",
-      "packages": [
-        "task-c-devel", "task-c++-devel", "libqt5-devel", "libgmp-devel", "libmpfr-devel", "libboost-devel", "eigen3-devel", "libglew-devel",
-        "bison", "flex", "cmake", "imagemagick", "glib2-devel", "python", "curl", "git", "x11-server-xvfb", "gettext", "double-conversion-devel", "tbb"
-      ],
-      "version_overrides": {}
-    },
-    "solus": {
-      "manager": "eopkg",
-      "packages": [
-        "system.devel", "qt5-base-devel", "qt5-multimedia-devel", "qt5-svg-devel", "qscintilla-devel", "CGAL-devel", "gmp-devel", "mpfr-devel",
-        "glib2-devel", "libboost-devel", "opencsg-devel", "glew-devel", "eigen3", "fontconfig-devel", "freetype2-devel", "harfbuzz-devel",
-        "libzip-devel", "double-conversion-devel", "bison", "flex", "intel-tbb-devel", "curl", "git"
-      ],
-      "version_overrides": {}
-    },
-    "altlinux": {
-      "manager": "apt",
-      "packages": [
-        "boost-devel", "gcc4.5", "gcc4.5-c++", "boost-program_options-devel", "boost-thread-devel", "boost-system-devel", "boost-regex-devel",
-        "eigen3", "libmpfr", "libgmp", "libgmp_cxx-devel", "qt5-devel", "libcgal-devel", "git-core", "tbb-devel", "libglew-devel", "flex",
-        "bison", "curl", "imagemagick", "gettext", "glib2-devel"
-      ],
-      "version_overrides": {}
-    },
-    "qomo": {
-      "manager": "dnf",
-      "packages": [
-        "qt5-qtbase-devel", "bison", "flex", "eigen3-devel", "harfbuzz-devel", "fontconfig-devel", "freetype-devel", "boost-devel", "mpfr-devel",
-        "gmp-devel", "glew-devel", "CGAL-devel", "gcc", "gcc-c++", "pkgconfig", "opencsg-devel", "git", "libXmu-devel", "curl", "ImageMagick",
-        "glib2-devel", "make", "xorg-x11-server-Xvfb", "gettext", "qscintilla-qt5-devel", "mesa-dri-drivers", "libzip-devel", "ccache",
-        "qt5-qtmultimedia-devel", "qt5-qtsvg-devel", "double-conversion-devel", "tbb-devel", "libxml2-devel", "libffi-devel", "redhat-rpm-config",
-        "qtchooser"
-      ],
-      "version_overrides": {}
-    },
-    "nixos": {
-      "manager": "nix-env",
-      "packages": [
-        "qt5.qtbase", "qt5.qtmultimedia", "qt5.qtsvg", "qscintilla", "boost", "cgal", "eigen", "gmp", "mpfr", "glew",
-        "opencsg", "freetype", "fontconfig", "harfbuzz", "pkg-config", "bison", "flex", "cmake", "ninja", "git", "curl",
-        "imagemagick", "tbb", "libzip", "libffi", "libxml2", "cairo", "double-conversion"
-      ],
-      "version_overrides": {}
+    "schema": 1,
+    "notes": "Base distro definitions (shared across profiles). Profiles add or extend packages without redefining managers.",
+    "distros": {
+        "debian": {
+            "manager": "apt",
+            "packages": [
+                "build-essential",
+                "bison",
+                "flex",
+                "git",
+                "cmake",
+                "ninja-build",
+                "libffi-dev",
+                "libboost-program-options-dev",
+                "libboost-regex-dev",
+                "libboost-system-dev",
+                "libmpfr-dev",
+                "libglew-dev",
+                "libcairo2-dev",
+                "libharfbuzz-dev",
+                "libeigen3-dev",
+                "libcgal-dev",
+                "libopencsg-dev",
+                "libgmp-dev",
+                "imagemagick",
+                "libfreetype-dev",
+                "libdouble-conversion-dev",
+                "libxml2-dev",
+                "gtk-doc-tools",
+                "libglib2.0-dev",
+                "gettext",
+                "xvfb",
+                "pkg-config",
+                "ragel",
+                "libtbb-dev",
+                "libgl1-mesa-dev",
+                "libxi-dev",
+                "libxmu-dev",
+                "libfontconfig-dev",
+                "libzip-dev",
+                "python3",
+                "python3-dev",
+                "python3-pip",
+                "python3-venv",
+                "qtbase5-dev",
+                "libqscintilla2-qt5-dev",
+                "libqt5opengl5-dev",
+                "libqt5svg5-dev",
+                "qtmultimedia5-dev",
+                "libqt5multimedia5-plugins",
+                "qt5-qmake"
+            ],
+            "version_overrides": {
+                "12": {
+                    "add": [],
+                    "remove": []
+                }
+            }
+        },
+        "ubuntu": {
+            "extends": "debian",
+            "version_overrides": {
+                "24": {
+                    "add": [],
+                    "remove": []
+                }
+            }
+        },
+        "fedora": {
+            "manager": "dnf",
+            "packages": [
+                "gcc",
+                "gcc-c++",
+                "qt5-qtbase-devel",
+                "bison",
+                "flex",
+                "eigen3-devel",
+                "harfbuzz-devel",
+                "fontconfig-devel",
+                "freetype-devel",
+                "boost-devel",
+                "mpfr-devel",
+                "gmp-devel",
+                "glew-devel",
+                "CGAL-devel",
+                "pkgconfig",
+                "opencsg-devel",
+                "git",
+                "libXmu-devel",
+                "ImageMagick",
+                "glib2-devel",
+                "make",
+                "xorg-x11-server-Xvfb",
+                "gettext",
+                "qscintilla-qt5-devel",
+                "mesa-dri-drivers",
+                "libzip-devel",
+                "ccache",
+                "qt5-qtmultimedia-devel",
+                "qt5-qtsvg-devel",
+                "double-conversion-devel",
+                "tbb-devel",
+                "libxml2-devel",
+                "libffi-devel",
+                "redhat-rpm-config",
+                "python3",
+                "python3-devel",
+                "python3-pip",
+                "qtchooser"
+            ],
+            "version_overrides": {
+                "42": {
+                    "add": [],
+                    "remove": []
+                }
+            }
+        },
+        "arch": {
+            "manager": "pacman",
+            "packages": [
+                "base-devel",
+                "gcc",
+                "bison",
+                "flex",
+                "make",
+                "libzip",
+                "qt5",
+                "qscintilla-qt5",
+                "cgal",
+                "gmp",
+                "mpfr",
+                "boost",
+                "opencsg",
+                "glew",
+                "eigen",
+                "glib2",
+                "fontconfig",
+                "freetype2",
+                "harfbuzz",
+                "double-conversion",
+                "imagemagick",
+                "tbb",
+                "git",
+                "pkgconf",
+                "mesa",
+                "python",
+                "python-pip",
+                "libxi",
+                "libxmu"
+            ],
+            "version_overrides": {}
+        },
+        "gentoo": {
+            "manager": "emerge",
+            "pre_commands": [
+                "emerge --sync"
+            ],
+            "packages": [
+                "sys-devel/gcc",
+                "sys-devel/bison",
+                "sys-devel/flex",
+                "dev-vcs/git",
+                "dev-util/cmake",
+                "dev-util/ninja",
+                "dev-libs/libffi",
+                "dev-libs/boost",
+                "dev-libs/mpfr",
+                "dev-libs/gmp",
+                "media-libs/glew",
+                "media-libs/freetype",
+                "media-libs/fontconfig",
+                "media-libs/harfbuzz",
+                "sci-libs/eigen",
+                "sci-mathematics/cgal",
+                "media-gfx/imagemagick",
+                "media-libs/opencsg",
+                "x11-libs/libXmu",
+                "dev-cpp/tbb",
+                "dev-libs/libzip",
+                "dev-libs/libxml2",
+                "dev-qt/qtcore",
+                "dev-qt/qtgui",
+                "dev-qt/qtopengl",
+                "dev-qt/qtsvg",
+                "dev-qt/qtmultimedia",
+                "dev-lang/python",
+                "dev-qt/linguist-tools",
+                "dev-util/ccache",
+                "dev-qt/qtchooser"
+            ],
+            "version_overrides": {}
+        },
+        "freebsd": {
+            "manager": "pkg",
+            "packages": [
+                "bison",
+                "boost-libs",
+                "cmake",
+                "git",
+                "bash",
+                "eigen3",
+                "flex",
+                "gmake",
+                "gmp",
+                "mpfr",
+                "xorg",
+                "libGLU",
+                "libXmu",
+                "libXi",
+                "xorg-vfbserver",
+                "glew",
+                "qt5-core",
+                "qt5-gui",
+                "qt5-buildtools",
+                "qt5-opengl",
+                "qt5-qmake",
+                "opencsg",
+                "cgal",
+                "python",
+                "imagemagick",
+                "gettext",
+                "double-conversion",
+                "onetbb",
+                "libzip",
+                "libxml2"
+            ],
+            "version_overrides": {}
+        },
+        "netbsd": {
+            "manager": "pkgin",
+            "packages": [
+                "bison",
+                "boost",
+                "cmake",
+                "git",
+                "bash",
+                "eigen3",
+                "flex",
+                "gmake",
+                "gmp",
+                "mpfr",
+                "qt5",
+                "glew",
+                "cgal",
+                "opencsg",
+                "python",
+                "ImageMagick",
+                "gettext",
+                "threadingbuildingblocks",
+                "libzip",
+                "libxml2"
+            ],
+            "version_overrides": {}
+        },
+        "macos": {
+            "manager": "brew",
+            "packages": [
+                "qt@5",
+                "qscintilla2",
+                "boost",
+                "cgal",
+                "eigen",
+                "gmp",
+                "mpfr",
+                "glew",
+                "opencsg",
+                "freetype",
+                "fontconfig",
+                "harfbuzz",
+                "pkg-config",
+                "bison",
+                "flex",
+                "cmake",
+                "ninja",
+                "git",
+                "imagemagick",
+                "tbb",
+                "libzip",
+                "libffi",
+                "libxml2",
+                "cairo",
+                "python@3.12",
+                "double-conversion"
+            ],
+            "version_overrides": {}
+        },
+        "opensuse": {
+            "manager": "zypper",
+            "packages": [
+                "mpfr-devel",
+                "gmp-devel",
+                "boost-devel",
+                "glew-devel",
+                "cmake",
+                "git",
+                "bison",
+                "flex",
+                "cgal-devel",
+                "glib2-devel",
+                "gettext",
+                "freetype-devel",
+                "harfbuzz-devel",
+                "qscintilla-qt5-devel",
+                "libqt5-qtbase-devel",
+                "libQt5OpenGL-devel",
+                "xvfb-run",
+                "libzip-devel",
+                "libqt5-qtmultimedia-devel",
+                "libqt5-qtsvg-devel",
+                "double-conversion-devel",
+                "tbb-devel",
+                "libeigen3-devel",
+                "python3",
+                "python3-devel",
+                "python3-pip",
+                "ImageMagick",
+                "opencsg-devel"
+            ],
+            "version_overrides": {}
+        },
+        "mageia": {
+            "manager": "urpmi",
+            "packages": [
+                "task-c-devel",
+                "task-c++-devel",
+                "libqt5-devel",
+                "libgmp-devel",
+                "libmpfr-devel",
+                "libboost-devel",
+                "eigen3-devel",
+                "libglew-devel",
+                "bison",
+                "flex",
+                "cmake",
+                "imagemagick",
+                "glib2-devel",
+                "python3",
+                "python3-devel",
+                "python3-pip",
+                "git",
+                "x11-server-xvfb",
+                "gettext",
+                "double-conversion-devel",
+                "tbb"
+            ],
+            "version_overrides": {}
+        },
+        "solus": {
+            "manager": "eopkg",
+            "packages": [
+                "system.devel",
+                "qt5-base-devel",
+                "qt5-multimedia-devel",
+                "qt5-svg-devel",
+                "qscintilla-devel",
+                "CGAL-devel",
+                "gmp-devel",
+                "mpfr-devel",
+                "glib2-devel",
+                "libboost-devel",
+                "opencsg-devel",
+                "glew-devel",
+                "eigen3",
+                "fontconfig-devel",
+                "freetype2-devel",
+                "harfbuzz-devel",
+                "libzip-devel",
+                "double-conversion-devel",
+                "bison",
+                "flex",
+                "intel-tbb-devel",
+                "git",
+                "python"
+            ],
+            "version_overrides": {}
+        },
+        "altlinux": {
+            "manager": "apt",
+            "packages": [
+                "boost-devel",
+                "gcc4.5",
+                "gcc4.5-c++",
+                "boost-program_options-devel",
+                "boost-thread-devel",
+                "boost-system-devel",
+                "boost-regex-devel",
+                "eigen3",
+                "libmpfr",
+                "libgmp",
+                "libgmp_cxx-devel",
+                "qt5-devel",
+                "libcgal-devel",
+                "git-core",
+                "tbb-devel",
+                "libglew-devel",
+                "flex",
+                "bison",
+                "imagemagick",
+                "gettext",
+                "glib2-devel",
+                "python3",
+                "python3-devel",
+                "python3-pip"
+            ],
+            "version_overrides": {}
+        },
+        "qomo": {
+            "manager": "dnf",
+            "packages": [
+                "qt5-qtbase-devel",
+                "bison",
+                "flex",
+                "eigen3-devel",
+                "harfbuzz-devel",
+                "fontconfig-devel",
+                "freetype-devel",
+                "boost-devel",
+                "mpfr-devel",
+                "gmp-devel",
+                "glew-devel",
+                "CGAL-devel",
+                "gcc",
+                "gcc-c++",
+                "pkgconfig",
+                "opencsg-devel",
+                "git",
+                "libXmu-devel",
+                "ImageMagick",
+                "glib2-devel",
+                "make",
+                "xorg-x11-server-Xvfb",
+                "gettext",
+                "qscintilla-qt5-devel",
+                "mesa-dri-drivers",
+                "libzip-devel",
+                "ccache",
+                "python3",
+                "python3-devel",
+                "python3-pip",
+                "qt5-qtmultimedia-devel",
+                "qt5-qtsvg-devel",
+                "double-conversion-devel",
+                "tbb-devel",
+                "libxml2-devel",
+                "libffi-devel",
+                "redhat-rpm-config",
+                "qtchooser"
+            ],
+            "version_overrides": {}
+        },
+        "nixos": {
+            "manager": "nix-env",
+            "packages": [
+                "qt5.qtbase",
+                "qt5.qtmultimedia",
+                "qt5.qtsvg",
+                "qscintilla",
+                "boost",
+                "cgal",
+                "eigen",
+                "gmp",
+                "mpfr",
+                "glew",
+                "opencsg",
+                "freetype",
+                "fontconfig",
+                "harfbuzz",
+                "pkg-config",
+                "bison",
+                "flex",
+                "cmake",
+                "ninja",
+                "git",
+                "python3",
+                "imagemagick",
+                "tbb",
+                "libzip",
+                "libffi",
+                "libxml2",
+                "cairo",
+                "double-conversion"
+            ],
+            "version_overrides": {}
+        }
     }
-  }
 }

--- a/scripts/deps/profiles/openscad.json
+++ b/scripts/deps/profiles/openscad.json
@@ -1,13 +1,37 @@
 {
-  "profile": "openscad",
-  "distros": {
-    "debian": {"extends": null, "packages": []},
-    "ubuntu": {"extends": "debian"},
-    "fedora": {"extends": null, "packages": []},
-    "arch": {"extends": null, "packages": []},
-    "gentoo": {"extends": null, "packages": []},
-    "freebsd": {"extends": null, "packages": []},
-    "netbsd": {"extends": null, "packages": []},
-    "macos": {"extends": null, "packages": []}
-  }
+    "profile": "openscad",
+    "notes": "Adds OpenSCAD build/runtime packages on top of OpenSCAD baseline.",
+    "distros": {
+        "debian": {
+            "extends": null,
+            "packages": []
+        },
+        "ubuntu": {
+            "extends": "debian"
+        },
+        "fedora": {
+            "extends": null,
+            "packages": []
+        },
+        "arch": {
+            "extends": null,
+            "packages": []
+        },
+        "gentoo": {
+            "extends": null,
+            "packages": []
+        },
+        "freebsd": {
+            "extends": null,
+            "packages": []
+        },
+        "netbsd": {
+            "extends": null,
+            "packages": []
+        },
+        "macos": {
+            "extends": null,
+            "packages": []
+        }
+    }
 }

--- a/scripts/deps/profiles/openscad.json
+++ b/scripts/deps/profiles/openscad.json
@@ -1,0 +1,13 @@
+{
+  "profile": "openscad",
+  "distros": {
+    "debian": {"extends": null, "packages": []},
+    "ubuntu": {"extends": "debian"},
+    "fedora": {"extends": null, "packages": []},
+    "arch": {"extends": null, "packages": []},
+    "gentoo": {"extends": null, "packages": []},
+    "freebsd": {"extends": null, "packages": []},
+    "netbsd": {"extends": null, "packages": []},
+    "macos": {"extends": null, "packages": []}
+  }
+}

--- a/scripts/install-deps.py
+++ b/scripts/install-deps.py
@@ -1,0 +1,355 @@
+#!/usr/bin/env python3
+"""Install OpenSCAD build dependencies across supported Unix flavors.
+
+Features:
+ - Detect distro & version (Debian, Ubuntu, Arch, Gentoo, Fedora, NetBSD, FreeBSD, macOS,
+     openSUSE, Mageia, Solus, ALT Linux, Qomo, NixOS)
+ - Configurable package lists via JSON with inheritance & version overrides
+ - Dry-run & confirmation support
+ - Minimal duplication ("extends" + per-version add/remove)
+
+Usage examples:
+  scripts/install-deps.py              # auto-detect and show plan
+  scripts/install-deps.py --yes        # auto-install without prompt
+  scripts/install-deps.py --dry-run    # show commands only
+  scripts/install-deps.py --distro fedora --version 42 --yes
+
+Config schema (packages.json):
+  distros: {
+    "ubuntu": { "extends": "debian", "manager": "apt", "packages": [...],
+                 "version_overrides": { "24": {"add": [...], "remove": [...] } } }
+  }
+
+Version resolution order: exact VERSION_ID -> major.minor -> major.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import platform
+import re
+import shutil
+import subprocess
+import sys
+from typing import Dict, List, Optional, Set
+
+SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
+CONFIG_PATH = os.path.join(SCRIPT_DIR, "deps", "packages.json")
+
+
+class DistroInfo:
+    def __init__(self, id: str, version: str):
+        self.id = id  # normalized id (see SUPPORTED)
+        self.version = version
+
+    def __repr__(self) -> str:  # pragma: no cover - trivial
+        return f"DistroInfo(id={self.id!r}, version={self.version!r})"
+
+
+SUPPORTED = {"debian", "ubuntu", "arch", "gentoo", "fedora", "netbsd", "freebsd", "macos",
+             "opensuse", "mageia", "solus", "altlinux", "qomo", "nixos"}
+
+
+def detect_distro() -> DistroInfo:
+    # macOS first
+    if sys.platform == "darwin":
+        ver = platform.mac_ver()[0]
+        return DistroInfo("macos", ver or "")
+
+    uname_s = platform.system().lower()
+    if "freebsd" in uname_s:
+        ver = platform.release().split("-")[0]
+        return DistroInfo("freebsd", ver)
+    if "netbsd" in uname_s:
+        ver = platform.release().split("-")[0]
+        return DistroInfo("netbsd", ver)
+
+    os_release = {}
+    for path in ("/etc/os-release", "/usr/lib/os-release"):
+        if os.path.exists(path):
+            with open(path) as fh:
+                for line in fh:
+                    line = line.strip()
+                    if not line or line.startswith('#') or '=' not in line:
+                        continue
+                    k, v = line.split("=", 1)
+                    os_release[k] = v.strip().strip('"')
+            break
+
+    rid = os_release.get("ID", "").lower()
+    version = os_release.get("VERSION_ID", "").strip()
+
+    # Fallbacks
+    if not rid and shutil.which("lsb_release"):
+        try:
+            rid = subprocess.check_output(["lsb_release", "-si"], text=True).strip().lower()
+        except Exception:  # pragma: no cover - best effort
+            pass
+    if not version and shutil.which("lsb_release"):
+        try:
+            version = subprocess.check_output(["lsb_release", "-sr"], text=True).strip()
+        except Exception:  # pragma: no cover
+            pass
+
+    # Normalize
+    mapping = {
+        "debian": "debian",
+        "ubuntu": "ubuntu",
+        "arch": "arch",
+        "archlinux": "arch",
+        "fedora": "fedora",
+        "gentoo": "gentoo",
+        "rhel": "fedora",
+        "redhatenterpriseserver": "fedora",
+        "opensuse": "opensuse",
+        "opensuse-leap": "opensuse",
+        "opensuse-tumbleweed": "opensuse",
+        "sles": "opensuse",
+        "suse": "opensuse",
+        "mageia": "mageia",
+        "solus": "solus",
+        "altlinux": "altlinux",
+        "qomo": "qomo",
+        "nixos": "nixos"
+    }
+    norm = mapping.get(rid, rid)
+
+    # Gentoo version from /etc/gentoo-release if missing
+    if norm == "gentoo" and not version:
+        gr = "/etc/gentoo-release"
+        if os.path.exists(gr):
+            txt = open(gr).read().strip()
+            m = re.search(r"release (\d+\.\d+|\d+)", txt.lower())
+            if m:
+                version = m.group(1)
+            else:
+                version = "rolling"
+
+    if norm not in SUPPORTED:
+        return DistroInfo(norm or "unknown", version)
+    return DistroInfo(norm, version)
+
+
+def load_config(path: str) -> dict:
+    with open(path) as fh:
+        return json.load(fh)
+
+
+def resolve_packages(cfg: dict, distro: DistroInfo) -> List[str]:
+    distros = cfg["distros"]
+    if distro.id not in distros:
+        raise SystemExit(f"Unsupported / unknown distro '{distro.id}'. Supported: {', '.join(sorted(distros))}")
+
+    # Inheritance chain
+    chain = []
+    cur = distro.id
+    seen = set()
+    while cur:
+        if cur in seen:
+            raise SystemExit(f"Inheritance loop at {cur}")
+        seen.add(cur)
+        d = distros[cur]
+        chain.append(cur)
+        cur = d.get("extends")
+
+    # Build package set preserving order
+    ordered: List[str] = []
+    seen_pkg: Set[str] = set()
+    for name in reversed(chain):  # base first
+        pkgs = distros[name].get("packages", [])
+        for p in pkgs:
+            if p not in seen_pkg:
+                ordered.append(p)
+                seen_pkg.add(p)
+
+    # Version overrides (apply on final distro only)
+    overrides = distros[distro.id].get("version_overrides", {})
+    if overrides and distro.version:
+        keys_to_try = []
+        v = distro.version
+        keys_to_try.append(v)
+        if v.count('.') >= 1:
+            major_minor = '.'.join(v.split('.')[:2])
+            if major_minor not in keys_to_try:
+                keys_to_try.append(major_minor)
+        major = v.split('.')[0]
+        if major not in keys_to_try:
+            keys_to_try.append(major)
+        for key in keys_to_try:
+            if key in overrides:
+                ov = overrides[key]
+                for r in ov.get("remove", []):
+                    if r in ordered:
+                        ordered = [x for x in ordered if x != r]
+                        seen_pkg.discard(r)
+                for a in ov.get("add", []):
+                    if a not in seen_pkg:
+                        ordered.append(a)
+                        seen_pkg.add(a)
+                break  # stop at first match
+    return ordered
+
+
+def build_commands(cfg: dict, distro: DistroInfo, packages: List[str], assume_yes: bool) -> List[List[str]]:
+    d = cfg["distros"][distro.id]
+    mgr = d.get("manager")
+    # Inherit package manager from ancestors if not defined locally (avoids duplication)
+    if not mgr:
+        parent_id = d.get("extends")
+        visited = set()
+        while parent_id and parent_id not in visited:
+            visited.add(parent_id)
+            parent = cfg["distros"].get(parent_id, {})
+            mgr = parent.get("manager")
+            if mgr:
+                break
+            parent_id = parent.get("extends")
+    if not mgr:
+        raise SystemExit(f"No package manager defined for {distro.id} (and none found in its inheritance chain)")
+
+    pre_cmds = [cmd.split() for cmd in d.get("pre_commands", [])]
+    cmds: List[List[str]] = []
+    cmds.extend(pre_cmds)
+    yes_flag = []
+    if mgr == "apt":
+        if assume_yes:
+            yes_flag = ["-y"]
+        cmds.append(["sudo", "apt-get", "update"])
+        cmds.append(["sudo", "apt-get", "install", *yes_flag, *packages])
+    elif mgr == "dnf":
+        if assume_yes:
+            yes_flag = ["-y"]
+        cmds.append(["sudo", "dnf", *yes_flag, "install", *packages])
+    elif mgr == "pacman":
+        # sync first
+        cmds.append(["sudo", "pacman", "-Sy", "--needed", "--noconfirm" if assume_yes else "--needed", *packages])
+    elif mgr == "emerge":
+        # assume pre_commands contains sync if needed
+        base = ["sudo", "emerge", "--ask=n" if assume_yes else "--ask=y", "--quiet-build" , *packages]
+        cmds.append(base)
+    elif mgr == "pkg":
+        cmds.append(["sudo", "pkg", "install", "-y" if assume_yes else "-y", *packages])
+    elif mgr == "pkgin":
+        cmds.append(["sudo", "pkgin", "-y" if assume_yes else "-y", "install", *packages])
+    elif mgr == "brew":
+        if shutil.which("brew") is None:
+            raise SystemExit("Homebrew not found. Install from https://brew.sh first.")
+        cmds.append(["brew", "update"])
+        cmds.append(["brew", "install", *packages])
+    elif mgr == "zypper":
+        if assume_yes:
+            cmds.append(["sudo", "zypper", "--non-interactive", "install", *packages])
+        else:
+            cmds.append(["sudo", "zypper", "install", *packages])
+    elif mgr == "urpmi":
+        # Mageia
+        cmds.append(["sudo", "urpmi", "--auto", *packages])
+    elif mgr == "eopkg":
+        # Solus
+        cmds.append(["sudo", "eopkg", "-y", "install", *packages])
+    elif mgr == "nix-env":
+        # NixOS: prefer user-level install; advise flakes separately
+        attr_pkgs = []
+        for p in packages:
+            if p.startswith("nixpkgs."):
+                attr_pkgs.append(p)
+            else:
+                attr_pkgs.append(f"nixpkgs.{p}")
+        cmds.append(["nix-env", "-iA", *attr_pkgs])
+    else:
+        raise SystemExit(f"Unsupported manager '{mgr}'")
+    for pc in d.get("post_commands", []):
+        cmds.append(pc.split())
+    return cmds
+
+
+def run_commands(cmds: List[List[str]], dry_run: bool):
+    for cmd in cmds:
+        print("$", " ".join(cmd))
+        if dry_run:
+            continue
+        try:
+            subprocess.check_call(cmd)
+        except subprocess.CalledProcessError as e:
+            print(f"Command failed ({e.returncode}): {' '.join(cmd)}", file=sys.stderr)
+            raise
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Install OpenSCAD (or fork) dependencies")
+    parser.add_argument("--config", default=CONFIG_PATH, help="Base config (shared) JSON path")
+    parser.add_argument("--profile", default="openscad", help="Profile name (e.g. openscad, pythonscad)")
+    parser.add_argument("--distro", help="Override detected distro id")
+    parser.add_argument("--version", help="Override detected distro version")
+    parser.add_argument("--yes", action="store_true", help="Assume yes / non-interactive")
+    parser.add_argument("--dry-run", action="store_true", help="Show commands without executing")
+    parser.add_argument("--list", action="store_true", help="Only list resolved packages")
+    args = parser.parse_args()
+
+    distro = detect_distro()
+    if args.distro:
+        distro.id = args.distro.lower()
+    if args.version:
+        distro.version = args.version
+
+    cfg = load_config(args.config)
+    # Merge in profile file if present (scripts/deps/profiles/<profile>.json)
+    profile_path = os.path.join(SCRIPT_DIR, "deps", "profiles", f"{args.profile.lower()}.json")
+    if os.path.exists(profile_path):
+        profile_cfg = load_config(profile_path)
+        # Profile distros override/extend base distros
+        base_distros = cfg.setdefault("distros", {})
+        for name, data in profile_cfg.get("distros", {}).items():
+            if name in base_distros:
+                # Merge: keep existing unless overridden; merge package lists if specified
+                merged = dict(base_distros[name])
+                for k, v in data.items():
+                    if k == "packages" and k in merged:
+                        # union preserving order
+                        seen = set(merged[k])
+                        for pkg in v:
+                            if pkg not in seen:
+                                merged[k].append(pkg)
+                                seen.add(pkg)
+                    else:
+                        merged[k] = v
+                base_distros[name] = merged
+            else:
+                base_distros[name] = data
+        cfg["active_profile"] = args.profile.lower()
+    else:
+        cfg["active_profile"] = "default"
+    try:
+        packages = resolve_packages(cfg, distro)
+    except SystemExit as e:
+        print(e, file=sys.stderr)
+        return 1
+
+    print(f"Detected distro: {distro.id} version: {distro.version}")
+    print(f"Package count: {len(packages)}")
+    # Always show package list for transparency; --list prints raw for scripting
+    if args.list:
+        for p in packages:
+            print(p)
+        return 0
+    else:
+        print("Packages to install:")
+        for p in packages:
+            print("  -", p)
+
+    if not args.yes and not args.dry_run:
+        reply = input("Proceed with installation? [y/N] ").strip().lower()
+        if reply not in {"y", "yes"}:
+            print("Aborted.")
+            return 0
+
+    cmds = build_commands(cfg, distro, packages, assume_yes=args.yes)
+    run_commands(cmds, dry_run=args.dry_run)
+    print("Done.")
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover
+    sys.exit(main())


### PR DESCRIPTION
This pull request will add a fancy new get-dependencies script to OpenSCAD which is intended to replace the old `uni-get-dependencies.sh`.

As Python is standard on all Unix flavors nowadays, and as OpenSCAD uses it itself, I took the liberty to rewrite the script in Python.

I've separated the business logic from the package config.
It has support for even more Linux distributions than the old script and even supports macOS (although I'm not able to test this on anything that doesn't run in a docker container).

Overrides for specific OS versions could be specified in the config to cover situations where a package changes it's name between versions of the same distribution.

It has a "--list" and "--dry-run" option as well.

One of the design goals was to cater for PythonSCAD (and possible other forks) as well.

Therefore there is a file `pacages.json`, which lists packages common to all forks and there could be additional files for forks, which add additional packages (e.g. PythonSCAD also requires "curl" and "libfive").

These fork-specific overrides are defined in separate files, so PythonSCAD can manage it's own file without interfering with OpenSCAD in any way.

I didn't update the readme or development documentation yet, as I wanted to hear your feedback first.

The script definitely needs some more testing. I'm currently setting up some Docker containers to test it on various Linux distributions.

This might not look like an important part of OpenSCAD, but it is the first thing people come in contact with when they try to compile OpenSCAD from source, so I think it's vital to provide a good user experience here.

Let me know what you think.