### PR TITLE
Made find highlighting and count case-insensitive

### DIFF
--- a/src/gui/ScintillaEditor.cc
+++ b/src/gui/ScintillaEditor.cc
@@ -820,8 +820,8 @@ int ScintillaEditor::updateFindIndicators(const QString& findText, bool visibili
   qsci->SendScintilla(QsciScintilla::SCI_SETINDICATORCURRENT, findIndicatorNumber);
   qsci->SendScintilla(qsci->SCI_INDICATORCLEARRANGE, 0, qsci->length());
 
-  const auto txt = qsci->text().toUtf8();
-  const auto findTextUtf8 = findText.toUtf8();
+  const auto txt = qsci->text().toUtf8().toLower();
+  const auto findTextUtf8 = findText.toUtf8().toLower();
   auto pos = txt.indexOf(findTextUtf8);
   auto len = findTextUtf8.length();
   if (visibility && len > 0) {


### PR DESCRIPTION
Fixes #5451 

Phase 1 (Complete) - Made **find highlighting** and **count** case-**insensitive** to match with Replace and Replace All behavior.

<img width="608" height="260" alt="fix_1" src="https://github.com/user-attachments/assets/39393ec8-18e9-4f13-9bb5-34948e4ee938" />


### Changes made:
Updated member function `ScintillaEditor::updateFindIndicators`
Normalized the search space and text to search to lowercase

### GUI Test flow:

1. open OpenSCAD with an empty file
2. write a word in lower case only (e.g. ‘error’)
3. write the same word with capital letters (e.g. ‘Error’) or mixed-case (e.g. 'eRRor', 'errOR') in the next line
4. select ‘Find and Replace’
5. enter the word in lower case (e.g. ‘error’) in the search field
-- highlights all matches irrespective of case (capital letters, lower case, mixed-case) and displays the number of occurrences at the end of the search field.
-- search is case-insensitive
6. write a word in the replacement field (e.g. ‘mistake’)
7. click on the ‘All’ button
-- both words are replaced
-- thus matching the behavior of 'Find'


### Planned work:
Phase 2 - Case-sensitive toggle
Phase 3 - Feature rich Search like BBEdit 