### PR TITLE
Fix docker working directory in wasm build script

### DIFF
--- a/scripts/wasm-base-docker-run.sh
+++ b/scripts/wasm-base-docker-run.sh
@@ -38,6 +38,7 @@ echo "
 
 docker run --rm -it \
   --platform=linux/amd64 \
+  -w /src \
   -v "$PWD:/src:rw" \
   -v $CCACHE_DIR:/root/.ccache:rw \
   openscad-wasm-ccache:local \


### PR DESCRIPTION
The `wasm-base-docker-run.sh` script currently mounts the source directory at `/src`
  inside the Docker container but doesn't set the working directory. This causes commands
  like `cmake` to run from `/home/ubuntu` (the default container working directory) instead
   of `/src` where the source code is mounted.

  This results in errors like:
  CMake Error: The source directory "/home/ubuntu" does not appear to contain
  CMakeLists.txt.

  **Fix:** Add `-w /src` to the `docker run` command to set the working directory inside
  the container to `/src` where the source code is mounted.

  **Testing:** This fix allows `make wasm` to work properly when building OpenSCAD WASM
  binaries from source.