### PR TITLE
Fix indentation of CC0 template text. Also clean up line endings.

### DIFF
--- a/templates/CC0.json
+++ b/templates/CC0.json
@@ -1,4 +1,4 @@
 {
 	"key" : "CC0",
-	"content" : "  // License: CC0 (aka CC Zero) - To the extent possible under law,\n // ^~^ has waived all copyright and related or neighboring rights to this work.\n// https://creativecommons.org/publicdomain/zero/1.0/"
+	"content" : "// License: CC0 (aka CC Zero) - To the extent possible under law,\n// ^~^ has waived all copyright and related or neighboring rights to this work.\n// https://creativecommons.org/publicdomain/zero/1.0/"
 }

--- a/templates/README.md
+++ b/templates/README.md
@@ -1,0 +1,20 @@
+Files in this directory define snippets that can be included in a file with a few clicks.
+
+In the editor pane, right click and then Insert Template pops a list of templates.
+Double-clicking one inserts the text.
+
+Sample:
+```
+{
+    "key" : "translate",
+    "content" : "translate([^~^])"
+}
+```
+
+* `key` is the name shown in the template list.
+* `content` is the content to insert.
+* `^~^` is removed and the cursor is left there.
+
+User-defined templates can be added at **[UserConfigPath]**/templates.
+
+https://en.wikibooks.org/wiki/OpenSCAD_User_Manual/The_OpenSCAD_User_Interface/Advanced#Editor_Templates


### PR DESCRIPTION
I noticed that the CC0 text resulting from the template was indented oddly - first line indented two spaces, second line indented one space, third line not indented.

```
  // License: CC0 (aka CC Zero) - To the extent possible under law,
 //  has waived all copyright and related or neighboring rights to this work.
// https://creativecommons.org/publicdomain/zero/1.0/
```

So I removed the leading spaces.

```
// License: CC0 (aka CC Zero) - To the extent possible under law,
//  has waived all copyright and related or neighboring rights to this work.
// https://creativecommons.org/publicdomain/zero/1.0/
```

Also, it seems that the original had CRLFs instead of NLs, and had no NL on the last line.  I fixed those up too, so that it's consistent with the other files in the repo.