### PR TITLE
More CircleCI cleanup

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -70,7 +70,7 @@ commands:
                 command: tar -xzf /tmp/artifacts/openscad-*.tar.gz --strip-components=1
 
 jobs:
-  openscad-mxe:
+  openscad-mxe-64bit:
     parameters:
       openscad_platform:
         type: string
@@ -116,7 +116,7 @@ jobs:
       - store_artifacts:
           path: /tmp/out
           destination: MXE
-  openscad-appimage:
+  openscad-appimage-64bit:
     parameters:
       openscad_platform:
         type: string
@@ -410,13 +410,13 @@ workflows:
   version: 2
   "CircleCI snapshot build (master)":
     jobs:
-      - openscad-mxe:
+      - openscad-mxe-64bit:
           context: secret-context
           filters:
               branches:
                   only:
                       - master
-      - openscad-appimage:
+      - openscad-appimage-64bit:
           context: secret-context
           filters:
               branches:
@@ -439,14 +439,14 @@ workflows:
                       - master
   "CircleCI branch build (PR)":
     jobs:
-      - openscad-mxe:
+      - openscad-mxe-64bit:
           filters:
               branches:
                   ignore:
                       - master
                       - coverity_scan
                       - /^(?i:continuous)$/
-      - openscad-appimage:
+      - openscad-appimage-64bit:
           filters:
               branches:
                   ignore:


### PR DESCRIPTION
* Remove obsolete macOS schedule (macOS now build on every master push)
* Don't use hardcoded directory names
* Use default workspace locations
* Naming cosmetics for executors and workflows
* Use `get_source` everywhere
