### PR TITLE
CI: enable sccache

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -27,25 +27,13 @@ executors:
 commands:
   # Provides OPENSCAD_VERSION and OPENSCAD_COMMIT
   establish_version:
-    parameters:
-      build_id:
-        type: string
-        default: ""
     steps:
       - run:
           name: Establish Version
           command: |
               source scripts/establish_version.sh
-              OPENSCAD_COMMIT=$(openscad_commit)
-              BASE_VERSION=$(openscad_version)
-              if [ -n "<< parameters.build_id >>" ]; then
-                  OPENSCAD_VERSION="${BASE_VERSION}.<< parameters.build_id >>"
-              else
-                  OPENSCAD_VERSION="${BASE_VERSION}"
-              fi
-              
-              echo "export OPENSCAD_COMMIT=$OPENSCAD_COMMIT" >> $BASH_ENV
-              echo "export OPENSCAD_VERSION=$OPENSCAD_VERSION" >> $BASH_ENV
+              echo "export OPENSCAD_COMMIT=$(openscad_commit)" >> $BASH_ENV
+              echo "export OPENSCAD_VERSION=$(openscad_version)" >> $BASH_ENV
   get_source:
     parameters:
       method:
@@ -68,6 +56,33 @@ commands:
             - run:
                 name: "Unpack tarball"
                 command: tar -xzf /tmp/workspace/openscad-*.src.tar.gz --strip-components=1
+  setup-sccache:
+    steps:
+      - run:
+          name: Install sccache
+          command: |
+              SCCACHE_VERSION=0.12.0
+              SCCACHE_TGZ="sccache-v${SCCACHE_VERSION}-x86_64-unknown-linux-musl.tar.gz"
+              curl -fsSL -o "/tmp/${SCCACHE_TGZ}" \
+                "https://github.com/mozilla/sccache/releases/download/v${SCCACHE_VERSION}/${SCCACHE_TGZ}"
+              tar -xzf "/tmp/${SCCACHE_TGZ}" -C /tmp
+              install -m 0755 "/tmp/sccache-v${SCCACHE_VERSION}-x86_64-unknown-linux-musl/sccache" /usr/local/bin/sccache
+  restore-sccache-cache:
+    steps:
+      - restore_cache:
+          name: Restore sccache cache
+          key: sccache-cache-stable-{{ arch }}-{{ .Environment.CIRCLE_JOB }}
+  save-sccache-cache:
+    steps:
+      - save_cache:
+          name: Save sccache cache
+          # We use {{ epoch }} to always upload a fresh cache:
+          # Of course, restore_cache will not find this exact key,
+          # but it will fall back to the closest key (aka the most recent).
+          # See https://discuss.circleci.com/t/add-mechanism-to-update-existing-cache-key/9014/13
+          key: sccache-cache-stable-{{ arch }}-{{ .Environment.CIRCLE_JOB }}-{{ epoch }}
+          paths:
+            - "~/.cache/sccache"
 
 jobs:
   openscad-mxe:
@@ -85,16 +100,19 @@ jobs:
     steps:
       - get_source:
           method: << parameters.source_method >>
-      - establish_version:
-          build_id: "ci${CIRCLE_BUILD_NUM}"
+      - setup-sccache
+      - restore-sccache-cache
+      - establish_version
       - run:
           name: Build OpenSCAD Windows Application (64bit)
           no_output_timeout: 18000
           command: |
+              sccache --start-server
               export NUMCPU=4
               export LC_ALL=C.UTF-8
               export MXEDIR=/mxe
               export PKG_CONFIG_PATH=/mxe/usr/x86_64-w64-mingw32.static.posix/lib/pkgconfig
+              export USE_SCCACHE=1
               ln -sf /usr/bin/python{3,}
               if [ x"${CIRCLE_BRANCH}" = xmaster ] || [ "<< parameters.openscad_build_type >>" != "snapshot" ]; then
                 export SUFFIX=""
@@ -103,6 +121,7 @@ jobs:
               fi
               
               ./scripts/release-common.sh mingw64 -v "$OPENSCAD_VERSION" -c "$OPENSCAD_COMMIT" << parameters.openscad_build_type >>
+              sccache --show-stats
               mkdir -p /tmp/artifacts
               for f in mingw*/*.zip mingw*/*.exe; do N=$(basename "$f" | sed -e "s/\\(-x86-[36][24]\\)/\\1${SUFFIX}/;"); cp -iv "$f" /tmp/artifacts/"$N"; done
               if [ -n "${CODE_SIGNING_KEY}" ]
@@ -115,6 +134,7 @@ jobs:
               else
                   echo "Skipping code signing."
               fi
+      - save-sccache-cache
       - store_artifacts:
           path: /tmp/artifacts
           destination: MXE
@@ -133,12 +153,14 @@ jobs:
     steps:
       - get_source:
           method: << parameters.source_method >>
-      - establish_version:
-          build_id: "ai${CIRCLE_BUILD_NUM}"
+      - setup-sccache
+      - restore-sccache-cache
+      - establish_version
       - run:
           name: Build OpenSCAD AppImage
           no_output_timeout: 18000
           command: |
+              sccache --start-server
               if [ x"${CIRCLE_BRANCH}" = xmaster ] || [ "<< parameters.openscad_build_type >>" != "snapshot" ]; then
                 export SUFFIX=""
               else
