### PR TITLE
Set [OK] as default for SVG and PDF exports.  Fixes #6170.

### DIFF
--- a/src/gui/AboutDialog.ui
+++ b/src/gui/AboutDialog.ui
@@ -108,6 +108,9 @@
      <property name="text">
       <string>OK</string>
      </property>
+     <property name="default">
+      <bool>true</bool>
+     </property>
     </widget>
    </item>
    <item row="4" column="1">

--- a/src/gui/Export3mfDialog.ui
+++ b/src/gui/Export3mfDialog.ui
@@ -581,6 +581,9 @@
        <property name="text">
         <string>OK</string>
        </property>
+       <property name="default">
+        <bool>true</bool>
+       </property>
       </widget>
      </item>
     </layout>

--- a/src/gui/ExportPdfDialog.ui
+++ b/src/gui/ExportPdfDialog.ui
@@ -718,6 +718,9 @@
        <property name="text">
         <string>OK</string>
        </property>
+       <property name="default">
+        <bool>true</bool>
+       </property>
       </widget>
      </item>
     </layout>

--- a/src/gui/ExportSvgDialog.ui
+++ b/src/gui/ExportSvgDialog.ui
@@ -205,6 +205,9 @@
        <property name="text">
         <string>OK</string>
        </property>
+       <property name="default">
+        <bool>true</bool>
+       </property>
       </widget>
      </item>
     </layout>

--- a/src/gui/FontListDialog.ui
+++ b/src/gui/FontListDialog.ui
@@ -31,6 +31,9 @@
      <property name="text">
       <string>&amp;OK</string>
      </property>
+     <property name="default">
+      <bool>true</bool>
+     </property>
     </widget>
    </item>
    <item row="4" column="3">

--- a/src/gui/LibraryInfoDialog.ui
+++ b/src/gui/LibraryInfoDialog.ui
@@ -63,6 +63,9 @@
      <property name="text">
       <string>&amp;OK</string>
      </property>
+     <property name="default">
+      <bool>true</bool>
+     </property>
     </widget>
    </item>
   </layout>

--- a/src/gui/OctoPrintApiKeyDialog.ui
+++ b/src/gui/OctoPrintApiKeyDialog.ui
@@ -95,6 +95,9 @@
        <property name="text">
         <string>OK</string>
        </property>
+       <property name="default">
+        <bool>true</bool>
+       </property>
       </widget>
      </item>
     </layout>

--- a/src/gui/PrintInitDialog.ui
+++ b/src/gui/PrintInitDialog.ui
@@ -183,6 +183,9 @@
        <property name="text">
         <string>OK</string>
        </property>
+       <property name="default">
+        <bool>true</bool>
+       </property>
       </widget>
      </item>
     </layout>


### PR DESCRIPTION
Like it says on the tin:  set [OK] as the default for the various dialogs.

Only PDF and SVG export had a problem.  I think the others were OK because their (perhaps implicit) tab stop order put [OK] first and so it was the "automatic" default.  I added the entry to all of them, for consistency.
