### PR TITLE
Add --args to dump command line arguments.

### DIFF
--- a/src/openscad.cc
+++ b/src/openscad.cc
@@ -791,6 +791,17 @@ struct CommaSeparatedVector {
   }
 };
 
+void
+dumpArgs(int argc, char **argv)
+{
+  PlatformUtils::dumpArgs(argc, argv);
+
+  for (int i = 0; i < argc; i++) {
+    std::cout << "argv[" << i << "] = >" << argv[i] << "<\n";
+  }
+  std::cout << "\n";
+}
+
 // OpenSCAD
 int openscad_main(int argc, char **argv)
 {
@@ -918,7 +929,8 @@ int openscad_main(int argc, char **argv)
           "check-parameter-ranges", po::value<std::string>(),
           "=true/false, configure the parameter range check for builtin modules")(
           "debug", po::value<std::string>(),
-          "special debug info - specify 'all' or a set of source file names")
+          "special debug info - specify 'all' or a set of source file names")(
+          "args", "dump command-line arguments")
 #ifdef ENABLE_PYTHON
           ("trust-python", "Trust python")("python-module", po::value<std::string>(),
                                            "=module Call pip python module")
@@ -960,6 +972,11 @@ int openscad_main(int argc, char **argv)
     OpenSCAD::debug = vm["debug"].as<std::string>();
     LOG("Debug on. --debug=%1$s", OpenSCAD::debug);
   }
+
+  if (vm.count("args")) {
+    dumpArgs(argc, argv);
+  }
+
 #ifdef ENABLE_PYTHON
   if (vm.count("trust-python")) {
     LOG("Python Engine enabled", OpenSCAD::debug);

--- a/src/platform/PlatformUtils-mac.mm
+++ b/src/platform/PlatformUtils-mac.mm
@@ -99,3 +99,5 @@ const std::string PlatformUtils::sysinfo(bool extended)
 }
 
 void PlatformUtils::ensureStdIO(void) {}
+
+void PlatformUtils::dumpArgs(int argc, char **argv) {}

--- a/src/platform/PlatformUtils-posix.cc
+++ b/src/platform/PlatformUtils-posix.cc
@@ -272,3 +272,5 @@ const std::string PlatformUtils::sysinfo(bool extended)
 }
 
 void PlatformUtils::ensureStdIO() {}
+
+void PlatformUtils::dumpArgs(int argc, char **argv) {}

--- a/src/platform/PlatformUtils-win.cc
+++ b/src/platform/PlatformUtils-win.cc
@@ -202,3 +202,8 @@ void PlatformUtils::ensureStdIO(void)
   mi_register_output(&mi_output, nullptr);
 #endif
 }
+
+void PlatformUtils::dumpArgs(int argc, char **argv)
+{
+  std::cout << "Raw: >" << GetCommandLineA() << "<\n\n";
+}

--- a/src/platform/PlatformUtils.h
+++ b/src/platform/PlatformUtils.h
@@ -119,4 +119,9 @@ void ensureStdIO();
  * a given number of digits.
  */
 std::string toMemorySizeString(uint64_t bytes, int digits);
+
+/**
+ * Print any platform-specific information about command-line arguments.
+ */
+void dumpArgs(int argc, char **argv);
 }  // namespace PlatformUtils


### PR DESCRIPTION
Fixes #6435.

The major reason that I'm creating a PR at this point is to get a CI-built Windows OpenSCAD to experiment with.