### PR TITLE
Refactor: switch LocalScope usage from mix of stuff to smart pointers

### DIFF
--- a/src/core/Children.h
+++ b/src/core/Children.h
@@ -14,7 +14,7 @@ class ScopeContext;
 class Children
 {
 public:
-  Children(const LocalScope *children_scope, std::shared_ptr<const Context> context)
+  Children(const std::shared_ptr<LocalScope> children_scope, std::shared_ptr<const Context> context)
     : children_scope(children_scope), context(std::move(context))
   {
   }
@@ -37,7 +37,7 @@ public:
   [[nodiscard]] const std::shared_ptr<const Context>& getContext() const { return context; }
 
 private:
-  const LocalScope *children_scope;
+  const std::shared_ptr<LocalScope> children_scope;
   std::shared_ptr<const Context> context;
 
   [[nodiscard]] ContextHandle<ScopeContext> scopeContext() const;

--- a/src/core/ModuleInstantiation.cc
+++ b/src/core/ModuleInstantiation.cc
@@ -22,14 +22,14 @@ void ModuleInstantiation::print(std::ostream& stream, const std::string& indent,
     if (!arg->getName().empty()) stream << arg->getName() << " = ";
     stream << *arg->getExpr();
   }
-  if (scope.numElements() == 0) {
+  if (scope->numElements() == 0) {
     stream << ");\n";
-  } else if (scope.numElements() == 1) {
+  } else if (scope->numElements() == 1) {
     stream << ") ";
-    scope.print(stream, indent, true);
+    scope->print(stream, indent, true);
   } else {
     stream << ") {\n";
-    scope.print(stream, indent + "\t", false);
+    scope->print(stream, indent + "\t", false);
     stream << indent << "}\n";
   }
 }
@@ -88,8 +88,8 @@ std::shared_ptr<AbstractNode> ModuleInstantiation::evaluate(
   }
 }
 
-LocalScope *IfElseModuleInstantiation::makeElseScope()
+std::shared_ptr<LocalScope> IfElseModuleInstantiation::makeElseScope()
 {
-  this->else_scope = std::make_unique<LocalScope>();
-  return this->else_scope.get();
+  this->else_scope = std::make_shared<LocalScope>();
+  return this->else_scope;
 }

--- a/src/core/ModuleInstantiation.h
+++ b/src/core/ModuleInstantiation.h
@@ -15,7 +15,7 @@ class ModuleInstantiation : public ASTNode
 public:
   ModuleInstantiation(std::string name, AssignmentList args = AssignmentList(),
                       const Location& loc = Location::NONE)
-    : ASTNode(loc), arguments(std::move(args)), modname(std::move(name))
+    : ASTNode(loc), arguments(std::move(args)), modname(std::move(name)), scope(std::make_shared<LocalScope>())
   {
   }
 
@@ -32,7 +32,7 @@ public:
   bool isRoot() const { return this->tag_root; }
 
   AssignmentList arguments;
-  LocalScope scope;
+  std::shared_ptr<LocalScope> scope;
 
   bool tag_root{false};
   bool tag_highlight{false};
@@ -50,10 +50,10 @@ public:
   {
   }
 
-  LocalScope *makeElseScope();
-  LocalScope *getElseScope() const { return this->else_scope.get(); }
+  std::shared_ptr<LocalScope> makeElseScope();
+  std::shared_ptr<LocalScope> getElseScope() const { return this->else_scope; }
   void print(std::ostream& stream, const std::string& indent, const bool inlined) const final;
 
 private:
-  std::unique_ptr<LocalScope> else_scope;
+  std::shared_ptr<LocalScope> else_scope;
 };

