### PR TITLE
Reset scope_stack when leaving parser with error

### DIFF
--- a/src/core/parser.y
+++ b/src/core/parser.y
@@ -833,7 +833,7 @@ bool parse(SourceFile *&file, const std::string& text, const std::string &filena
   file = rootfile;
   if (parserretval != 0) {
     // Clear scope_stack when parsing aborted
-    scope_stack = std::stack<std::shared_ptr<LocalScope>>();
+    scope_stack = {};
     return false;
   }
 


### PR DESCRIPTION
Fixes #6189

Manually validated with test case.

Should fix leaking LocalScope objects when getting parser errors.

No other returns appear to happen between the first interaction with scope_stack and the assert for size==0.