### PR TITLE
Check for save/discard/cancel on quit.  Fixes #3971.

### DIFF
--- a/src/gui/OpenSCADApp.cc
+++ b/src/gui/OpenSCADApp.cc
@@ -93,3 +93,24 @@ void OpenSCADApp::setApplicationFont(const QString& family, uint size)
   )");
   scadApp->setStyleSheet(stylesheet.arg(family, QString::number(size)));
 }
+
+#if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
+// https://doc.qt.io/qt-6/qtcore-changes-qt6.html#other-classes
+//
+//     In Qt 5, QCoreApplication::quit() was equivalent to calling QCoreApplication::exit().
+//     This just exited the main event loop.
+//
+//     In Qt 6, the method will instead try to close all top-level windows by posting a close
+//     event. The windows are free to cancel the shutdown process by ignoring the event.
+//
+// For Qt5, simulate the Qt6 behavior.
+void OpenSCADApp::quit()
+{
+  for (MainWindow *mw : scadApp->windowManager.getWindows()) {
+    if (!mw->close()) {
+      return;
+    }
+  }
+  QApplication::quit();
+}
+#endif

--- a/src/gui/OpenSCADApp.h
+++ b/src/gui/OpenSCADApp.h
@@ -18,6 +18,10 @@ public:
 
   bool notify(QObject *object, QEvent *event) override;
   void requestOpenFile(const QString& filename);
+#if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
+  // See comments in OpenSCADApp.cc.
+  static void quit();
+#endif
 
 public slots:
   void showFontCacheDialog();


### PR DESCRIPTION
When the user requests a quit, ask each MainWindow to close.  If any of them refuse, don't quit.

One can imagine a number of different behaviors here.

If you have two MainWindows, and one of them says "yes" and the other says "no", should you leave both MWs open, or should you close the one that said "yes"?  I started out with the more transactional "if any of them say no, don't close any", but when I actually tried that it seemed wrong:  if I said "discard" on a window and another window declined to close, the "discard" decision was ... discarded, and I'd be asked again on the next quit attempt.  This one closes any MW that agrees to close, so the next time you aren't asked again about that window (because it's gone).

There's a similar question around "cancel".  If you say "cancel", does that mean "stop trying to quit" or does it mean "don't close *this* window, but keep trying to close other windows".  I started out with continuing to close other windows, but that didn't seem very cancel-y; this iteration stops trying to quit the first time you hit "cancel".

---

One thing slightly confuses me:  I originally marked OpenSCADApp::quit as "override", but the compiler tells me it doesn't override.  OpenSCADApp is a subclass of QApplication, and QApplication has a quit(), so it sure looks like an override to me.  But it's happy without the "override" marker.
