### PR TITLE
Allow minkowski where one operand is non-manifold

### DIFF
--- a/scripts/macosx-build-dependencies.sh
+++ b/scripts/macosx-build-dependencies.sh
@@ -89,7 +89,7 @@ PACKAGES=(
     "cairo 1.18.0"
 
     # https://github.com/CGAL/cgal/releases
-    "cgal 6.0.1"
+    "cgal 6.0.2"
 
     # Using Qt6 going forward, leaving Qt5 config just in case
     # "qt5 5.15.16"

--- a/src/geometry/cgal/cgalutils-polyhedron.cc
+++ b/src/geometry/cgal/cgalutils-polyhedron.cc
@@ -272,9 +272,48 @@ void convertNefToSurfaceMesh(const CGAL_Nef_polyhedron3& nef, SurfaceMesh& mesh)
   CGAL::convert_nef_polyhedron_to_polygon_mesh(nef, mesh, triangulate);
 }
 
-void convertSurfaceMeshToNef(const CGAL_Kernel3Mesh& mesh, CGAL_Nef_polyhedron3& nef)
+CGAL_Nef_polyhedron3 convertSurfaceMeshToNef(const CGAL_Kernel3Mesh& mesh)
 {
-  nef = CGAL_Nef_polyhedron3(mesh);
+  // Note: The CGAL_Nef_polyhedron3 constructor may throw an exception if the input mesh is
+  // self-intersecting, e.g. if a very thin part of an object collapses into one
+  // floating point coordinate, but the vertices are still distinct, it's
+  // considered a self-intersection. This is valid in e.g. Manifold, but invalid
+  // in SurfaceMesh -> Nef.
+  // If this happens, we fall back to unioning all faces, which is slower but more
+  // robust.
+  try {
+    return CGAL_Nef_polyhedron3(mesh);
+  } catch (const CGAL::Assertion_exception& e) {
+    std::cerr << "Warning: CGAL error in CGAL_Nef_polyhedron3(): Attempting union..." << std::endl;
+
+    CGAL::Nef_nary_union_3<CGAL_Nef_polyhedron3> nary_union;
+    int discarded_facets = 0;
+    for (const auto face : mesh.faces()) {
+      std::vector<CGAL::Point_3<CGAL_Kernel3>> vertices;
+      for (auto vd : CGAL::vertices_around_face(mesh.halfedge(face), mesh)) {
+        vertices.push_back(mesh.point(vd));
+      }
+
+      bool is_nef = false;
+      if (vertices.size() >= 1) {
+        CGAL_Nef_polyhedron3 nef(vertices.begin(), vertices.end());
+        if (!nef.is_empty()) {
+          nary_union.add_polyhedron(nef);
+          is_nef = true;
+        }
+      }
+      if (!is_nef) {
+        discarded_facets++;
+      }
+    }
+    if (discarded_facets > 0) {
+      std::cerr << "Discarded " << discarded_facets << " facets." << std::endl;
+    }
+    CGAL_Nef_polyhedron3 nef_union = nary_union.get_union();
+    CGAL::Mark_bounded_volumes<CGAL_Nef_polyhedron3> mbv(true);
+    nef_union.delegate(mbv);
+    return nef_union;
+  }
 }
 
 template <typename Polyhedron>

