### PR TITLE
show error dialog when JSON parameter file fails to load

### DIFF
--- a/src/core/customizer/ParameterSet.cc
+++ b/src/core/customizer/ParameterSet.cc
@@ -1,8 +1,13 @@
 #include "core/customizer/ParameterSet.h"
 #include "utils/printutils.h"
 #include <boost/property_tree/json_parser.hpp>
-
 #include <string>
+
+#if !defined(OPENSCAD_NOGUI)
+#include <QApplication>
+#include <QMessageBox>
+#endif
+
 
 static std::string parameterSetsKey("parameterSets");
 static std::string fileFormatVersionKey("fileFormatVersion");
@@ -16,6 +21,17 @@ bool ParameterSets::readFile(const std::string& filename)
     boost::property_tree::read_json(filename, root);
   } catch (const boost::property_tree::json_parser_error& e) {
     LOG(message_group::Error, "Cannot open Parameter Set '%1$s': %2$s", filename, e.what());
+
+#if !defined(OPENSCAD_NOGUI)
+    if (QApplication::instance()) {
+        QString msg = QString("Failed to load parameter set JSON:\n%1\n\nReason: %2")
+            .arg(QString::fromStdString(filename))
+            .arg(QString::fromStdString(e.what()));
+        QMessageBox::critical(nullptr,
+                QObject::tr("JSON Load Error"), msg);
+    }
+#endif
+
     return false;
   }
 


### PR DESCRIPTION
Problem:
When a malformed or missing JSON parameter file is loaded, OpenSCAD only logs
an internal error message and gives no visible feedback to the user. This makes
it appear as if the Customizer simply has no presets.

Changes:
Added a GUI dialog using QMessageBox to report JSON parsing or structure errors
when reading parameter set files. The dialog is shown only when a QApplication
instance exists, keeping CLI and headless modes unaffected.

Before:
Malformed JSON files failed silently; no user-visible indication.

After:
Users now see a clear message box explaining why the parameter file failed to
load, including filename and parser error details.
<img width="560" height="262" alt="Screenshot_20251012_032600-1" src="https://github.com/user-attachments/assets/8f9c1e5c-363a-4d52-8792-a4dcf2f9d30d" />

Fixes #6224

I'm not entirely sure this is the best implementation or the ideal place for this code, 
but I did my best. If anything looks off, please feel free to provide feedback
I'm very open to making adjustments.