### PR TITLE
Change console font size via mouse wheel event (fixes #6186).

### DIFF
--- a/src/gui/Console.h
+++ b/src/gui/Console.h
@@ -56,6 +56,8 @@ public:
   QString clickedAnchor;
   void contextMenuEvent(QContextMenuEvent *event) override;
 
+  void wheelEvent(QWheelEvent *event) override;
+
   void mousePressEvent(QMouseEvent *e) override
   {
     clickedAnchor = (e->button() & Qt::LeftButton) ? anchorAt(e->pos()) : QString();
@@ -84,6 +86,6 @@ public slots:
   void actionClearConsole_triggered();
   void actionSaveAs_triggered();
   void hyperlinkClicked(const QString& loc);
-  void setFont(const QString& fontFamily, uint ptSize);
+  void setConsoleFont(const QString& fontFamily, uint ptSize);
   void update();
 };

--- a/src/gui/MainWindow.cc
+++ b/src/gui/MainWindow.cc
@@ -340,8 +340,9 @@ MainWindow::MainWindow(const QStringList& filenames) : rubberBandManager(this)
           &MainWindow::onTabManagerEditorContentReloaded);
 
   connect(GlobalPreferences::inst(), &Preferences::consoleFontChanged, this->console, &Console::setFont);
-  this->console->setFont(GlobalPreferences::inst()->getValue("advanced/consoleFontFamily").toString(),
-                         GlobalPreferences::inst()->getValue("advanced/consoleFontSize").toUInt());
+  this->console->setConsoleFont(
+    GlobalPreferences::inst()->getValue("advanced/consoleFontFamily").toString(),
+    GlobalPreferences::inst()->getValue("advanced/consoleFontSize").toUInt());
 
   const QString version =
     QString("<b>OpenSCAD %1</b>").arg(QString::fromStdString(std::string(openscad_versionnumber)));


### PR DESCRIPTION
This is only changing the current console widget, not the value in the preferences.

As this only uses the mouse wheel event handler, pinch probably will not work. If that's needed we can open a dedicated issue. That will need someone with setup to actually test that.