### PR TITLE
Revert "Workaround for pinned CMake": The underlying bug was fixed by GitHub

### DIFF
--- a/.github/workflows/macos-tests.yml
+++ b/.github/workflows/macos-tests.yml
@@ -51,13 +51,6 @@ jobs:
       run: |
         brew unlink python3
         brew link --overwrite python3
-    - name: Workaround for https://github.com/actions/runner-images/pull/12791
-      run: |
-        if brew tap-info local/pinned; then
-          brew uninstall cmake
-          brew untap local/pinned
-          brew install cmake
-        fi
     - name: Install Homebrew packages
       env:
         HOMEBREW_NO_AUTO_UPDATE: 1


### PR DESCRIPTION
Reverts openscad/openscad#6145

The underlying bug was fixed by GitHub: https://github.com/actions/runner-images/issues/12912