### PR TITLE
parser: increase parser stack depth

### DIFF
--- a/src/core/parser.y
+++ b/src/core/parser.y
@@ -51,7 +51,7 @@
 
 namespace fs = std::filesystem;
 
-#define YYMAXDEPTH 20000
+#define YYMAXDEPTH 200000
 #define LOC(loc) Location(loc.first_line, loc.first_column, loc.last_line, loc.last_column, sourcefile())
 #ifdef DEBUG
 static Location debug_location(const std::string& info, const struct YYLTYPE& loc);


### PR DESCRIPTION
When parsing large generated scad files with a structure like:

    module passages() {
        color([0.5, 0.5, 0.5])
            passage(9 * dx, -5 * dy, -8 * dz, r2, 3);
        color([1, 0.5, 0.5])
            passage(7 * dx, -7 * dy, -10 * dz, r, 1)
    ...
    }

I experienced an error

    ERROR: Parser error: memory exhausted in file design.scad, line 40108

Increasing the parser stack depth solves the issue.

The same issue has been encountered before, see commit cc1f9e13534a ("quickfix: Increase parser stack depth to allow for larger designs")

Bison uses malloc() by default. The program stack size does not need to be adjusted.