### PR TITLE
Check print service name only if remote print service is selected.

### DIFF
--- a/src/gui/PrintInitDialog.cc
+++ b/src/gui/PrintInitDialog.cc
@@ -254,9 +254,12 @@ int PrintInitDialog::exec()
 
   // Show the dialog if icon was shift-clicked, if no print service is selected,
   // or if the selected print service is not available.
-  if ((QApplication::keyboardModifiers() & Qt::ShiftModifier) != 0 ||
-      this->selectedPrintService == print_service_t::NONE ||
-      !PrintService::getPrintService(this->selectedServiceName.toStdString())) {
+  const bool isShiftKeyModifier = (QApplication::keyboardModifiers() & Qt::ShiftModifier) != 0;
+  const bool isNoPrintService = this->selectedPrintService == print_service_t::NONE;
+  const bool isRemotePrintService = this->selectedPrintService == print_service_t::PRINT_SERVICE;
+  const auto printService = PrintService::getPrintService(this->selectedServiceName.toStdString());
+  const bool noRemotePrintServiceSelected = isRemotePrintService && !printService;
+  if (isShiftKeyModifier || isNoPrintService || noRemotePrintServiceSelected) {
     showDialog = true;
   }
 


### PR DESCRIPTION
This fixes the issue that the print dialog is always shown if the local application is selected for printing.