### PR TITLE
Bugfix #6183 save a copy without changing editor state

### DIFF
--- a/src/gui/TabManager.cc
+++ b/src/gui/TabManager.cc
@@ -612,7 +612,6 @@ bool TabManager::save(EditorInterface *edt, const QString& path)
   QSaveFile file(path);
   if (!file.open(QIODevice::WriteOnly | QIODevice::Truncate | QIODevice::Text)) {
     saveError(file, _("Failed to open file for writing"), path);
-    LOG("Failed to open for write '%1$s'.", path.toLocal8Bit().constData());
     return false;
   }
 


### PR DESCRIPTION
i have carefully tested that 

1. a new editor tab is called Untitled and doing Save A Copy saves it as Untitled.scan unless you change the filename
2. doing Save or Save As still makes a file of the name you give, or Untitled.scad by default. Doing these operations updates the app's title bar, the editor tab, and the file name of record.
3. doing Save A Copy after the editor tab is saved offers to save the file with name "OGfilename_copy" and will save it out to "OGfilename_copy.scad" .. and does not update the editor and does not change the filename that will be offered the next time the editor tab is saved
4. it correctly detects existing files of the same name and offers to overwrite them
so i think my work here is done