### PR TITLE
Reduce header pollution

### DIFF
--- a/src/core/Arguments.cc
+++ b/src/core/Arguments.cc
@@ -28,7 +28,9 @@
 
 #include <ostream>
 #include <memory>
+#include "core/Context.h"
 #include "core/Expression.h"
+#include "core/EvaluationSession.h"
 
 Arguments::Arguments(const AssignmentList& argument_expressions,
                      const std::shared_ptr<const Context>& context)
@@ -49,6 +51,11 @@ Arguments Arguments::clone() const
     output.emplace_back(argument.name, argument.value.clone());
   }
   return output;
+}
+
+const std::string& Arguments::documentRoot() const
+{
+  return evaluation_session->documentRoot();
 }
 
 std::ostream& operator<<(std::ostream& stream, const Argument& argument)

--- a/src/core/Arguments.h
+++ b/src/core/Arguments.h
@@ -8,7 +8,9 @@
 #include <boost/optional.hpp>
 
 #include "core/Assignment.h"
-#include "core/Context.h"
+#include "core/Value.h"
+
+class EvaluationSession;
 
 struct Argument {
   boost::optional<std::string> name;
@@ -45,7 +47,7 @@ public:
   [[nodiscard]] Arguments clone() const;
 
   [[nodiscard]] EvaluationSession *session() const { return evaluation_session; }
-  [[nodiscard]] const std::string& documentRoot() const { return evaluation_session->documentRoot(); }
+  const std::string& documentRoot() const;
 
 private:
   EvaluationSession *evaluation_session;

--- a/src/core/BuiltinContext.h
+++ b/src/core/BuiltinContext.h
@@ -2,8 +2,9 @@
 
 #include <string>
 
-#include "core/AST.h"
 #include "core/Context.h"
+
+class Location;
 
 class BuiltinContext : public Context
 {

--- a/src/core/CgalAdvNode.cc
+++ b/src/core/CgalAdvNode.cc
@@ -26,9 +26,9 @@
 
 #include "core/CgalAdvNode.h"
 #include "core/module.h"
-#include "core/ModuleInstantiation.h"
 #include "core/Builtins.h"
 #include "core/Children.h"
+#include "core/ModuleInstantiation.h"
 #include "core/Parameters.h"
 #include <utility>
 #include <memory>

--- a/src/core/Children.cc
+++ b/src/core/Children.cc
@@ -30,6 +30,8 @@
 #include <cstddef>
 #include <vector>
 
+#include "core/Context.h"
+#include "core/LocalScope.h"
 #include "core/ScopeContext.h"
 
 std::shared_ptr<AbstractNode> Children::instantiate(const std::shared_ptr<AbstractNode>& target) const
@@ -46,4 +48,14 @@ std::shared_ptr<AbstractNode> Children::instantiate(const std::shared_ptr<Abstra
 ContextHandle<ScopeContext> Children::scopeContext() const
 {
   return Context::create<ScopeContext>(context, children_scope);
+}
+
+bool Children::empty() const
+{
+  return !children_scope->hasChildren();
+}
+
+size_t Children:: size() const
+{
+  return children_scope->moduleInstantiations.size();
 }

--- a/src/core/Children.h
+++ b/src/core/Children.h
@@ -5,11 +5,12 @@
 #include <memory>
 #include <vector>
 
-#include "core/Context.h"
-#include "core/LocalScope.h"
-
 class AbstractNode;
 class ScopeContext;
+template <typename T>
+class ContextHandle;
+class Context;
+class LocalScope;
 
 class Children
 {
@@ -32,8 +33,8 @@ public:
                                             const std::vector<size_t>& indices) const;
   // NOLINTEND(modernize-use-nodiscard)
 
-  [[nodiscard]] bool empty() const { return !children_scope->hasChildren(); }
-  [[nodiscard]] size_t size() const { return children_scope->moduleInstantiations.size(); }
+  bool empty() const;
+  size_t size() const;
   [[nodiscard]] const std::shared_ptr<const Context>& getContext() const { return context; }
 
 private:

--- a/src/core/ColorNode.cc
+++ b/src/core/ColorNode.cc
@@ -35,10 +35,10 @@
 #include <boost/assign/std/vector.hpp>
 #include <boost/assign/list_of.hpp>
 
-#include "core/module.h"
-#include "core/ModuleInstantiation.h"
 #include "core/Builtins.h"
 #include "core/Children.h"
+#include "core/module.h"
+#include "core/ModuleInstantiation.h"
 #include "core/Parameters.h"
 #include "core/ColorUtil.h"
 #include "geometry/linalg.h"

--- a/src/core/Context.h
+++ b/src/core/Context.h
@@ -19,44 +19,15 @@ template <typename T>
 class ContextHandle : ContextFrameHandle
 {
 public:
-  ContextHandle(std::shared_ptr<T>&& context)
-    : ContextFrameHandle(context.get()), context(std::move(context))
-  {
-    try {
-      this->context->init();
-    } catch (...) {
-      session->contextMemoryManager().addContext(std::move(this->context));
-      throw;
-    }
-  }
-
-  ~ContextHandle()
-  {
-    assert(!!session == !!context);
-    if (session) {
-      session->contextMemoryManager().addContext(std::move(this->context));
-    }
-  }
+  ContextHandle(std::shared_ptr<T>&& context);
+  ~ContextHandle();
 
   ContextHandle(const ContextHandle&) = delete;
   ContextHandle& operator=(const ContextHandle&) = delete;
   ContextHandle(ContextHandle&& other) noexcept = default;
 
   // Valid only if $other is on the top of the stack.
-  ContextHandle& operator=(ContextHandle&& other) noexcept
-  {
-    assert(session);
-    assert(context);
-    assert(other.context);
-    assert(other.session);
-
-    // session->contextMemoryManager().releaseContext();
-    session->contextMemoryManager().addContext(std::move(this->context));
-    other.release();
-    context = std::move(other.context);
-    ContextFrameHandle::operator=(context.get());
-    return *this;
-  }
+  ContextHandle& operator=(ContextHandle&& other) noexcept;
 
   const T *operator->() const { return context.get(); }
   T *operator->() { return context.get(); }
@@ -75,15 +46,20 @@ protected:
 public:
   ~Context() override;
 
+  /**
+   * @brief Create a new Context or descendent
+   *
+   * Exists to ensure each Context object shares a single shared_ptr
+   */
   template <typename C, typename... T>
   static ContextHandle<C> create(T&&...t)
   {
     return ContextHandle<C>{std::shared_ptr<C>(new C(std::forward<T>(t)...))};
   }
+  std::shared_ptr<const Context> get_shared_ptr() const { return shared_from_this(); }
 
   virtual void init() {}
 
-  std::shared_ptr<const Context> get_shared_ptr() const { return shared_from_this(); }
   virtual const class Children *user_module_children() const;
   virtual std::vector<const std::shared_ptr<const Context> *> list_referenced_contexts() const;
 

--- a/src/core/CsgOpNode.cc
+++ b/src/core/CsgOpNode.cc
@@ -26,10 +26,10 @@
 
 #include "core/CsgOpNode.h"
 
-#include "core/module.h"
-#include "core/ModuleInstantiation.h"
 #include "core/Builtins.h"
 #include "core/Children.h"
+#include "core/module.h"
+#include "core/ModuleInstantiation.h"
 #include "core/Parameters.h"
 
 #include <utility>

--- a/src/core/Expression.cc
+++ b/src/core/Expression.cc
@@ -40,11 +40,12 @@
 #include <typeinfo>
 #include <utility>
 #include <variant>
+#include "core/Context.h"
+#include "core/EvaluationSession.h"
+#include "core/Parameters.h"
 #include "utils/printutils.h"
 #include "utils/StackCheck.h"
-#include "core/Context.h"
 #include "utils/exceptions.h"
-#include "core/Parameters.h"
 #include "utils/printutils.h"
 #include "utils/boost-utils.h"
 #include <boost/regex.hpp>

--- a/src/core/GroupModule.cc
+++ b/src/core/GroupModule.cc
@@ -26,10 +26,10 @@
 
 #include <utility>
 #include <memory>
-#include "core/ModuleInstantiation.h"
-#include "core/node.h"
 #include "core/Builtins.h"
 #include "core/Children.h"
+#include "core/ModuleInstantiation.h"
+#include "core/node.h"
 #include "core/Parameters.h"
 
 std::shared_ptr<AbstractNode> builtin_group(const ModuleInstantiation *inst, Arguments arguments,

--- a/src/core/LinearExtrudeNode.cc
+++ b/src/core/LinearExtrudeNode.cc
@@ -26,9 +26,9 @@
 
 #include "core/LinearExtrudeNode.h"
 
+#include "core/Children.h"
 #include "core/module.h"
 #include "core/ModuleInstantiation.h"
-#include "core/Children.h"
 #include "core/Parameters.h"
 #include "utils/printutils.h"
 #include "io/fileutils.h"

--- a/src/core/OffsetNode.cc
+++ b/src/core/OffsetNode.cc
@@ -26,9 +26,9 @@
 
 #include "core/OffsetNode.h"
 
+#include "core/Children.h"
 #include "core/module.h"
 #include "core/ModuleInstantiation.h"
-#include "core/Children.h"
 #include "core/Parameters.h"
 #include "core/Builtins.h"
 

--- a/src/core/ProjectionNode.cc
+++ b/src/core/ProjectionNode.cc
@@ -25,11 +25,12 @@
  */
 
 #include "core/ProjectionNode.h"
+
+#include "core/Builtins.h"
+#include "core/Children.h"
 #include "core/module.h"
 #include "core/ModuleInstantiation.h"
-#include "core/Children.h"
 #include "core/Parameters.h"
-#include "core/Builtins.h"
 
 #include <utility>
 #include <memory>

--- a/src/core/RenderNode.cc
+++ b/src/core/RenderNode.cc
@@ -25,10 +25,11 @@
  */
 
 #include "core/RenderNode.h"
-#include "core/module.h"
-#include "core/ModuleInstantiation.h"
+
 #include "core/Builtins.h"
 #include "core/Children.h"
+#include "core/module.h"
+#include "core/ModuleInstantiation.h"
 #include "core/Parameters.h"
 
 #include <utility>

--- a/src/core/RenderVariables.h
+++ b/src/core/RenderVariables.h
@@ -1,6 +1,7 @@
 #include "glview/Camera.h"
-#include "core/Context.h"
-#include "core/BuiltinContext.h"
+class BuiltinContext;
+template <typename T>
+class ContextHandle;
 
 class RenderVariables
 {

--- a/src/core/RotateExtrudeNode.cc
+++ b/src/core/RotateExtrudeNode.cc
@@ -25,13 +25,14 @@
  */
 
 #include "core/RotateExtrudeNode.h"
+
+#include "core/Builtins.h"
+#include "core/Children.h"
 #include "core/module.h"
 #include "core/ModuleInstantiation.h"
-#include "core/Children.h"
 #include "core/Parameters.h"
 #include "utils/printutils.h"
 #include "io/fileutils.h"
-#include "core/Builtins.h"
 #include "handle_dep.h"
 #include <ios>
 #include <utility>

--- a/src/core/SurfaceNode.cc
+++ b/src/core/SurfaceNode.cc
@@ -26,13 +26,13 @@
 
 #include "core/SurfaceNode.h"
 
-#include "core/module.h"
-#include "core/ModuleInstantiation.h"
-#include "core/node.h"
 #include "geometry/PolySet.h"
 #include "geometry/PolySetBuilder.h"
 #include "core/Builtins.h"
 #include "core/Children.h"
+#include "core/module.h"
+#include "core/ModuleInstantiation.h"
+#include "core/node.h"
 #include "core/Parameters.h"
 #include "utils/printutils.h"
 #include "io/fileutils.h"

--- a/src/core/TextNode.cc
+++ b/src/core/TextNode.cc
@@ -31,6 +31,7 @@
 #include <vector>
 
 #include "core/Children.h"
+#include "core/EvaluationSession.h"
 #include "core/module.h"
 #include "core/ModuleInstantiation.h"
 #include "core/Parameters.h"

--- a/src/core/TransformNode.cc
+++ b/src/core/TransformNode.cc
@@ -25,12 +25,13 @@
  */
 
 #include "core/TransformNode.h"
+
 #include "geometry/linalg.h"
-#include "core/ModuleInstantiation.h"
-#include "core/Children.h"
 #include "core/Builtins.h"
-#include "core/Value.h"
+#include "core/Children.h"
+#include "core/ModuleInstantiation.h"
 #include "core/Parameters.h"
+#include "core/Value.h"
 #include "utils/printutils.h"
 #include "utils/degree_trig.h"
 #include <algorithm>

--- a/src/core/UserModule.cc
+++ b/src/core/UserModule.cc
@@ -31,14 +31,15 @@
 #include <vector>
 
 #include "core/AST.h"
+#include "core/Arguments.h"
+#include "core/Expression.h"
 #include "core/ModuleInstantiation.h"
 #include "core/node.h"
-#include "utils/exceptions.h"
-#include "utils/StackCheck.h"
 #include "core/ScopeContext.h"
-#include "core/Expression.h"
-#include "utils/printutils.h"
 #include "utils/compiler_specific.h"
+#include "utils/exceptions.h"
+#include "utils/printutils.h"
+#include "utils/StackCheck.h"
 #include <cstddef>
 #include <sstream>
 #include <string>

--- a/src/core/builtin_functions.cc
+++ b/src/core/builtin_functions.cc
@@ -25,15 +25,18 @@
  */
 
 #include "core/function.h"
+
 #include "core/AST.h"
 #include "core/Arguments.h"
-#include "core/Expression.h"
 #include "core/Builtins.h"
-#include "utils/printutils.h"
-#include "core/UserModule.h"
-#include "utils/degree_trig.h"
+#include "core/Context.h"
+#include "core/EvaluationSession.h"
+#include "core/Expression.h"
 #include "core/FreetypeRenderer.h"
 #include "core/Parameters.h"
+#include "core/UserModule.h"
+#include "utils/printutils.h"
+#include "utils/degree_trig.h"
 #include "io/import.h"
 #include "io/fileutils.h"
 

--- a/src/core/control.cc
+++ b/src/core/control.cc
@@ -29,13 +29,15 @@
 #include <cstddef>
 #include <vector>
 
+#include "core/Arguments.h"
+#include "core/Builtins.h"
+#include "core/Children.h"
+#include "core/Context.h"
+#include "core/ContextFrame.h"
+#include "core/Expression.h"
 #include "core/module.h"
 #include "core/ModuleInstantiation.h"
 #include "core/node.h"
-#include "core/Arguments.h"
-#include "core/Children.h"
-#include "core/Expression.h"
-#include "core/Builtins.h"
 #include "core/Parameters.h"
 #include "utils/printutils.h"
 #include <cstdint>

--- a/src/core/primitives.cc
+++ b/src/core/primitives.cc
@@ -25,18 +25,19 @@
  */
 
 #include "core/primitives.h"
+
 #include "geometry/Geometry.h"
 #include "geometry/linalg.h"
-#include "core/Builtins.h"
-#include "core/Children.h"
-#include "core/ModuleInstantiation.h"
-#include "core/Parameters.h"
 #include "geometry/PolySet.h"
 #include "geometry/Polygon2d.h"
-#include "utils/calc.h"
-#include "core/node.h"
-#include "utils/degree_trig.h"
+#include "core/Builtins.h"
+#include "core/Children.h"
 #include "core/module.h"
+#include "core/ModuleInstantiation.h"
+#include "core/node.h"
+#include "core/Parameters.h"
+#include "utils/calc.h"
+#include "utils/degree_trig.h"
 #include "utils/printutils.h"
 #include <algorithm>
 #include <utility>

--- a/src/geometry/GeometryEvaluator.cc
+++ b/src/geometry/GeometryEvaluator.cc
@@ -1,40 +1,46 @@
 #include "geometry/GeometryEvaluator.h"
-#include "geometry/Geometry.h"
+
+#include "Feature.h"
+#include "geometry/boolean_utils.h"
 #include "geometry/cgal/cgal.h"
+#include "geometry/ClipperUtils.h"
 #include "geometry/linalg.h"
-#include "core/Tree.h"
+#include "geometry/linear_extrude.h"
+#include "geometry/Geometry.h"
 #include "geometry/GeometryCache.h"
 #include "geometry/Polygon2d.h"
-#include "core/ModuleInstantiation.h"
-#include "core/State.h"
-#include "core/ColorNode.h"
-#include "core/OffsetNode.h"
-#include "core/TransformNode.h"
-#include "core/LinearExtrudeNode.h"
-#include "core/RoofNode.h"
-#include "geometry/roof_ss.h"
-#include "geometry/roof_vd.h"
-#include "core/RotateExtrudeNode.h"
-#include "core/CgalAdvNode.h"
-#include "core/ProjectionNode.h"
-#include "core/CsgOpNode.h"
-#include "core/TextNode.h"
-#include "core/RenderNode.h"
-#include "geometry/ClipperUtils.h"
 #include "geometry/PolySetUtils.h"
 #include "geometry/PolySet.h"
 #include "geometry/PolySetBuilder.h"
-#include "utils/calc.h"
-#include "utils/printutils.h"
-#include "utils/calc.h"
+#include "geometry/roof_ss.h"
+#include "geometry/roof_vd.h"
+#include "geometry/rotate_extrude.h"
+
 #include "glview/RenderSettings.h"
+
+#include "core/CgalAdvNode.h"
+#include "core/ColorNode.h"
+#include "core/CsgOpNode.h"
+#include "core/ModuleInstantiation.h"
+#include "core/LinearExtrudeNode.h"
+#include "core/OffsetNode.h"
+#include "core/ProjectionNode.h"
+#include "core/RenderNode.h"
+#include "core/RoofNode.h"
+#include "core/RotateExtrudeNode.h"
+#include "core/State.h"
+#include "core/TextNode.h"
+#include "core/TransformNode.h"
+#include "core/Tree.h"
+#include "utils/calc.h"
 #include "utils/degree_trig.h"
+#include "utils/printutils.h"
+
 #include <iterator>
 #include <cassert>
 #include <list>
 #include <utility>
 #include <memory>
-#include "geometry/boolean_utils.h"
 #ifdef ENABLE_CGAL
 #include "geometry/cgal/CGALCache.h"
 #include "geometry/cgal/cgalutils.h"
@@ -44,8 +50,6 @@
 #ifdef ENABLE_MANIFOLD
 #include "geometry/manifold/manifoldutils.h"
 #endif
-#include "geometry/linear_extrude.h"
-#include "geometry/rotate_extrude.h"
 
 #include <vector>
 


### PR DESCRIPTION
A problem all started when I couldn't dynamic_cast a BuiltinContext
and apparently header pollution can be the cause or trigger. This is
just a good start toward cleaning up.  Several
cc files had to be updated because of indirect includes that are now missing.

Though it turned out it was a typo and I was comparing the
value-to-be-assigned for nullptr and not the
value-from-dynamic-cast. C'est la vie.
