### PR TITLE
docs: Document operators `&`, `|` and `-` between two objects

### DIFF
--- a/doc/openscad.pyi
+++ b/doc/openscad.pyi
@@ -292,6 +292,21 @@ class OpenSCADObject:
     def __getitem__(self, name): ...
     def __setitem__(self, name, value): ...
 
+    # Operators:
+
+    def __or__(self, other: OpenSCADObjects) -> "OpenSCADObject":
+        """Create a union of two objects"""
+        ...
+
+    def __and__(self, other: OpenSCADObjects) -> "OpenSCADObject":
+        """Create an intersection of two objects"""
+        ...
+
+    def __sub__(self, other: OpenSCADObjects) -> "OpenSCADObject":
+        """Create a difference of two objects"""
+        ...
+    # TODO: document __add__, __sub__ and __mul__ with a list of vectors
+
 def square(
     dim: Optional[Union[float, list[float]]] = None, center: Optional[bool] = None
 ) -> OpenSCADObject:


### PR DESCRIPTION
As suggested by @gsohler in #6203, document the Python operators between two objects:

* `&` returns the intersection of the two operands
* `|` returns the union of the two operands
* `-` returns the difference of the two operands

The code also seems to support `+`, `-` and `*` between an object and a vector, but I left that as a TODO, because if I understand the code correctly, it currently requires a _list of vectors_ on the RHS, not just a vector.