### PR TITLE
fixing #6224 read JSON error reporting for Customiser

### DIFF
--- a/src/core/customizer/ParameterSet.h
+++ b/src/core/customizer/ParameterSet.h
@@ -15,9 +15,24 @@ private:
   std::string _name;
 };
 
+// Structure to hold JSON parsing error details
+struct JsonErrorInfo {
+  std::string message;     // The error message (e.g., "expected '}' or ','")
+  std::string filename;    // The JSON file path
+  unsigned long line = 0;  // Line number where error occurred (0 if unknown)
+
+  bool hasError() const { return !message.empty(); }
+  void clear()
+  {
+    message.clear();
+    filename.clear();
+    line = 0;
+  }
+};
+
 class ParameterSets : public std::vector<ParameterSet>
 {
 public:
-  bool readFile(const std::string& filename);
+  bool readFile(const std::string& filename, JsonErrorInfo& errorInfo);
   void writeFile(const std::string& filename) const;
 };

--- a/src/gui/MainWindow.cc
+++ b/src/gui/MainWindow.cc
@@ -2092,6 +2092,9 @@ std::shared_ptr<SourceFile> MainWindow::parseDocument(EditorInterface *editor)
 {
   resetSuppressedMessages();
 
+  // Report any JSON parsing errors from the parameter set file
+  editor->parameterWidget->reportJsonErrors();
+
   auto document = editor->toPlainText();
   auto fulltext = std::string(document.toUtf8().constData()) + "\n\x03\n" + commandline_commands;
 

--- a/src/gui/parameter/ParameterWidget.h
+++ b/src/gui/parameter/ParameterWidget.h
@@ -48,7 +48,7 @@ private:
   ParameterObjects parameters;
   std::map<ParameterObject *, std::vector<ParameterVirtualWidget *>> widgets;
 
-  QString invalidJsonFile;  // set if a json file was read that could not be parsed
+  JsonErrorInfo jsonError;  // structured error info from parsing the json file
   QTimer autoPreviewTimer;
   bool modified = false;
 
@@ -59,6 +59,7 @@ public:
   void saveBackupFile(const QString& scadFile);
   void setParameters(const SourceFile *sourceFile, const std::string& source);
   void applyParameters(SourceFile *sourceFile);
+  void reportJsonErrors();
   bool childHasFocus();
   bool isModified() const { return modified; }
 

--- a/src/openscad.cc
+++ b/src/openscad.cc
@@ -622,7 +622,14 @@ int cmdline(const CommandLine& cmd)
   if (!cmd.parameterFile.empty() && !cmd.setName.empty()) {
     ParameterObjects parameters = ParameterObjects::fromSourceFile(root_file);
     ParameterSets sets;
-    sets.readFile(cmd.parameterFile);
+    JsonErrorInfo errorInfo;
+    sets.readFile(cmd.parameterFile, errorInfo);
+    if (errorInfo.hasError()) {
+      LOG(message_group::Error,
+          Location(static_cast<int>(errorInfo.line), 0, static_cast<int>(errorInfo.line), 0,
+                   std::make_shared<fs::path>(errorInfo.filename)),
+          "", "%1$s", errorInfo.message);
+    }
     for (const auto& set : sets) {
       if (set.name() == cmd.setName) {
         parameters.importValues(set);

--- a/tests/bad-json/customizer-all-bad.json
+++ b/tests/bad-json/customizer-all-bad.json
@@ -1,0 +1,21 @@
+{
+    "fileFormatVersion": "1",
+    "parameterSets": {
+        "New set 1": "",
+        "New set 2": "",
+        "New set 3": 
+            "Labeled_Strings": "S",
+            "Labeled_Values": "10",
+            "Nu5
+            "Strings": "foo",
+            "TextBox": "hello",
+            "Two_Bee": "true",
+            "Vector1": "[12]",
+            "Vector2": "[12, 34]",
+            "Vector3": "[12, 34, 46]",
+            "Vector4": "[0.5, 0.5, 0.5, 0.5]",
+            "slider": "34",
+            "stepSlider": "2"
+        }
+    }
+}

--- a/tests/bad-json/customizer-all-bad.scad
+++ b/tests/bad-json/customizer-all-bad.scad
@@ -1,0 +1,172 @@
+// Using all the parameters in the customizer
+//
+// parameters are adjusted in the Customizer
+//  to define a parameter use comments and a variable
+//    //Description
+//    variable=value; //Parameter Widget spec
+//
+// Comments of this form define a group of parameters
+//  /*[ group name ]*/
+//
+/* [Combo Boxes] */
+// select a number
+Numbers=2; // [0, 1, 2, 3,4]
+echo( "Number selected ", Numbers );
+
+// select a string
+Strings="foo"; // [foo, bar, baz]
+echo( "String selected ", Strings );
+
+num_select_rev_lookup = object(
+  [
+  ["5","S"],["10","L"], ["20","M"], ["30","XL"]
+  ]);
+//labeled combo box for numbers
+Labeled_Values=10; // [5:S, 10:L, 20:M, 30:XL]
+echo( "Selected ",
+    num_select_rev_lookup[str(Labeled_Values)],
+    " got ",
+    Labeled_Values
+    );
+
+str_select_rev_lookup = object(
+  [
+  ["S","Small"],["M","Medium"], ["L","Large"]
+  ]);
+//labeled combo box for string
+Labeled_Strings="S"; // [S:Small, M:Medium, L:Large]
+
+echo( "Selected ",
+    str_select_rev_lookup[Labeled_Strings],
+    " got ",
+    Labeled_Strings
+    );
+
+/*[ Sliders ]*/
+// slider widget for number
+slider =34; // [10:100]
+echo( "Slider Selected ", slider );
+
+//step slider for number
+stepSlider=2; //[0:5:100]
+echo( "Step Selected ", stepSlider );
+
+/* [Checkboxes (booleans)] */
+
+// 2B or Not 2B
+Two_Bee = true;
+echo( Two_Bee ? true : false, " selected " );
+
+/*[Spinbox Group] */
+
+// spinbox with step size 1
+SpinCube = 5;
+echo( "Spinner Cube Size ", SpinCube );
+translate([0,0,15]) cube(SpinCube);
+
+// spinbox with step size 5
+SpinSphere = 5;  //[0:5:100]
+PolySides  = 1;  //[1:1:100]
+echo( "Spinner Sphere Size ", SpinSphere );
+translate([0,6,0]) sphere(SpinSphere, $fn=PolySides);
+
+/* [Textbox Group] */
+// Text box for string
+TextBox="hello";
+echo( "What you said ", TextBox );
+
+/* [Vector Examples Group] */
+//Text boxes for up to 4 elements
+Vector1=[12]; //[0:2:50]
+v1=[Vector1.x, Vector1.x, Vector1.x];
+translate(v1) color("green")
+  cube(SpinCube);
+echo("Vector 1 moves the green cube.");
+
+Vector2=[12,34]; //[-50:2:50]
+translate(Vector2)
+  color("red")
+    sphere(SpinSphere, $fn=5);
+echo("Vector 2 translates the Red Sphere only in the X-Y plane");
+
+Vector3=[12,34,46]; //[-50:2:50]
+translate(Vector3)
+  color("yellow")
+    sphere(SpinSphere, $fn=8);
+echo("Vector 2 translates the Yellow Sphere 3D space");
+
+Vector4=[.5,.5,.5,.5]; //[0:0.1:1.0]
+translate(v1*-1.0)
+  color(Vector4)
+    sphere(SpinSphere, $fn=PolySides);
+echo("Vector 1 also moves the multicolored sphere");
+
+/* [Functions] */
+// function literals are only in versions
+//  after 2025
+// has to be last because if() {} creates a local scope
+//  that stops the customizer collecting widgets
+
+
+/* [Objects] */
+// objects are only in versions from 2025
+// has to be last because if() {} creates a local scope
+//  that stops the customizer collecting widgets
+
+barney_data = [["name","Barney"],["spouse","Betty"]];
+
+
+if( version_num() >= 2.02503e7 ) {
+// set up for selecting a function
+  f = function (s) str( "f ",s);
+  g = function (s) is_num(s)?
+    "g: want string"
+    :
+    str("<", s, ">")
+    ;
+  h = function (s) is_string(s)?
+    "h: want number"
+    :
+    s * 12
+    ;
+  //labeled combo box for functions
+  functions=g; // [f():Eff, g():Gee, h():Ach]
+
+  echo( "Function gets string ", fs=functions("test"));
+  echo( "Function gets number ", fn=functions(3));
+  }
+
+
+
+if( version_num() >= 2.02503e7 ) {
+// set up for selecting a function
+  o = object( name="Fred", spouse="Wilma" );
+
+  barney_data = [["name","Barney"],["spouse","Betty"]];
+  p = object(barney_data);
+
+  //labeled combo box for functions
+  objects=o; // [o:Oh, p():Pee]
+
+  echo( "Selected Objext ", objects);
+  }
+
+echo( "You wont see the next one" );
+/* [Hidden] */
+debugMode = true;
+
+
+/*
+ 2025 by bitbasher (Jeff Hayes)
+
+ To the extent possible under law, the author(s)
+  have dedicated all copyright and related and
+  neighboring rights to this software to the
+  public domain worldwide. This software is
+  distributed without anywarranty.
+
+  You should have received a copy of the
+  Creative Commons Zero (CC0)
+  Public Domain Dedication along with this software.
+  If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */

--- a/tests/bad-json/customizer-all.json
+++ b/tests/bad-json/customizer-all.json
@@ -1,0 +1,24 @@
+{
+    "fileFormatVersion": "1",
+    "parameterSets": {
+        "New set 1": "",
+        "New set 2": "",
+        "New set 3": {
+            "Labeled_Strings": "S",
+            "Labeled_Values": "10",
+            "Numbers": "1",
+            "PolySides": "1",
+            "SpinCube": "5",
+            "SpinSphere": "5",
+            "Strings": "foo",
+            "TextBox": "hello",
+            "Two_Bee": "true",
+            "Vector1": "[12]",
+            "Vector2": "[12, 34]",
+            "Vector3": "[12, 34, 46]",
+            "Vector4": "[0.5, 0.5, 0.5, 0.5]",
+            "slider": "34",
+            "stepSlider": "2"
+        }
+    }
+}

--- a/tests/bad-json/customizer-all.scad
+++ b/tests/bad-json/customizer-all.scad
@@ -1,0 +1,172 @@
+// Using all the parameters in the customizer
+//
+// parameters are adjusted in the Customizer
+//  to define a parameter use comments and a variable
+//    //Description
+//    variable=value; //Parameter Widget spec
+//
+// Comments of this form define a group of parameters
+//  /*[ group name ]*/
+//
+/* [Combo Boxes] */
+// select a number
+Numbers=2; // [0, 1, 2, 3,4]
+echo( "Number selected ", Numbers );
+
+// select a string
+Strings="foo"; // [foo, bar, baz]
+echo( "String selected ", Strings );
+
+num_select_rev_lookup = object(
+  [
+  ["5","S"],["10","L"], ["20","M"], ["30","XL"]
+  ]);
+//labeled combo box for numbers
+Labeled_Values=10; // [5:S, 10:L, 20:M, 30:XL]
+echo( "Selected ",
+    num_select_rev_lookup[str(Labeled_Values)],
+    " got ",
+    Labeled_Values
+    );
+
+str_select_rev_lookup = object(
+  [
+  ["S","Small"],["M","Medium"], ["L","Large"]
+  ]);
+//labeled combo box for string
+Labeled_Strings="S"; // [S:Small, M:Medium, L:Large]
+
+echo( "Selected ",
+    str_select_rev_lookup[Labeled_Strings],
+    " got ",
+    Labeled_Strings
+    );
+
+/*[ Sliders ]*/
+// slider widget for number
+slider =34; // [10:100]
+echo( "Slider Selected ", slider );
+
+//step slider for number
+stepSlider=2; //[0:5:100]
+echo( "Step Selected ", stepSlider );
+
+/* [Checkboxes (booleans)] */
+
+// 2B or Not 2B
+Two_Bee = true;
+echo( Two_Bee ? true : false, " selected " );
+
+/*[Spinbox Group] */
+
+// spinbox with step size 1
+SpinCube = 5;
+echo( "Spinner Cube Size ", SpinCube );
+translate([0,0,15]) cube(SpinCube);
+
+// spinbox with step size 5
+SpinSphere = 5;  //[0:5:100]
+PolySides  = 1;  //[1:1:100]
+echo( "Spinner Sphere Size ", SpinSphere );
+translate([0,6,0]) sphere(SpinSphere, $fn=PolySides);
+
+/* [Textbox Group] */
+// Text box for string
+TextBox="hello";
+echo( "What you said ", TextBox );
+
+/* [Vector Examples Group] */
+//Text boxes for up to 4 elements
+Vector1=[12]; //[0:2:50]
+v1=[Vector1.x, Vector1.x, Vector1.x];
+translate(v1) color("green")
+  cube(SpinCube);
+echo("Vector 1 moves the green cube.");
+
+Vector2=[12,34]; //[-50:2:50]
+translate(Vector2)
+  color("red")
+    sphere(SpinSphere, $fn=5);
+echo("Vector 2 translates the Red Sphere only in the X-Y plane");
+
+Vector3=[12,34,46]; //[-50:2:50]
+translate(Vector3)
+  color("yellow")
+    sphere(SpinSphere, $fn=8);
+echo("Vector 2 translates the Yellow Sphere 3D space");
+
+Vector4=[.5,.5,.5,.5]; //[0:0.1:1.0]
+translate(v1*-1.0)
+  color(Vector4)
+    sphere(SpinSphere, $fn=PolySides);
+echo("Vector 1 also moves the multicolored sphere");
+
+/* [Functions] */
+// function literals are only in versions
+//  after 2025
+// has to be last because if() {} creates a local scope
+//  that stops the customizer collecting widgets
+
+
+/* [Objects] */
+// objects are only in versions from 2025
+// has to be last because if() {} creates a local scope
+//  that stops the customizer collecting widgets
+
+barney_data = [["name","Barney"],["spouse","Betty"]];
+
+
+if( version_num() >= 2.02503e7 ) {
+// set up for selecting a function
+  f = function (s) str( "f ",s);
+  g = function (s) is_num(s)?
+    "g: want string"
+    :
+    str("<", s, ">")
+    ;
+  h = function (s) is_string(s)?
+    "h: want number"
+    :
+    s * 12
+    ;
+  //labeled combo box for functions
+  functions=g; // [f():Eff, g():Gee, h():Ach]
+
+  echo( "Function gets string ", fs=functions("test"));
+  echo( "Function gets number ", fn=functions(3));
+  }
+
+
+
+if( version_num() >= 2.02503e7 ) {
+// set up for selecting a function
+  o = object( name="Fred", spouse="Wilma" );
+
+  barney_data = [["name","Barney"],["spouse","Betty"]];
+  p = object(barney_data);
+
+  //labeled combo box for functions
+  objects=o; // [o:Oh, p():Pee]
+
+  echo( "Selected Objext ", objects);
+  }
+
+echo( "You wont see the next one" );
+/* [Hidden] */
+debugMode = true;
+
+
+/*
+ 2025 by bitbasher (Jeff Hayes)
+
+ To the extent possible under law, the author(s)
+  have dedicated all copyright and related and
+  neighboring rights to this software to the
+  public domain worldwide. This software is
+  distributed without anywarranty.
+
+  You should have received a copy of the
+  Creative Commons Zero (CC0)
+  Public Domain Dedication along with this software.
+  If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */

--- a/tests/bad-json/full-test-fix-session.txt
+++ b/tests/bad-json/full-test-fix-session.txt
@@ -1,0 +1,115 @@
+
+Read openscad.cc, lines 615 to 640
+
+openscad.cc+2-2
+Now let's build and see if it compiles:
+
+
+cd /d/repositories/openscad-6224/build && cmake --build . --config Release -j4 2>&1 | tail -80
+I see the issue - Location needs a std::shared_ptr<fs::path>fs::path not a string. Let me check the AST.h for Location:
+
+Read AST.h
+
+Summarized conversation history
+
+I see. I need to use Location::NONE as the default and create a proper Location with fs::path. Let me check the current state of ParameterWidget.cc and fix it:
+
+Read ParameterWidget.cc, lines 148 to 185
+
+Summarized conversation history
+
+ParameterWidget.cc+4-3
+Summarized conversation history
+
+Now rebuild:
+
+
+cd /d/repositories/openscad-6224/build && cmake --build . --config Release -j4 2>&1 | tail -60
+Summarized conversation history
+
+The build succeeded! Now let's test with the bad JSON files that were created earlier. First, let me check if they exist:
+
+
+ls -la /d/repositories/openscad-6224/tests/bad-json/
+Let me look at the bad JSON file to understand the expected error:
+
+Read customizer-all-bad.json
+
+Good - there's a missing brace and malformed JSON. Now let's run OpenSCAD with this file to see if our error is reported:
+
+
+cd /d/repositories/openscad-6224/build && ./openscad.exe -o /tmp/out.csg "/d/repositories/openscad-6224/tests/bad-json/customizer-all-bad.scad" 2>&1
+The command-line version ran but didn't show the JSON error. Let me check the code in openscad.cc - it looks like we changed it, but the error might still not be output. Let me look at how LOG() works there:
+
+Read openscad.cc, lines 620 to 650
+
+I see - in the command-line version, we read the error info but don't report it! Let me fix that:
+
+openscad.cc+5-0
+Now check if we need the Location include:
+
+Good, Location is already used in the file. Let me rebuild and test:
+
+
+cd /d/repositories/openscad-6224/build && cmake --build . --config Release -j4 2>&1 | tail -20
+I see - the Location constructor order is different. Let me look at the correct signature:
+
+Read AST.h, lines 1 to 40
+
+I see, it's (firstLine, firstCol, lastLine, lastCol, path) - lines/columns first, then path. Let me fix both usages:
+
+Read openscad.cc, lines 625 to 640
+
+openscad.cc+4-4
+Now also fix ParameterWidget.cc with the correct Location constructor order:
+
+Read ParameterWidget.cc, lines 155 to 180
+
+That's already correct! Let's rebuild:
+
+
+cd /d/repositories/openscad-6224/build && cmake --build . --config Release -j4 2>&1 | tail -20
+Build succeeded. Now let's test the command-line version:
+
+
+cd /d/repositories/openscad-6224/build && ./openscad.exe -o /tmp/out.csg -p "/d/repositories/openscad-6224/tests/bad-json/customizer-all-bad.json" -P "New set 1" "/d/repositories/openscad-6224/tests/bad-json/customizer-all-bad.scad" 2>&1
+Excellent! Now we see two error messages:
+
+ERROR: Cannot open Parameter Set 'D:/repositories/openscad-6224/tests/bad-json/customizer-all-bad.json': <unspecified file>(7): expected '}' or ','
+ERROR: expected '}' or ',' in file ../tests/bad-json/customizer-all-bad.json, line 7
+The second one looks like it's coming from the original LOG() call in ParameterSet.cc. Let me clean that up since we now have our own error reporting:
+
+Read ParameterSet.cc, lines 76 to 76
+
+Read ParameterSet.cc, lines 50 to 76
+
+Read ParameterSet.cc, lines 20 to 50
+
+I see. The LOG() call at line 30 is the old one that's still there. Since we're now storing the error info and it will be reported by the caller, we should remove this LOG() call. However, this would change behavior for calling code that doesn't check the error. Let me think about this...
+
+Actually, looking at the output, we have:
+
+Our new error from openscad.cc using our structured error (line 7, message about expected '}' or ',')
+The old LOG() from ParameterSet.cc that includes the full e.what()
+But e.what() includes <unspecified file>(7): prefix which isn't very clean. Our new one is cleaner because we're using the actual filename. However, it's still showing <unspecified file> in the message, because the boost message includes it. Let me look at what e.message() returns vs e.what():
+
+The issue is that e.message() is the message part without file/line, while e.what() is the formatted string including file/line but with <unspecified file> when reading from a stream.
+
+Let's remove the old LOG() call since we now properly capture the error info for the caller to report:
+
+ParameterSet.cc+2-1
+Now rebuild and test again:
+
+
+cd /d/repositories/openscad-6224/build && cmake --build . --config Release -j4 2>&1 | tail -10
+
+cd /d/repositories/openscad-6224/build && ./openscad.exe -o /tmp/out.csg -p "/d/repositories/openscad-6224/tests/bad-json/customizer-all-bad.json" -P "New set 1" "/d/repositories/openscad-6224/tests/bad-json/customizer-all-bad.scad" 2>&1
+Now we get a single, clean error message:
+
+This is exactly what we want - a clear error message with the filename and line number.
+
+Now let's also test the GUI version. Let me start OpenSCAD to test opening the bad JSON in the GUI:
+
+
+cd /d/repositories/openscad-6224/build && ./openscad.exe "/d/repositories/openscad-6224/tests/bad-json/customizer-all-bad.scad" &
+The GUI is launched. Let me create a summary of all the changes made to fix this issue:


### PR DESCRIPTION
… capture improved. it has been confirmed as working in the GUI (Windows only so far) and for the command line

the errors are logged to the Error DB and so are visible in that table as well as in the console

running from the command line i notices that customizer errors were not being logged .. turned out that was due to the reading of the JSON file happening before error reporting was set up. Opus figured out a way to log and preserve the error message so it could be shown in the console after the fact