### PR TITLE
python: Fix `fs` is required when generating some objects

### DIFF
--- a/src/python/pyopenscad.cc
+++ b/src/python/pyopenscad.cc
@@ -276,8 +276,8 @@ void get_fnas(double& fn, double& fa, double& fs)
     }
   }
 
-  PyObjectUniquePtr varFs(PyObject_GetAttrString(mainModule, "fs"), PyObjectDeleter);
   if (PyObject_HasAttrString(mainModule, "fs")) {
+    PyObjectUniquePtr varFs(PyObject_GetAttrString(mainModule, "fs"), PyObjectDeleter);
     if (varFs.get() != nullptr) {
       fs = PyFloat_AsDouble(varFs.get());
     }


### PR DESCRIPTION
The `get_fnas` function accidentally tries to load `fs` even if it is not defined, resulting in an exception when generating some objects like sphere() or text().

Fixes: c3d173854efafdc95aa9ff962e5a69b69e7f1590