### PR TITLE
python: Run python when called as `python` or `python3` in addition to `openscad-python`

### DIFF
--- a/src/openscad.cc
+++ b/src/openscad.cc
@@ -824,7 +824,8 @@ int main(int argc, char **argv)
   // The original name as called, not resolving links and so on. This will
   // just forward everything to the python main.
   const auto applicationName = fs::path(argv[0]).filename().generic_string();
-  if (applicationName == "openscad-python") {
+  if (applicationName == "python" || applicationName == "python3" ||
+      applicationName.rfind("python3.", 0) == 0 || applicationName == "openscad-python") {
     return pythonRunArgs(argc, argv);
   }
 #endif


### PR DESCRIPTION
This is arguably a PEBKAC problem, but I couldn't make the virtualenv created by OpenSCAD to work, until I realize that it only works when you call `bin/openscad-python`, and `bin/python` and `bin/python3` are broken.

Support calling the OpenSCAD binary as `python` or `python3` in addition to `openscad-python`.