### PR TITLE
Don't crash MouseSelector, debug GL init

### DIFF
--- a/src/gui/MouseSelector.cc
+++ b/src/gui/MouseSelector.cc
@@ -69,6 +69,10 @@ void MouseSelector::setupFramebuffer(int width, int height)
   if (!this->framebuffer || this->framebuffer->width() != width ||
       this->framebuffer->height() != height) {
     this->framebuffer = createFBO(width, height);
+    if (!this->framebuffer) {
+      LOG(message_group::Error, "MouseSelector: Failed to create framebuffer; disabling mouse selection.");
+      return;
+    }
     // We bind the framebuffer before initializing shaders since
     // shader validation requires a valid framebuffer.
     this->framebuffer->bind();
@@ -86,6 +90,8 @@ void MouseSelector::setupFramebuffer(int width, int height)
  */
 int MouseSelector::select(const Renderer *renderer, int x, int y)
 {
+  if (!this->framebuffer) return -1;
+
   // This function should render a frame, as usual, with the following changes:
   // * Render to as custom framebuffer
   // * The shader should be the selector shader

--- a/src/gui/QGLView.cc
+++ b/src/gui/QGLView.cc
@@ -118,6 +118,9 @@ void QGLView::initializeGL()
   }
   PRINTDB("GLAD: Loaded OpenGL %d.%d", GLAD_VERSION_MAJOR(version) % GLAD_VERSION_MINOR(version));
 #endif  // ifdef USE_GLAD
+
+  PRINTD(gl_dump());
+
   GLView::initializeGL();
 
   this->selector = std::make_unique<MouseSelector>(this);


### PR DESCRIPTION
Addressing #6243:

* Disable MouseSelector if the current GL context doesn't support FBOs.
* Debug GL info after Qt has created and initialized the GL context