### PR TITLE
Ignore .clangd in workspace directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -101,3 +101,4 @@ tests/regression/export-pdf-fill/simple-pdf.pdf
 tests/regression/export-pdf/centered.pdf
 tests/regression/export-pdf/simple-pdf.pdf
 scripts/run-clang-tidy-cached
+.clangd


### PR DESCRIPTION
I have a .clangd directory in the workspace from some tooling. I'd like to exclude it from the git repo.