### PR TITLE
Fix editor lexing of strings.  Fixes #5303.

### DIFF
--- a/src/gui/ScadLexer.cc
+++ b/src/gui/ScadLexer.cc
@@ -144,7 +144,7 @@ void Lex::default_rules()
   std::string operators(R"(\+ - \* \/ % \^ < <= >= == != >= > && \|\| ! = #)");
   defineRules(operators, eoperator);
 
-  rules_.push(R"(["](([\\]["])|[^"])*["])", eQuotedString);
+  rules_.push(R"(["](([\\].)|[^\\"])*["])", eQuotedString);
 
   std::string values("true false undef PI");
   defineRules(values, enumber);


### PR DESCRIPTION
Would previously recognize only \\" as special, which would mean that \\\\ would not be special, and that \\\\" would be interpreted as a backslash followed by \\" and that's not a string terminator. Now interprets all \\\<anychar> as special, so that the character after the \\ is consumed.