### PR TITLE
Update boost dependencies (used in vcpkg based build steps)

### DIFF
--- a/vcpkg.json
+++ b/vcpkg.json
@@ -2,7 +2,8 @@
   "name": "openscad",
   "version-string": "1.0.0",
   "dependencies": [
-    "boost",
+    "boost-regex",
+    "boost-program-options",
     "eigen3",
     "cgal",
     "cairo",


### PR DESCRIPTION
Instead of installing Boost for vcpkg, installing the above packages would help reduce the build time overall as opposed to including all of boost. Alternatively, setting the versions manually (like [here](https://github.com/roel-v/openscad/blob/vcpkg-build/vcpkg.json)) could be used. Another issue I came across when building has to do with running cmake not detecting Cairo, so it be specific to how the MSVC section of the cmake lists. I can add it to the issue #6152 in case other users also face it.