### PR TITLE
add correct StartupWMClass to set the correct icon on Gnome

### DIFF
--- a/resources/icons/openscad.desktop.in
+++ b/resources/icons/openscad.desktop.in
@@ -5,6 +5,7 @@ Name=OpenSCAD
 Comment=The Programmers Solid 3D CAD Modeller
 Icon=openscad${SNAPSHOT_SUFFIX}
 Exec=openscad${SUFFIX_WITH_DASH} %f
+StartupWMClass=org.openscad.openscad
 MimeType=application/x-openscad;
 Categories=Graphics;3DGraphics;Engineering;
 Keywords=3d;solid;geometry;csg;model;stl;


### PR DESCRIPTION
I believe this is the XDG way to do this, but I am not sure.

https://specifications.freedesktop.org/desktop-entry-spec/1.1/recognized-keys.html

It sets the runtime icon.

addresses: #6315
