### PR TITLE
Experiment with the CGAL Epeck kernel

### DIFF
--- a/src/geometry/cgal/cgal.h
+++ b/src/geometry/cgal/cgal.h
@@ -50,7 +50,7 @@ using CGAL_Iso_rectangle_2e = CGAL::Iso_rectangle_2<CGAL::Simple_cartesian<NT2>>
 // 3D
 
 using NT3 = CGAL::Gmpq;
-using CGAL_Kernel3 = CGAL::Cartesian<NT3>;
+using CGAL_Kernel3 = CGAL::Epeck;
 using CGAL_Nef_polyhedron3 = CGAL::Nef_polyhedron_3<CGAL_Kernel3>;
 
 using CGAL_Polyhedron = CGAL::Polyhedron_3<CGAL_Kernel3>;

--- a/src/geometry/cgal/cgalutils-kernel.cc
+++ b/src/geometry/cgal/cgalutils-kernel.cc
@@ -1,4 +1,5 @@
 // Portions of this file are Copyright 2021 Google LLC, and licensed under GPL2+. See COPYING.
+#include "geometry/cgal/cgal.h"
 #include "geometry/cgal/cgalutils.h"
 #include <CGAL/Cartesian_converter.h>
 #include <CGAL/gmpxx.h>
@@ -6,13 +7,13 @@
 namespace CGALUtils {
 
 template <>
-double KernelConverter<CGAL::Cartesian<CGAL::Gmpq>, CGAL::Epick>::operator()(const CGAL::Gmpq& n) const
+double KernelConverter<CGAL_Kernel3, CGAL::Epick>::operator()(const CGAL_Kernel3::FT& n) const
 {
   return CGAL::to_double(n);
 }
 
 template <>
-CGAL::Gmpq KernelConverter<CGAL::Epick, CGAL::Cartesian<CGAL::Gmpq>>::operator()(const double& n) const
+CGAL_Kernel3::FT KernelConverter<CGAL::Epick, CGAL_Kernel3>::operator()(const double& n) const
 {
   return n;
 }


### PR DESCRIPTION
We currently use the `CGAL::Cartesian<Gmpq>` kernel. The main challenge with this kernel is that it has severe performance challenges. Discussing with some CGAL folks revealed that the `Epeck` "filtered" kernel _should_ give the same guarantees as this kernel, but will only use `Gmpq` numbers when necessary, yielding a significant performance boost compared to the kernel we use today.

Before making the switch, we need to run a significant amount of corner-case tests + performance tests to both validate the performance impact and make sure we don't introduce any stability issues.