### PR TITLE
Set QSCINTILLA_DLL for MINGW (and not MXECROSS).

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -169,6 +169,9 @@ if (MINGW)
       >
     )
   endif()
+  if (NOT MXECROSS)
+    target_compile_definitions(OpenSCAD PRIVATE QSCINTILLA_DLL)
+  endif()
 endif()
 
 set(CMAKE_MODULE_PATH "${CMAKE_SOURCE_DIR}/submodules/sanitizers-cmake/cmake" ${CMAKE_MODULE_PATH})


### PR DESCRIPTION
Qscintilla signal connection doesn't work if we're linked against a Qscintilla DLL (rather than statically) - as we are for MSYS2 builds.  This causes a number of small things in the editor to not work; the easiest to see is that typing into a new window doesn't put the `*` on the tab to indicate an unsaved change.

This probably isn't exactly the right place for this setting, because it applies only to MINGW and not to MSVC... but it's a conservative place.