### PR TITLE
Fix QFile::open nodiscard warning with Qt6 6.10.0.

### DIFF
--- a/src/gui/UIUtils.cc
+++ b/src/gui/UIUtils.cc
@@ -119,10 +119,8 @@ void enumerateExamples(const fs::path& dir)
     auto fileInfo =
       QFileInfo{QDir{QString::fromStdString(entry.path().generic_string())}, "example-dir.json"};
     QJsonObject obj;
-    if (fileInfo.isReadable()) {
-      QFile file;
-      file.setFileName(fileInfo.filePath());
-      file.open(QIODevice::ReadOnly);
+    QFile file(fileInfo.filePath());
+    if (file.open(QIODevice::ReadOnly)) {
       obj = QJsonDocument::fromJson(file.readAll()).object();
     }
     readExamplesDir(obj, entry.path());


### PR DESCRIPTION
In Qt 6.10.0, `QFile::open()` becomes `[[nodiscard]]`.

Paths elided:
```
.../src/gui/UIUtils.cc: In function 'void {anonymous}::enumerateExamples(const std::filesystem::__cxx11::path&)':
.../src/gui/UIUtils.cc:125:16: warning: ignoring return value of 'virtual bool QFile::open(QIODeviceBase::OpenMode)', declared with attribute 'nodiscard' [-Wunused-result]
  125 |       file.open(QIODevice::ReadOnly);
      |       ~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~
.../ucrt64/include/qt6/QtCore/qfileinfo.h:9,
                 from .../ucrt64/include/qt6/QtCore/QFileInfoList:1,
                 from .../src/gui/UIUtils.h:32,
                 from .../src/gui/UIUtils.cc:27:
.../ucrt64/include/qt6/QtCore/qfile.h:291:32: note: declared here
  291 |     QFILE_MAYBE_NODISCARD bool open(OpenMode flags) override;
      |                                ^~~~
```

Theoretically there was a TOCTOU problem:  it would check whether the file was readable, then if so would open it (and ignore the result from the open).  If it was not openable something bad might happen.

But really there's no need for the `isReadable()` test.  Just try to open it.  If the open succeeds, great.  If the open fails, that's OK too, just don't read it.  (Note that `readExamplesDir()` supplies defaults, so an empty `QJsonObject` is OK.)

Tested (on MSYS2) with Qt5 and Qt6, with the JSON file existing and not-existing.