### PR TITLE
Fix uni-get-dependencies.sh

### DIFF
--- a/scripts/uni-get-dependencies.sh
+++ b/scripts/uni-get-dependencies.sh
@@ -176,7 +176,7 @@ if [ -e /etc/issue ]; then
   get_mageia_deps
  elif [ "`grep -i qomo /etc/issue`" ]; then
   get_qomo_deps
- elif [ "`grep -i arch /etc/issue`" ]; then
+ elif test -r /etc/arch-release ; then
    get_arch_deps
  elif [ -e /etc/fedora-release ]; then
   if [ "`grep -i fedora.release /etc/fedora-release`" ]; then

--- a/scripts/uni-get-dependencies.sh
+++ b/scripts/uni-get-dependencies.sh
@@ -104,21 +104,22 @@ get_debian_deps()
 {
  apt-get update
  apt-get -y install \
-  build-essential bison flex git curl cmake ninja-build libffi-dev \
+  bison build-essential cmake curl flex gettext git gtk-doc-tools imagemagick \
   libboost-program-options-dev libboost-regex-dev libboost-system-dev \
-  libmpfr-dev libglew-dev libcairo2-dev libharfbuzz-dev \
-  libeigen3-dev libcgal-dev libopencsg-dev libgmp-dev \
-  imagemagick libfreetype-dev libdouble-conversion-dev libxml2-dev \
-  gtk-doc-tools libglib2.0-dev gettext xvfb pkg-config ragel libtbb-dev \
-  libgl1-mesa-dev libxi-dev libxmu-dev libfontconfig-dev libzip-dev \
-  python3-venv
+  libcairo2-dev libcgal-dev libdouble-conversion-dev libeigen3-dev libffi-dev \
+  libfontconfig-dev libfreetype-dev libgl1-mesa-dev libglew-dev libglib2.0-dev \
+  libgmp-dev libharfbuzz-dev libmimalloc-dev libmpfr-dev libopencsg-dev \
+  libqt5gamepad5-dev libtbb-dev libxi-dev libxml2-dev libxmu-dev libzip-dev \
+  nettle-dev ninja-build pkg-config python3-dev python3-dev python3-setuptools \
+  python3-venv ragel xvfb
  get_qt5_deps_debian
 }
 
 get_qt5_deps_debian()
 {
- apt-get -y install qtbase5-dev libqscintilla2-qt5-dev libqt5opengl5-dev \
-  libqt5svg5-dev qtmultimedia5-dev libqt5multimedia5-plugins qt5-qmake
+ apt-get -y install \
+  libqscintilla2-qt5-dev libqt5multimedia5-plugins libqt5opengl5-dev \
+  libqt5svg5-dev qt5-qmake qtbase5-dev qtmultimedia5-dev
 }
 
 get_arch_deps()

--- a/scripts/uni-get-dependencies.sh
+++ b/scripts/uni-get-dependencies.sh
@@ -123,11 +123,13 @@ get_qt5_deps_debian()
 
 get_arch_deps()
 {
-  pacman -S --noconfirm \
-	base-devel gcc bison flex make libzip \
-	qt5 qscintilla-qt5 cgal gmp mpfr boost opencsg \
-	glew eigen glib2 fontconfig freetype2 harfbuzz \
-	double-conversion imagemagick tbb
+  pacman -Syu --noconfirm --needed \
+	base-devel boost cairo cgal cmake double-conversion eigen fontconfig \
+  freetype2 gcc-libs ghostscript glew glib2 glibc glu gmp harfbuzz \
+  hicolor-icon-theme hidapi imagemagick lib3mf libglvnd libspnav libx11 \
+  libxml2 libzip mimalloc mpfr nettle opencsg procps-ng python python-pip \
+  python-setuptools qscintilla-qt5 qt5-base qt5-multimedia qt5-svg tbb \
+  xorg-server-xvfb
 }
 
 get_solus_deps()


### PR DESCRIPTION
I did experiments with building PythonSCAD using Docker.

My Dockerfile looks like this:

```Docker
FROM archlinux:latest

COPY . /opt/openscad

RUN rm -rf /opt/openscad/build

WORKDIR /opt/openscad

RUN scripts/uni-get-dependencies.sh

RUN cmake -B build

RUN cmake --build build -j$(nproc)

WORKDIR /opt/openscad/build

RUN ctest -j$(nproc) --output-on-failure

# Default command
CMD ["build/openscad"]
```

You can build it with `docker build -f /path/to/dockerfile /path/to/openscad/repository`.

I did tests with a few Linux distributions by changing the `FROM` line accordingly:

```Docker
FROM archlinux:latest
FROM debian:12
FROM fedora:42
FROM linuxmintd/mint22.2-amd64
FROM ubuntu:22.04
FROM ubuntu:25.04
```

With this approach, it's extremely low effort to test whether OpenSCAD builds on a particular flavor of Linux (would be nice it this worked for Windows, macOS and *BSD too but unfortunately it doesn't). As those Docker base images are quite minimalist, this seems to be a good approach to test for the completeness of `scripts/uni-get-dependencies.sh`.

There were a few build failures, mainly due to `cmake` not finding required libraries, but also some compile time issues due to missing libs.

I updated `scripts/uni-get-dependencies.sh` accordingly until all builds were successful and ported the changes over to OpenSCAD. During that porting I removed "curl" and "libsvg", as at the moment those are not required by OpenSCAD yet.

The result is this PR.

So far I have those Docker files locally on my machine only, but if you like, I'm happy to contribute them to OpenSCAD in a new PR.
Maybe in `/docker-files/ubuntu22.04/Dockerfile` or something like this, with a small documentation of how to use them properly in `/docker-files/README.md`.

Let me know what you think please.