### PR TITLE
python: Respect virtualenv set externally

### DIFF
--- a/src/gui/MainWindow.cc
+++ b/src/gui/MainWindow.cc
@@ -2116,8 +2116,7 @@ std::shared_ptr<SourceFile> MainWindow::parseDocument(EditorInterface *editor)
     auto fulltext_py = std::string(this->lastCompiledDoc.toUtf8().constData());
 
     const auto& venv = venvBinDirFromSettings();
-    const auto& binDir = venv.empty() ? PlatformUtils::applicationPath() : venv;
-    initPython(binDir, this->animateWidget->getAnimTval());
+    initPython(venv, this->animateWidget->getAnimTval());
 
     if (venv.empty()) {
       LOG("Running %1$s without venv.", python_version());

--- a/src/openscad.cc
+++ b/src/openscad.cc
@@ -601,7 +601,7 @@ int cmdline(const CommandLine& cmd)
 
   if (python_active) {
     auto fulltext_py = text;
-    initPython(PlatformUtils::applicationPath(), 0.0);
+    initPython("", 0.0);
     auto error = evaluatePython(fulltext_py, false);
     if (error.size() > 0) LOG(error.c_str());
     text = "\n";

--- a/src/python/pyopenscad.cc
+++ b/src/python/pyopenscad.cc
@@ -324,8 +324,6 @@ void python_catch_error(std::string& errorstr)
 
 void initPython(const std::string& binDir, double time)
 {
-  const auto name = "openscad-python";
-  const auto exe = binDir + "/" + name;
   if (pythonInitDict) { /* If already initialized, undo to reinitialize after */
     PyObject *key, *value;
     Py_ssize_t pos = 0;
@@ -418,8 +416,9 @@ void initPython(const std::string& binDir, double time)
     stream << sep << PlatformUtils::userLibraryPath();
     stream << sepchar << ".";
 
-    PyConfig_SetBytesString(&config, &config.program_name, name);
-    PyConfig_SetBytesString(&config, &config.executable, exe.c_str());
+    if (!binDir.empty()) {
+      PyConfig_SetBytesString(&config, &config.executable, (binDir + "/python").c_str());
+    }
 
     PyStatus status = Py_InitializeFromConfig(&config);
     if (PyStatus_Exception(status)) {


### PR DESCRIPTION
This applies to two cases:

 * The GUI when a virtualenv was not set
 * The CLI/headless in all cases

(Note that the virtualenv path is detected at runtime via the `python` executable, there is no separate environment variable for it)

Fixes #6246