--- a/src/core/ScopeContext.cc
+++ b/src/core/ScopeContext.cc
@@ -61,7 +61,7 @@ boost::optional<InstantiableModule> ScopeContext::lookup_local_module(const std:
 UserModuleContext::UserModuleContext(const std::shared_ptr<const Context>& parent,
                                      const UserModule *module, const Location& loc, Arguments arguments,
                                      Children children)
-  : ScopeContext(parent, &module->body), children(std::move(children))
+  : ScopeContext(parent, module->body), children(std::move(children))
 {
   set_variable("$children", Value(double(this->children.size())));
   set_variable("$parent_modules", Value(double(StaticModuleNameStack::size())));
@@ -87,13 +87,13 @@ boost::optional<CallableFunction> FileContext::lookup_local_function(const std::
   for (const auto& m : source_file->usedlibs) {
     // usedmod is nullptr if the library wasn't be compiled (error or file-not-found)
     auto usedmod = SourceFileCache::instance()->lookup(m);
-    if (usedmod && usedmod->scope.functions.find(name) != usedmod->scope.functions.end()) {
+    if (usedmod && usedmod->scope->functions.find(name) != usedmod->scope->functions.end()) {
       ContextHandle<FileContext> context{Context::create<FileContext>(this->parent, usedmod)};
 #ifdef DEBUG
       PRINTDB("FileContext for function %s::%s:", m % name);
       PRINTDB("%s", context->dump());
 #endif
-      return CallableFunction{CallableUserFunction{*context, usedmod->scope.functions[name].get()}};
+      return CallableFunction{CallableUserFunction{*context, usedmod->scope->functions[name].get()}};
     }
   }
   return boost::none;
@@ -110,13 +110,13 @@ boost::optional<InstantiableModule> FileContext::lookup_local_module(const std::
   for (const auto& m : source_file->usedlibs) {
     // usedmod is nullptr if the library wasn't be compiled (error or file-not-found)
     auto usedmod = SourceFileCache::instance()->lookup(m);
-    if (usedmod && usedmod->scope.modules.find(name) != usedmod->scope.modules.end()) {
+    if (usedmod && usedmod->scope->modules.find(name) != usedmod->scope->modules.end()) {
       ContextHandle<FileContext> context{Context::create<FileContext>(this->parent, usedmod)};
 #ifdef DEBUG
       PRINTDB("FileContext for module %s::%s:", m % name);
       PRINTDB("%s", context->dump());
 #endif
-      return InstantiableModule{*context, usedmod->scope.modules[name].get()};
+      return InstantiableModule{*context, usedmod->scope->modules[name].get()};
     }
   }
   return boost::none;

--- a/src/core/ScopeContext.h
+++ b/src/core/ScopeContext.h
@@ -22,13 +22,13 @@ public:
                                                           const Location& loc) const override;
 
 protected:
-  ScopeContext(const std::shared_ptr<const Context>& parent, const LocalScope *scope)
+  ScopeContext(const std::shared_ptr<const Context>& parent, const std::shared_ptr<LocalScope> scope)
     : Context(parent), scope(scope)
   {
   }
 
 private:
-  const LocalScope *scope;
+  const std::shared_ptr<LocalScope> scope;
 
   friend class Context;
 };
@@ -59,7 +59,7 @@ public:
 
 protected:
   FileContext(const std::shared_ptr<const Context>& parent, const SourceFile *source_file)
-    : ScopeContext(parent, &source_file->scope), source_file(source_file)
+    : ScopeContext(parent, source_file->scope), source_file(source_file)
   {
   }
 

--- a/src/core/SourceFile.cc
+++ b/src/core/SourceFile.cc
@@ -47,13 +47,13 @@ namespace fs = std::filesystem;
 #include <sys/stat.h>
 
 SourceFile::SourceFile(std::string path, std::string filename)
-  : ASTNode(Location::NONE), path(std::move(path)), filename(std::move(filename))
+  : ASTNode(Location::NONE), path(std::move(path)), filename(std::move(filename)), scope(std::make_shared<LocalScope>())
 {
 }
 
 void SourceFile::print(std::ostream& stream, const std::string& indent) const
 {
-  scope.print(stream, indent);
+  scope->print(stream, indent);
 }
 
 void SourceFile::registerUse(const std::string& path, const Location& loc)
@@ -179,7 +179,7 @@ std::shared_ptr<AbstractNode> SourceFile::instantiate(
   try {
     ContextHandle<FileContext> file_context{Context::create<FileContext>(context, this)};
     *resulting_file_context = *file_context;
-    this->scope.instantiateModules(*file_context, node);
+    this->scope->instantiateModules(*file_context, node);
   } catch (HardWarningException& e) {
     throw;
   } catch (EvaluationException& e) {

--- a/src/core/SourceFile.h
+++ b/src/core/SourceFile.h
@@ -36,7 +36,7 @@ public:
   const std::string& getFilename() const { return this->filename; }
   const std::string getFullpath() const;
 
-  LocalScope scope;
+  std::shared_ptr<LocalScope> scope;
   std::vector<std::string> usedlibs;
 
   std::vector<IndicatorData> indicatorData;

--- a/src/core/UserModule.cc
+++ b/src/core/UserModule.cc
@@ -97,7 +97,7 @@ std::shared_ptr<AbstractNode> UserModule::instantiate(
   StaticModuleNameStack name{inst->name()};  // push on static stack, pop at end of method!
   ContextHandle<UserModuleContext> module_context{Context::create<UserModuleContext>(
     defining_context, this, inst->location(), Arguments(inst->arguments, context),
-    Children(&inst->scope, context))};
+    Children(inst->scope, context))};
 #if 0 && DEBUG
   PRINTDB("UserModuleContext for module %s(%s):\n", this->name % STR(this->parameters));
   PRINTDB("%s", module_context->dump());
@@ -105,7 +105,7 @@ std::shared_ptr<AbstractNode> UserModule::instantiate(
 
   std::shared_ptr<AbstractNode> ret;
   try {
-    ret = this->body.instantiateModules(
+    ret = this->body->instantiateModules(
       *module_context, std::make_shared<GroupNode>(inst, std::string("module ") + this->name));
   } catch (EvaluationException& e) {
     if (OpenSCAD::traceUsermoduleParameters && e.traceDepth > 0) {
@@ -131,7 +131,7 @@ void UserModule::print(std::ostream& stream, const std::string& indent) const
     stream << ") {\n";
     tab = "\t";
   }
-  body.print(stream, indent + tab);
+  body->print(stream, indent + tab);
   if (!this->name.empty()) {
     stream << indent << "}\n";
   }

--- a/src/core/UserModule.h
+++ b/src/core/UserModule.h
@@ -27,11 +27,10 @@ private:
 class UserModule : public AbstractModule, public ASTNode
 {
 public:
-  UserModule(const char *name, const Location& loc) : ASTNode(loc), name(name) {}
+  UserModule(const char *name, const Location& loc)
+    : ASTNode(loc), name(name), body(std::make_shared<LocalScope>()) {}
   UserModule(const char *name, const Feature& feature, const Location& loc)
-    : AbstractModule(feature), ASTNode(loc), name(name)
-  {
-  }
+    : AbstractModule(feature), ASTNode(loc), name(name), body(std::make_shared<LocalScope>()) {}
 
   std::shared_ptr<AbstractNode> instantiate(
     const std::shared_ptr<const Context>& defining_context, const ModuleInstantiation *inst,
@@ -42,5 +41,5 @@ public:
 
   std::string name;
   AssignmentList parameters;
-  LocalScope body;
+  std::shared_ptr<LocalScope> body;
 };

--- a/src/core/control.cc
+++ b/src/core/control.cc
@@ -182,7 +182,7 @@ static std::shared_ptr<AbstractNode> builtin_assert(const ModuleInstantiation *i
 {
   Assert::performAssert(inst->arguments, inst->location(), context);
 
-  auto node = Children(&inst->scope, context).instantiate(lazyUnionNode(inst));
+  auto node = Children(inst->scope, context).instantiate(lazyUnionNode(inst));
   // assert without child geometries should not count as valid CSGNode
   if (node->children.empty()) {
     return {};
@@ -193,7 +193,7 @@ static std::shared_ptr<AbstractNode> builtin_assert(const ModuleInstantiation *i
 static std::shared_ptr<AbstractNode> builtin_let(const ModuleInstantiation *inst,
                                                  const std::shared_ptr<const Context>& context)
 {
-  return Children(&inst->scope,
+  return Children(inst->scope,
                   *Let::sequentialAssignmentContext(inst->arguments, inst->location(), context))
     .instantiate(lazyUnionNode(inst));
 }
@@ -220,7 +220,7 @@ static std::shared_ptr<AbstractNode> builtin_assign(const ModuleInstantiation *i
     }
   }
 
-  return Children(&inst->scope, *assignContext).instantiate(lazyUnionNode(inst));
+  return Children(inst->scope, *assignContext).instantiate(lazyUnionNode(inst));
 }
 
 static std::shared_ptr<AbstractNode> builtin_for(const ModuleInstantiation *inst,
@@ -230,7 +230,7 @@ static std::shared_ptr<AbstractNode> builtin_for(const ModuleInstantiation *inst
   if (!inst->arguments.empty()) {
     LcFor::forEach(inst->arguments, inst->location(), context,
                    [inst, node](const std::shared_ptr<const Context>& iterationContext) {
-                     Children(&inst->scope, iterationContext).instantiate(node);
+                     Children(inst->scope, iterationContext).instantiate(node);
                    });
   }
   return node;
@@ -243,7 +243,7 @@ static std::shared_ptr<AbstractNode> builtin_intersection_for(
   if (!inst->arguments.empty()) {
     LcFor::forEach(inst->arguments, inst->location(), context,
                    [inst, node](const std::shared_ptr<const Context>& iterationContext) {
-                     Children(&inst->scope, iterationContext).instantiate(node);
+                     Children(inst->scope, iterationContext).instantiate(node);
                    });
   }
   return node;
@@ -255,7 +255,7 @@ static std::shared_ptr<AbstractNode> builtin_if(const ModuleInstantiation *inst,
   Arguments arguments{inst->arguments, context};
   const auto *ifelse = dynamic_cast<const IfElseModuleInstantiation *>(inst);
   if (arguments.size() > 0 && arguments[0]->toBool()) {
-    return Children(&inst->scope, context).instantiate(lazyUnionNode(inst));
+    return Children(inst->scope, context).instantiate(lazyUnionNode(inst));
   } else if (ifelse->getElseScope()) {
     return Children(ifelse->getElseScope(), context).instantiate(lazyUnionNode(inst));
   } else {

--- a/src/core/customizer/CommentParser.cc
+++ b/src/core/customizer/CommentParser.cc
@@ -265,7 +265,7 @@ void CommentParser::collectParameters(const std::string& fulltext, SourceFile *r
   GroupList groupList = collectGroups(fulltext);
   int parseTill = getLineToStop(fulltext);
   // Extract parameters for all literal assignments
-  for (auto& assignment : root_file->scope.assignments) {
+  for (auto& assignment : root_file->scope->assignments) {
     if (!assignment->getExpr()->isLiteral()) continue;  // Only consider literals
 
     // get location of assignment node

--- a/src/core/customizer/ParameterObject.cc
+++ b/src/core/customizer/ParameterObject.cc
@@ -531,7 +531,7 @@ std::unique_ptr<ParameterObject> ParameterObject::fromAssignment(const Assignmen
 ParameterObjects ParameterObjects::fromSourceFile(const SourceFile *sourceFile)
 {
   ParameterObjects output;
-  for (const auto& assignment : sourceFile->scope.assignments) {
+  for (const auto& assignment : sourceFile->scope->assignments) {
     std::unique_ptr<ParameterObject> parameter = ParameterObject::fromAssignment(assignment.get());
     if (parameter) {
       output.push_back(std::move(parameter));
@@ -576,7 +576,7 @@ void ParameterObjects::apply(SourceFile *sourceFile) const
     namedParameters[parameter->name()] = parameter.get();
   }
 
-  for (auto& assignment : sourceFile->scope.assignments) {
+  for (auto& assignment : sourceFile->scope->assignments) {
     if (namedParameters.count(assignment->getName())) {
       namedParameters[assignment->getName()]->apply(assignment.get());
     }

--- a/src/core/module.cc
+++ b/src/core/module.cc
@@ -48,7 +48,7 @@ BuiltinModule::BuiltinModule(std::shared_ptr<AbstractNode> (*instantiate)(const 
 {
   do_instantiate = [instantiate](const ModuleInstantiation *inst,
                                  const std::shared_ptr<const Context>& context) {
-    return instantiate(inst, Arguments(inst->arguments, context), Children(&inst->scope, context));
+    return instantiate(inst, Arguments(inst->arguments, context), Children(inst->scope, context));
   };
 }
 
@@ -74,7 +74,7 @@ std::shared_ptr<AbstractNode> BuiltinModule::instantiate(
 
 void BuiltinModule::noChildren(const ModuleInstantiation *inst, Arguments& arguments, std::string auxmsg)
 {
-  if (inst->scope.hasChildren()) {
+  if (inst->scope->hasChildren()) {
     LOG(message_group::Warning, inst->location(), arguments.documentRoot(),
         "module %1$s() does not support child modules%2$s%3$s", inst->name(),
         auxmsg.size() != 0 ? " " : "", auxmsg);

--- a/src/core/parser.y
+++ b/src/core/parser.y
@@ -73,7 +73,7 @@ int lexerlex_destroy(void);
 int lexerlex(void);
 static void handle_assignment(const std::string token, Expression *expr, const Location loc);
 
-std::stack<LocalScope *> scope_stack;
+std::stack<std::shared_ptr<LocalScope>> scope_stack;
 SourceFile *rootfile;
 
 extern void lexerdestroy();
@@ -195,7 +195,7 @@ statement
               UserModule *newmodule = new UserModule($2, LOCD("module", @$));
               newmodule->parameters = *$4;
               auto top = scope_stack.top();
-              scope_stack.push(&newmodule->body);
+              scope_stack.push(newmodule->body);
               top->addModule(std::shared_ptr<UserModule>(newmodule));
               free($2);
               delete $4;
@@ -255,7 +255,7 @@ module_instantiation
         | single_module_instantiation
             {
                 $<inst>$ = $1;
-                scope_stack.push(&$1->scope);
+                scope_stack.push($1->scope);
             }
           child_statement
             {
@@ -288,7 +288,7 @@ if_statement
         : TOK_IF '(' expr ')'
             {
                 $<ifelse>$ = new IfElseModuleInstantiation(std::shared_ptr<Expression>($3), LOCD("if", @$));
-                scope_stack.push(&$<ifelse>$->scope);
+                scope_stack.push($<ifelse>$->scope);
             }
           child_statement
             {
@@ -816,7 +816,7 @@ bool parse(SourceFile *&file, const std::string& text, const std::string &filena
   fileEnded = false;
 
   rootfile = new SourceFile(parser_sourcefile.parent_path().string(), parser_sourcefile.filename().string());
-  scope_stack.push(&rootfile->scope);
+  scope_stack.push(rootfile->scope);
   //        PRINTB_NOCACHE("New module: %s %p", "root" % rootfile);
 
   parserdebug = debug;


### PR DESCRIPTION
The code is grabbing a pointer from a unique_ptr and then fobbing it off random places; that's definitely not the right way to use unique_ptr...

This standardizes on shared_ptr everywhere for usage of LocalScope.