### PR TITLE
Refactor Discretization Special Usage

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -853,6 +853,7 @@ set(CORE_SOURCES
   src/core/ContextFrame.cc
   src/core/ContextMemoryManager.cc
   src/core/CsgOpNode.cc
+  src/core/CurveDiscretizer.cc
   src/core/DrawingCallback.cc
   src/core/EvaluationSession.cc
   src/core/Expression.cc
@@ -878,7 +879,6 @@ set(CORE_SOURCES
   src/core/SourceFileCache.cc
   src/core/StatCache.cc
   src/core/SurfaceNode.cc
-  src/core/TessellationControl.cc
   src/core/TextNode.cc
   src/core/TransformNode.cc
   src/core/Tree.cc

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -878,6 +878,7 @@ set(CORE_SOURCES
   src/core/SourceFileCache.cc
   src/core/StatCache.cc
   src/core/SurfaceNode.cc
+  src/core/TessellationControl.cc
   src/core/TextNode.cc
   src/core/TransformNode.cc
   src/core/Tree.cc

--- a/src/core/CurveDiscretizer.cc
+++ b/src/core/CurveDiscretizer.cc
@@ -1,4 +1,4 @@
-#include "core/TessellationControl.h"
+#include "core/CurveDiscretizer.h"
 
 #ifdef ENABLE_PYTHON
 #include "python/pyopenscad.h"
@@ -12,7 +12,7 @@
 
 #define F_MINIMUM 0.01
 
-TessellationControl::TessellationControl(const Parameters& parameters, const ModuleInstantiation *inst)
+CurveDiscretizer::CurveDiscretizer(const Parameters& parameters, const ModuleInstantiation *inst)
 {
   fn = parameters["$fn"].toDouble();
   fs = parameters["$fs"].toDouble();
@@ -74,7 +74,7 @@ void trySetVariable(PyObject *kwargs, const char *string_input, double *var_ptr)
   }
 }
 
-TessellationControl::TessellationControl(PyObject *kwargs)
+CurveDiscretizer::CurveDiscretizer(PyObject *kwargs)
 {
   setValuesFromPyMain();
   if (kwargs == nullptr || !PyDict_Check(kwargs)) {
@@ -86,7 +86,7 @@ TessellationControl::TessellationControl(PyObject *kwargs)
   trySetVariable(kwargs, "fa", &this->fa);
 }
 
-void TessellationControl::setValuesFromPyMain()
+void CurveDiscretizer::setValuesFromPyMain()
 {
   PyObject *mainModule = PyImport_AddModule("__main__");
   if (mainModule == nullptr) {
@@ -133,7 +133,7 @@ void TessellationControl::setValuesFromPyMain()
    Returns the number of subdivision of a whole circle, given radius and
    the three special variables $fn, $fs and $fa
  */
-std::optional<int> TessellationControl::circular_segments(double r, double angle_degrees) const
+std::optional<int> CurveDiscretizer::GetCircularSegmentCount(double r, double angle_degrees) const
 {
   // FIXME: It would be better to refuse to create an object. Let's do more strict error handling
   // in future versions of OpenSCAD
@@ -146,10 +146,10 @@ std::optional<int> TessellationControl::circular_segments(double r, double angle
                   1);
 }
 
-std::ostream& operator<<(std::ostream& stream, const std::shared_ptr<TessellationControl>& f)
+std::ostream& operator<<(std::ostream& stream, const std::shared_ptr<CurveDiscretizer>& f)
 {
   if (!f) {
-    return stream << "[null TessellationControl]";
+    return stream << "[null CurveDiscretizer]";
   }
   stream << "$fn = " << f->fn << ", $fa = " << f->fa << ", $fs = " << f->fs;
   return stream;

--- a/src/core/CurveDiscretizer.h
+++ b/src/core/CurveDiscretizer.h
@@ -11,51 +11,51 @@
 class Parameters;
 class ModuleInstantiation;
 
-class TessellationControl
+class CurveDiscretizer
 {
 public:
-  TessellationControl(const Parameters& parameters, const ModuleInstantiation *inst = nullptr);
+  CurveDiscretizer(const Parameters& parameters, const ModuleInstantiation *inst = nullptr);
 #ifdef ENABLE_PYTHON
   /**
    * Extract discretization values from environment if possible,
    * then override any which are explicitly set as keyword arguments.
    */
-  TessellationControl(PyObject *kwargs);
+  CurveDiscretizer(PyObject *kwargs);
 #endif
 
   /**
-   * Create a TessellationControl for a spot in dxfdim.cc that used a hardcoded value.
+   * Create a CurveDiscretizer for a spot in dxfdim.cc that used a hardcoded value.
    * These values of 36,0,0 go back to the first commit in Github.
    * Unknown why it is that.
    */
-  static std::shared_ptr<TessellationControl> DefaultForDxf()
+  static std::shared_ptr<CurveDiscretizer> DefaultForDxf()
   {
-    return std::make_shared<TessellationControl>(std::move(TessellationControl(36, 0, 0)));
+    return std::make_shared<CurveDiscretizer>(std::move(CurveDiscretizer(36, 0, 0)));
   }
 
   /**
    * Calculate segments for a circle or circular arc.
    */
-  std::optional<int> circular_segments(double r, double angle_degrees = 360.0) const;
+  std::optional<int> GetCircularSegmentCount(double r, double angle_degrees = 360.0) const;
 
   /**
    * @brief Calculate segments for a path.
    * Currently only uses $fn. Won't use $fs or $fa, but future variables could be used.
    */
-  unsigned long path_segments(unsigned long minimum) const
+  unsigned long GetPathSegmentCount(unsigned long minimum) const
   {
     unsigned long result = (fn > 3.0) ? static_cast<unsigned long>(fn) : 3;
     return std::max(result, minimum);
   }
 
-  friend std::ostream& operator<<(std::ostream& stream, const std::shared_ptr<TessellationControl>& f);
+  friend std::ostream& operator<<(std::ostream& stream, const std::shared_ptr<CurveDiscretizer>& f);
   bool IsFnSpecifiedAndOdd() { return static_cast<int>(fn) & 1; }
 
 private:
-  TessellationControl(double fn, double fs, double fa) : fn(fn), fs(fs), fa(fa) {}
+  CurveDiscretizer(double fn, double fs, double fa) : fn(fn), fs(fs), fa(fa) {}
   double fn, fs, fa;
 #ifdef ENABLE_PYTHON
   void setValuesFromPyMain();
 #endif
 };
-std::ostream& operator<<(std::ostream& stream, const std::shared_ptr<TessellationControl>& f);
+std::ostream& operator<<(std::ostream& stream, const std::shared_ptr<CurveDiscretizer>& f);

--- a/src/core/FreetypeRenderer.cc
+++ b/src/core/FreetypeRenderer.cc
@@ -41,7 +41,7 @@
 
 #include "FontCache.h"
 #include "core/DrawingCallback.h"
-#include "core/TessellationControl.h"
+#include "core/CurveDiscretizer.h"
 #include "utils/calc.h"
 
 #include FT_OUTLINE_H
@@ -251,7 +251,7 @@ void FreetypeRenderer::Params::detect_properties()
   hb_direction_t hbdirection = detect_direction(hbscript);
   set_direction(hb_direction_to_string(hbdirection));
 
-  auto segments = tessFIXME->circular_segments(size).value_or(3);
+  auto segments = discretizer->GetCircularSegmentCount(size).value_or(3);
   // The curved segments of most fonts are relatively short, so
   // by using a fraction of the number of full circle segments
   // the resolution will be better matching the detail level of
@@ -266,7 +266,7 @@ std::ostream& operator<<(std::ostream& stream, const FreetypeRenderer::Params& p
                 << ", spacing = " << params.spacing << ", font = \"" << params.font
                 << "\", direction = \"" << params.direction << "\", language = \"" << params.language
                 << (params.script.empty() ? "" : "\", script = \"") << params.script << "\", halign = \""
-                << params.halign << "\", valign = \"" << params.valign << "\", " << params.tessFIXME;
+                << params.halign << "\", valign = \"" << params.valign << "\", " << params.discretizer;
 }
 
 const FontFacePtr FreetypeRenderer::Params::get_font_face() const
@@ -309,7 +309,7 @@ void FreetypeRenderer::Params::set(Parameters& parameters)
   (void)parameters.valid("halign", Value::Type::STRING);
   (void)parameters.valid("valign", Value::Type::STRING);
 
-  tessFIXME = std::make_shared<TessellationControl>(parameters);
+  discretizer = std::make_shared<CurveDiscretizer>(parameters);
 
   set_size(parameters.get("size", 10.0));
   set_text(parameters.get("text", ""));
@@ -325,7 +325,7 @@ void FreetypeRenderer::Params::set(Parameters& parameters)
 #ifdef ENABLE_PYTHON
 void FreetypeRenderer::Params::set(PyObject *kwargs)
 {
-  tessFIXME = std::make_shared<TessellationControl>(kwargs);
+  discretizer = std::make_shared<CurveDiscretizer>(kwargs);
 
   set_size(10.0);
   set_text("");

--- a/src/core/FreetypeRenderer.h
+++ b/src/core/FreetypeRenderer.h
@@ -41,7 +41,7 @@
 #include FT_FREETYPE_H
 #include FT_GLYPH_H
 
-class TessellationControl;
+class CurveDiscretizer;
 
 class FreetypeRenderer
 {
@@ -71,7 +71,7 @@ public:
 
   private:
     double size, spacing;
-    std::shared_ptr<TessellationControl> tessFIXME;
+    std::shared_ptr<CurveDiscretizer> discretizer;
     unsigned int segments;
     std::string text, font, direction, language, script, halign, valign;
     Location loc = Location::NONE;

--- a/src/core/FreetypeRenderer.h
+++ b/src/core/FreetypeRenderer.h
@@ -29,6 +29,9 @@
 #include <string>
 #include <vector>
 #include <ostream>
+#ifdef ENABLE_PYTHON
+#include <Python.h>
+#endif
 
 #include "core/AST.h"
 #include "core/Parameters.h"
@@ -38,6 +41,8 @@
 #include FT_FREETYPE_H
 #include FT_GLYPH_H
 
+class TessellationControl;
+
 class FreetypeRenderer
 {
 public:
@@ -46,9 +51,6 @@ public:
   public:
     void set_size(double size) { this->size = size; }
     void set_spacing(double spacing) { this->spacing = spacing; }
-    void set_fn(double fn) { this->fn = fn; }
-    void set_fa(double fa) { this->fa = fa; }
-    void set_fs(double fs) { this->fs = fs; }
     void set_segments(unsigned int segments) { this->segments = segments; }
     void set_text(const std::string& text) { this->text = text; }
     void set_font(const std::string& font) { this->font = font; }
@@ -60,20 +62,16 @@ public:
     void set_loc(const Location& loc) { this->loc = loc; }
     void set_documentPath(const std::string& path) { this->documentPath = path; }
     void set(Parameters& parameters);
+#ifdef ENABLE_PYTHON
+    void set(PyObject *kwargs);
+#endif
     [[nodiscard]] const FontFacePtr get_font_face() const;
     void detect_properties();
-    friend std::ostream& operator<<(std::ostream& stream, const FreetypeRenderer::Params& params)
-    {
-      return stream << "text = \"" << params.text << "\", size = " << params.size
-                    << ", spacing = " << params.spacing << ", font = \"" << params.font
-                    << "\", direction = \"" << params.direction << "\", language = \"" << params.language
-                    << (params.script.empty() ? "" : "\", script = \"") << params.script
-                    << "\", halign = \"" << params.halign << "\", valign = \"" << params.valign
-                    << "\", $fn = " << params.fn << ", $fa = " << params.fa << ", $fs = " << params.fs;
-    }
+    friend std::ostream& operator<<(std::ostream& stream, const FreetypeRenderer::Params& params);
 
   private:
-    double size, spacing, fn, fa, fs;
+    double size, spacing;
+    std::shared_ptr<TessellationControl> tessFIXME;
     unsigned int segments;
     std::string text, font, direction, language, script, halign, valign;
     Location loc = Location::NONE;

--- a/src/core/ImportNode.cc
+++ b/src/core/ImportNode.cc
@@ -39,7 +39,7 @@
 #include "core/module.h"
 #include "core/ModuleInstantiation.h"
 #include "core/Parameters.h"
-#include "core/TessellationControl.h"
+#include "core/CurveDiscretizer.h"
 #include "io/DxfData.h"
 #include "io/fileutils.h"
 #include "utils/printutils.h"
@@ -95,8 +95,8 @@ static std::shared_ptr<AbstractNode> do_import(const ModuleInstantiation *inst, 
     else if (ext == ".obj") actualtype = ImportType::OBJ;
   }
 
-  auto node = std::make_shared<ImportNode>(inst, actualtype,
-                                           std::make_shared<TessellationControl>(parameters, inst));
+  auto node =
+    std::make_shared<ImportNode>(inst, actualtype, std::make_shared<CurveDiscretizer>(parameters, inst));
 
   node->filename = filename;
   const auto& layerval = parameters["layer"];
@@ -219,12 +219,13 @@ std::unique_ptr<const Geometry> ImportNode::createGeometry() const
     break;
   }
   case ImportType::SVG: {
-    g = import_svg(this->tessFIXME, this->filename, this->id, this->layer, this->dpi, this->center, loc);
+    g =
+      import_svg(this->discretizer, this->filename, this->id, this->layer, this->dpi, this->center, loc);
     break;
   }
   case ImportType::DXF: {
-    DxfData dd(this->tessFIXME, this->filename, this->layer.value_or(""), this->origin_x, this->origin_y,
-               this->scale);
+    DxfData dd(this->discretizer, this->filename, this->layer.value_or(""), this->origin_x,
+               this->origin_y, this->scale);
     g = optionally_center(dd.toPolygon2d(), this->center);
     break;
   }
@@ -263,7 +264,7 @@ std::string ImportNode::toString() const
     stream << ", dpi = " << this->dpi;
   }
   stream << ", scale = " << this->scale << ", center = " << (this->center ? "true" : "false")
-         << ", convexity = " << this->convexity << ", " << this->tessFIXME
+         << ", convexity = " << this->convexity << ", " << this->discretizer
          << ", timestamp = " << fs_timestamp(path) << ")";
 
   return stream.str();

--- a/src/core/ImportNode.cc
+++ b/src/core/ImportNode.cc
@@ -93,11 +93,7 @@ static std::shared_ptr<AbstractNode> do_import(const ModuleInstantiation *inst, 
     else if (ext == ".obj") actualtype = ImportType::OBJ;
   }
 
-  auto node = std::make_shared<ImportNode>(inst, actualtype);
-
-  node->fn = parameters["$fn"].toDouble();
-  node->fs = parameters["$fs"].toDouble();
-  node->fa = parameters["$fa"].toDouble();
+  auto node = std::make_shared<ImportNode>(inst, actualtype, TessellationControl(parameters, inst));
 
   node->filename = filename;
   const auto& layerval = parameters["layer"];
@@ -220,13 +216,12 @@ std::unique_ptr<const Geometry> ImportNode::createGeometry() const
     break;
   }
   case ImportType::SVG: {
-    g = import_svg(this->fn, this->fs, this->fa, this->filename, this->id, this->layer, this->dpi,
-                   this->center, loc);
+    g = import_svg(this->tess, this->filename, this->id, this->layer, this->dpi, this->center, loc);
     break;
   }
   case ImportType::DXF: {
-    DxfData dd(this->fn, this->fs, this->fa, this->filename, this->layer.value_or(""), this->origin_x,
-               this->origin_y, this->scale);
+    DxfData dd(this->tess, this->filename, this->layer.value_or(""), this->origin_x, this->origin_y,
+               this->scale);
     g = optionally_center(dd.toPolygon2d(), this->center);
     break;
   }
@@ -265,8 +260,8 @@ std::string ImportNode::toString() const
     stream << ", dpi = " << this->dpi;
   }
   stream << ", scale = " << this->scale << ", center = " << (this->center ? "true" : "false")
-         << ", convexity = " << this->convexity << ", $fn = " << this->fn << ", $fa = " << this->fa
-         << ", $fs = " << this->fs << ", timestamp = " << fs_timestamp(path) << ")";
+         << ", convexity = " << this->convexity << ", " << this->tess
+         << ", timestamp = " << fs_timestamp(path) << ")";
 
   return stream.str();
 }

--- a/src/core/ImportNode.h
+++ b/src/core/ImportNode.h
@@ -5,6 +5,7 @@
 #include <boost/optional.hpp>
 
 #include "core/node.h"
+#include "core/TessellationControl.h"
 #include "core/ModuleInstantiation.h"
 #include "core/Value.h"
 
@@ -26,7 +27,10 @@ public:
   constexpr static double SVG_DEFAULT_DPI = 72.0;
 
   VISITABLE();
-  ImportNode(const ModuleInstantiation *mi, ImportType type) : LeafNode(mi), type(type) {}
+  ImportNode(const ModuleInstantiation *mi, ImportType type, TessellationControl&& tess)
+    : LeafNode(mi), type(type), tess(tess)
+  {
+  }
   std::string toString() const override;
   std::string name() const override;
 
@@ -37,7 +41,7 @@ public:
   int convexity;
   bool center;
   double dpi;
-  double fn, fs, fa;
+  TessellationControl tess;
   double origin_x, origin_y, scale;
   double width, height;
   std::unique_ptr<const class Geometry> createGeometry() const override;

--- a/src/core/ImportNode.h
+++ b/src/core/ImportNode.h
@@ -5,7 +5,6 @@
 #include <boost/optional.hpp>
 
 #include "core/node.h"
-#include "core/TessellationControl.h"
 #include "core/ModuleInstantiation.h"
 #include "core/Value.h"
 
@@ -21,14 +20,17 @@ enum class ImportType {
   OBJ,
 };
 
+class TessellationControl;
+
 class ImportNode : public LeafNode
 {
 public:
   constexpr static double SVG_DEFAULT_DPI = 72.0;
 
   VISITABLE();
-  ImportNode(const ModuleInstantiation *mi, ImportType type, TessellationControl&& tess)
-    : LeafNode(mi), type(type), tess(tess)
+  ImportNode(const ModuleInstantiation *mi, ImportType type,
+             std::shared_ptr<TessellationControl> tessFIXME)
+    : LeafNode(mi), type(type), tessFIXME(tessFIXME)
   {
   }
   std::string toString() const override;
@@ -41,7 +43,7 @@ public:
   int convexity;
   bool center;
   double dpi;
-  TessellationControl tess;
+  std::shared_ptr<TessellationControl> tessFIXME;
   double origin_x, origin_y, scale;
   double width, height;
   std::unique_ptr<const class Geometry> createGeometry() const override;

--- a/src/core/ImportNode.h
+++ b/src/core/ImportNode.h
@@ -20,7 +20,7 @@ enum class ImportType {
   OBJ,
 };
 
-class TessellationControl;
+class CurveDiscretizer;
 
 class ImportNode : public LeafNode
 {
@@ -29,8 +29,8 @@ public:
 
   VISITABLE();
   ImportNode(const ModuleInstantiation *mi, ImportType type,
-             std::shared_ptr<TessellationControl> tessFIXME)
-    : LeafNode(mi), type(type), tessFIXME(tessFIXME)
+             std::shared_ptr<CurveDiscretizer> discretizer)
+    : LeafNode(mi), type(type), discretizer(discretizer)
   {
   }
   std::string toString() const override;
@@ -43,7 +43,7 @@ public:
   int convexity;
   bool center;
   double dpi;
-  std::shared_ptr<TessellationControl> tessFIXME;
+  std::shared_ptr<CurveDiscretizer> discretizer;
   double origin_x, origin_y, scale;
   double width, height;
   std::unique_ptr<const class Geometry> createGeometry() const override;

--- a/src/core/OffsetNode.cc
+++ b/src/core/OffsetNode.cc
@@ -81,7 +81,7 @@ std::string OffsetNode::toString() const
   if (!isRadius) {
     stream << ", chamfer = " << (this->chamfer ? "true" : "false");
   }
-  stream << ", " << *this->tessFIXME << ")";
+  stream << ", " << this->tessFIXME << ")";
 
   return stream.str();
 }

--- a/src/core/OffsetNode.cc
+++ b/src/core/OffsetNode.cc
@@ -31,7 +31,7 @@
 #include "core/module.h"
 #include "core/ModuleInstantiation.h"
 #include "core/Parameters.h"
-#include "core/TessellationControl.h"
+#include "core/CurveDiscretizer.h"
 
 #include <clipper2/clipper.offset.h>
 #include <ios>
@@ -41,7 +41,7 @@
 #include <boost/assign/std/vector.hpp>
 using namespace boost::assign;  // bring 'operator+=()' into scope
 
-// Needed here for full definition of TessellationControl.
+// Needed here for full definition of CurveDiscretizer.
 OffsetNode::~OffsetNode() = default;
 
 static std::shared_ptr<AbstractNode> builtin_offset(const ModuleInstantiation *inst, Arguments arguments,
@@ -49,7 +49,7 @@ static std::shared_ptr<AbstractNode> builtin_offset(const ModuleInstantiation *i
 {
   Parameters parameters =
     Parameters::parse(std::move(arguments), inst->location(), {"r"}, {"delta", "chamfer"});
-  auto node = std::make_shared<OffsetNode>(inst, std::make_shared<TessellationControl>(parameters));
+  auto node = std::make_shared<OffsetNode>(inst, std::make_shared<CurveDiscretizer>(parameters));
 
   // default with no argument at all is (r = 1, chamfer = false)
   // radius takes precedence if both r and delta are given.
@@ -81,7 +81,7 @@ std::string OffsetNode::toString() const
   if (!isRadius) {
     stream << ", chamfer = " << (this->chamfer ? "true" : "false");
   }
-  stream << ", " << this->tessFIXME << ")";
+  stream << ", " << this->discretizer << ")";
 
   return stream.str();
 }

--- a/src/core/OffsetNode.cc
+++ b/src/core/OffsetNode.cc
@@ -26,11 +26,11 @@
 
 #include "core/OffsetNode.h"
 
+#include "core/Builtins.h"
 #include "core/Children.h"
 #include "core/module.h"
 #include "core/ModuleInstantiation.h"
 #include "core/Parameters.h"
-#include "core/Builtins.h"
 
 #include <clipper2/clipper.offset.h>
 #include <ios>
@@ -43,14 +43,9 @@ using namespace boost::assign;  // bring 'operator+=()' into scope
 static std::shared_ptr<AbstractNode> builtin_offset(const ModuleInstantiation *inst, Arguments arguments,
                                                     const Children& children)
 {
-  auto node = std::make_shared<OffsetNode>(inst);
-
   Parameters parameters =
     Parameters::parse(std::move(arguments), inst->location(), {"r"}, {"delta", "chamfer"});
-
-  node->fn = parameters["$fn"].toDouble();
-  node->fs = parameters["$fs"].toDouble();
-  node->fa = parameters["$fa"].toDouble();
+  auto node = std::make_shared<OffsetNode>(inst, TessellationControl(parameters));
 
   // default with no argument at all is (r = 1, chamfer = false)
   // radius takes precedence if both r and delta are given.
@@ -82,7 +77,7 @@ std::string OffsetNode::toString() const
   if (!isRadius) {
     stream << ", chamfer = " << (this->chamfer ? "true" : "false");
   }
-  stream << ", $fn = " << this->fn << ", $fa = " << this->fa << ", $fs = " << this->fs << ")";
+  stream << ", " << this->tess << ")";
 
   return stream.str();
 }

--- a/src/core/OffsetNode.cc
+++ b/src/core/OffsetNode.cc
@@ -31,6 +31,7 @@
 #include "core/module.h"
 #include "core/ModuleInstantiation.h"
 #include "core/Parameters.h"
+#include "core/TessellationControl.h"
 
 #include <clipper2/clipper.offset.h>
 #include <ios>
@@ -40,12 +41,15 @@
 #include <boost/assign/std/vector.hpp>
 using namespace boost::assign;  // bring 'operator+=()' into scope
 
+// Needed here for full definition of TessellationControl.
+OffsetNode::~OffsetNode() = default;
+
 static std::shared_ptr<AbstractNode> builtin_offset(const ModuleInstantiation *inst, Arguments arguments,
                                                     const Children& children)
 {
   Parameters parameters =
     Parameters::parse(std::move(arguments), inst->location(), {"r"}, {"delta", "chamfer"});
-  auto node = std::make_shared<OffsetNode>(inst, TessellationControl(parameters));
+  auto node = std::make_shared<OffsetNode>(inst, std::make_shared<TessellationControl>(parameters));
 
   // default with no argument at all is (r = 1, chamfer = false)
   // radius takes precedence if both r and delta are given.
@@ -77,7 +81,7 @@ std::string OffsetNode::toString() const
   if (!isRadius) {
     stream << ", chamfer = " << (this->chamfer ? "true" : "false");
   }
-  stream << ", " << this->tess << ")";
+  stream << ", " << *this->tessFIXME << ")";
 
   return stream.str();
 }

--- a/src/core/OffsetNode.h
+++ b/src/core/OffsetNode.h
@@ -1,25 +1,30 @@
 #pragma once
 
+#include <memory>
+#include <string>
+
 #include "core/ModuleInstantiation.h"
 #include "core/node.h"
-#include "core/TessellationControl.h"
 #include "clipper2/clipper.h"
 
-#include <string>
+class TessellationControl;
 
 class OffsetNode : public AbstractPolyNode
 {
 public:
   VISITABLE();
-  OffsetNode(const ModuleInstantiation *mi, TessellationControl&& tess)
-    : AbstractPolyNode(mi), tess(tess)
+  OffsetNode(const ModuleInstantiation *mi, std::shared_ptr<TessellationControl> tessFIXME)
+    : AbstractPolyNode(mi), tessFIXME(std::move(tessFIXME))
   {
   }
+
+  ~OffsetNode();
+
   std::string toString() const override;
   std::string name() const override { return "offset"; }
 
   bool chamfer{false};
-  TessellationControl tess;
+  std::shared_ptr<TessellationControl> tessFIXME;
   double delta{1};
   double miter_limit{1000000.0};  // currently fixed high value to disable chamfers with jtMiter
   Clipper2Lib::JoinType join_type{Clipper2Lib::JoinType::Round};

--- a/src/core/OffsetNode.h
+++ b/src/core/OffsetNode.h
@@ -7,14 +7,14 @@
 #include "core/node.h"
 #include "clipper2/clipper.h"
 
-class TessellationControl;
+class CurveDiscretizer;
 
 class OffsetNode : public AbstractPolyNode
 {
 public:
   VISITABLE();
-  OffsetNode(const ModuleInstantiation *mi, std::shared_ptr<TessellationControl> tessFIXME)
-    : AbstractPolyNode(mi), tessFIXME(std::move(tessFIXME))
+  OffsetNode(const ModuleInstantiation *mi, std::shared_ptr<CurveDiscretizer> discretizer)
+    : AbstractPolyNode(mi), discretizer(std::move(discretizer))
   {
   }
 
@@ -24,7 +24,7 @@ public:
   std::string name() const override { return "offset"; }
 
   bool chamfer{false};
-  std::shared_ptr<TessellationControl> tessFIXME;
+  std::shared_ptr<CurveDiscretizer> discretizer;
   double delta{1};
   double miter_limit{1000000.0};  // currently fixed high value to disable chamfers with jtMiter
   Clipper2Lib::JoinType join_type{Clipper2Lib::JoinType::Round};

--- a/src/core/OffsetNode.h
+++ b/src/core/OffsetNode.h
@@ -1,7 +1,8 @@
 #pragma once
 
-#include "core/node.h"
 #include "core/ModuleInstantiation.h"
+#include "core/node.h"
+#include "core/TessellationControl.h"
 #include "clipper2/clipper.h"
 
 #include <string>
@@ -10,12 +11,16 @@ class OffsetNode : public AbstractPolyNode
 {
 public:
   VISITABLE();
-  OffsetNode(const ModuleInstantiation *mi) : AbstractPolyNode(mi) {}
+  OffsetNode(const ModuleInstantiation *mi, TessellationControl&& tess)
+    : AbstractPolyNode(mi), tess(tess)
+  {
+  }
   std::string toString() const override;
   std::string name() const override { return "offset"; }
 
   bool chamfer{false};
-  double fn{0}, fs{0}, fa{0}, delta{1};
+  TessellationControl tess;
+  double delta{1};
   double miter_limit{1000000.0};  // currently fixed high value to disable chamfers with jtMiter
   Clipper2Lib::JoinType join_type{Clipper2Lib::JoinType::Round};
 };

--- a/src/core/RotateExtrudeNode.cc
+++ b/src/core/RotateExtrudeNode.cc
@@ -31,7 +31,7 @@
 #include "core/module.h"
 #include "core/ModuleInstantiation.h"
 #include "core/Parameters.h"
-#include "core/TessellationControl.h"
+#include "core/CurveDiscretizer.h"
 #include "utils/printutils.h"
 #include "io/fileutils.h"
 #include "handle_dep.h"
@@ -51,7 +51,7 @@ std::shared_ptr<AbstractNode> builtin_rotate_extrude(const ModuleInstantiation *
     Parameters::parse(std::move(arguments), inst->location(), {"angle", "start"}, {"convexity", "a"});
 
   auto node =
-    std::make_shared<RotateExtrudeNode>(inst, std::make_shared<TessellationControl>(parameters, inst));
+    std::make_shared<RotateExtrudeNode>(inst, std::make_shared<CurveDiscretizer>(parameters, inst));
 
   node->convexity = std::max(2, static_cast<int>(parameters["convexity"].toDouble()));
 
@@ -67,7 +67,7 @@ std::shared_ptr<AbstractNode> builtin_rotate_extrude(const ModuleInstantiation *
     node->start = 180;
   }
   bool hasStart = parameters["start"].getFiniteDouble(node->start);
-  if (!hasAngle && !hasStart && node->tessFIXME->IsFnSpecifiedAndOdd()) {
+  if (!hasAngle && !hasStart && node->discretizer->IsFnSpecifiedAndOdd()) {
     LOG(message_group::Deprecated,
         "In future releases, rotational extrusion without \"angle\" will start at zero, the +X axis.  "
         "Set start=180 to explicitly start on the -X axis.");
@@ -80,7 +80,7 @@ std::shared_ptr<AbstractNode> builtin_rotate_extrude(const ModuleInstantiation *
 
 }  // namespace
 
-// Needs the full definition of TessellationControl
+// Needs the full definition of CurveDiscretizer
 // to generate the code to delete.
 RotateExtrudeNode::~RotateExtrudeNode() = default;
 
@@ -97,7 +97,7 @@ std::string RotateExtrudeNode::toString() const
          << this->start
          << ", "
             "convexity = "
-         << this->convexity << ", " << tessFIXME << ")";
+         << this->convexity << ", " << discretizer << ")";
 
   return stream.str();
 }

--- a/src/core/RotateExtrudeNode.cc
+++ b/src/core/RotateExtrudeNode.cc
@@ -97,7 +97,7 @@ std::string RotateExtrudeNode::toString() const
          << this->start
          << ", "
             "convexity = "
-         << this->convexity << ", " << *tessFIXME << ")";
+         << this->convexity << ", " << tessFIXME << ")";
 
   return stream.str();
 }

--- a/src/core/RotateExtrudeNode.cc
+++ b/src/core/RotateExtrudeNode.cc
@@ -31,12 +31,12 @@
 #include "core/module.h"
 #include "core/ModuleInstantiation.h"
 #include "core/Parameters.h"
+#include "core/TessellationControl.h"
 #include "utils/printutils.h"
 #include "io/fileutils.h"
 #include "handle_dep.h"
 #include <ios>
 #include <utility>
-#include <memory>
 #include <cmath>
 #include <sstream>
 #include <boost/assign/std/vector.hpp>
@@ -50,7 +50,8 @@ std::shared_ptr<AbstractNode> builtin_rotate_extrude(const ModuleInstantiation *
   const Parameters parameters =
     Parameters::parse(std::move(arguments), inst->location(), {"angle", "start"}, {"convexity", "a"});
 
-  auto node = std::make_shared<RotateExtrudeNode>(inst, TessellationControl(parameters, inst));
+  auto node =
+    std::make_shared<RotateExtrudeNode>(inst, std::make_shared<TessellationControl>(parameters, inst));
 
   node->convexity = std::max(2, static_cast<int>(parameters["convexity"].toDouble()));
 
@@ -66,7 +67,7 @@ std::shared_ptr<AbstractNode> builtin_rotate_extrude(const ModuleInstantiation *
     node->start = 180;
   }
   bool hasStart = parameters["start"].getFiniteDouble(node->start);
-  if (!hasAngle && !hasStart && node->tess.IsFnSpecifiedAndOdd()) {
+  if (!hasAngle && !hasStart && node->tessFIXME->IsFnSpecifiedAndOdd()) {
     LOG(message_group::Deprecated,
         "In future releases, rotational extrusion without \"angle\" will start at zero, the +X axis.  "
         "Set start=180 to explicitly start on the -X axis.");
@@ -78,6 +79,10 @@ std::shared_ptr<AbstractNode> builtin_rotate_extrude(const ModuleInstantiation *
 }
 
 }  // namespace
+
+// Needs the full definition of TessellationControl
+// to generate the code to delete.
+RotateExtrudeNode::~RotateExtrudeNode() = default;
 
 std::string RotateExtrudeNode::toString() const
 {
@@ -92,7 +97,7 @@ std::string RotateExtrudeNode::toString() const
          << this->start
          << ", "
             "convexity = "
-         << this->convexity << ", " << tess << ")";
+         << this->convexity << ", " << *tessFIXME << ")";
 
   return stream.str();
 }

--- a/src/core/RotateExtrudeNode.h
+++ b/src/core/RotateExtrudeNode.h
@@ -1,27 +1,30 @@
 #pragma once
 
+#include <memory>
 #include <string>
 
 #include "core/node.h"
 #include "core/ModuleInstantiation.h"
 #include "core/Value.h"
-#include "core/TessellationControl.h"
+
+class TessellationControl;
 
 class RotateExtrudeNode : public AbstractPolyNode
 {
 public:
   VISITABLE();
-  RotateExtrudeNode(const ModuleInstantiation *mi, TessellationControl&& tess)
-    : AbstractPolyNode(mi), tess(tess)
+  RotateExtrudeNode(const ModuleInstantiation *mi, std::shared_ptr<TessellationControl> tessFIXME)
+    : AbstractPolyNode(mi), tessFIXME(std::move(tessFIXME))
   {
     convexity = 0;
     angle = 360;
     start = 0;
   }
+  ~RotateExtrudeNode();
   std::string toString() const override;
   std::string name() const override { return "rotate_extrude"; }
 
   int convexity;
-  TessellationControl tess;
+  std::shared_ptr<TessellationControl> tessFIXME;
   double angle, start;
 };

--- a/src/core/RotateExtrudeNode.h
+++ b/src/core/RotateExtrudeNode.h
@@ -7,14 +7,14 @@
 #include "core/ModuleInstantiation.h"
 #include "core/Value.h"
 
-class TessellationControl;
+class CurveDiscretizer;
 
 class RotateExtrudeNode : public AbstractPolyNode
 {
 public:
   VISITABLE();
-  RotateExtrudeNode(const ModuleInstantiation *mi, std::shared_ptr<TessellationControl> tessFIXME)
-    : AbstractPolyNode(mi), tessFIXME(std::move(tessFIXME))
+  RotateExtrudeNode(const ModuleInstantiation *mi, std::shared_ptr<CurveDiscretizer> discretizer)
+    : AbstractPolyNode(mi), discretizer(std::move(discretizer))
   {
     convexity = 0;
     angle = 360;
@@ -25,6 +25,6 @@ public:
   std::string name() const override { return "rotate_extrude"; }
 
   int convexity;
-  std::shared_ptr<TessellationControl> tessFIXME;
+  std::shared_ptr<CurveDiscretizer> discretizer;
   double angle, start;
 };

--- a/src/core/RotateExtrudeNode.h
+++ b/src/core/RotateExtrudeNode.h
@@ -11,7 +11,8 @@ class RotateExtrudeNode : public AbstractPolyNode
 {
 public:
   VISITABLE();
-  RotateExtrudeNode(const ModuleInstantiation *mi) : AbstractPolyNode(mi)
+  RotateExtrudeNode(const ModuleInstantiation *mi, TessellationControl&& tess)
+    : AbstractPolyNode(mi), tess(tess)
   {
     convexity = 0;
     angle = 360;

--- a/src/core/RotateExtrudeNode.h
+++ b/src/core/RotateExtrudeNode.h
@@ -5,6 +5,7 @@
 #include "core/node.h"
 #include "core/ModuleInstantiation.h"
 #include "core/Value.h"
+#include "core/TessellationControl.h"
 
 class RotateExtrudeNode : public AbstractPolyNode
 {
@@ -13,7 +14,6 @@ public:
   RotateExtrudeNode(const ModuleInstantiation *mi) : AbstractPolyNode(mi)
   {
     convexity = 0;
-    fn = fs = fa = 0;
     angle = 360;
     start = 0;
   }
@@ -21,6 +21,6 @@ public:
   std::string name() const override { return "rotate_extrude"; }
 
   int convexity;
-  double fn, fs, fa;
+  TessellationControl tess;
   double angle, start;
 };

--- a/src/core/TessellationControl.cc
+++ b/src/core/TessellationControl.cc
@@ -33,13 +33,15 @@ TessellationControl::TessellationControl(const Parameters& parameters, const Mod
    Returns the number of subdivision of a whole circle, given radius and
    the three special variables $fn, $fs and $fa
  */
-std::optional<int> TessellationControl::circular_segments(double r) const
+std::optional<int> TessellationControl::circular_segments(double r, double angle_degrees) const
 {
   // FIXME: It would be better to refuse to create an object. Let's do more strict error handling
   // in future versions of OpenSCAD
   if (r < GRID_FINE || std::isinf(fn) || std::isnan(fn)) return {};
-  if (fn > 0.0) return static_cast<int>(fn >= 3 ? fn : 3);
-  return static_cast<int>(ceil(fmax(fmin(360.0 / fa, r * 2 * M_PI / fs), 5)));
+  if (fn > 0.0) return max(static_cast<int>(ceil((fn >= 3 ? fn : 3) * abs(angle_degrees) / 360.0)), 1);
+  return max(
+    static_cast<int>(ceil(fmax(fmin(360.0 / fa, r * 2 * M_PI / fs), 5) * abs(angle_degrees) / 360.0)),
+    1);
 }
 
 std::ostream& operator<<(std::ostream& stream, const TessellationControl& f)

--- a/src/core/TessellationControl.cc
+++ b/src/core/TessellationControl.cc
@@ -43,11 +43,10 @@ TessellationControl::TessellationControl(const Parameters& parameters, const Mod
 
 #ifdef ENABLE_PYTHON
 /**
- * Attempts to set a variable from a Python dictionary, handling
- * double* (direct assignment) and int* (rounding) targets.
+ * Attempts to set a variable from a Python dictionary.
  * On any error, target unchanged.
- * @param kwargs The Python dict (PyObject*) to look up the value in.
- * @param string_input The key (const char*) to search for.
+ * @param kwargs The Python dict to look up the value in.
+ * @param string_input The key to search for.
  * @param var_ptr A pointer to the variable to set on success.
  */
 void trySetVariable(PyObject *kwargs, const char *string_input, double *var_ptr)
@@ -145,12 +144,6 @@ std::optional<int> TessellationControl::circular_segments(double r, double angle
   return std::max(static_cast<int>(std::ceil(std::fabs(angle_degrees) / 360.0 *
                                              std::max(std::min(360.0 / fa, r * 2 * M_PI / fs), 5.0))),
                   1);
-}
-
-std::ostream& operator<<(std::ostream& stream, const TessellationControl& f)
-{
-  stream << "$fn = " << f.fn << ", $fa = " << f.fa << ", $fs = " << f.fs;
-  return stream;
 }
 
 std::ostream& operator<<(std::ostream& stream, const std::shared_ptr<TessellationControl>& f)

--- a/src/core/TessellationControl.cc
+++ b/src/core/TessellationControl.cc
@@ -1,0 +1,49 @@
+#include "core/TessellationControl.h"
+
+#include "core/ModuleInstantiation.h"
+#include "core/Parameters.h"
+#include "geometry/Grid.h"
+#include "utils/printutils.h"
+
+#define F_MINIMUM 0.01
+
+TessellationControl::TessellationControl(const Parameters& parameters, const ModuleInstantiation *inst)
+{
+  fn = parameters["$fn"].toDouble();
+  fs = parameters["$fs"].toDouble();
+  fa = parameters["$fa"].toDouble();
+
+  if (fs < F_MINIMUM) {
+    if (inst) {
+      LOG(message_group::Warning, inst->location(), parameters.documentRoot(),
+          "$fs too small - clamping to %1$f", F_MINIMUM);
+    }
+    fs = F_MINIMUM;
+  }
+  if (fa < F_MINIMUM) {
+    if (inst) {
+      LOG(message_group::Warning, inst->location(), parameters.documentRoot(),
+          "$fa too small - clamping to %1$f", F_MINIMUM);
+    }
+    fa = F_MINIMUM;
+  }
+}
+
+/*!
+   Returns the number of subdivision of a whole circle, given radius and
+   the three special variables $fn, $fs and $fa
+ */
+std::optional<int> TessellationControl::circular_segments(double r) const
+{
+  // FIXME: It would be better to refuse to create an object. Let's do more strict error handling
+  // in future versions of OpenSCAD
+  if (r < GRID_FINE || std::isinf(fn) || std::isnan(fn)) return {};
+  if (fn > 0.0) return static_cast<int>(fn >= 3 ? fn : 3);
+  return static_cast<int>(ceil(fmax(fmin(360.0 / fa, r * 2 * M_PI / fs), 5)));
+}
+
+std::ostream& operator<<(std::ostream& stream, const TessellationControl& f)
+{
+  stream << "$fn = " << f.fn << ", $fa = " << f.fa << ", $fs = " << f.fs;
+  return stream;
+}

--- a/src/core/TessellationControl.cc
+++ b/src/core/TessellationControl.cc
@@ -1,5 +1,10 @@
 #include "core/TessellationControl.h"
 
+#ifdef ENABLE_PYTHON
+#include "python/pyopenscad.h"
+#endif
+#include <algorithm>
+
 #include "core/ModuleInstantiation.h"
 #include "core/Parameters.h"
 #include "geometry/Grid.h"
@@ -13,6 +18,13 @@ TessellationControl::TessellationControl(const Parameters& parameters, const Mod
   fs = parameters["$fs"].toDouble();
   fa = parameters["$fa"].toDouble();
 
+  if (fn < 0.0) {
+    if (inst) {
+      LOG(message_group::Warning, inst->location(), parameters.documentRoot(),
+          "$fn negative - setting to 0");
+    }
+    fn = 0.0;
+  }
   if (fs < F_MINIMUM) {
     if (inst) {
       LOG(message_group::Warning, inst->location(), parameters.documentRoot(),
@@ -29,6 +41,95 @@ TessellationControl::TessellationControl(const Parameters& parameters, const Mod
   }
 }
 
+#ifdef ENABLE_PYTHON
+/**
+ * Attempts to set a variable from a Python dictionary, handling
+ * double* (direct assignment) and int* (rounding) targets.
+ * On any error, target unchanged.
+ * @param kwargs The Python dict (PyObject*) to look up the value in.
+ * @param string_input The key (const char*) to search for.
+ * @param var_ptr A pointer to the variable to set on success.
+ */
+void trySetVariable(PyObject *kwargs, const char *string_input, double *var_ptr)
+{
+  if (!kwargs || !string_input || !var_ptr) {
+    return;
+  }
+
+  PyObject *value = nullptr;
+
+  // PyDict_GetItemStringRef returns 1 (found), 0 (missing), or -1 (error).
+  int res = PyDict_GetItemStringRef(kwargs, string_input, &value);
+
+  if (res == 1) {
+    double result = PyFloat_AsDouble(value);
+    Py_DECREF(value);
+
+    if (PyErr_Occurred()) {
+      PyErr_Clear();
+    } else {
+      *var_ptr = result;
+    }
+  } else if (res == -1) {
+    PyErr_Clear();
+  }
+}
+
+TessellationControl::TessellationControl(PyObject *kwargs)
+{
+  setValuesFromPyMain();
+  if (kwargs == nullptr || !PyDict_Check(kwargs)) {
+    return;
+  }
+
+  trySetVariable(kwargs, "fn", &this->fn);
+  trySetVariable(kwargs, "fs", &this->fs);
+  trySetVariable(kwargs, "fa", &this->fa);
+}
+
+void TessellationControl::setValuesFromPyMain()
+{
+  PyObject *mainModule = PyImport_AddModule("__main__");
+  if (mainModule == nullptr) {
+    fn = fa = fs = 0;
+    return;
+  }
+  fn = 0;
+  fa = 12;
+  fs = 2;
+
+  if (PyObject_HasAttrString(mainModule, "fn")) {
+    PyObjectUniquePtr varFn(PyObject_GetAttrString(mainModule, "fn"), PyObjectDeleter);
+    if (varFn.get() != nullptr) {
+      fn = PyFloat_AsDouble(varFn.get());
+      if (isnan(fn)) {
+        fn = 0;
+      }
+    }
+  }
+
+  if (PyObject_HasAttrString(mainModule, "fa")) {
+    PyObjectUniquePtr varFa(PyObject_GetAttrString(mainModule, "fa"), PyObjectDeleter);
+    if (varFa.get() != nullptr) {
+      fa = PyFloat_AsDouble(varFa.get());
+      if (isnan(fa)) {
+        fa = 0;
+      }
+    }
+  }
+
+  if (PyObject_HasAttrString(mainModule, "fs")) {
+    PyObjectUniquePtr varFs(PyObject_GetAttrString(mainModule, "fs"), PyObjectDeleter);
+    if (varFs.get() != nullptr) {
+      fs = PyFloat_AsDouble(varFs.get());
+      if (isnan(fs)) {
+        fs = 0;
+      }
+    }
+  }
+}
+#endif
+
 /*!
    Returns the number of subdivision of a whole circle, given radius and
    the three special variables $fn, $fs and $fa
@@ -38,10 +139,12 @@ std::optional<int> TessellationControl::circular_segments(double r, double angle
   // FIXME: It would be better to refuse to create an object. Let's do more strict error handling
   // in future versions of OpenSCAD
   if (r < GRID_FINE || std::isinf(fn) || std::isnan(fn)) return {};
-  if (fn > 0.0) return max(static_cast<int>(ceil((fn >= 3 ? fn : 3) * abs(angle_degrees) / 360.0)), 1);
-  return max(
-    static_cast<int>(ceil(fmax(fmin(360.0 / fa, r * 2 * M_PI / fs), 5) * abs(angle_degrees) / 360.0)),
-    1);
+  if (fn > 0.0)
+    return std::max(static_cast<int>(std::ceil((fn >= 3 ? fn : 3) * std::abs(angle_degrees) / 360.0)),
+                    1);
+  return std::max(static_cast<int>(std::ceil(std::abs(angle_degrees) / 360.0 *
+                                             std::max(std::min(360.0 / fa, r * 2 * M_PI / fs), 5.0))),
+                  1);
 }
 
 std::ostream& operator<<(std::ostream& stream, const TessellationControl& f)

--- a/src/core/TessellationControl.cc
+++ b/src/core/TessellationControl.cc
@@ -140,9 +140,9 @@ std::optional<int> TessellationControl::circular_segments(double r, double angle
   // in future versions of OpenSCAD
   if (r < GRID_FINE || std::isinf(fn) || std::isnan(fn)) return {};
   if (fn > 0.0)
-    return std::max(static_cast<int>(std::ceil((fn >= 3 ? fn : 3) * std::abs(angle_degrees) / 360.0)),
+    return std::max(static_cast<int>(std::ceil((fn >= 3 ? fn : 3) * std::fabs(angle_degrees) / 360.0)),
                     1);
-  return std::max(static_cast<int>(std::ceil(std::abs(angle_degrees) / 360.0 *
+  return std::max(static_cast<int>(std::ceil(std::fabs(angle_degrees) / 360.0 *
                                              std::max(std::min(360.0 / fa, r * 2 * M_PI / fs), 5.0))),
                   1);
 }

--- a/src/core/TessellationControl.cc
+++ b/src/core/TessellationControl.cc
@@ -152,3 +152,12 @@ std::ostream& operator<<(std::ostream& stream, const TessellationControl& f)
   stream << "$fn = " << f.fn << ", $fa = " << f.fa << ", $fs = " << f.fs;
   return stream;
 }
+
+std::ostream& operator<<(std::ostream& stream, const std::shared_ptr<TessellationControl>& f)
+{
+  if (!f) {
+    return stream << "[null TessellationControl]";
+  }
+  stream << "$fn = " << f->fn << ", $fa = " << f->fa << ", $fs = " << f->fs;
+  return stream;
+}

--- a/src/core/TessellationControl.h
+++ b/src/core/TessellationControl.h
@@ -46,6 +46,7 @@ public:
   }
 
   friend std::ostream& operator<<(std::ostream& stream, const TessellationControl& f);
+  friend std::ostream& operator<<(std::ostream& stream, const std::shared_ptr<TessellationControl>& f);
   bool IsFnSpecifiedAndOdd() { return static_cast<int>(fn) & 1; }
 
 private:
@@ -55,4 +56,5 @@ private:
   void setValuesFromPyMain();
 #endif
 };
-std::ostream& operator<<(std::ostream& stream, const TessellationControl& f);
+std::ostream& operator<<(std::ostream& stream, const TessellationControl& f);  // TODO: coryrc - Remove
+std::ostream& operator<<(std::ostream& stream, const std::shared_ptr<TessellationControl>& f);

--- a/src/core/TessellationControl.h
+++ b/src/core/TessellationControl.h
@@ -11,7 +11,7 @@ class TessellationControl
 {
 public:
   TessellationControl(const Parameters& parameters, const ModuleInstantiation *inst = nullptr);
-  std::optional<int> circular_segments(double r) const;
+  std::optional<int> circular_segments(double r, double angle_degrees = 360.0) const;
   friend std::ostream& operator<<(std::ostream& stream, const TessellationControl& f);
 
 private:

--- a/src/core/TessellationControl.h
+++ b/src/core/TessellationControl.h
@@ -16,26 +16,29 @@ class TessellationControl
 public:
   TessellationControl(const Parameters& parameters, const ModuleInstantiation *inst = nullptr);
 #ifdef ENABLE_PYTHON
-  /*
+  /**
    * Extract discretization values from environment if possible,
    * then override any which are explicitly set as keyword arguments.
    */
   TessellationControl(PyObject *kwargs);
 #endif
 
-  /*
+  /**
    * Create a TessellationControl for a spot in dxfdim.cc that used a hardcoded value.
    * These values of 36,0,0 go back to the first commit in Github.
    * Unknown why it is that.
    */
-  static TessellationControl DefaultForDxf() { return TessellationControl(36, 0, 0); }
+  static std::shared_ptr<TessellationControl> DefaultForDxf()
+  {
+    return std::make_shared<TessellationControl>(std::move(TessellationControl(36, 0, 0)));
+  }
 
-  /*
+  /**
    * Calculate segments for a circle or circular arc.
    */
   std::optional<int> circular_segments(double r, double angle_degrees = 360.0) const;
 
-  /*
+  /**
    * @brief Calculate segments for a path.
    * Currently only uses $fn. Won't use $fs or $fa, but future variables could be used.
    */

--- a/src/core/TessellationControl.h
+++ b/src/core/TessellationControl.h
@@ -48,7 +48,6 @@ public:
     return std::max(result, minimum);
   }
 
-  friend std::ostream& operator<<(std::ostream& stream, const TessellationControl& f);
   friend std::ostream& operator<<(std::ostream& stream, const std::shared_ptr<TessellationControl>& f);
   bool IsFnSpecifiedAndOdd() { return static_cast<int>(fn) & 1; }
 
@@ -59,5 +58,4 @@ private:
   void setValuesFromPyMain();
 #endif
 };
-std::ostream& operator<<(std::ostream& stream, const TessellationControl& f);  // TODO: coryrc - Remove
 std::ostream& operator<<(std::ostream& stream, const std::shared_ptr<TessellationControl>& f);

--- a/src/core/TessellationControl.h
+++ b/src/core/TessellationControl.h
@@ -5,16 +5,32 @@
 #include <sstream>
 #include <string>
 
+#ifdef ENABLE_PYTHON
+#include <Python.h>
+#endif
 class Parameters;
 class ModuleInstantiation;
+
 class TessellationControl
 {
 public:
   TessellationControl(const Parameters& parameters, const ModuleInstantiation *inst = nullptr);
+#ifdef ENABLE_PYTHON
+  /*
+   * Extract discretization values from environment if possible,
+   * then override any which are explicitly set as keyword arguments.
+   */
+  TessellationControl(PyObject *kwargs);
+#endif
+
   std::optional<int> circular_segments(double r, double angle_degrees = 360.0) const;
   friend std::ostream& operator<<(std::ostream& stream, const TessellationControl& f);
+  bool IsFnSpecifiedAndOdd() { return static_cast<int>(fn) & 1; }
 
 private:
   double fn, fs, fa;
+#ifdef ENABLE_PYTHON
+  void setValuesFromPyMain();
+#endif
 };
 std::ostream& operator<<(std::ostream& stream, const TessellationControl& f);

--- a/src/core/TessellationControl.h
+++ b/src/core/TessellationControl.h
@@ -23,11 +23,33 @@ public:
   TessellationControl(PyObject *kwargs);
 #endif
 
+  /*
+   * Create a TessellationControl for a spot in dxfdim.cc that used a hardcoded value.
+   * These values of 36,0,0 go back to the first commit in Github.
+   * Unknown why it is that.
+   */
+  static TessellationControl DefaultForDxf() { return TessellationControl(36, 0, 0); }
+
+  /*
+   * Calculate segments for a circle or circular arc.
+   */
   std::optional<int> circular_segments(double r, double angle_degrees = 360.0) const;
+
+  /*
+   * @brief Calculate segments for a path.
+   * Currently only uses $fn. Won't use $fs or $fa, but future variables could be used.
+   */
+  unsigned long path_segments(unsigned long minimum) const
+  {
+    unsigned long result = (fn > 3.0) ? static_cast<unsigned long>(fn) : 3;
+    return std::max(result, minimum);
+  }
+
   friend std::ostream& operator<<(std::ostream& stream, const TessellationControl& f);
   bool IsFnSpecifiedAndOdd() { return static_cast<int>(fn) & 1; }
 
 private:
+  TessellationControl(double fn, double fs, double fa) : fn(fn), fs(fs), fa(fa) {}
   double fn, fs, fa;
 #ifdef ENABLE_PYTHON
   void setValuesFromPyMain();

--- a/src/core/TessellationControl.h
+++ b/src/core/TessellationControl.h
@@ -1,0 +1,20 @@
+#pragma once
+
+#include <memory>
+#include <optional>
+#include <sstream>
+#include <string>
+
+class Parameters;
+class ModuleInstantiation;
+class TessellationControl
+{
+public:
+  TessellationControl(const Parameters& parameters, const ModuleInstantiation *inst = nullptr);
+  std::optional<int> circular_segments(double r) const;
+  friend std::ostream& operator<<(std::ostream& stream, const TessellationControl& f);
+
+private:
+  double fn, fs, fa;
+};
+std::ostream& operator<<(std::ostream& stream, const TessellationControl& f);

--- a/src/core/primitives.cc
+++ b/src/core/primitives.cc
@@ -36,7 +36,7 @@
 #include "core/ModuleInstantiation.h"
 #include "core/node.h"
 #include "core/Parameters.h"
-#include "core/TessellationControl.h"
+#include "core/CurveDiscretizer.h"
 #include "utils/calc.h"
 #include "utils/degree_trig.h"
 #include "utils/printutils.h"
@@ -169,7 +169,7 @@ static std::shared_ptr<AbstractNode> builtin_cube(const ModuleInstantiation *ins
 std::string SphereNode::toString() const
 {
   std::ostringstream stream;
-  stream << "sphere(" << tessFIXME << ", r = " << r << ")";
+  stream << "sphere(" << discretizer << ", r = " << r << ")";
   return stream.str();
 }
 
@@ -179,7 +179,7 @@ std::unique_ptr<const Geometry> SphereNode::createGeometry() const
     return PolySet::createEmpty();
   }
 
-  int num_fragments = tessFIXME->circular_segments(r).value_or(3);
+  int num_fragments = discretizer->GetCircularSegmentCount(r).value_or(3);
   auto num_rings = (num_fragments + 1) / 2;
   // Uncomment the following three lines to enable experimental sphere
   // tessellation
@@ -225,8 +225,7 @@ static std::shared_ptr<AbstractNode> builtin_sphere(const ModuleInstantiation *i
 {
   Parameters parameters = Parameters::parse(std::move(arguments), inst->location(), {"r"}, {"d"});
 
-  auto node =
-    std::make_shared<SphereNode>(inst, std::make_shared<TessellationControl>(parameters, inst));
+  auto node = std::make_shared<SphereNode>(inst, std::make_shared<CurveDiscretizer>(parameters, inst));
 
   const auto r = lookup_radius(parameters, inst, "d", "r");
   if (r.type() == Value::Type::NUMBER) {
@@ -243,7 +242,7 @@ static std::shared_ptr<AbstractNode> builtin_sphere(const ModuleInstantiation *i
 std::string CylinderNode::toString() const
 {
   std::ostringstream stream;
-  stream << "cylinder(" << tessFIXME << ", h = " << h << ", r1 = " << r1 << ", r2 = " << r2
+  stream << "cylinder(" << discretizer << ", h = " << h << ", r1 = " << r1 << ", r2 = " << r2
          << ", center = " << (center ? "true" : "false") << ")";
   return stream.str();
 }
@@ -255,7 +254,7 @@ std::unique_ptr<const Geometry> CylinderNode::createGeometry() const
     return PolySet::createEmpty();
   }
 
-  int num_fragments = tessFIXME->circular_segments(std::fmax(this->r1, this->r2)).value_or(3);
+  int num_fragments = discretizer->GetCircularSegmentCount(std::fmax(this->r1, this->r2)).value_or(3);
 
   double z1, z2;
   if (this->center) {
@@ -312,8 +311,7 @@ static std::shared_ptr<AbstractNode> builtin_cylinder(const ModuleInstantiation 
 {
   Parameters parameters = Parameters::parse(std::move(arguments), inst->location(),
                                             {"h", "r1", "r2", "center"}, {"r", "d", "d1", "d2"});
-  auto node =
-    std::make_shared<CylinderNode>(inst, std::make_shared<TessellationControl>(parameters, inst));
+  auto node = std::make_shared<CylinderNode>(inst, std::make_shared<CurveDiscretizer>(parameters, inst));
 
   if (parameters["h"].type() == Value::Type::NUMBER) {
     node->h = parameters["h"].toDouble();
@@ -554,7 +552,7 @@ static std::shared_ptr<AbstractNode> builtin_square(const ModuleInstantiation *i
 std::string CircleNode::toString() const
 {
   std::ostringstream stream;
-  stream << "circle(" << tessFIXME << ", r = " << r << ")";
+  stream << "circle(" << discretizer << ", r = " << r << ")";
   return stream.str();
 }
 
@@ -564,7 +562,7 @@ std::unique_ptr<const Geometry> CircleNode::createGeometry() const
     return std::make_unique<Polygon2d>();
   }
 
-  int num_fragments = tessFIXME->circular_segments(this->r).value_or(3);
+  int num_fragments = discretizer->GetCircularSegmentCount(this->r).value_or(3);
   Outline2d o;
   o.vertices.resize(num_fragments);
   for (int i = 0; i < num_fragments; ++i) {
@@ -577,8 +575,7 @@ std::unique_ptr<const Geometry> CircleNode::createGeometry() const
 static std::shared_ptr<AbstractNode> builtin_circle(const ModuleInstantiation *inst, Arguments arguments)
 {
   Parameters parameters = Parameters::parse(std::move(arguments), inst->location(), {"r"}, {"d"});
-  auto node =
-    std::make_shared<CircleNode>(inst, std::make_shared<TessellationControl>(parameters, inst));
+  auto node = std::make_shared<CircleNode>(inst, std::make_shared<CurveDiscretizer>(parameters, inst));
 
   const auto r = lookup_radius(parameters, inst, "d", "r");
   if (r.type() == Value::Type::NUMBER) {

--- a/src/core/primitives.h
+++ b/src/core/primitives.h
@@ -29,13 +29,14 @@
 #include "geometry/Geometry.h"
 #include "geometry/linalg.h"
 #include "core/node.h"
-#include "core/TessellationControl.h"
 
 #include <memory>
 #include <cstddef>
 #include <sstream>
 #include <string>
 #include <vector>
+
+class TessellationControl;
 
 class CubeNode : public LeafNode
 {
@@ -58,41 +59,30 @@ public:
 class SphereNode : public LeafNode
 {
 public:
-  SphereNode(const ModuleInstantiation *mi, TessellationControl&& fragments)
-    : LeafNode(mi), fragments(std::move(fragments))
+  SphereNode(const ModuleInstantiation *mi, std::shared_ptr<TessellationControl> tessFIXME)
+    : LeafNode(mi), tessFIXME(std::move(tessFIXME))
   {
   }
-  std::string toString() const override
-  {
-    std::ostringstream stream;
-    stream << "sphere(" << fragments << ", r = " << r << ")";
-    return stream.str();
-  }
+  std::string toString() const override;
   std::string name() const override { return "sphere"; }
   std::unique_ptr<const Geometry> createGeometry() const override;
 
-  TessellationControl fragments;
+  std::shared_ptr<TessellationControl> tessFIXME;
   double r = 1;
 };
 
 class CylinderNode : public LeafNode
 {
 public:
-  CylinderNode(const ModuleInstantiation *mi, TessellationControl&& fragments)
-    : LeafNode(mi), fragments(std::move(fragments))
+  CylinderNode(const ModuleInstantiation *mi, std::shared_ptr<TessellationControl> tessFIXME)
+    : LeafNode(mi), tessFIXME(std::move(tessFIXME))
   {
   }
-  std::string toString() const override
-  {
-    std::ostringstream stream;
-    stream << "cylinder(" << fragments << ", h = " << h << ", r1 = " << r1 << ", r2 = " << r2
-           << ", center = " << (center ? "true" : "false") << ")";
-    return stream.str();
-  }
+  std::string toString() const override;
   std::string name() const override { return "cylinder"; }
   std::unique_ptr<const Geometry> createGeometry() const override;
 
-  TessellationControl fragments;
+  std::shared_ptr<TessellationControl> tessFIXME;
   double r1 = 1, r2 = 1, h = 1;
   bool center = false;
 };
@@ -131,20 +121,15 @@ public:
 class CircleNode : public LeafNode
 {
 public:
-  CircleNode(const ModuleInstantiation *mi, TessellationControl&& fragments)
-    : LeafNode(mi), fragments(std::move(fragments))
+  CircleNode(const ModuleInstantiation *mi, std::shared_ptr<TessellationControl> tessFIXME)
+    : LeafNode(mi), tessFIXME(std::move(tessFIXME))
   {
   }
-  std::string toString() const override
-  {
-    std::ostringstream stream;
-    stream << "circle(" << fragments << ", r = " << r << ")";
-    return stream.str();
-  }
+  std::string toString() const override;
   std::string name() const override { return "circle"; }
   std::unique_ptr<const Geometry> createGeometry() const override;
 
-  TessellationControl fragments;
+  std::shared_ptr<TessellationControl> tessFIXME;
   double r = 1;
 };
 

--- a/src/core/primitives.h
+++ b/src/core/primitives.h
@@ -36,6 +36,19 @@
 #include <string>
 #include <vector>
 
+class Parameters;
+class Fragments
+{
+public:
+  Fragments(const Parameters& parameters, const ModuleInstantiation *inst = nullptr);
+  std::optional<int> subdivisions_from_r(double r) const;
+  friend std::ostream& operator<<(std::ostream& stream, const Fragments& f);
+
+private:
+  double fn, fs, fa;
+};
+std::ostream& operator<<(std::ostream& stream, const Fragments& f);
+
 class CubeNode : public LeafNode
 {
 public:
@@ -57,36 +70,41 @@ public:
 class SphereNode : public LeafNode
 {
 public:
-  SphereNode(const ModuleInstantiation *mi) : LeafNode(mi) {}
+  SphereNode(const ModuleInstantiation *mi, Fragments&& fragments)
+    : LeafNode(mi), fragments(std::move(fragments))
+  {
+  }
   std::string toString() const override
   {
     std::ostringstream stream;
-    stream << "sphere" << "($fn = " << fn << ", $fa = " << fa << ", $fs = " << fs << ", r = " << r
-           << ")";
+    stream << "sphere(" << fragments << ", r = " << r << ")";
     return stream.str();
   }
   std::string name() const override { return "sphere"; }
   std::unique_ptr<const Geometry> createGeometry() const override;
 
-  double fn, fs, fa;
+  Fragments fragments;
   double r = 1;
 };
 
 class CylinderNode : public LeafNode
 {
 public:
-  CylinderNode(const ModuleInstantiation *mi) : LeafNode(mi) {}
+  CylinderNode(const ModuleInstantiation *mi, Fragments&& fragments)
+    : LeafNode(mi), fragments(std::move(fragments))
+  {
+  }
   std::string toString() const override
   {
     std::ostringstream stream;
-    stream << "cylinder" << "($fn = " << fn << ", $fa = " << fa << ", $fs = " << fs << ", h = " << h
-           << ", r1 = " << r1 << ", r2 = " << r2 << ", center = " << (center ? "true" : "false") << ")";
+    stream << "cylinder(" << fragments << ", h = " << h << ", r1 = " << r1 << ", r2 = " << r2
+           << ", center = " << (center ? "true" : "false") << ")";
     return stream.str();
   }
   std::string name() const override { return "cylinder"; }
   std::unique_ptr<const Geometry> createGeometry() const override;
 
-  double fn, fs, fa;
+  Fragments fragments;
   double r1 = 1, r2 = 1, h = 1;
   bool center = false;
 };
@@ -125,18 +143,20 @@ public:
 class CircleNode : public LeafNode
 {
 public:
-  CircleNode(const ModuleInstantiation *mi) : LeafNode(mi) {}
+  CircleNode(const ModuleInstantiation *mi, Fragments&& fragments)
+    : LeafNode(mi), fragments(std::move(fragments))
+  {
+  }
   std::string toString() const override
   {
     std::ostringstream stream;
-    stream << "circle" << "($fn = " << fn << ", $fa = " << fa << ", $fs = " << fs << ", r = " << r
-           << ")";
+    stream << "circle(" << fragments << ", r = " << r << ")";
     return stream.str();
   }
   std::string name() const override { return "circle"; }
   std::unique_ptr<const Geometry> createGeometry() const override;
 
-  double fn, fs, fa;
+  Fragments fragments;
   double r = 1;
 };
 

--- a/src/core/primitives.h
+++ b/src/core/primitives.h
@@ -36,7 +36,7 @@
 #include <string>
 #include <vector>
 
-class TessellationControl;
+class CurveDiscretizer;
 
 class CubeNode : public LeafNode
 {
@@ -59,30 +59,30 @@ public:
 class SphereNode : public LeafNode
 {
 public:
-  SphereNode(const ModuleInstantiation *mi, std::shared_ptr<TessellationControl> tessFIXME)
-    : LeafNode(mi), tessFIXME(std::move(tessFIXME))
+  SphereNode(const ModuleInstantiation *mi, std::shared_ptr<CurveDiscretizer> discretizer)
+    : LeafNode(mi), discretizer(std::move(discretizer))
   {
   }
   std::string toString() const override;
   std::string name() const override { return "sphere"; }
   std::unique_ptr<const Geometry> createGeometry() const override;
 
-  std::shared_ptr<TessellationControl> tessFIXME;
+  std::shared_ptr<CurveDiscretizer> discretizer;
   double r = 1;
 };
 
 class CylinderNode : public LeafNode
 {
 public:
-  CylinderNode(const ModuleInstantiation *mi, std::shared_ptr<TessellationControl> tessFIXME)
-    : LeafNode(mi), tessFIXME(std::move(tessFIXME))
+  CylinderNode(const ModuleInstantiation *mi, std::shared_ptr<CurveDiscretizer> discretizer)
+    : LeafNode(mi), discretizer(std::move(discretizer))
   {
   }
   std::string toString() const override;
   std::string name() const override { return "cylinder"; }
   std::unique_ptr<const Geometry> createGeometry() const override;
 
-  std::shared_ptr<TessellationControl> tessFIXME;
+  std::shared_ptr<CurveDiscretizer> discretizer;
   double r1 = 1, r2 = 1, h = 1;
   bool center = false;
 };
@@ -121,15 +121,15 @@ public:
 class CircleNode : public LeafNode
 {
 public:
-  CircleNode(const ModuleInstantiation *mi, std::shared_ptr<TessellationControl> tessFIXME)
-    : LeafNode(mi), tessFIXME(std::move(tessFIXME))
+  CircleNode(const ModuleInstantiation *mi, std::shared_ptr<CurveDiscretizer> discretizer)
+    : LeafNode(mi), discretizer(std::move(discretizer))
   {
   }
   std::string toString() const override;
   std::string name() const override { return "circle"; }
   std::unique_ptr<const Geometry> createGeometry() const override;
 
-  std::shared_ptr<TessellationControl> tessFIXME;
+  std::shared_ptr<CurveDiscretizer> discretizer;
   double r = 1;
 };
 

--- a/src/core/primitives.h
+++ b/src/core/primitives.h
@@ -29,25 +29,13 @@
 #include "geometry/Geometry.h"
 #include "geometry/linalg.h"
 #include "core/node.h"
+#include "core/TessellationControl.h"
 
 #include <memory>
 #include <cstddef>
 #include <sstream>
 #include <string>
 #include <vector>
-
-class Parameters;
-class Fragments
-{
-public:
-  Fragments(const Parameters& parameters, const ModuleInstantiation *inst = nullptr);
-  std::optional<int> subdivisions_from_r(double r) const;
-  friend std::ostream& operator<<(std::ostream& stream, const Fragments& f);
-
-private:
-  double fn, fs, fa;
-};
-std::ostream& operator<<(std::ostream& stream, const Fragments& f);
 
 class CubeNode : public LeafNode
 {
@@ -70,7 +58,7 @@ public:
 class SphereNode : public LeafNode
 {
 public:
-  SphereNode(const ModuleInstantiation *mi, Fragments&& fragments)
+  SphereNode(const ModuleInstantiation *mi, TessellationControl&& fragments)
     : LeafNode(mi), fragments(std::move(fragments))
   {
   }
@@ -83,14 +71,14 @@ public:
   std::string name() const override { return "sphere"; }
   std::unique_ptr<const Geometry> createGeometry() const override;
 
-  Fragments fragments;
+  TessellationControl fragments;
   double r = 1;
 };
 
 class CylinderNode : public LeafNode
 {
 public:
-  CylinderNode(const ModuleInstantiation *mi, Fragments&& fragments)
+  CylinderNode(const ModuleInstantiation *mi, TessellationControl&& fragments)
     : LeafNode(mi), fragments(std::move(fragments))
   {
   }
@@ -104,7 +92,7 @@ public:
   std::string name() const override { return "cylinder"; }
   std::unique_ptr<const Geometry> createGeometry() const override;
 
-  Fragments fragments;
+  TessellationControl fragments;
   double r1 = 1, r2 = 1, h = 1;
   bool center = false;
 };
@@ -143,7 +131,7 @@ public:
 class CircleNode : public LeafNode
 {
 public:
-  CircleNode(const ModuleInstantiation *mi, Fragments&& fragments)
+  CircleNode(const ModuleInstantiation *mi, TessellationControl&& fragments)
     : LeafNode(mi), fragments(std::move(fragments))
   {
   }
@@ -156,7 +144,7 @@ public:
   std::string name() const override { return "circle"; }
   std::unique_ptr<const Geometry> createGeometry() const override;
 
-  Fragments fragments;
+  TessellationControl fragments;
   double r = 1;
 };
 

--- a/src/geometry/GeometryEvaluator.cc
+++ b/src/geometry/GeometryEvaluator.cc
@@ -31,7 +31,7 @@
 #include "core/State.h"
 #include "core/TextNode.h"
 #include "core/TransformNode.h"
-#include "core/TessellationControl.h"
+#include "core/CurveDiscretizer.h"
 #include "core/Tree.h"
 #include "utils/calc.h"
 #include "utils/degree_trig.h"
@@ -603,7 +603,7 @@ Response GeometryEvaluator::visit(State& state, const OffsetNode& node)
       if (const auto polygon = applyToChildren2D(node, OpenSCADOperator::UNION)) {
         // ClipperLib documentation: The formula for the number of steps in a full
         // circular arc is ... Pi / acos(1 - arc_tolerance / abs(delta))
-        double n = node.tessFIXME->circular_segments(std::abs(node.delta)).value_or(3);
+        double n = node.discretizer->GetCircularSegmentCount(std::abs(node.delta)).value_or(3);
         double arc_tolerance = std::abs(node.delta) * (1 - cos_degrees(180 / n));
         geom = ClipperUtils::applyOffset(*polygon, node.delta, node.join_type, node.miter_limit,
                                          arc_tolerance);

--- a/src/geometry/GeometryEvaluator.cc
+++ b/src/geometry/GeometryEvaluator.cc
@@ -602,7 +602,7 @@ Response GeometryEvaluator::visit(State& state, const OffsetNode& node)
       if (const auto polygon = applyToChildren2D(node, OpenSCADOperator::UNION)) {
         // ClipperLib documentation: The formula for the number of steps in a full
         // circular arc is ... Pi / acos(1 - arc_tolerance / abs(delta))
-        double n = Calc::get_fragments_from_r(std::abs(node.delta), node.fn, node.fs, node.fa);
+        double n = node.tess.circular_segments(std::abs(node.delta)).value_or(3);
         double arc_tolerance = std::abs(node.delta) * (1 - cos_degrees(180 / n));
         geom = ClipperUtils::applyOffset(*polygon, node.delta, node.join_type, node.miter_limit,
                                          arc_tolerance);

--- a/src/geometry/GeometryEvaluator.cc
+++ b/src/geometry/GeometryEvaluator.cc
@@ -31,6 +31,7 @@
 #include "core/State.h"
 #include "core/TextNode.h"
 #include "core/TransformNode.h"
+#include "core/TessellationControl.h"
 #include "core/Tree.h"
 #include "utils/calc.h"
 #include "utils/degree_trig.h"
@@ -602,7 +603,7 @@ Response GeometryEvaluator::visit(State& state, const OffsetNode& node)
       if (const auto polygon = applyToChildren2D(node, OpenSCADOperator::UNION)) {
         // ClipperLib documentation: The formula for the number of steps in a full
         // circular arc is ... Pi / acos(1 - arc_tolerance / abs(delta))
-        double n = node.tess.circular_segments(std::abs(node.delta)).value_or(3);
+        double n = node.tessFIXME->circular_segments(std::abs(node.delta)).value_or(3);
         double arc_tolerance = std::abs(node.delta) * (1 - cos_degrees(180 / n));
         geom = ClipperUtils::applyOffset(*polygon, node.delta, node.join_type, node.miter_limit,
                                          arc_tolerance);

--- a/src/geometry/rotate_extrude.cc
+++ b/src/geometry/rotate_extrude.cc
@@ -101,7 +101,7 @@ std::unique_ptr<Geometry> rotatePolygon(const RotateExtrudeNode& node, const Pol
 
   // # of sections. For closed rotations, # vertices is thus fragments*outline_size. For open
   // rotations # vertices is (fragments+1)*outline_size.
-  const int num_sections = node.tess.circular_segments(max_x - min_x, node.angle).value_or(5);
+  const int num_sections = node.tessFIXME->circular_segments(max_x - min_x, node.angle).value_or(5);
   const bool closed = node.angle == 360;
   // # of rings of vertices
   const size_t num_rings = num_sections + (closed ? 0 : 1);

--- a/src/geometry/rotate_extrude.cc
+++ b/src/geometry/rotate_extrude.cc
@@ -101,7 +101,7 @@ std::unique_ptr<Geometry> rotatePolygon(const RotateExtrudeNode& node, const Pol
 
   // # of sections. For closed rotations, # vertices is thus fragments*outline_size. For open
   // rotations # vertices is (fragments+1)*outline_size.
-  const int num_sections = node.tess.circular_segments(max_x - min_x, node.angle).value_or(1);
+  const int num_sections = node.tess.circular_segments(max_x - min_x, node.angle).value_or(5);
   const bool closed = node.angle == 360;
   // # of rings of vertices
   const size_t num_rings = num_sections + (closed ? 0 : 1);

--- a/src/geometry/rotate_extrude.cc
+++ b/src/geometry/rotate_extrude.cc
@@ -10,6 +10,7 @@
 #include <vector>
 
 #include "core/RotateExtrudeNode.h"
+#include "core/TessellationControl.h"
 #include "geometry/GeometryUtils.h"
 #include "geometry/Geometry.h"
 #include "geometry/PolySetBuilder.h"
@@ -100,9 +101,7 @@ std::unique_ptr<Geometry> rotatePolygon(const RotateExtrudeNode& node, const Pol
 
   // # of sections. For closed rotations, # vertices is thus fragments*outline_size. For open
   // rotations # vertices is (fragments+1)*outline_size.
-  const auto num_sections = (unsigned int)std::ceil(fmax(
-    Calc::get_fragments_from_r(max_x - min_x, node.fn, node.fs, node.fa) * std::abs(node.angle) / 360,
-    1));
+  const int num_sections = node.tess.circular_segments(max_x - min_x, node.angle).value_or(1);
   const bool closed = node.angle == 360;
   // # of rings of vertices
   const size_t num_rings = num_sections + (closed ? 0 : 1);

--- a/src/geometry/rotate_extrude.cc
+++ b/src/geometry/rotate_extrude.cc
@@ -10,7 +10,7 @@
 #include <vector>
 
 #include "core/RotateExtrudeNode.h"
-#include "core/TessellationControl.h"
+#include "core/CurveDiscretizer.h"
 #include "geometry/GeometryUtils.h"
 #include "geometry/Geometry.h"
 #include "geometry/PolySetBuilder.h"
@@ -101,7 +101,8 @@ std::unique_ptr<Geometry> rotatePolygon(const RotateExtrudeNode& node, const Pol
 
   // # of sections. For closed rotations, # vertices is thus fragments*outline_size. For open
   // rotations # vertices is (fragments+1)*outline_size.
-  const int num_sections = node.tessFIXME->circular_segments(max_x - min_x, node.angle).value_or(5);
+  const int num_sections =
+    node.discretizer->GetCircularSegmentCount(max_x - min_x, node.angle).value_or(5);
   const bool closed = node.angle == 360;
   // # of rings of vertices
   const size_t num_rings = num_sections + (closed ? 0 : 1);

--- a/src/io/DxfData.cc
+++ b/src/io/DxfData.cc
@@ -78,7 +78,7 @@ struct Line {
 /*!
    Reads a layer from the given file, or all layers if layername.empty()
  */
-DxfData::DxfData(double fn, double fs, double fa, const std::string& filename,
+DxfData::DxfData(const TessellationControl& tessFIXME, const std::string& filename,
                  const std::string& layername, double xorigin, double yorigin, double scale)
 {
   std::ifstream stream(filename.c_str());
@@ -187,7 +187,7 @@ DxfData::DxfData(double fn, double fs, double fa, const std::string& filename,
             ADD_LINE(xverts.at(numverts - 1), yverts.at(numverts - 1), xverts.at(0), yverts.at(0));
           }
         } else if (mode == "CIRCLE") {
-          const int n = Calc::get_fragments_from_r(radius, fn, fs, fa);
+          const int n = tessFIXME.circular_segments(radius).value_or(3);
           Vector2d center(xverts.at(0), yverts.at(0));
           for (int i = 0; i < n; ++i) {
             const double a1 = (360.0 * i) / n;
@@ -197,12 +197,11 @@ DxfData::DxfData(double fn, double fs, double fa, const std::string& filename,
           }
         } else if (mode == "ARC") {
           Vector2d center(xverts.at(0), yverts.at(0));
-          int n = Calc::get_fragments_from_r(radius, fn, fs, fa);
           while (arc_start_angle > arc_stop_angle) {
             arc_stop_angle += 360.0;
           }
           const double arc_angle = arc_stop_angle - arc_start_angle;
-          n = static_cast<int>(ceil(n * arc_angle / 360));
+          const int n = tessFIXME.circular_segments(radius, arc_angle).value_or(1);
           for (int i = 0; i < n; ++i) {
             const double a1 = arc_start_angle + arc_angle * i / n;
             const double a2 = arc_start_angle + arc_angle * (i + 1) / n;
@@ -233,8 +232,8 @@ DxfData::DxfData(double fn, double fs, double fa, const std::string& filename,
           // the ratio stored in 'radius; due to the parser code not checking entity type
           const double r_minor = r_major * radius;
           const double sweep_angle = ellipse_stop_angle - ellipse_start_angle;
-          int n = Calc::get_fragments_from_r(r_major, fn, fs, fa);
-          n = static_cast<int>(ceil(n * sweep_angle / (2 * M_PI)));
+          const int n =
+            tessFIXME.circular_segments(r_major, sweep_angle / (2 * M_PI) * 360.0).value_or(1);
           //				Vector2d p1;
           Vector2d p1{0.0, 0.0};
           for (int i = 0; i <= n; ++i) {

--- a/src/io/DxfData.cc
+++ b/src/io/DxfData.cc
@@ -42,6 +42,7 @@
 #include <boost/algorithm/string.hpp>
 #include <boost/lexical_cast.hpp>
 
+#include "core/TessellationControl.h"
 #include "core/Value.h"
 #include "geometry/Grid.h"
 #include "geometry/linalg.h"
@@ -78,7 +79,7 @@ struct Line {
 /*!
    Reads a layer from the given file, or all layers if layername.empty()
  */
-DxfData::DxfData(const TessellationControl& tessFIXME, const std::string& filename,
+DxfData::DxfData(std::shared_ptr<TessellationControl> tessFIXME, const std::string& filename,
                  const std::string& layername, double xorigin, double yorigin, double scale)
 {
   std::ifstream stream(filename.c_str());
@@ -187,7 +188,7 @@ DxfData::DxfData(const TessellationControl& tessFIXME, const std::string& filena
             ADD_LINE(xverts.at(numverts - 1), yverts.at(numverts - 1), xverts.at(0), yverts.at(0));
           }
         } else if (mode == "CIRCLE") {
-          const int n = tessFIXME.circular_segments(radius).value_or(3);
+          const int n = tessFIXME->circular_segments(radius).value_or(3);
           Vector2d center(xverts.at(0), yverts.at(0));
           for (int i = 0; i < n; ++i) {
             const double a1 = (360.0 * i) / n;
@@ -201,7 +202,7 @@ DxfData::DxfData(const TessellationControl& tessFIXME, const std::string& filena
             arc_stop_angle += 360.0;
           }
           const double arc_angle = arc_stop_angle - arc_start_angle;
-          const int n = tessFIXME.circular_segments(radius, arc_angle).value_or(1);
+          const int n = tessFIXME->circular_segments(radius, arc_angle).value_or(1);
           for (int i = 0; i < n; ++i) {
             const double a1 = arc_start_angle + arc_angle * i / n;
             const double a2 = arc_start_angle + arc_angle * (i + 1) / n;
@@ -233,7 +234,7 @@ DxfData::DxfData(const TessellationControl& tessFIXME, const std::string& filena
           const double r_minor = r_major * radius;
           const double sweep_angle = ellipse_stop_angle - ellipse_start_angle;
           const int n =
-            tessFIXME.circular_segments(r_major, sweep_angle / (2 * M_PI) * 360.0).value_or(1);
+            tessFIXME->circular_segments(r_major, sweep_angle / (2 * M_PI) * 360.0).value_or(1);
           //				Vector2d p1;
           Vector2d p1{0.0, 0.0};
           for (int i = 0; i <= n; ++i) {

--- a/src/io/DxfData.cc
+++ b/src/io/DxfData.cc
@@ -42,7 +42,7 @@
 #include <boost/algorithm/string.hpp>
 #include <boost/lexical_cast.hpp>
 
-#include "core/TessellationControl.h"
+#include "core/CurveDiscretizer.h"
 #include "core/Value.h"
 #include "geometry/Grid.h"
 #include "geometry/linalg.h"
@@ -79,7 +79,7 @@ struct Line {
 /*!
    Reads a layer from the given file, or all layers if layername.empty()
  */
-DxfData::DxfData(std::shared_ptr<TessellationControl> tessFIXME, const std::string& filename,
+DxfData::DxfData(std::shared_ptr<CurveDiscretizer> discretizer, const std::string& filename,
                  const std::string& layername, double xorigin, double yorigin, double scale)
 {
   std::ifstream stream(filename.c_str());
@@ -188,7 +188,7 @@ DxfData::DxfData(std::shared_ptr<TessellationControl> tessFIXME, const std::stri
             ADD_LINE(xverts.at(numverts - 1), yverts.at(numverts - 1), xverts.at(0), yverts.at(0));
           }
         } else if (mode == "CIRCLE") {
-          const int n = tessFIXME->circular_segments(radius).value_or(3);
+          const int n = discretizer->GetCircularSegmentCount(radius).value_or(3);
           Vector2d center(xverts.at(0), yverts.at(0));
           for (int i = 0; i < n; ++i) {
             const double a1 = (360.0 * i) / n;
@@ -202,7 +202,7 @@ DxfData::DxfData(std::shared_ptr<TessellationControl> tessFIXME, const std::stri
             arc_stop_angle += 360.0;
           }
           const double arc_angle = arc_stop_angle - arc_start_angle;
-          const int n = tessFIXME->circular_segments(radius, arc_angle).value_or(1);
+          const int n = discretizer->GetCircularSegmentCount(radius, arc_angle).value_or(1);
           for (int i = 0; i < n; ++i) {
             const double a1 = arc_start_angle + arc_angle * i / n;
             const double a2 = arc_start_angle + arc_angle * (i + 1) / n;
@@ -234,7 +234,7 @@ DxfData::DxfData(std::shared_ptr<TessellationControl> tessFIXME, const std::stri
           const double r_minor = r_major * radius;
           const double sweep_angle = ellipse_stop_angle - ellipse_start_angle;
           const int n =
-            tessFIXME->circular_segments(r_major, sweep_angle / (2 * M_PI) * 360.0).value_or(1);
+            discretizer->GetCircularSegmentCount(r_major, sweep_angle / (2 * M_PI) * 360.0).value_or(1);
           //				Vector2d p1;
           Vector2d p1{0.0, 0.0};
           for (int i = 0; i <= n; ++i) {

--- a/src/io/DxfData.h
+++ b/src/io/DxfData.h
@@ -4,8 +4,9 @@
 #include <string>
 #include <vector>
 
-#include "core/TessellationControl.h"
 #include "geometry/linalg.h"
+
+class TessellationControl;
 
 class DxfData
 {
@@ -39,7 +40,7 @@ public:
   std::vector<Dim> dims;
 
   DxfData() = default;
-  DxfData(const TessellationControl& tessFIXME, const std::string& filename,
+  DxfData(std::shared_ptr<TessellationControl> tessFIXME, const std::string& filename,
           const std::string& layername = "", double xorigin = 0.0, double yorigin = 0.0,
           double scale = 1.0);
 

--- a/src/io/DxfData.h
+++ b/src/io/DxfData.h
@@ -6,7 +6,7 @@
 
 #include "geometry/linalg.h"
 
-class TessellationControl;
+class CurveDiscretizer;
 
 class DxfData
 {
@@ -40,7 +40,7 @@ public:
   std::vector<Dim> dims;
 
   DxfData() = default;
-  DxfData(std::shared_ptr<TessellationControl> tessFIXME, const std::string& filename,
+  DxfData(std::shared_ptr<CurveDiscretizer> discretizer, const std::string& filename,
           const std::string& layername = "", double xorigin = 0.0, double yorigin = 0.0,
           double scale = 1.0);
 

--- a/src/io/DxfData.h
+++ b/src/io/DxfData.h
@@ -4,6 +4,7 @@
 #include <string>
 #include <vector>
 
+#include "core/TessellationControl.h"
 #include "geometry/linalg.h"
 
 class DxfData
@@ -38,7 +39,7 @@ public:
   std::vector<Dim> dims;
 
   DxfData() = default;
-  DxfData(double fn, double fs, double fa, const std::string& filename,
+  DxfData(const TessellationControl& tessFIXME, const std::string& filename,
           const std::string& layername = "", double xorigin = 0.0, double yorigin = 0.0,
           double scale = 1.0);
 

--- a/src/io/dxfdim.cc
+++ b/src/io/dxfdim.cc
@@ -94,7 +94,7 @@ static Value builtin_dxf_dim(Arguments arguments, const Location& loc)
   auto result = dxf_dim_cache.find(key);
   if (result != dxf_dim_cache.end()) return {result->second};
   handle_dep(filepath.string());
-  DxfData dxf(36, 0, 0, filename, layername, xorigin, yorigin, scale);
+  DxfData dxf(TessellationControl::DefaultForDxf(), filename, layername, xorigin, yorigin, scale);
 
   for (auto& dim : dxf.dims) {
     if (!name.empty() && dim.name != name) continue;
@@ -207,7 +207,7 @@ static Value builtin_dxf_cross(Arguments arguments, const Location& loc)
     return {std::move(ret)};
   }
   handle_dep(filepath.string());
-  DxfData dxf(36, 0, 0, filename, layername, xorigin, yorigin, scale);
+  DxfData dxf(TessellationControl::DefaultForDxf(), filename, layername, xorigin, yorigin, scale);
 
   double coords[4][2];
 

--- a/src/io/dxfdim.cc
+++ b/src/io/dxfdim.cc
@@ -39,7 +39,7 @@
 #include "core/Builtins.h"
 #include "core/function.h"
 #include "core/Parameters.h"
-#include "core/TessellationControl.h"
+#include "core/CurveDiscretizer.h"
 #include "core/Value.h"
 #include "handle_dep.h"
 #include "io/DxfData.h"
@@ -95,7 +95,7 @@ static Value builtin_dxf_dim(Arguments arguments, const Location& loc)
   auto result = dxf_dim_cache.find(key);
   if (result != dxf_dim_cache.end()) return {result->second};
   handle_dep(filepath.string());
-  DxfData dxf(TessellationControl::DefaultForDxf(), filename, layername, xorigin, yorigin, scale);
+  DxfData dxf(CurveDiscretizer::DefaultForDxf(), filename, layername, xorigin, yorigin, scale);
 
   for (auto& dim : dxf.dims) {
     if (!name.empty() && dim.name != name) continue;
@@ -208,7 +208,7 @@ static Value builtin_dxf_cross(Arguments arguments, const Location& loc)
     return {std::move(ret)};
   }
   handle_dep(filepath.string());
-  DxfData dxf(TessellationControl::DefaultForDxf(), filename, layername, xorigin, yorigin, scale);
+  DxfData dxf(CurveDiscretizer::DefaultForDxf(), filename, layername, xorigin, yorigin, scale);
 
   double coords[4][2];
 

--- a/src/io/dxfdim.cc
+++ b/src/io/dxfdim.cc
@@ -39,6 +39,7 @@
 #include "core/Builtins.h"
 #include "core/function.h"
 #include "core/Parameters.h"
+#include "core/TessellationControl.h"
 #include "core/Value.h"
 #include "handle_dep.h"
 #include "io/DxfData.h"

--- a/src/io/import.h
+++ b/src/io/import.h
@@ -7,7 +7,7 @@
 
 #include "core/AST.h"
 
-class TessellationControl;
+class CurveDiscretizer;
 
 std::unique_ptr<class PolySet> import_stl(const std::string& filename, const Location& loc);
 std::unique_ptr<class PolySet> import_obj(const std::string& filename, const Location& loc);
@@ -15,7 +15,7 @@ std::unique_ptr<class PolySet> import_off(const std::string& filename, const Loc
 std::unique_ptr<class PolySet> import_amf(const std::string&, const Location& loc);
 std::unique_ptr<class PolySet> import_3mf(const std::string&, const Location& loc);
 
-std::unique_ptr<class Polygon2d> import_svg(std::shared_ptr<TessellationControl> tessFIXME,
+std::unique_ptr<class Polygon2d> import_svg(std::shared_ptr<CurveDiscretizer> discretizer,
                                             const std::string& filename,
                                             const boost::optional<std::string>& id,
                                             const boost::optional<std::string>& layer, const double dpi,

--- a/src/io/import.h
+++ b/src/io/import.h
@@ -6,6 +6,7 @@
 #include <boost/optional.hpp>
 
 #include "core/AST.h"
+#include "core/TessellationControl.h"
 
 std::unique_ptr<class PolySet> import_stl(const std::string& filename, const Location& loc);
 std::unique_ptr<class PolySet> import_obj(const std::string& filename, const Location& loc);
@@ -13,7 +14,8 @@ std::unique_ptr<class PolySet> import_off(const std::string& filename, const Loc
 std::unique_ptr<class PolySet> import_amf(const std::string&, const Location& loc);
 std::unique_ptr<class PolySet> import_3mf(const std::string&, const Location& loc);
 
-std::unique_ptr<class Polygon2d> import_svg(double fn, double fs, double fa, const std::string& filename,
+std::unique_ptr<class Polygon2d> import_svg(const TessellationControl& tessFIXME,
+                                            const std::string& filename,
                                             const boost::optional<std::string>& id,
                                             const boost::optional<std::string>& layer, const double dpi,
                                             const bool center, const Location& loc);

--- a/src/io/import.h
+++ b/src/io/import.h
@@ -6,7 +6,8 @@
 #include <boost/optional.hpp>
 
 #include "core/AST.h"
-#include "core/TessellationControl.h"
+
+class TessellationControl;
 
 std::unique_ptr<class PolySet> import_stl(const std::string& filename, const Location& loc);
 std::unique_ptr<class PolySet> import_obj(const std::string& filename, const Location& loc);
@@ -14,7 +15,7 @@ std::unique_ptr<class PolySet> import_off(const std::string& filename, const Loc
 std::unique_ptr<class PolySet> import_amf(const std::string&, const Location& loc);
 std::unique_ptr<class PolySet> import_3mf(const std::string&, const Location& loc);
 
-std::unique_ptr<class Polygon2d> import_svg(const TessellationControl& tessFIXME,
+std::unique_ptr<class Polygon2d> import_svg(std::shared_ptr<TessellationControl> tessFIXME,
                                             const std::string& filename,
                                             const boost::optional<std::string>& id,
                                             const boost::optional<std::string>& layer, const double dpi,

--- a/src/io/import_svg.cc
+++ b/src/io/import_svg.cc
@@ -36,7 +36,7 @@
 #include <clipper2/clipper.h>
 
 #include "core/AST.h"
-#include "core/TessellationControl.h"
+#include "core/CurveDiscretizer.h"
 #include "geometry/ClipperUtils.h"
 #include "geometry/Polygon2d.h"
 #include "libsvg/libsvg.h"
@@ -82,14 +82,14 @@ double calc_alignment(const libsvg::align_t alignment, double page_mm, double sc
 
 }  // namespace
 
-std::unique_ptr<Polygon2d> import_svg(std::shared_ptr<TessellationControl> tessFIXME,
+std::unique_ptr<Polygon2d> import_svg(std::shared_ptr<CurveDiscretizer> discretizer,
                                       const std::string& filename,
                                       const boost::optional<std::string>& id,
                                       const boost::optional<std::string>& layer, const double dpi,
                                       const bool center, const Location& loc)
 {
   try {
-    fnContext scadContext(tessFIXME);
+    fnContext scadContext(discretizer);
     if (id) {
       scadContext.selector = [&scadContext, id, layer](const libsvg::shape *s) {
         bool layer_match = true;

--- a/src/io/import_svg.cc
+++ b/src/io/import_svg.cc
@@ -81,13 +81,13 @@ double calc_alignment(const libsvg::align_t alignment, double page_mm, double sc
 
 }  // namespace
 
-std::unique_ptr<Polygon2d> import_svg(double fn, double fs, double fa, const std::string& filename,
+std::unique_ptr<Polygon2d> import_svg(const TessellationControl& tessFIXME, const std::string& filename,
                                       const boost::optional<std::string>& id,
                                       const boost::optional<std::string>& layer, const double dpi,
                                       const bool center, const Location& loc)
 {
   try {
-    fnContext scadContext(fn, fs, fa);
+    fnContext scadContext(tessFIXME);
     if (id) {
       scadContext.selector = [&scadContext, id, layer](const libsvg::shape *s) {
         bool layer_match = true;

--- a/src/io/import_svg.cc
+++ b/src/io/import_svg.cc
@@ -36,6 +36,7 @@
 #include <clipper2/clipper.h>
 
 #include "core/AST.h"
+#include "core/TessellationControl.h"
 #include "geometry/ClipperUtils.h"
 #include "geometry/Polygon2d.h"
 #include "libsvg/libsvg.h"
@@ -81,7 +82,8 @@ double calc_alignment(const libsvg::align_t alignment, double page_mm, double sc
 
 }  // namespace
 
-std::unique_ptr<Polygon2d> import_svg(const TessellationControl& tessFIXME, const std::string& filename,
+std::unique_ptr<Polygon2d> import_svg(std::shared_ptr<TessellationControl> tessFIXME,
+                                      const std::string& filename,
                                       const boost::optional<std::string>& id,
                                       const boost::optional<std::string>& layer, const double dpi,
                                       const bool center, const Location& loc)

--- a/src/libsvg/path.cc
+++ b/src/libsvg/path.cc
@@ -81,15 +81,6 @@ static double vector_angle(double ux, double uy, double vx, double vy)
   return angle;
 }
 
-static inline unsigned long CalcFn(double fn, unsigned long minimum)
-{
-  unsigned long result = 3;
-  if (fn > 3.0)  // > 0.0 && > 3
-    result = static_cast<unsigned long>(fn);
-  if (result < minimum) result = minimum;
-  return result;
-}
-
 void path::arc_to(path_t& path, double x1, double y1, double rx, double ry, double x2, double y2,
                   double angle, bool large, bool sweep, void *context)
 {
@@ -141,13 +132,11 @@ void path::arc_to(path_t& path, double x1, double y1, double rx, double ry, doub
     delta -= 360;
   }
 
-  double rmax = fmax(rx, ry);
-  unsigned long fn = Calc::get_fragments_from_r(rmax, fValues->fn, fValues->fs, fValues->fa);
-  fn = (unsigned long)ceil(
-    fn * fabs(delta) / 360.0);  // because we are creating a section of an ellipse, not the full ellipse
-  unsigned int steps = (std::fabs(delta) * 10.0 / 180) + 4;
-  if (steps < fn)  // use the maximum of calculated steps and user specified steps
-    steps = fn;
+  double rmax = std::max(rx, ry);
+  unsigned int fn =
+    fValues->tessFIXME.circular_segments(rmax, delta)
+      .value_or(3);  // because we are creating a section of an ellipse, not the full ellipse
+  unsigned int steps = std::max(fn, static_cast<unsigned int>((std::fabs(delta) * 10.0 / 180) + 4));
   for (unsigned int a = 0; a <= steps; ++a) {
     double phi = theta + delta * a / steps;
 
@@ -164,7 +153,7 @@ void path::curve_to(path_t& path, double x, double y, double cx1, double cy1, do
   // NOTE - this could be done better using a chord length iteration (uniform in space) to implement $fa
   // (lot of work, little gain)
   const auto *fValues = reinterpret_cast<const fnContext *>(context);
-  unsigned long fn = CalcFn(fValues->fn, 20);  // preserve the old minimum
+  unsigned long fn = fValues->tessFIXME.path_segments(20);  // preserve the old minimum
   for (unsigned long idx = 1; idx <= fn; ++idx) {
     const double a = idx * (1.0 / (double)fn);
     const double xx = x * t(a, 2) + cx1 * 2 * t(a, 1) * a + x2 * a * a;
@@ -179,7 +168,7 @@ void path::curve_to(path_t& path, double x, double y, double cx1, double cy1, do
   // NOTE - this could be done better using a chord length iteration (uniform in space) to implement $fa
   // (lot of work, little gain)
   const auto *fValues = reinterpret_cast<const fnContext *>(context);
-  unsigned long fn = CalcFn(fValues->fn, 20);  // preserve the old minimum
+  unsigned long fn = fValues->tessFIXME.path_segments(20);  // preserve the old minimum
   for (unsigned long idx = 1; idx <= fn; ++idx) {
     const double a = idx * (1.0 / (double)fn);
     const double xx = x * t(a, 3) + cx1 * 3 * t(a, 2) * a + cx2 * 3 * t(a, 1) * a * a + x2 * a * a * a;

--- a/src/libsvg/path.cc
+++ b/src/libsvg/path.cc
@@ -40,6 +40,7 @@
 #include <boost/tokenizer.hpp>
 #include <boost/algorithm/string.hpp>
 
+#include "core/TessellationControl.h"
 #include "utils/degree_trig.h"
 #include "utils/calc.h"
 #include "libsvg/util.h"
@@ -134,7 +135,7 @@ void path::arc_to(path_t& path, double x1, double y1, double rx, double ry, doub
 
   double rmax = std::max(rx, ry);
   unsigned int fn =
-    fValues->tessFIXME.circular_segments(rmax, delta)
+    fValues->tessFIXME->circular_segments(rmax, delta)
       .value_or(3);  // because we are creating a section of an ellipse, not the full ellipse
   unsigned int steps = std::max(fn, static_cast<unsigned int>((std::fabs(delta) * 10.0 / 180) + 4));
   for (unsigned int a = 0; a <= steps; ++a) {
@@ -153,7 +154,7 @@ void path::curve_to(path_t& path, double x, double y, double cx1, double cy1, do
   // NOTE - this could be done better using a chord length iteration (uniform in space) to implement $fa
   // (lot of work, little gain)
   const auto *fValues = reinterpret_cast<const fnContext *>(context);
-  unsigned long fn = fValues->tessFIXME.path_segments(20);  // preserve the old minimum
+  unsigned long fn = fValues->tessFIXME->path_segments(20);  // preserve the old minimum
   for (unsigned long idx = 1; idx <= fn; ++idx) {
     const double a = idx * (1.0 / (double)fn);
     const double xx = x * t(a, 2) + cx1 * 2 * t(a, 1) * a + x2 * a * a;
@@ -168,7 +169,7 @@ void path::curve_to(path_t& path, double x, double y, double cx1, double cy1, do
   // NOTE - this could be done better using a chord length iteration (uniform in space) to implement $fa
   // (lot of work, little gain)
   const auto *fValues = reinterpret_cast<const fnContext *>(context);
-  unsigned long fn = fValues->tessFIXME.path_segments(20);  // preserve the old minimum
+  unsigned long fn = fValues->tessFIXME->path_segments(20);  // preserve the old minimum
   for (unsigned long idx = 1; idx <= fn; ++idx) {
     const double a = idx * (1.0 / (double)fn);
     const double xx = x * t(a, 3) + cx1 * 3 * t(a, 2) * a + cx2 * 3 * t(a, 1) * a * a + x2 * a * a * a;

--- a/src/libsvg/path.cc
+++ b/src/libsvg/path.cc
@@ -40,7 +40,7 @@
 #include <boost/tokenizer.hpp>
 #include <boost/algorithm/string.hpp>
 
-#include "core/TessellationControl.h"
+#include "core/CurveDiscretizer.h"
 #include "utils/degree_trig.h"
 #include "utils/calc.h"
 #include "libsvg/util.h"
@@ -135,7 +135,7 @@ void path::arc_to(path_t& path, double x1, double y1, double rx, double ry, doub
 
   double rmax = std::max(rx, ry);
   unsigned int fn =
-    fValues->tessFIXME->circular_segments(rmax, delta)
+    fValues->discretizer->GetCircularSegmentCount(rmax, delta)
       .value_or(3);  // because we are creating a section of an ellipse, not the full ellipse
   unsigned int steps = std::max(fn, static_cast<unsigned int>((std::fabs(delta) * 10.0 / 180) + 4));
   for (unsigned int a = 0; a <= steps; ++a) {
@@ -154,7 +154,7 @@ void path::curve_to(path_t& path, double x, double y, double cx1, double cy1, do
   // NOTE - this could be done better using a chord length iteration (uniform in space) to implement $fa
   // (lot of work, little gain)
   const auto *fValues = reinterpret_cast<const fnContext *>(context);
-  unsigned long fn = fValues->tessFIXME->path_segments(20);  // preserve the old minimum
+  unsigned long fn = fValues->discretizer->GetPathSegmentCount(20);  // preserve the old minimum
   for (unsigned long idx = 1; idx <= fn; ++idx) {
     const double a = idx * (1.0 / (double)fn);
     const double xx = x * t(a, 2) + cx1 * 2 * t(a, 1) * a + x2 * a * a;
@@ -169,7 +169,7 @@ void path::curve_to(path_t& path, double x, double y, double cx1, double cy1, do
   // NOTE - this could be done better using a chord length iteration (uniform in space) to implement $fa
   // (lot of work, little gain)
   const auto *fValues = reinterpret_cast<const fnContext *>(context);
-  unsigned long fn = fValues->tessFIXME->path_segments(20);  // preserve the old minimum
+  unsigned long fn = fValues->discretizer->GetPathSegmentCount(20);  // preserve the old minimum
   for (unsigned long idx = 1; idx <= fn; ++idx) {
     const double a = idx * (1.0 / (double)fn);
     const double xx = x * t(a, 3) + cx1 * 3 * t(a, 2) * a + cx2 * 3 * t(a, 1) * a * a + x2 * a * a * a;

--- a/src/libsvg/shape.cc
+++ b/src/libsvg/shape.cc
@@ -37,7 +37,7 @@
 
 #include <clipper2/clipper.offset.h>
 
-#include "core/TessellationControl.h"
+#include "core/CurveDiscretizer.h"
 #include "geometry/ClipperUtils.h"
 #include "libsvg/circle.h"
 #include "libsvg/ellipse.h"
@@ -303,7 +303,7 @@ void shape::draw_ellipse(path_t& path, double x, double y, double rx, double ry,
 {
   const auto *fValues = reinterpret_cast<const fnContext *>(context);
   double rmax = fmax(rx, ry);
-  unsigned long fn = fValues->tessFIXME->circular_segments(rmax).value_or(3);
+  unsigned long fn = fValues->discretizer->GetCircularSegmentCount(rmax).value_or(3);
   if (fn < 40) fn = 40;  // preserve the old minimum value
   for (unsigned long idx = 1; idx <= fn; ++idx) {
     const double a = idx * 360.0 / fn;

--- a/src/libsvg/shape.cc
+++ b/src/libsvg/shape.cc
@@ -37,6 +37,7 @@
 
 #include <clipper2/clipper.offset.h>
 
+#include "core/TessellationControl.h"
 #include "geometry/ClipperUtils.h"
 #include "libsvg/circle.h"
 #include "libsvg/ellipse.h"
@@ -302,7 +303,7 @@ void shape::draw_ellipse(path_t& path, double x, double y, double rx, double ry,
 {
   const auto *fValues = reinterpret_cast<const fnContext *>(context);
   double rmax = fmax(rx, ry);
-  unsigned long fn = fValues->tessFIXME.circular_segments(rmax).value_or(3);
+  unsigned long fn = fValues->tessFIXME->circular_segments(rmax).value_or(3);
   if (fn < 40) fn = 40;  // preserve the old minimum value
   for (unsigned long idx = 1; idx <= fn; ++idx) {
     const double a = idx * 360.0 / fn;

--- a/src/libsvg/shape.cc
+++ b/src/libsvg/shape.cc
@@ -302,7 +302,7 @@ void shape::draw_ellipse(path_t& path, double x, double y, double rx, double ry,
 {
   const auto *fValues = reinterpret_cast<const fnContext *>(context);
   double rmax = fmax(rx, ry);
-  unsigned long fn = Calc::get_fragments_from_r(rmax, fValues->fn, fValues->fs, fValues->fa);
+  unsigned long fn = fValues->tessFIXME.circular_segments(rmax).value_or(3);
   if (fn < 40) fn = 40;  // preserve the old minimum value
   for (unsigned long idx = 1; idx <= fn; ++idx) {
     const double a = idx * 360.0 / fn;

--- a/src/libsvg/shape.h
+++ b/src/libsvg/shape.h
@@ -39,7 +39,8 @@
 #include <boost/optional.hpp>
 
 #include "clipper2/clipper.h"
-#include "core/TessellationControl.h"
+
+class TessellationControl;
 
 namespace libsvg {
 class shape;
@@ -48,7 +49,7 @@ class shape;
 // ccox - I don't like putting this here, but the svg library code did not plan ahead for app
 // customization. And this is one of the few sensible places to put it without adding new header files.
 struct fnContext {
-  fnContext(const TessellationControl& tessFIXME) : tessFIXME(tessFIXME) {}
+  fnContext(std::shared_ptr<TessellationControl> tessFIXME) : tessFIXME(std::move(tessFIXME)) {}
   bool match(bool val)
   {
     if (val) matches++;
@@ -56,7 +57,7 @@ struct fnContext {
   }
   bool has_matches() { return matches.load() > 0; }
 
-  const TessellationControl& tessFIXME;
+  std::shared_ptr<TessellationControl> tessFIXME;
   std::function<bool(const libsvg::shape *)> selector;
 
 private:

--- a/src/libsvg/shape.h
+++ b/src/libsvg/shape.h
@@ -40,7 +40,7 @@
 
 #include "clipper2/clipper.h"
 
-class TessellationControl;
+class CurveDiscretizer;
 
 namespace libsvg {
 class shape;
@@ -49,7 +49,7 @@ class shape;
 // ccox - I don't like putting this here, but the svg library code did not plan ahead for app
 // customization. And this is one of the few sensible places to put it without adding new header files.
 struct fnContext {
-  fnContext(std::shared_ptr<TessellationControl> tessFIXME) : tessFIXME(std::move(tessFIXME)) {}
+  fnContext(std::shared_ptr<CurveDiscretizer> discretizer) : discretizer(std::move(discretizer)) {}
   bool match(bool val)
   {
     if (val) matches++;
@@ -57,7 +57,7 @@ struct fnContext {
   }
   bool has_matches() { return matches.load() > 0; }
 
-  std::shared_ptr<TessellationControl> tessFIXME;
+  std::shared_ptr<CurveDiscretizer> discretizer;
   std::function<bool(const libsvg::shape *)> selector;
 
 private:

--- a/src/libsvg/shape.h
+++ b/src/libsvg/shape.h
@@ -39,6 +39,7 @@
 #include <boost/optional.hpp>
 
 #include "clipper2/clipper.h"
+#include "core/TessellationControl.h"
 
 namespace libsvg {
 class shape;
@@ -47,7 +48,7 @@ class shape;
 // ccox - I don't like putting this here, but the svg library code did not plan ahead for app
 // customization. And this is one of the few sensible places to put it without adding new header files.
 struct fnContext {
-  fnContext(double fNN, double fSS, double fAA) : fn(fNN), fs(fSS), fa(fAA) {}
+  fnContext(const TessellationControl& tessFIXME) : tessFIXME(tessFIXME) {}
   bool match(bool val)
   {
     if (val) matches++;
@@ -55,9 +56,7 @@ struct fnContext {
   }
   bool has_matches() { return matches.load() > 0; }
 
-  double fn;
-  double fs;
-  double fa;
+  const TessellationControl& tessFIXME;
   std::function<bool(const libsvg::shape *)> selector;
 
 private:

--- a/src/python/pyfunctions.cc
+++ b/src/python/pyfunctions.cc
@@ -1862,28 +1862,22 @@ PyObject *python_surface(PyObject *self, PyObject *args, PyObject *kwargs)
 PyObject *python_text(PyObject *self, PyObject *args, PyObject *kwargs)
 {
   DECLARE_INSTANCE();
-  auto node = std::make_shared<TextNode>(instance);
-
-  char *kwlist[] = {"text",   "size",   "font", "spacing", "direction", "language", "script",
-                    "halign", "valign", "fn",   "fa",      "fs",        NULL};
+  char *kwlist[] = {"text",     "size",   "font",   "spacing", "direction",
+                    "language", "script", "halign", "valign",  NULL};
 
   double size = 1.0, spacing = 1.0;
-  double fn = NAN, fa = NAN, fs = NAN;
-
-  get_fnas(fn, fa, fs);
 
   const char *text = "", *font = NULL, *direction = "ltr", *language = "en", *script = "latin",
              *valign = "baseline", *halign = "left";
 
-  if (!PyArg_ParseTupleAndKeywords(args, kwargs, "s|dsdsssssddd", kwlist, &text, &size, &font, &spacing,
-                                   &direction, &language, &script, &halign, &valign, &fn, &fa, &fs)) {
+  if (!PyArg_ParseTupleAndKeywords(args, kwargs, "s|dsdsssss", kwlist, &text, &size, &font, &spacing,
+                                   &direction, &language, &script, &halign, &valign)) {
     PyErr_SetString(PyExc_TypeError, "Error during parsing text(string, ...))");
     return NULL;
   }
 
-  node->params.set_fn(fn);
-  node->params.set_fa(fa);
-  node->params.set_fs(fs);
+  auto node = std::make_shared<TextNode>(instance);
+  node->params.set(kwargs);
   node->params.set_size(size);
   if (text != NULL) node->params.set_text(text);
   node->params.set_spacing(spacing);
@@ -1907,8 +1901,6 @@ PyObject *python_text(PyObject *self, PyObject *args, PyObject *kwargs)
 PyObject *python_textmetrics(PyObject *self, PyObject *args, PyObject *kwargs)
 {
   DECLARE_INSTANCE();
-  auto node = std::make_shared<TextNode>(instance);
-
   char *kwlist[] = {"text",     "size",   "font",   "spacing", "direction",
                     "language", "script", "halign", "valign",  NULL};
 

--- a/src/python/pyfunctions.cc
+++ b/src/python/pyfunctions.cc
@@ -1117,11 +1117,11 @@ PyObject *python_oo_mesh(PyObject *obj, PyObject *args, PyObject *kwargs)
 
 PyObject *rotate_extrude_core(PyObject *obj, int convexity, double scale, double angle, PyObject *twist,
                               PyObject *origin, PyObject *offset, PyObject *vp, char *method,
-                              TessellationControl&& tess)
+                              TessellationControl&& tessFIXME)
 {
   DECLARE_INSTANCE();
   std::shared_ptr<AbstractNode> child;
-  auto node = std::make_shared<RotateExtrudeNode>(instance, std::move(tess));
+  auto node = std::make_shared<RotateExtrudeNode>(instance, std::make_shared<TessellationControl>(std::move(tessFIXME)));
   if (1) {
     PyObject *dummydict;
     child = PyOpenSCADObjectToNodeMulti(obj, &dummydict);
@@ -1967,10 +1967,10 @@ PyObject *python_textmetrics(PyObject *self, PyObject *args, PyObject *kwargs)
 }
 
 PyObject *python_offset_core(PyObject *obj, double r, double delta, PyObject *chamfer,
-                             TessellationControl&& tess)
+                             TessellationControl&& tessFIXME)
 {
   DECLARE_INSTANCE();
-  auto node = std::make_shared<OffsetNode>(instance, std::move(tess));
+  auto node = std::make_shared<OffsetNode>(instance, std::make_shared<TessellationControl>(std::move(tessFIXME)));
 
   PyObject *dummydict;
   std::shared_ptr<AbstractNode> child = PyOpenSCADObjectToNodeMulti(obj, &dummydict);

--- a/src/python/pyfunctions.cc
+++ b/src/python/pyfunctions.cc
@@ -38,6 +38,7 @@
 #include "core/RenderNode.h"
 #include "core/SurfaceNode.h"
 #include "core/TextNode.h"
+#include "core/TessellationControl.h"
 #include "core/OffsetNode.h"
 #include "core/ProjectionNode.h"
 #include "core/Tree.h"
@@ -122,7 +123,7 @@ PyObject *python_sphere(PyObject *self, PyObject *args, PyObject *kwargs)
     vr = d / 2.0;
   }
 
-  auto node = std::make_shared<SphereNode>(instance, TessellationControl(kwargs));
+  auto node = std::make_shared<SphereNode>(instance, std::make_shared<TessellationControl>(kwargs));
 
   node->r = vr;
 
@@ -195,7 +196,7 @@ PyObject *python_cylinder(PyObject *self, PyObject *args, PyObject *kwargs)
     vr2 = d / 2.0;
   }
 
-  auto node = std::make_shared<CylinderNode>(instance, TessellationControl(kwargs));
+  auto node = std::make_shared<CylinderNode>(instance, std::make_shared<TessellationControl>(kwargs));
 
   node->r1 = vr1;
   node->r2 = vr2;
@@ -364,7 +365,7 @@ PyObject *python_circle(PyObject *self, PyObject *args, PyObject *kwargs)
     vr = d / 2.0;
   }
 
-  auto node = std::make_shared<CircleNode>(instance, TessellationControl(kwargs));
+  auto node = std::make_shared<CircleNode>(instance, std::make_shared<TessellationControl>(kwargs));
 
   node->r = vr;
 
@@ -1121,7 +1122,8 @@ PyObject *rotate_extrude_core(PyObject *obj, int convexity, double scale, double
 {
   DECLARE_INSTANCE();
   std::shared_ptr<AbstractNode> child;
-  auto node = std::make_shared<RotateExtrudeNode>(instance, std::make_shared<TessellationControl>(std::move(tessFIXME)));
+  auto node = std::make_shared<RotateExtrudeNode>(
+    instance, std::make_shared<TessellationControl>(std::move(tessFIXME)));
   if (1) {
     PyObject *dummydict;
     child = PyOpenSCADObjectToNodeMulti(obj, &dummydict);
@@ -1970,7 +1972,8 @@ PyObject *python_offset_core(PyObject *obj, double r, double delta, PyObject *ch
                              TessellationControl&& tessFIXME)
 {
   DECLARE_INSTANCE();
-  auto node = std::make_shared<OffsetNode>(instance, std::make_shared<TessellationControl>(std::move(tessFIXME)));
+  auto node =
+    std::make_shared<OffsetNode>(instance, std::make_shared<TessellationControl>(std::move(tessFIXME)));
 
   PyObject *dummydict;
   std::shared_ptr<AbstractNode> child = PyOpenSCADObjectToNodeMulti(obj, &dummydict);

--- a/src/python/pyfunctions.cc
+++ b/src/python/pyfunctions.cc
@@ -38,7 +38,7 @@
 #include "core/RenderNode.h"
 #include "core/SurfaceNode.h"
 #include "core/TextNode.h"
-#include "core/TessellationControl.h"
+#include "core/CurveDiscretizer.h"
 #include "core/OffsetNode.h"
 #include "core/ProjectionNode.h"
 #include "core/Tree.h"
@@ -123,7 +123,7 @@ PyObject *python_sphere(PyObject *self, PyObject *args, PyObject *kwargs)
     vr = d / 2.0;
   }
 
-  auto node = std::make_shared<SphereNode>(instance, std::make_shared<TessellationControl>(kwargs));
+  auto node = std::make_shared<SphereNode>(instance, std::make_shared<CurveDiscretizer>(kwargs));
 
   node->r = vr;
 
@@ -196,7 +196,7 @@ PyObject *python_cylinder(PyObject *self, PyObject *args, PyObject *kwargs)
     vr2 = d / 2.0;
   }
 
-  auto node = std::make_shared<CylinderNode>(instance, std::make_shared<TessellationControl>(kwargs));
+  auto node = std::make_shared<CylinderNode>(instance, std::make_shared<CurveDiscretizer>(kwargs));
 
   node->r1 = vr1;
   node->r2 = vr2;
@@ -365,7 +365,7 @@ PyObject *python_circle(PyObject *self, PyObject *args, PyObject *kwargs)
     vr = d / 2.0;
   }
 
-  auto node = std::make_shared<CircleNode>(instance, std::make_shared<TessellationControl>(kwargs));
+  auto node = std::make_shared<CircleNode>(instance, std::make_shared<CurveDiscretizer>(kwargs));
 
   node->r = vr;
 
@@ -1118,12 +1118,12 @@ PyObject *python_oo_mesh(PyObject *obj, PyObject *args, PyObject *kwargs)
 
 PyObject *rotate_extrude_core(PyObject *obj, int convexity, double scale, double angle, PyObject *twist,
                               PyObject *origin, PyObject *offset, PyObject *vp, char *method,
-                              TessellationControl&& tessFIXME)
+                              CurveDiscretizer&& discretizer)
 {
   DECLARE_INSTANCE();
   std::shared_ptr<AbstractNode> child;
   auto node = std::make_shared<RotateExtrudeNode>(
-    instance, std::make_shared<TessellationControl>(std::move(tessFIXME)));
+    instance, std::make_shared<CurveDiscretizer>(std::move(discretizer)));
   if (1) {
     PyObject *dummydict;
     child = PyOpenSCADObjectToNodeMulti(obj, &dummydict);
@@ -1167,7 +1167,7 @@ PyObject *python_rotate_extrude(PyObject *self, PyObject *args, PyObject *kwargs
     return NULL;
   }
   return rotate_extrude_core(obj, convexity, scale, angle, twist, origin, offset, v, method,
-                             TessellationControl(kwargs));
+                             CurveDiscretizer(kwargs));
 }
 
 PyObject *python_oo_rotate_extrude(PyObject *obj, PyObject *args, PyObject *kwargs)
@@ -1187,7 +1187,7 @@ PyObject *python_oo_rotate_extrude(PyObject *obj, PyObject *args, PyObject *kwar
     return NULL;
   }
   return rotate_extrude_core(obj, convexity, scale, angle, twist, origin, offset, v, method,
-                             TessellationControl(kwargs));
+                             CurveDiscretizer(kwargs));
 }
 
 PyObject *linear_extrude_core(PyObject *obj, PyObject *height, int convexity, PyObject *origin,
@@ -1961,11 +1961,11 @@ PyObject *python_textmetrics(PyObject *self, PyObject *args, PyObject *kwargs)
 }
 
 PyObject *python_offset_core(PyObject *obj, double r, double delta, PyObject *chamfer,
-                             TessellationControl&& tessFIXME)
+                             CurveDiscretizer&& discretizer)
 {
   DECLARE_INSTANCE();
   auto node =
-    std::make_shared<OffsetNode>(instance, std::make_shared<TessellationControl>(std::move(tessFIXME)));
+    std::make_shared<OffsetNode>(instance, std::make_shared<CurveDiscretizer>(std::move(discretizer)));
 
   PyObject *dummydict;
   std::shared_ptr<AbstractNode> child = PyOpenSCADObjectToNodeMulti(obj, &dummydict);
@@ -2005,7 +2005,7 @@ PyObject *python_offset(PyObject *self, PyObject *args, PyObject *kwargs)
     PyErr_SetString(PyExc_TypeError, "Error during parsing offset(object,r,delta)");
     return NULL;
   }
-  return python_offset_core(obj, r, delta, chamfer, TessellationControl(kwargs));
+  return python_offset_core(obj, r, delta, chamfer, CurveDiscretizer(kwargs));
 }
 
 PyObject *python_oo_offset(PyObject *obj, PyObject *args, PyObject *kwargs)
@@ -2017,7 +2017,7 @@ PyObject *python_oo_offset(PyObject *obj, PyObject *args, PyObject *kwargs)
     PyErr_SetString(PyExc_TypeError, "Error during parsing offset(object,r,delta)");
     return NULL;
   }
-  return python_offset_core(obj, r, delta, chamfer, TessellationControl(kwargs));
+  return python_offset_core(obj, r, delta, chamfer, CurveDiscretizer(kwargs));
 }
 
 PyObject *python_projection_core(PyObject *obj, const char *cutmode, int convexity)

--- a/src/python/pyfunctions.cc
+++ b/src/python/pyfunctions.cc
@@ -51,7 +51,7 @@
 
 PyObject *python_cube(PyObject *self, PyObject *args, PyObject *kwargs)
 {
-  DECLARE_INSTANCE
+  DECLARE_INSTANCE();
   auto node = std::make_shared<CubeNode>(instance);
 
   char *kwlist[] = {"size", "center", NULL};
@@ -88,18 +88,16 @@ PyObject *python_cube(PyObject *self, PyObject *args, PyObject *kwargs)
 
 PyObject *python_sphere(PyObject *self, PyObject *args, PyObject *kwargs)
 {
-  DECLARE_INSTANCE
-  auto node = std::make_shared<SphereNode>(instance);
+  DECLARE_INSTANCE();
 
-  char *kwlist[] = {"r", "d", "fn", "fa", "fs", NULL};
+  char *kwlist[] = {"r", "d", NULL};
   double r = NAN;
   PyObject *rp = nullptr;
   double d = NAN;
-  double fn = NAN, fa = NAN, fs = NAN;
 
   double vr = 1;
 
-  if (!PyArg_ParseTupleAndKeywords(args, kwargs, "|Odddd", kwlist, &rp, &d, &fn, &fa, &fs)) {
+  if (!PyArg_ParseTupleAndKeywords(args, kwargs, "|Od", kwlist, &rp, &d)) {
     PyErr_SetString(PyExc_TypeError, "Error during parsing sphere(r|d)");
     return NULL;
   }
@@ -125,10 +123,7 @@ PyObject *python_sphere(PyObject *self, PyObject *args, PyObject *kwargs)
     vr = d / 2.0;
   }
 
-  get_fnas(node->fn, node->fa, node->fs);
-  if (!isnan(fn)) node->fn = fn;
-  if (!isnan(fa)) node->fa = fa;
-  if (!isnan(fs)) node->fs = fs;
+  auto node = std::make_shared<SphereNode>(instance, TessellationControl(kwargs));
 
   node->r = vr;
 
@@ -137,10 +132,9 @@ PyObject *python_sphere(PyObject *self, PyObject *args, PyObject *kwargs)
 
 PyObject *python_cylinder(PyObject *self, PyObject *args, PyObject *kwargs)
 {
-  DECLARE_INSTANCE
-  auto node = std::make_shared<CylinderNode>(instance);
+  DECLARE_INSTANCE();
 
-  char *kwlist[] = {"h", "r1", "r2", "center", "r", "d", "d1", "d2", "fn", "fa", "fs", NULL};
+  char *kwlist[] = {"h", "r1", "r2", "center", "r", "d", "d1", "d2", NULL};
   double h = NAN;
   double r = NAN;
   double r1 = NAN;
@@ -149,13 +143,11 @@ PyObject *python_cylinder(PyObject *self, PyObject *args, PyObject *kwargs)
   double d1 = NAN;
   double d2 = NAN;
 
-  double fn = NAN, fa = NAN, fs = NAN;
-
   PyObject *center = NULL;
   double vr1 = 1, vr2 = 1, vh = 1;
 
-  if (!PyArg_ParseTupleAndKeywords(args, kwargs, "|dddOddddddd", kwlist, &h, &r1, &r2, &center, &r, &d,
-                                   &d1, &d2, &fn, &fa, &fs)) {
+  if (!PyArg_ParseTupleAndKeywords(args, kwargs, "|dddOdddd", kwlist, &h, &r1, &r2, &center, &r, &d, &d1,
+                                   &d2)) {
     PyErr_SetString(PyExc_TypeError, "Error during parsing cylinder(h,r|r1+r2|d1+d2)");
     return NULL;
   }
@@ -204,10 +196,7 @@ PyObject *python_cylinder(PyObject *self, PyObject *args, PyObject *kwargs)
     vr2 = d / 2.0;
   }
 
-  get_fnas(node->fn, node->fa, node->fs);
-  if (!isnan(fn)) node->fn = fn;
-  if (!isnan(fa)) node->fa = fa;
-  if (!isnan(fs)) node->fs = fs;
+  auto node = std::make_shared<CylinderNode>(instance, TessellationControl(kwargs));
 
   node->r1 = vr1;
   node->r2 = vr2;
@@ -225,7 +214,7 @@ PyObject *python_cylinder(PyObject *self, PyObject *args, PyObject *kwargs)
 
 PyObject *python_polyhedron(PyObject *self, PyObject *args, PyObject *kwargs)
 {
-  DECLARE_INSTANCE
+  DECLARE_INSTANCE();
   unsigned int i, j, pointIndex;
   auto node = std::make_shared<PolyhedronNode>(instance);
 
@@ -314,7 +303,7 @@ PyObject *python_polyhedron(PyObject *self, PyObject *args, PyObject *kwargs)
 
 PyObject *python_square(PyObject *self, PyObject *args, PyObject *kwargs)
 {
-  DECLARE_INSTANCE
+  DECLARE_INSTANCE();
   auto node = std::make_shared<SquareNode>(instance);
 
   char *kwlist[] = {"dim", "center", NULL};
@@ -344,17 +333,15 @@ PyObject *python_square(PyObject *self, PyObject *args, PyObject *kwargs)
 }
 PyObject *python_circle(PyObject *self, PyObject *args, PyObject *kwargs)
 {
-  DECLARE_INSTANCE
-  auto node = std::make_shared<CircleNode>(instance);
+  DECLARE_INSTANCE();
 
-  char *kwlist[] = {"r", "d", "fn", "fa", "fs", NULL};
+  char *kwlist[] = {"r", "d", NULL};
   double r = NAN;
   double d = NAN;
-  double fn = NAN, fa = NAN, fs = NAN;
 
   double vr = 1;
 
-  if (!PyArg_ParseTupleAndKeywords(args, kwargs, "|ddddd", kwlist, &r, &d, &fn, &fa, &fs)) {
+  if (!PyArg_ParseTupleAndKeywords(args, kwargs, "|ddddd", kwlist, &r, &d)) {
     PyErr_SetString(PyExc_TypeError, "Error during parsing circle(r|d)");
     return NULL;
   }
@@ -378,18 +365,16 @@ PyObject *python_circle(PyObject *self, PyObject *args, PyObject *kwargs)
     vr = d / 2.0;
   }
 
-  get_fnas(node->fn, node->fa, node->fs);
-  if (!isnan(fn)) node->fn = fn;
-  if (!isnan(fa)) node->fa = fa;
-  if (!isnan(fs)) node->fs = fs;
+  auto node = std::make_shared<CircleNode>(instance, TessellationControl(kwargs));
 
   node->r = vr;
 
   return PyOpenSCADObjectFromNode(&PyOpenSCADType, node);
 }
+
 PyObject *python_polygon(PyObject *self, PyObject *args, PyObject *kwargs)
 {
-  DECLARE_INSTANCE
+  DECLARE_INSTANCE();
   unsigned int i, j, pointIndex;
   auto node = std::make_shared<PolygonNode>(instance);
 
@@ -510,7 +495,7 @@ PyObject *python_scale_sub(PyObject *obj, Vector3d scalevec)
   PyObject *mat = python_matrix_scale(obj, scalevec);
   if (mat != nullptr) return mat;
 
-  DECLARE_INSTANCE
+  DECLARE_INSTANCE();
   std::shared_ptr<AbstractNode> child;
   auto node = std::make_shared<TransformNode>(instance, "scale");
   PyObject *child_dict;
@@ -624,7 +609,7 @@ PyObject *python_rotate_sub(PyObject *obj, Vector3d vec3, double angle)
   PyObject *mat = python_matrix_rot(obj, M);
   if (mat != nullptr) return mat;
 
-  DECLARE_INSTANCE
+  DECLARE_INSTANCE();
   auto node = std::make_shared<TransformNode>(instance, "rotate");
 
   PyObject *child_dict;
@@ -712,7 +697,7 @@ PyObject *python_mirror_sub(PyObject *obj, Matrix4d& m)
   PyObject *mat = python_matrix_mirror(obj, m);
   if (mat != nullptr) return mat;
 
-  DECLARE_INSTANCE
+  DECLARE_INSTANCE();
   auto node = std::make_shared<TransformNode>(instance, "mirror");
   node->matrix = m;
   PyObject *child_dict;
@@ -843,7 +828,7 @@ PyObject *python_multmatrix_sub(PyObject *pyobj, PyObject *pymat, int div)
     return python_frommatrix(objmat);
   }
 
-  DECLARE_INSTANCE
+  DECLARE_INSTANCE();
   auto node = std::make_shared<TransformNode>(instance, "multmatrix");
   std::shared_ptr<AbstractNode> child;
   PyObject *child_dict;
@@ -986,7 +971,7 @@ PyObject *python_color_core(PyObject *obj, PyObject *color, double alpha)
     PyErr_SetString(PyExc_TypeError, "Invalid type for Object in color");
     return NULL;
   }
-  DECLARE_INSTANCE
+  DECLARE_INSTANCE();
   auto node = std::make_shared<ColorNode>(instance);
 
   Vector4d col(0, 0, 0, alpha);
@@ -1132,12 +1117,12 @@ PyObject *python_oo_mesh(PyObject *obj, PyObject *args, PyObject *kwargs)
 }
 
 PyObject *rotate_extrude_core(PyObject *obj, int convexity, double scale, double angle, PyObject *twist,
-                              PyObject *origin, PyObject *offset, PyObject *vp, char *method, double fn,
-                              double fa, double fs)
+                              PyObject *origin, PyObject *offset, PyObject *vp, char *method,
+                              TessellationControl&& tess)
 {
-  DECLARE_INSTANCE
+  DECLARE_INSTANCE();
   std::shared_ptr<AbstractNode> child;
-  auto node = std::make_shared<RotateExtrudeNode>(instance);
+  auto node = std::make_shared<RotateExtrudeNode>(instance, std::move(tess));
   if (1) {
     PyObject *dummydict;
     child = PyOpenSCADObjectToNodeMulti(obj, &dummydict);
@@ -1147,11 +1132,6 @@ PyObject *rotate_extrude_core(PyObject *obj, int convexity, double scale, double
     }
     node->children.push_back(child);
   }
-
-  get_fnas(node->fn, node->fa, node->fs);
-  if (!isnan(fn)) node->fn = fn;
-  if (!isnan(fa)) node->fa = fa;
-  if (!isnan(fs)) node->fs = fs;
 
   node->convexity = convexity;
   node->angle = angle;
@@ -1178,16 +1158,15 @@ PyObject *python_rotate_extrude(PyObject *self, PyObject *args, PyObject *kwargs
   char *method = NULL;
   PyObject *origin = NULL;
   PyObject *offset = NULL;
-  double fn = NAN, fa = NAN, fs = NAN;
-  get_fnas(fn, fa, fs);
-  char *kwlist[] = {"obj", "convexity", "scale", "angle", "twist", "origin", "offset",
-                    "v",   "method",    "fn",    "fa",    "fs",    NULL};
-  if (!PyArg_ParseTupleAndKeywords(args, kwargs, "O|iddOOOOsddd", kwlist, &obj, &convexity, &scale,
-                                   &angle, &twist, &origin, &offset, &v, &method, &fn, &fa, &fs)) {
+  char *kwlist[] = {"obj",    "convexity", "scale", "angle",  "twist",
+                    "origin", "offset",    "v",     "method", NULL};
+  if (!PyArg_ParseTupleAndKeywords(args, kwargs, "O|iddOOOOs", kwlist, &obj, &convexity, &scale, &angle,
+                                   &twist, &origin, &offset, &v, &method)) {
     PyErr_SetString(PyExc_TypeError, "Error during parsing rotate_extrude(object,...)");
     return NULL;
   }
-  return rotate_extrude_core(obj, convexity, scale, angle, twist, origin, offset, v, method, fn, fa, fs);
+  return rotate_extrude_core(obj, convexity, scale, angle, twist, origin, offset, v, method,
+                             TessellationControl(kwargs));
 }
 
 PyObject *python_oo_rotate_extrude(PyObject *obj, PyObject *args, PyObject *kwargs)
@@ -1198,25 +1177,23 @@ PyObject *python_oo_rotate_extrude(PyObject *obj, PyObject *args, PyObject *kwar
   PyObject *twist = NULL;
   PyObject *origin = NULL;
   PyObject *offset = NULL;
-  double fn = NAN, fa = NAN, fs = NAN;
-  get_fnas(fn, fa, fs);
   PyObject *v = NULL;
   char *method = NULL;
-  char *kwlist[] = {"convexity", "scale",  "angle", "twist", "origin", "offset",
-                    "v",         "method", "fn",    "fa",    "fs",     NULL};
-  if (!PyArg_ParseTupleAndKeywords(args, kwargs, "|iddOOOOsddd", kwlist, &convexity, &scale, &angle,
-                                   &twist, &origin, &offset, &v, &method, &fn, &fa, &fs)) {
+  char *kwlist[] = {"convexity", "scale", "angle", "twist", "origin", "offset", "v", "method", NULL};
+  if (!PyArg_ParseTupleAndKeywords(args, kwargs, "|iddOOOOs", kwlist, &convexity, &scale, &angle, &twist,
+                                   &origin, &offset, &v, &method)) {
     PyErr_SetString(PyExc_TypeError, "error during parsing\n");
     return NULL;
   }
-  return rotate_extrude_core(obj, convexity, scale, angle, twist, origin, offset, v, method, fn, fa, fs);
+  return rotate_extrude_core(obj, convexity, scale, angle, twist, origin, offset, v, method,
+                             TessellationControl(kwargs));
 }
 
 PyObject *linear_extrude_core(PyObject *obj, PyObject *height, int convexity, PyObject *origin,
                               PyObject *scale, PyObject *center, int slices, int segments,
                               PyObject *twist, double fn, double fa, double fs)
 {
-  DECLARE_INSTANCE
+  DECLARE_INSTANCE();
   std::shared_ptr<AbstractNode> child;
   auto node = std::make_shared<LinearExtrudeNode>(instance);
 
@@ -1323,7 +1300,7 @@ PyObject *python_oo_linear_extrude(PyObject *obj, PyObject *args, PyObject *kwar
 }
 PyObject *python_csg_sub(PyObject *self, PyObject *args, PyObject *kwargs, OpenSCADOperator mode)
 {
-  DECLARE_INSTANCE
+  DECLARE_INSTANCE();
   int i;
 
   auto node = std::make_shared<CsgOpNode>(instance, mode);
@@ -1395,7 +1372,7 @@ PyObject *python_intersection(PyObject *self, PyObject *args, PyObject *kwargs)
 
 PyObject *python_oo_csg_sub(PyObject *self, PyObject *args, PyObject *kwargs, OpenSCADOperator mode)
 {
-  DECLARE_INSTANCE
+  DECLARE_INSTANCE();
   int i;
 
   auto node = std::make_shared<CsgOpNode>(instance, mode);
@@ -1458,7 +1435,7 @@ PyObject *python_oo_intersection(PyObject *self, PyObject *args, PyObject *kwarg
 
 PyObject *python_nb_sub(PyObject *arg1, PyObject *arg2, OpenSCADOperator mode)
 {
-  DECLARE_INSTANCE
+  DECLARE_INSTANCE();
   std::shared_ptr<AbstractNode> child[2];
   PyObject *child_dict[2];
 
@@ -1495,7 +1472,7 @@ PyObject *python_nb_sub(PyObject *arg1, PyObject *arg2, OpenSCADOperator mode)
 PyObject *python_nb_sub_vec3(PyObject *arg1, PyObject *arg2,
                              int mode)  // 0: translate, 1: scale, 2: translateneg, 3=translate-exp
 {
-  DECLARE_INSTANCE
+  DECLARE_INSTANCE();
   std::shared_ptr<AbstractNode> child;
   PyObject *child_dict;
 
@@ -1537,7 +1514,7 @@ PyObject *python_nb_sub_vec3(PyObject *arg1, PyObject *arg2,
       return pyresult;
     } else {
       auto node = std::make_shared<CsgOpNode>(instance, OpenSCADOperator::UNION);
-      DECLARE_INSTANCE
+      DECLARE_INSTANCE();
       for (auto x : nodes) node->children.push_back(x->clone());
       return PyOpenSCADObjectFromNode(&PyOpenSCADType, node);
     }
@@ -1576,7 +1553,7 @@ PyObject *python_nb_and(PyObject *arg1, PyObject *arg2)
 
 PyObject *python_csg_adv_sub(PyObject *self, PyObject *args, PyObject *kwargs, CgalAdvType mode)
 {
-  DECLARE_INSTANCE
+  DECLARE_INSTANCE();
   std::shared_ptr<AbstractNode> child;
   int i;
   PyObject *dummydict;
@@ -1610,7 +1587,7 @@ PyObject *python_csg_adv_sub(PyObject *self, PyObject *args, PyObject *kwargs, C
 
 PyObject *python_minkowski(PyObject *self, PyObject *args, PyObject *kwargs)
 {
-  DECLARE_INSTANCE
+  DECLARE_INSTANCE();
   std::shared_ptr<AbstractNode> child;
   int i;
   int n;
@@ -1654,7 +1631,7 @@ PyObject *python_fill(PyObject *self, PyObject *args, PyObject *kwargs)
 
 PyObject *python_resize_core(PyObject *obj, PyObject *newsize, PyObject *autosize, int convexity)
 {
-  DECLARE_INSTANCE
+  DECLARE_INSTANCE();
   std::shared_ptr<AbstractNode> child;
 
   auto node = std::make_shared<CgalAdvNode>(instance, CgalAdvType::RESIZE);
@@ -1730,7 +1707,7 @@ PyObject *python_oo_resize(PyObject *obj, PyObject *args, PyObject *kwargs)
 PyObject *python_roof_core(PyObject *obj, const char *method, int convexity, double fn, double fa,
                            double fs)
 {
-  DECLARE_INSTANCE
+  DECLARE_INSTANCE();
   std::shared_ptr<AbstractNode> child;
   auto node = std::make_shared<RoofNode>(instance);
   PyObject *dummydict;
@@ -1803,7 +1780,7 @@ PyObject *python_oo_roof(PyObject *obj, PyObject *args, PyObject *kwargs)
 
 PyObject *python_render_core(PyObject *obj, int convexity)
 {
-  DECLARE_INSTANCE
+  DECLARE_INSTANCE();
   auto node = std::make_shared<RenderNode>(instance);
 
   PyObject *dummydict;
@@ -1838,7 +1815,7 @@ PyObject *python_oo_render(PyObject *obj, PyObject *args, PyObject *kwargs)
 
 PyObject *python_surface_core(const char *file, PyObject *center, PyObject *invert, int convexity)
 {
-  DECLARE_INSTANCE
+  DECLARE_INSTANCE();
   std::shared_ptr<AbstractNode> child;
 
   auto node = std::make_shared<SurfaceNode>(instance);
@@ -1883,7 +1860,7 @@ PyObject *python_surface(PyObject *self, PyObject *args, PyObject *kwargs)
 
 PyObject *python_text(PyObject *self, PyObject *args, PyObject *kwargs)
 {
-  DECLARE_INSTANCE
+  DECLARE_INSTANCE();
   auto node = std::make_shared<TextNode>(instance);
 
   char *kwlist[] = {"text",   "size",   "font", "spacing", "direction", "language", "script",
@@ -1928,7 +1905,7 @@ PyObject *python_text(PyObject *self, PyObject *args, PyObject *kwargs)
 
 PyObject *python_textmetrics(PyObject *self, PyObject *args, PyObject *kwargs)
 {
-  DECLARE_INSTANCE
+  DECLARE_INSTANCE();
   auto node = std::make_shared<TextNode>(instance);
 
   char *kwlist[] = {"text",     "size",   "font",   "spacing", "direction",
@@ -1993,7 +1970,7 @@ PyObject *python_textmetrics(PyObject *self, PyObject *args, PyObject *kwargs)
 PyObject *python_offset_core(PyObject *obj, double r, double delta, PyObject *chamfer, double fn,
                              double fa, double fs)
 {
-  DECLARE_INSTANCE
+  DECLARE_INSTANCE();
   auto node = std::make_shared<OffsetNode>(instance);
 
   PyObject *dummydict;
@@ -2060,7 +2037,7 @@ PyObject *python_oo_offset(PyObject *obj, PyObject *args, PyObject *kwargs)
 
 PyObject *python_projection_core(PyObject *obj, const char *cutmode, int convexity)
 {
-  DECLARE_INSTANCE
+  DECLARE_INSTANCE();
   auto node = std::make_shared<ProjectionNode>(instance);
   PyObject *dummydict;
   std::shared_ptr<AbstractNode> child = PyOpenSCADObjectToNodeMulti(obj, &dummydict);
@@ -2104,7 +2081,7 @@ PyObject *python_oo_projection(PyObject *obj, PyObject *args, PyObject *kwargs)
 
 PyObject *python_group(PyObject *self, PyObject *args, PyObject *kwargs)
 {
-  DECLARE_INSTANCE
+  DECLARE_INSTANCE();
   std::shared_ptr<AbstractNode> child;
 
   auto node = std::make_shared<GroupNode>(instance);
@@ -2134,7 +2111,7 @@ PyObject *python_align_core(PyObject *obj, PyObject *pyrefmat, PyObject *pydstma
     PyErr_SetString(PyExc_TypeError, "Invalid align object");
     return Py_None;
   }
-  DECLARE_INSTANCE
+  DECLARE_INSTANCE();
   auto multmatnode = std::make_shared<TransformNode>(instance, "align");
   multmatnode->children.push_back(dstnode);
   Matrix4d mat;

--- a/src/python/pyfunctions.cc
+++ b/src/python/pyfunctions.cc
@@ -40,7 +40,6 @@
 #include "core/TextNode.h"
 #include "core/OffsetNode.h"
 #include "core/ProjectionNode.h"
-#include "core/ImportNode.h"
 #include "core/Tree.h"
 #include "geometry/PolySet.h"
 #include "geometry/PolySetUtils.h"

--- a/src/python/pyopenscad.cc
+++ b/src/python/pyopenscad.cc
@@ -140,7 +140,7 @@ std::shared_ptr<AbstractNode> PyOpenSCADObjectToNodeMulti(PyObject *objs, PyObje
     }
     *dict = ((PyOpenSCADObject *)objs)->dict;
   } else if (PyList_Check(objs)) {
-    DECLARE_INSTANCE
+    DECLARE_INSTANCE();
     auto node = std::make_shared<CsgOpNode>(instance, OpenSCADOperator::UNION);
 
     int n = PyList_Size(objs);
@@ -256,6 +256,7 @@ std::vector<Vector3d> python_vectors(PyObject *vec, int mindim, int maxdim)
 
 void get_fnas(double& fn, double& fa, double& fs)
 {
+  // TODO: coryrc - Delete this function
   PyObject *mainModule = PyImport_AddModule("__main__");
   if (mainModule == nullptr) return;
   fn = 0;

--- a/src/python/pyopenscad.cc
+++ b/src/python/pyopenscad.cc
@@ -256,7 +256,7 @@ std::vector<Vector3d> python_vectors(PyObject *vec, int mindim, int maxdim)
 
 void get_fnas(double& fn, double& fa, double& fs)
 {
-  // TODO: coryrc - Delete this function
+  // TODO: github.com/openscad/openscad/issues/4246 - Delete this function
   PyObject *mainModule = PyImport_AddModule("__main__");
   if (mainModule == nullptr) return;
   fn = 0;

--- a/src/python/pyopenscad.h
+++ b/src/python/pyopenscad.h
@@ -9,10 +9,10 @@
 
 #pragma GCC diagnostic ignored "-Wwrite-strings"
 
-#define DECLARE_INSTANCE       \
+#define DECLARE_INSTANCE()     \
   std::string instance_name;   \
   AssignmentList inst_asslist; \
-  ModuleInstantiation *instance = new ModuleInstantiation(instance_name, inst_asslist, Location::NONE);
+  ModuleInstantiation *instance = new ModuleInstantiation(instance_name, inst_asslist, Location::NONE)
 
 typedef struct {
   PyObject_HEAD std::shared_ptr<AbstractNode> node;

--- a/src/utils/calc.cc
+++ b/src/utils/calc.cc
@@ -35,19 +35,6 @@
 // Linear interpolate.  Can replace with std::lerp in C++20
 double Calc::lerp(double a, double b, double t) { return (1 - t) * a + t * b; }
 
-/*!
-   Returns the number of subdivision of a whole circle, given radius and
-   the three special variables $fn, $fs and $fa
- */
-int Calc::get_fragments_from_r(double r, double fn, double fs, double fa)
-{
-  // FIXME: It would be better to refuse to create an object. Let's do more strict error handling
-  // in future versions of OpenSCAD
-  if (r < GRID_FINE || std::isinf(fn) || std::isnan(fn)) return 3;
-  if (fn > 0.0) return static_cast<int>(fn >= 3 ? fn : 3);
-  return static_cast<int>(ceil(fmax(fmin(360.0 / fa, r * 2 * M_PI / fs), 5)));
-}
-
 /*
    https://mathworld.wolfram.com/Helix.html
    For a helix defined as:         F(t) = [r*cost(t), r*sin(t), c*t]  for t in [0,T)

--- a/src/utils/calc.h
+++ b/src/utils/calc.h
@@ -2,7 +2,6 @@
 
 namespace Calc {
 double lerp(double a, double b, double t);
-int get_fragments_from_r(double r, double fn, double fs, double fa);
 int get_helix_slices(double r_sqr, double h, double twist, double fn, double fs, double fa);
 int get_conical_helix_slices(double r, double height, double twist, double scale, double fn, double fs,
                              double fa);


### PR DESCRIPTION
First step for #4246 The discussion there explains the motivation and naming.

Currently every single function which uses any discretization specials ($fn, $fs, $fn) or calls anything using them must save and/or pass them along individually. This refactors the code toward having one class own the formulas and code to extract the control variables from the environment, thus making it simple to add a new discretization special.

This is almost a no-op; the Python version of the `text` function was not setting the defaults for unspecified variables like OpenSCAD does. I changed it to do so. If this is unwanted, it can trivially be removed, but it sure seems like it should be this way.