### PR TITLE
Always open print dialog if an unavailable print service is selected

### DIFF
--- a/src/gui/PrintInitDialog.cc
+++ b/src/gui/PrintInitDialog.cc
@@ -251,8 +251,12 @@ void PrintInitDialog::on_pushButtonCancel_clicked() { reject(); }
 int PrintInitDialog::exec()
 {
   bool showDialog = this->checkBoxAlwaysShowDialog->isChecked();
+
+  // Show the dialog if icon was shift-clicked, if no print service is selected,
+  // or if the selected print service is not available.
   if ((QApplication::keyboardModifiers() & Qt::ShiftModifier) != 0 ||
-      this->selectedPrintService == print_service_t::NONE) {
+      this->selectedPrintService == print_service_t::NONE ||
+      !PrintService::getPrintService(this->selectedServiceName.toStdString())) {
     showDialog = true;
   }
 


### PR DESCRIPTION
This may happen if a print service was selected, but then network services was subsequently disabled.
Currently, that causes an error message in the console, with no indication how to resolve:
```
Unknown print service "print-a-thing"
Error: Unable to create service: 1 print-a-thing 0
```
