### PR TITLE
Reset caches on backend change

### DIFF
--- a/src/gui/OpenSCADApp.cc
+++ b/src/gui/OpenSCADApp.cc
@@ -4,6 +4,13 @@
 #include "gui/EventFilter.h"
 #endif
 
+#include "geometry/GeometryCache.h"
+#ifdef ENABLE_CGAL
+#include "geometry/cgal/CGALCache.h"
+#endif
+#include "glview/RenderSettings.h"
+#include "gui/Preferences.h"
+
 #include <QApplication>
 #include <QEvent>
 #include <QObject>
@@ -19,6 +26,9 @@ OpenSCADApp::OpenSCADApp(int& argc, char **argv) : QApplication(argc, argv)
 #ifdef Q_OS_MACOS
   this->installEventFilter(new SCADEventFilter(this));
 #endif
+
+  connect(GlobalPreferences::inst(), &Preferences::renderBackend3DChanged, this,
+          &OpenSCADApp::setRenderBackend3D);
 }
 
 OpenSCADApp::~OpenSCADApp() { delete this->fontCacheDialog; }
@@ -75,6 +85,13 @@ void OpenSCADApp::hideFontCacheDialog()
 {
   assert(this->fontCacheDialog);
   this->fontCacheDialog->reset();
+}
+
+void OpenSCADApp::setRenderBackend3D(RenderBackend3D backend)
+{
+  RenderSettings::inst()->backend3D = backend;
+  CGALCache::instance()->clear();
+  GeometryCache::instance()->clear();
 }
 
 void OpenSCADApp::setApplicationFont(const QString& family, uint size)

--- a/src/gui/OpenSCADApp.h
+++ b/src/gui/OpenSCADApp.h
@@ -4,6 +4,7 @@
 #include <QObject>
 #include <QString>
 #include <QApplication>
+#include "glview/RenderSettings.h"
 #include "gui/WindowManager.h"
 
 class QProgressDialog;
@@ -27,6 +28,7 @@ public slots:
   void showFontCacheDialog();
   void hideFontCacheDialog();
   void setApplicationFont(const QString& family, uint size);
+  void setRenderBackend3D(RenderBackend3D backend);
 
 public:
   WindowManager windowManager;

--- a/src/gui/Preferences.cc
+++ b/src/gui/Preferences.cc
@@ -853,9 +853,9 @@ void Preferences::on_enableRangeCheckBox_toggled(bool state)
 void Preferences::on_comboBoxRenderBackend3D_activated(int val)
 {
   applyComboBox(this->comboBoxRenderBackend3D, val, Settings::Settings::renderBackend3D);
-  RenderSettings::inst()->backend3D =
-    renderBackend3DFromString(Settings::Settings::renderBackend3D.value())
-      .value_or(DEFAULT_RENDERING_BACKEND_3D);
+  auto backend = renderBackend3DFromString(Settings::Settings::renderBackend3D.value())
+                   .value_or(DEFAULT_RENDERING_BACKEND_3D);
+  emit renderBackend3DChanged(backend);
 }
 
 void Preferences::on_comboBoxToolbarExport3D_activated(int val)

--- a/src/gui/Preferences.h
+++ b/src/gui/Preferences.h
@@ -17,6 +17,7 @@
 #include <QSettings>
 #include <string>
 
+#include "glview/RenderSettings.h"
 #include "gui/qtgettext.h"  // IWYU pragma: keep
 #include "openscad_gui.h"
 #include "ui_Preferences.h"
@@ -177,6 +178,7 @@ signals:
   void characterThresholdChanged(int val) const;
   void stepSizeChanged(int val) const;
   void toolbarExportChanged() const;
+  void renderBackend3DChanged(RenderBackend3D backend) const;
 
 private slots:
   void on_lineEditStepSize_textChanged(const QString& arg1);


### PR DESCRIPTION
This resets all caches when the render backend changes.

Fixes #6516

