### PR TITLE
Fully separate zoom levels for each tab.  Fixes #4742.

### DIFF
--- a/src/gui/TabManager.cc
+++ b/src/gui/TabManager.cc
@@ -51,6 +51,9 @@ TabManager::TabManager(MainWindow *o, const QString& filename)
   connect(tabWidget, &QTabWidget::currentChanged, this, &TabManager::updateFindState);
   connect(tabWidget, &QTabWidget::currentChanged, this, &TabManager::tabSwitched);
 
+  connect(par->editActionZoomTextIn, &QAction::triggered, this, &TabManager::zoomIn);
+  connect(par->editActionZoomTextOut, &QAction::triggered, this, &TabManager::zoomOut);
+
   createTab(filename);
 
   // Disable the closing button for the first tabbar
@@ -198,9 +201,6 @@ void TabManager::createTab(const QString& filename)
           &ScintillaEditor::onCharacterThresholdChanged);
   scintillaEditor->applySettings();
   editor->addTemplate();
-
-  connect(par->editActionZoomTextIn, &QAction::triggered, editor, &EditorInterface::zoomIn);
-  connect(par->editActionZoomTextOut, &QAction::triggered, editor, &EditorInterface::zoomOut);
 
   connect(editor, &EditorInterface::contentsChanged, this, &TabManager::updateActionUndoState);
   connect(editor, &EditorInterface::contentsChanged, par, &MainWindow::editorContentChanged);
@@ -749,4 +749,18 @@ bool TabManager::saveAll()
     }
   }
   return true;
+}
+
+void TabManager::zoomIn()
+{
+  if (editor) {
+    editor->zoomIn();
+  }
+}
+
+void TabManager::zoomOut()
+{
+  if (editor) {
+    editor->zoomOut();
+  }
 }

--- a/src/gui/TabManager.h
+++ b/src/gui/TabManager.h
@@ -70,6 +70,8 @@ private:
   void setTabsCloseButtonVisibility(int tabIndice, bool isVisible);
 
   QTabBar::ButtonPosition getClosingButtonPosition();
+  void zoomIn();
+  void zoomOut();
 
 private slots:
   void tabSwitched(int);


### PR DESCRIPTION
This implements what I called option 2, with the new tabs starting at the Preferences value.

Before this change, the zoom actions are linked to all of the tabs, individually, so they all see the event and modify their zoom levels.  With this change, the zoom actions are linked to the TabManager, which dispatches to the current editor and only that tab modifies its zoom level.

I'm not married to this option, but if it's the preferred one then this seems like a reasonable implementation.
