### PR TITLE
Fix premature assignment expiration warning

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -10,3 +10,6 @@ updates:
       github-actions:
         patterns:
           - "*"
+    ignore:
+      - dependency-name: "takanome-dev/assign-issue-action"
+        versions: ["2.3.x"]

--- a/.github/workflows/assign.yml
+++ b/.github/workflows/assign.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Assign the user or unassign stale assignments
-        uses: takanome-dev/assign-issue-action@v2.3
+        uses: takanome-dev/assign-issue-action@v2.2
         with:
           maintainers: 'abshk-jr,amarjeetkapoor1,brad,cliffordwolf,donbright,gsohler,justbuchanan,kintel,MichaelAtOz,MichaelPFrey,minad,nophead,pca006132,rcolyer,shaina7837,Sharma-Hrishabh,t-paul,tbharathchandra,thehans'
           days_until_unassign: 30


### PR DESCRIPTION
I tested with 2.2, but I didn't know this dependabot thing was going to change it.

I filed a bug
https://github.com/takanome-dev/assign-issue-action/issues/411 but in the meantime, just go back to 2.2 which was fine, and prevent dependabot from doing this again.