### PR TITLE
python: Fully destroy the intepreter on re-evaluation

### DIFF
--- a/src/gui/MainWindow.cc
+++ b/src/gui/MainWindow.cc
@@ -2127,6 +2127,7 @@ std::shared_ptr<SourceFile> MainWindow::parseDocument(EditorInterface *editor)
     auto error = evaluatePython(fulltext_py, false);
     if (error.size() > 0) LOG(message_group::Error, Location::NONE, "", error.c_str());
     fulltext = "\n";
+    finishPython();
   }
 #endif  // ifdef ENABLE_PYTHON
 

--- a/src/openscad.cc
+++ b/src/openscad.cc
@@ -605,6 +605,7 @@ int cmdline(const CommandLine& cmd)
     auto error = evaluatePython(fulltext_py, false);
     if (error.size() > 0) LOG(error.c_str());
     text = "\n";
+    finishPython();
   }
 #endif  // ifdef ENABLE_PYTHON
   text += "\n\x03\n" + commandline_commands;


### PR DESCRIPTION
I have seen a crash in the current code when importing a file that is not part of a package, like:

```
├── foo
│   ├── bar
│   │   └── baz.py
│   └── __init__.py
└── scad.py
```

scad.py:

```
import os
import sys

if os.getcwd() not in sys.path:
    sys.path.append(os.getcwd())

import foo.bar.baz
```

Would crash `openscad` on re-evaluation of the `scad.py` file.

The crashdump is in `initPython`, somewhere where it tries to empty the `sys.modules` dict:

```
#0  0x00007fa843b7e12e PyUnicode_AsEncodedString (libpython3.13.so.1.0 + 0x17e12e)
#1  0x0000000000d2f093 _Z10initPythonRKNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEd (/home/damz/Downloads/openscad/build/openscad + 0x92f0>
#2  0x0000000000f0b40b _ZN10MainWindow13parseDocumentEP15EditorInterface (/home/damz/Downloads/openscad/build/openscad + 0xb0b40b)
```

## Proposed solution

Instead of trying to manually reinit the environment, which is messy and doesn't reverts all the side-effects that could have happened (like modifying `sys.path` above), tear down the interpreter with `Py_FinalizeEx` (available since Python 3.6, released in 2016).

Note that the patch is messy but trivial: it is literally just removing a bunch of code from `initPython`. Look at it with ["Hide whitespace" enabled](https://github.blog/news-insights/product-news/ignore-white-space-in-code-review/) in the diff view (or `git show -w` in the CLI).