--- a/src/geometry/cgal/cgalutils.cc
+++ b/src/geometry/cgal/cgalutils.cc
@@ -48,17 +48,24 @@ std::unique_ptr<CGALNefGeometry> createNefPolyhedronFromPolySet(const PolySet& p
   assert(ps.getDimension() == 3);
 
   // Since is_convex doesn't work well with non-planar faces,
-  // we tessellate the polyset before checking.
-  PolySet psq(ps);
-  std::vector<Vector3d> points3d;
-  psq.quantizeVertices(&points3d);
-  auto ps_tri = PolySetUtils::tessellate_faces(psq);
-  if (ps_tri->isConvex()) {
+  // we tessellate the polyset first, if necessary.
+  std::unique_ptr<PolySet> tmp;
+  const PolySet& triangle_set = [&tmp](const PolySet& ps) {
+    if (ps.isTriangular()) {
+      return ps;
+    }
+    PolySet psq(ps);
+    psq.quantizeVertices();
+    tmp = PolySetUtils::tessellate_faces(psq);
+    return *tmp;
+  }(ps);
+
+  if (triangle_set.isConvex()) {
     using Hull_kernel = CGAL::Epick;
     // Collect point cloud
-    std::vector<Hull_kernel::Point_3> points(points3d.size());
-    for (size_t i = 0, n = points3d.size(); i < n; i++) {
-      points[i] = vector_convert<Hull_kernel::Point_3>(points3d[i]);
+    std::vector<Hull_kernel::Point_3> points(triangle_set.vertices.size());
+    for (size_t i = 0, n = triangle_set.vertices.size(); i < n; i++) {
+      points[i] = vector_convert<Hull_kernel::Point_3>(triangle_set.vertices[i]);
     }
 
     if (points.size() <= 3) return std::make_unique<CGALNefGeometry>();
@@ -75,7 +82,7 @@ std::unique_ptr<CGALNefGeometry> createNefPolyhedronFromPolySet(const PolySet& p
   auto plane_error = false;
   try {
     CGAL_Polyhedron P;
-    auto err = CGALUtils::createPolyhedronFromPolySet(psq, P);
+    auto err = CGALUtils::createPolyhedronFromPolySet(triangle_set, P);
     if (!err) {
       if (!P.is_closed()) {
         LOG(message_group::Error, "The given mesh is not closed! Unable to convert to CGALNefGeometry.");
@@ -99,7 +106,7 @@ std::unique_ptr<CGALNefGeometry> createNefPolyhedronFromPolySet(const PolySet& p
   }
   if (plane_error) try {
       CGAL_Polyhedron P;
-      auto err = CGALUtils::createPolyhedronFromPolySet(*ps_tri, P);
+      auto err = CGALUtils::createPolyhedronFromPolySet(triangle_set, P);
       if (!err) {
         PRINTDB("Polyhedron is closed: %d", P.is_closed());
         PRINTDB("Polyhedron is valid: %d", P.is_valid(false, 0));

--- a/src/geometry/cgal/cgalutils.h
+++ b/src/geometry/cgal/cgalutils.h
@@ -116,7 +116,7 @@ template <typename K>
 void convertNefToPolyhedron(const CGAL::Nef_polyhedron_3<K>& nef, CGAL::Polyhedron_3<K>& polyhedron);
 
 void convertNefToSurfaceMesh(const CGAL_Nef_polyhedron3& nef, CGAL_Kernel3Mesh& mesh);
-void convertSurfaceMeshToNef(const CGAL_Kernel3Mesh& mesh, CGAL_Nef_polyhedron3& nef);
+CGAL_Nef_polyhedron3 convertSurfaceMeshToNef(const CGAL_Kernel3Mesh& mesh);
 
 #endif
 std::unique_ptr<PolySet> createTriangulatedPolySetFromPolygon2d(const Polygon2d& polygon2d);

--- a/src/geometry/manifold/manifold-applyops-minkowski.cc
+++ b/src/geometry/manifold/manifold-applyops-minkowski.cc
@@ -101,10 +101,11 @@ std::shared_ptr<const Geometry> applyMinkowski(const Geometry::Geometries& child
           } else {
             // The CGAL_Nef_polyhedron3 constructor can crash on bad polyhedron, so don't try
             if (!mesh->is_valid()) throw 0;
-            CGAL_Nef_polyhedron3 decomposed_nef;
-            CGALUtils::convertSurfaceMeshToNef(*mesh, decomposed_nef);
+            CGAL_Nef_polyhedron3 decomposed_nef = CGALUtils::convertSurfaceMeshToNef(*mesh);
             CGAL::Timer t;
             t.start();
+            // TODO(kintel): If !decomposed_nef.is_valid(), we probably should not continue. When will
+            // this happen though?
             CGAL::convex_decomposition_3(decomposed_nef);
 
             // the first volume is the outer volume, which ignored in the decomposition


### PR DESCRIPTION
This is an attempt at fixing #5866 by implementing a fallback mechanism for creating nef polyhedrons from non-manifold (e.g. self-intersecting) geometry.