@@ -153,20 +175,23 @@ jobs:
                   -DOPENSCAD_COMMIT="$OPENSCAD_COMMIT" \
                   -DCMAKE_INSTALL_PREFIX=/usr \
                   -DCMAKE_BUILD_TYPE=Release \
+                  -DCMAKE_C_COMPILER_LAUNCHER=sccache \
+                  -DCMAKE_CXX_COMPILER_LAUNCHER=sccache \
                   -DUSE_BUILTIN_OPENCSG=ON \
                   -DMANIFOLD_PYBIND=OFF \
                   -DMANIFOLD_TEST=OFF \
                   -DENABLE_PYTHON=ON \
                   -DENABLE_TESTS=OFF \
                   $CMAKE_EXTRA_ARGS
-              make -j4
-              make install DESTDIR=../AppDir
+              cmake --build . -j 2  # using all 4 cores OOMs
+              DESTDIR=../AppDir cmake --install .
               cd ..
               export PATH=/appimage/usr/bin:"$PATH"
               export EXTRA_QT_PLUGINS=svg
               export PYTHON_VERSION=$(python3 -c "import sys; v=sys.version_info; print(f'{v.major}.{v.minor}.{v.micro}')")
               export LINUXDEPLOY_OUTPUT_VERSION="${OPENSCAD_VERSION}${SUFFIX}"
               linuxdeploy --plugin python --plugin qt --output appimage --appdir AppDir
+              sccache --show-stats
               mkdir -p /tmp/artifacts
               cp -iv OpenSCAD-*.AppImage /tmp/artifacts
               if [ -n "${CODE_SIGNING_KEY}" ]; then
@@ -178,6 +203,7 @@ jobs:
               else
                   echo "Skipping code signing."
               fi
+      - save-sccache-cache
       - store_artifacts:
           path: /tmp/artifacts
           destination: AppImage
@@ -196,6 +222,8 @@ jobs:
     steps:
       - get_source:
           method: << parameters.source_method >>
+      - setup-sccache
+      - restore-sccache-cache
       - run:
           name: Install latest node.js
           command: |
@@ -216,12 +244,12 @@ jobs:
                     npm init -y
                     npm i puppeteer
                     npx puppeteer browsers install chrome
-      - establish_version:
-          build_id: "wasm${CIRCLE_BUILD_NUM}"
+      - establish_version
       - run:
           name: Build OpenSCAD WASM (<< parameters.openscad_platform >>)
           no_output_timeout: 18000
           command: |
+              sccache --start-server
               export WASM_TYPE=$(echo "<< parameters.openscad_platform >>" | sed 's/^wasm-//')
               if [ x"${CIRCLE_BRANCH}" = xmaster ] || [ "<< parameters.openscad_build_type >>" != "snapshot" ]; then
                 export SUFFIX=""
@@ -231,14 +259,17 @@ jobs:
               if [ "<< parameters.openscad_build_type >>" == "snapshot" ]; then
                 export CMAKE_EXTRA_ARGS="-DSNAPSHOT=ON -DEXPERIMENTAL=ON"
               fi
-              emcmake cmake -B ../build . \
+              emcmake cmake -G Ninja -B ../build . \
                   -DCMAKE_BUILD_TYPE=Release \
+                  -DCMAKE_C_COMPILER_LAUNCHER=sccache \
+                  -DCMAKE_CXX_COMPILER_LAUNCHER=sccache \
                   -DWASM_BUILD_TYPE=$WASM_TYPE \
                   -DOPENSCAD_COMMIT="$OPENSCAD_COMMIT" \
                   -DOPENSCAD_VERSION="$OPENSCAD_VERSION" \
                   $CMAKE_EXTRA_ARGS
               cd ../build
-              make -j4 VERBOSE=1
+              cmake --build .
+              sccache --show-stats
               mkdir -p /tmp/artifacts
               zip -9r "/tmp/artifacts/OpenSCAD-${OPENSCAD_VERSION}${SUFFIX}-WebAssembly-$WASM_TYPE.zip" openscad.*
               if [ -n "${CODE_SIGNING_KEY}" ]; then
@@ -250,6 +281,7 @@ jobs:
               else
                   echo "Skipping code signing."
               fi
+      - save-sccache-cache
       - run:
           name: Verify OpenSCAD WASM build
           command: |

--- a/scripts/release-common.sh
+++ b/scripts/release-common.sh
@@ -63,6 +63,10 @@ fi
 
 CMAKE_CONFIG="-DCMAKE_BUILD_TYPE=Release -DENABLE_TESTS=OFF"
 
+if [ -n "${USE_SCCACHE}" ] && command -v sccache >/dev/null 2>&1; then
+  CMAKE_CONFIG="$CMAKE_CONFIG -DCMAKE_C_COMPILER_LAUNCHER=sccache -DCMAKE_CXX_COMPILER_LAUNCHER=sccache"
+fi
+
 if [[ "$OSTYPE" =~ "darwin" ]]; then
   OS=MACOSX
 elif [[ $OSTYPE == "msys" ]]; then


### PR DESCRIPTION
This avoids doing redundant work by caching compiler results. Because CI does less work, we can run more redundant CI jobs and avoid the mental overhead of manually de-duping jobs.

replacement for https://github.com/openscad/openscad/pull/6466