### PR TITLE
Fix invalid HTML structure in examples menu

### DIFF
--- a/scripts/examples-html/assets/js/menu.js
+++ b/scripts/examples-html/assets/js/menu.js
@@ -1,6 +1,10 @@
 function addSubmenu(menu, name, files) {
     var ul = document.createElement('ul');
-    ul.appendChild(document.createElement('h3'));
+    var li = document.createElement('li');
+    var h3 = document.createElement('h3');
+    h3.appendChild(document.createTextNode(name));
+    li.appendChild(h3);
+    ul.appendChild(li);
     for (var a = 0; a < files.length; a++) {
         var menulink = document.createElement('a');
         menulink.href = "../" + name + "/" + files[a] + ".html";


### PR DESCRIPTION
The `<h3>` element was being directly appended to `<ul>`, which violates HTML standards. According to W3C specifications, `<ul>` elements can only contain `<li>` elements as direct children.

This fix:
- Wraps the `<h3>` heading in an `<li>` element
- Adds the submenu name as text content to the heading
- Ensures proper HTML5 compliance