### PR TITLE
clang-format: Add AllowShortFunctionsOnASingleLine: InlineOnly

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -35,3 +35,4 @@ BraceWrapping:
   AfterFunction: true
 
 AllowShortIfStatementsOnASingleLine: AllIfsAndElse
+AllowShortFunctionsOnASingleLine: InlineOnly

--- a/src/Feature.cc
+++ b/src/Feature.cc
@@ -57,9 +57,15 @@ Feature::Feature(const std::string& name, std::string description, bool hidden)
   if (!hidden) feature_list.push_back(this);
 }
 
-const std::string& Feature::get_name() const { return name; }
+const std::string& Feature::get_name() const
+{
+  return name;
+}
 
-const std::string& Feature::get_description() const { return description; }
+const std::string& Feature::get_description() const
+{
+  return description;
+}
 
 bool Feature::is_enabled() const
 {
@@ -70,7 +76,10 @@ bool Feature::is_enabled() const
 #endif
 }
 
-void Feature::enable(bool status) { enabled = status; }
+void Feature::enable(bool status)
+{
+  enabled = status;
+}
 
 // Note, features are also accessed by iterator with begin/end.
 void Feature::enable_feature(const std::string& feature_name, bool status)
@@ -90,9 +99,15 @@ void Feature::enable_all(bool status)
   }
 }
 
-Feature::iterator Feature::begin() { return feature_list.begin(); }
+Feature::iterator Feature::begin()
+{
+  return feature_list.begin();
+}
 
-Feature::iterator Feature::end() { return feature_list.end(); }
+Feature::iterator Feature::end()
+{
+  return feature_list.end();
+}
 
 std::string Feature::features()
 {

--- a/src/FontCache.cc
+++ b/src/FontCache.cc
@@ -74,7 +74,10 @@ std::string get_harfbuzz_version()
   return OpenSCAD::get_version_string(header_version, runtime_version);
 }
 
-std::string get_freetype_version() { return FontCache::instance()->get_freetype_version(); }
+std::string get_freetype_version()
+{
+  return FontCache::instance()->get_freetype_version();
+}
 
 FontInfo::FontInfo(std::string family, std::string style, std::string file, uint32_t hash)
   : family(std::move(family)), style(std::move(style)), file(std::move(file)), hash(hash)
@@ -92,13 +95,25 @@ bool FontInfo::operator<(const FontInfo& rhs) const
   return file < rhs.file;
 }
 
-const std::string& FontInfo::get_family() const { return family; }
+const std::string& FontInfo::get_family() const
+{
+  return family;
+}
 
-const std::string& FontInfo::get_style() const { return style; }
+const std::string& FontInfo::get_style() const
+{
+  return style;
+}
 
-const std::string& FontInfo::get_file() const { return file; }
+const std::string& FontInfo::get_file() const
+{
+  return file;
+}
 
-const uint32_t FontInfo::get_hash() const { return hash; }
+const uint32_t FontInfo::get_hash() const
+{
+  return hash;
+}
 
 FontCache *FontCache::self = nullptr;
 FontCache::InitHandlerFunc *FontCache::cb_handler = FontCache::defaultInitHandler;
@@ -110,7 +125,10 @@ const std::string FontCache::DEFAULT_FONT("Liberation Sans:style=Regular");
  * handler is registered, the cache build is just called synchronously in the
  * current thread by this handler.
  */
-void FontCache::defaultInitHandler(FontCacheInitializer *initializer, void *) { initializer->run(); }
+void FontCache::defaultInitHandler(FontCacheInitializer *initializer, void *)
+{
+  initializer->run();
+}
 
 FontCache::FontCache()
 {
@@ -302,9 +320,15 @@ FontInfoList *FontCache::list_fonts() const
   return list;
 }
 
-bool FontCache::is_init_ok() const { return this->init_ok; }
+bool FontCache::is_init_ok() const
+{
+  return this->init_ok;
+}
 
-void FontCache::clear() { this->cache.clear(); }
+void FontCache::clear()
+{
+  this->cache.clear();
+}
 
 void FontCache::dump_cache(const std::string& info)
 {

--- a/src/RenderStatistic.cc
+++ b/src/RenderStatistic.cc
@@ -172,9 +172,14 @@ static nlohmann::json getCache(C cache)
 
 }  // namespace
 
-RenderStatistic::RenderStatistic() : begin(std::chrono::steady_clock::now()) {}
+RenderStatistic::RenderStatistic() : begin(std::chrono::steady_clock::now())
+{
+}
 
-void RenderStatistic::start() { begin = std::chrono::steady_clock::now(); }
+void RenderStatistic::start()
+{
+  begin = std::chrono::steady_clock::now();
+}
 
 std::chrono::milliseconds RenderStatistic::ms()
 {
@@ -329,9 +334,13 @@ void LogVisitor::printRenderingTime(const std::chrono::milliseconds ms)
       (ms.count() / 1000 / 60 % 60), (ms.count() / 1000 % 60), (ms.count() % 1000));
 }
 
-void LogVisitor::finish() {}
+void LogVisitor::finish()
+{
+}
 
-void StreamVisitor::visit(const GeometryList& geomlist) {}
+void StreamVisitor::visit(const GeometryList& geomlist)
+{
+}
 
 void StreamVisitor::visit(const Polygon2d& poly)
 {
@@ -443,4 +452,7 @@ void StreamVisitor::printRenderingTime(const std::chrono::milliseconds ms)
   }
 }
 
-void StreamVisitor::finish() { stream << json; }
+void StreamVisitor::finish()
+{
+  stream << json;
+}

--- a/src/core/AST.cc
+++ b/src/core/AST.cc
@@ -15,9 +15,15 @@ bool operator==(Location const& lhs, Location const& rhs)
          lhs.filePath() == rhs.filePath();
 }
 
-bool operator!=(Location const& lhs, Location const& rhs) { return !(lhs == rhs); }
+bool operator!=(Location const& lhs, Location const& rhs)
+{
+  return !(lhs == rhs);
+}
 
-bool Location::isNone() const { return ((*this) == Location::NONE); }
+bool Location::isNone() const
+{
+  return ((*this) == Location::NONE);
+}
 
 std::string Location::toRelativeString(const std::string& docPath) const
 {

--- a/src/core/Arguments.cc
+++ b/src/core/Arguments.cc
@@ -53,7 +53,10 @@ Arguments Arguments::clone() const
   return output;
 }
 
-const std::string& Arguments::documentRoot() const { return evaluation_session->documentRoot(); }
+const std::string& Arguments::documentRoot() const
+{
+  return evaluation_session->documentRoot();
+}
 
 std::ostream& operator<<(std::ostream& stream, const Argument& argument)
 {

--- a/src/core/Assignment.cc
+++ b/src/core/Assignment.cc
@@ -37,7 +37,10 @@ void Assignment::addAnnotations(AnnotationList *annotations)
   }
 }
 
-bool Assignment::hasAnnotations() const { return !annotations.empty(); }
+bool Assignment::hasAnnotations() const
+{
+  return !annotations.empty();
+}
 
 const Annotation *Assignment::annotation(const std::string& name) const
 {

--- a/src/core/BuiltinContext.cc
+++ b/src/core/BuiltinContext.cc
@@ -9,7 +9,9 @@
 #include "core/module.h"
 #include "utils/printutils.h"
 
-BuiltinContext::BuiltinContext(EvaluationSession *session) : Context(session) {}
+BuiltinContext::BuiltinContext(EvaluationSession *session) : Context(session)
+{
+}
 
 void BuiltinContext::init()
 {

--- a/src/core/CSGNode.cc
+++ b/src/core/CSGNode.cc
@@ -157,9 +157,15 @@ void CSGOperation::initBoundingBox()
   }
 }
 
-bool CSGLeaf::isEmptySet() const { return polyset == nullptr || polyset->isEmpty(); }
+bool CSGLeaf::isEmptySet() const
+{
+  return polyset == nullptr || polyset->isEmpty();
+}
 
-std::string CSGLeaf::dump() const { return this->label; }
+std::string CSGLeaf::dump() const
+{
+  return this->label;
+}
 
 // Recursive traversal can cause stack overflow with very large loops of child nodes,
 // so tree is traverse iteratively, managing our own stack.

--- a/src/core/Children.cc
+++ b/src/core/Children.cc
@@ -50,6 +50,12 @@ ContextHandle<ScopeContext> Children::scopeContext() const
   return Context::create<ScopeContext>(context, children_scope);
 }
 
-bool Children::empty() const { return !children_scope->hasChildren(); }
+bool Children::empty() const
+{
+  return !children_scope->hasChildren();
+}
 
-size_t Children::size() const { return children_scope->moduleInstantiations.size(); }
+size_t Children::size() const
+{
+  return children_scope->moduleInstantiations.size();
+}

--- a/src/core/ColorNode.cc
+++ b/src/core/ColorNode.cc
@@ -91,7 +91,10 @@ std::string ColorNode::toString() const
              this->color.a(), "])");
 }
 
-std::string ColorNode::name() const { return "color"; }
+std::string ColorNode::name() const
+{
+  return "color";
+}
 
 void register_builtin_color()
 {

--- a/src/core/Context.cc
+++ b/src/core/Context.cc
@@ -37,7 +37,9 @@
 #include "core/function.h"
 #include "utils/printutils.h"
 
-Context::Context(EvaluationSession *session) : ContextFrame(session), parent(nullptr) {}
+Context::Context(EvaluationSession *session) : ContextFrame(session), parent(nullptr)
+{
+}
 
 Context::Context(const std::shared_ptr<const Context>& parent)
   : ContextFrame(parent->evaluation_session), parent(parent)

--- a/src/core/ContextFrame.cc
+++ b/src/core/ContextFrame.cc
@@ -40,7 +40,9 @@
 #include <string>
 #include <vector>
 #include <boost/format.hpp>
-ContextFrame::ContextFrame(EvaluationSession *session) : evaluation_session(session) {}
+ContextFrame::ContextFrame(EvaluationSession *session) : evaluation_session(session)
+{
+}
 
 boost::optional<const Value&> ContextFrame::lookup_local_variable(const std::string& name) const
 {
@@ -149,7 +151,10 @@ bool ContextFrame::is_config_variable(const std::string& name)
   return name[0] == '$' && name != "$children";
 }
 
-const std::string& ContextFrame::documentRoot() const { return evaluation_session->documentRoot(); }
+const std::string& ContextFrame::documentRoot() const
+{
+  return evaluation_session->documentRoot();
+}
 
 #ifdef DEBUG
 std::string ContextFrame::dumpFrame() const

--- a/src/core/CsgOpNode.cc
+++ b/src/core/CsgOpNode.cc
@@ -58,7 +58,10 @@ static std::shared_ptr<AbstractNode> builtin_intersection(const ModuleInstantiat
   return children.instantiate(std::make_shared<CsgOpNode>(inst, OpenSCADOperator::INTERSECTION));
 }
 
-std::string CsgOpNode::toString() const { return this->name() + "()"; }
+std::string CsgOpNode::toString() const
+{
+  return this->name() + "()";
+}
 
 std::string CsgOpNode::name() const
 {

--- a/src/core/CurveDiscretizer.cc
+++ b/src/core/CurveDiscretizer.cc
@@ -392,7 +392,10 @@ RoofDiscretizer::RoofDiscretizer(const CurveDiscretizer& d, double scale)
 {
 }
 
-bool RoofDiscretizer::overMaxAngle(double radians) const { return radians > max_angle_deviation; }
+bool RoofDiscretizer::overMaxAngle(double radians) const
+{
+  return radians > max_angle_deviation;
+}
 
 bool RoofDiscretizer::overMaxSegmentSqrLength(double segment_sqr_length) const
 {

--- a/src/core/DrawingCallback.cc
+++ b/src/core/DrawingCallback.cc
@@ -36,7 +36,9 @@ DrawingCallback::DrawingCallback(unsigned long fn, double size)
 {
 }
 
-DrawingCallback::~DrawingCallback() {}
+DrawingCallback::~DrawingCallback()
+{
+}
 
 void DrawingCallback::start_glyph()
 {
@@ -61,7 +63,10 @@ void DrawingCallback::finish_glyph()
   }
 }
 
-std::vector<std::shared_ptr<const Polygon2d>> DrawingCallback::get_result() { return this->polygons; }
+std::vector<std::shared_ptr<const Polygon2d>> DrawingCallback::get_result()
+{
+  return this->polygons;
+}
 
 void DrawingCallback::set_glyph_offset(double offset_x, double offset_y)
 {

--- a/src/core/Expression.cc
+++ b/src/core/Expression.cc
@@ -63,7 +63,10 @@ Value Expression::checkUndef(Value&& val, const std::shared_ptr<const Context>& 
   return std::move(val);
 }
 
-bool Expression::isLiteral() const { return false; }
+bool Expression::isLiteral() const
+{
+  return false;
+}
 
 UnaryOp::UnaryOp(UnaryOp::Op op, Expression *expr, const Location& loc)
   : Expression(loc), op(op), expr(expr)
@@ -94,7 +97,10 @@ const char *UnaryOp::opString() const
   }
 }
 
-bool UnaryOp::isLiteral() const { return this->expr->isLiteral(); }
+bool UnaryOp::isLiteral() const
+{
+  return this->expr->isLiteral();
+}
 
 void UnaryOp::print(std::ostream& stream, const std::string&) const
 {
@@ -218,9 +224,15 @@ void ArrayLookup::print(std::ostream& stream, const std::string&) const
   stream << *array << "[" << *index << "]";
 }
 
-Value Literal::evaluate(const std::shared_ptr<const Context>&) const { return value.clone(); }
+Value Literal::evaluate(const std::shared_ptr<const Context>&) const
+{
+  return value.clone();
+}
 
-void Literal::print(std::ostream& stream, const std::string&) const { stream << value; }
+void Literal::print(std::ostream& stream, const std::string&) const
+{
+  stream << value;
+}
 
 Range::Range(Expression *begin, Expression *end, const Location& loc)
   : Expression(loc), begin(begin), end(end)
@@ -285,7 +297,9 @@ bool Range::isLiteral() const
                     : begin->isLiteral() && end->isLiteral();
 }
 
-Vector::Vector(const Location& loc) : Expression(loc), literal_flag(unknown) {}
+Vector::Vector(const Location& loc) : Expression(loc), literal_flag(unknown)
+{
+}
 
 bool Vector::isLiteral() const
 {
@@ -303,7 +317,10 @@ bool Vector::isLiteral() const
   }
 }
 
-void Vector::emplace_back(Expression *expr) { this->children.emplace_back(expr); }
+void Vector::emplace_back(Expression *expr)
+{
+  this->children.emplace_back(expr);
+}
 
 Value Vector::evaluate(const std::shared_ptr<const Context>& context) const
 {
@@ -335,14 +352,19 @@ void Vector::print(std::ostream& stream, const std::string&) const
   stream << "]";
 }
 
-Lookup::Lookup(std::string name, const Location& loc) : Expression(loc), name(std::move(name)) {}
+Lookup::Lookup(std::string name, const Location& loc) : Expression(loc), name(std::move(name))
+{
+}
 
 Value Lookup::evaluate(const std::shared_ptr<const Context>& context) const
 {
   return context->lookup_variable(this->name, loc).clone();
 }
 
-void Lookup::print(std::ostream& stream, const std::string&) const { stream << this->name; }
+void Lookup::print(std::ostream& stream, const std::string&) const
+{
+  stream << this->name;
+}
 
 MemberLookup::MemberLookup(Expression *expr, std::string member, const Location& loc)
   : Expression(loc), expr(expr), member(std::move(member))
@@ -750,7 +772,9 @@ void Let::print(std::ostream& stream, const std::string&) const
   stream << "let(" << this->arguments << ") " << *expr;
 }
 
-ListComprehension::ListComprehension(const Location& loc) : Expression(loc) {}
+ListComprehension::ListComprehension(const Location& loc) : Expression(loc)
+{
+}
 
 LcIf::LcIf(Expression *cond, Expression *ifexpr, Expression *elseexpr, const Location& loc)
   : ListComprehension(loc), cond(cond), ifexpr(ifexpr), elseexpr(elseexpr)
@@ -776,7 +800,9 @@ void LcIf::print(std::ostream& stream, const std::string&) const
   }
 }
 
-LcEach::LcEach(Expression *expr, const Location& loc) : ListComprehension(loc), expr(expr) {}
+LcEach::LcEach(Expression *expr, const Location& loc) : ListComprehension(loc), expr(expr)
+{
+}
 
 // Need this for recurring into already embedded vectors, and performing "each" on their elements
 //    Context is only passed along for the possible use in Range warning.

--- a/src/core/FunctionType.cc
+++ b/src/core/FunctionType.cc
@@ -4,8 +4,14 @@
 #include "core/Value.h"
 #include "core/Expression.h"
 
-Value FunctionType::operator==(const FunctionType& other) const { return this == &other; }
-Value FunctionType::operator!=(const FunctionType& other) const { return this != &other; }
+Value FunctionType::operator==(const FunctionType& other) const
+{
+  return this == &other;
+}
+Value FunctionType::operator!=(const FunctionType& other) const
+{
+  return this != &other;
+}
 Value FunctionType::operator<(const FunctionType& /*other*/) const
 {
   return Value::undef("operation undefined (function < function)");

--- a/src/core/ImportNode.cc
+++ b/src/core/ImportNode.cc
@@ -269,7 +269,10 @@ std::string ImportNode::toString() const
   return stream.str();
 }
 
-std::string ImportNode::name() const { return "import"; }
+std::string ImportNode::name() const
+{
+  return "import";
+}
 
 void register_builtin_import()
 {

--- a/src/core/MouseConfig.h
+++ b/src/core/MouseConfig.h
@@ -113,6 +113,7 @@ static std::map<ViewAction, std::string> viewActionNames = {
 
 const static int ACTION_DIMENSION = 14;
 static std::map<ViewAction, std::array<float, ACTION_DIMENSION>> viewActionArrays = {
+  // clang-format off
   {NONE,
    {
      0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f,  // Rotation
@@ -149,5 +150,6 @@ static std::map<ViewAction, std::array<float, ACTION_DIMENSION>> viewActionArray
      0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f,  // Translation
      0.0f, 0.0f,                          // Zoom
    }},
+  // clang-format on
 };
 };  // namespace MouseConfig

--- a/src/core/NodeDumper.cc
+++ b/src/core/NodeDumper.cc
@@ -63,9 +63,15 @@ void NodeDumper::initCache()
   this->cache.clear();
 }
 
-void NodeDumper::finalizeCache() { this->cache.setRootString(this->dumpstream.str()); }
+void NodeDumper::finalizeCache()
+{
+  this->cache.setRootString(this->dumpstream.str());
+}
 
-bool NodeDumper::isCached(const AbstractNode& node) const { return this->cache.contains(node); }
+bool NodeDumper::isCached(const AbstractNode& node) const
+{
+  return this->cache.contains(node);
+}
 
 Response NodeDumper::visit(State& state, const GroupNode& node)
 {

--- a/src/core/Parameters.cc
+++ b/src/core/Parameters.cc
@@ -276,7 +276,10 @@ Parameters Parameters::parse(Arguments arguments, const Location& loc,
   return Parameters{std::move(frame), loc};
 }
 
-void Parameters::set_caller(const std::string& caller) { this->caller = caller; }
+void Parameters::set_caller(const std::string& caller)
+{
+  this->caller = caller;
+}
 
 void print_argCnt_warning(const std::string& name, int found, const std::string& expected,
                           const Location& loc, const std::string& documentRoot)

--- a/src/core/RenderNode.cc
+++ b/src/core/RenderNode.cc
@@ -50,7 +50,10 @@ static std::shared_ptr<AbstractNode> builtin_render(const ModuleInstantiation *i
   return children.instantiate(node);
 }
 
-std::string RenderNode::toString() const { return STR(this->name(), "(convexity = ", convexity, ")"); }
+std::string RenderNode::toString() const
+{
+  return STR(this->name(), "(convexity = ", convexity, ")");
+}
 
 void register_builtin_render()
 {

--- a/src/core/Settings.cc
+++ b/src/core/Settings.cc
@@ -71,7 +71,10 @@ SettingsEntryBase::SettingsEntryBase(std::string category, std::string name)
   entries.push_back(this);
 }
 
-std::string SettingsEntryBool::encode() const { return _value ? "true" : "false"; }
+std::string SettingsEntryBool::encode() const
+{
+  return _value ? "true" : "false";
+}
 
 const bool SettingsEntryBool::decode(const std::string& encoded) const
 {
@@ -89,7 +92,10 @@ const bool SettingsEntryBool::decode(const std::string& encoded) const
   }
 }
 
-std::string SettingsEntryInt::encode() const { return STR(_value); }
+std::string SettingsEntryInt::encode() const
+{
+  return STR(_value);
+}
 
 const int SettingsEntryInt::decode(const std::string& encoded) const
 {
@@ -100,7 +106,10 @@ const int SettingsEntryInt::decode(const std::string& encoded) const
   }
 }
 
-std::string SettingsEntryDouble::encode() const { return STR(_value); }
+std::string SettingsEntryDouble::encode() const
+{
+  return STR(_value);
+}
 
 const double SettingsEntryDouble::decode(const std::string& encoded) const
 {

--- a/src/core/SourceFileCache.cc
+++ b/src/core/SourceFileCache.cc
@@ -123,7 +123,10 @@ std::time_t SourceFileCache::process(const std::string& mainFile, const std::str
   return std::max({deps_mtime, cacheEntry.mtime, cacheEntry.includes_mtime});
 }
 
-void SourceFileCache::clear() { this->entries.clear(); }
+void SourceFileCache::clear()
+{
+  this->entries.clear();
+}
 
 SourceFile *SourceFileCache::lookup(const std::string& filename)
 {

--- a/src/core/TextNode.cc
+++ b/src/core/TextNode.cc
@@ -63,7 +63,10 @@ std::vector<std::shared_ptr<const Polygon2d>> TextNode::createPolygonList() cons
   return renderer.render(params);
 }
 
-std::string TextNode::toString() const { return STR(name(), "(", this->params, ")"); }
+std::string TextNode::toString() const
+{
+  return STR(name(), "(", this->params, ")");
+}
 
 void register_builtin_text()
 {

--- a/src/core/TransformNode.cc
+++ b/src/core/TransformNode.cc
@@ -272,9 +272,15 @@ TransformNode::TransformNode(const ModuleInstantiation *mi, std::string verbose_
 {
 }
 
-std::string TransformNode::name() const { return "transform"; }
+std::string TransformNode::name() const
+{
+  return "transform";
+}
 
-std::string TransformNode::verbose_name() const { return _name; }
+std::string TransformNode::verbose_name() const
+{
+  return _name;
+}
 
 void register_builtin_transform()
 {

--- a/src/core/Tree.cc
+++ b/src/core/Tree.cc
@@ -6,7 +6,10 @@
 #include <string>
 #include <tuple>
 
-Tree::~Tree() { this->nodecachemap.clear(); }
+Tree::~Tree()
+{
+  this->nodecachemap.clear();
+}
 
 /*!
    Returns the cached string representation of the subtree rooted by \a node.
@@ -63,6 +66,12 @@ void Tree::setRoot(const std::shared_ptr<const AbstractNode>& root)
   this->nodecachemap.clear();
 }
 
-void Tree::setDocumentPath(const std::string& path) { this->document_path = path; }
+void Tree::setDocumentPath(const std::string& path)
+{
+  this->document_path = path;
+}
 
-const std::string Tree::getDocumentPath() const { return this->document_path; }
+const std::string Tree::getDocumentPath() const
+{
+  return this->document_path;
+}

--- a/src/core/Value.cc
+++ b/src/core/Value.cc
@@ -231,7 +231,10 @@ Value Value::clone() const
   }
 }
 
-Value Value::undef(const std::string& why) { return Value{UndefType{why}}; }
+Value Value::undef(const std::string& why)
+{
+  return Value{UndefType{why}};
+}
 
 std::string Value::typeName(Type type)
 {
@@ -248,17 +251,44 @@ std::string Value::typeName(Type type)
   }
 }
 
-const std::string Value::typeName() const { return typeName(this->type()); }
+const std::string Value::typeName() const
+{
+  return typeName(this->type());
+}
 
 // free functions for use by static_visitor templated functions in creating undef messages.
-std::string getTypeName(const UndefType&) { return "undefined"; }
-std::string getTypeName(bool) { return "bool"; }
-std::string getTypeName(double) { return "number"; }
-std::string getTypeName(const str_utf8_wrapper&) { return "string"; }
-std::string getTypeName(const VectorType&) { return "vector"; }
-std::string getTypeName(const ObjectType&) { return "object"; }
-std::string getTypeName(const RangePtr&) { return "range"; }
-std::string getTypeName(const FunctionPtr&) { return "function"; }
+std::string getTypeName(const UndefType&)
+{
+  return "undefined";
+}
+std::string getTypeName(bool)
+{
+  return "bool";
+}
+std::string getTypeName(double)
+{
+  return "number";
+}
+std::string getTypeName(const str_utf8_wrapper&)
+{
+  return "string";
+}
+std::string getTypeName(const VectorType&)
+{
+  return "vector";
+}
+std::string getTypeName(const ObjectType&)
+{
+  return "object";
+}
+std::string getTypeName(const RangePtr&)
+{
+  return "range";
+}
+std::string getTypeName(const FunctionPtr&)
+{
+  return "function";
+}
 
 bool Value::toBool() const
 {
@@ -280,9 +310,15 @@ bool Value::toBool() const
 // Convert the value to a double with an integer value, for use in bitwise operations.
 // Since there are several possible ways to do this (floor, ceil, round, trunc) this function
 // centralizes the choice for consistency.
-double Value::toInteger() const { return trunc(this->toDouble()); }
+double Value::toInteger() const
+{
+  return trunc(this->toDouble());
+}
 
-int64_t Value::toInt64() const { return this->toInteger(); }
+int64_t Value::toInt64() const
+{
+  return this->toInteger();
+}
 
 double Value::toDouble() const
 {
@@ -472,7 +508,10 @@ public:
   std::string operator()(const FunctionPtr& v) const { return STR(*v); }
 };
 
-std::string Value::toString() const { return std::visit(tostring_visitor(), this->value); }
+std::string Value::toString() const
+{
+  return std::visit(tostring_visitor(), this->value);
+}
 
 std::string Value::toEchoString() const
 {
@@ -494,9 +533,15 @@ std::string Value::toEchoStringNoThrow() const
   return ret;
 }
 
-const UndefType& Value::toUndef() const { return std::get<UndefType>(this->value); }
+const UndefType& Value::toUndef() const
+{
+  return std::get<UndefType>(this->value);
+}
 
-std::string Value::toUndefString() const { return std::get<UndefType>(this->value).toString(); }
+std::string Value::toUndefString() const
+{
+  return std::get<UndefType>(this->value).toString();
+}
 
 class chr_visitor
 {
@@ -544,7 +589,10 @@ public:
   }
 };
 
-std::string Value::chrString() const { return std::visit(chr_visitor(), this->value); }
+std::string Value::chrString() const
+{
+  return std::visit(chr_visitor(), this->value);
+}
 
 VectorType::VectorType(EvaluationSession *session)
   : ptr(std::shared_ptr<VectorObject>(new VectorObject(), VectorObjectDeleter()))
@@ -647,7 +695,10 @@ const VectorType& Value::toVector() const
   return v ? *v : empty;
 }
 
-VectorType& Value::toVectorNonConst() { return std::get<VectorType>(this->value); }
+VectorType& Value::toVectorNonConst()
+{
+  return std::get<VectorType>(this->value);
+}
 
 const ObjectType& Value::toObject() const
 {
@@ -711,7 +762,10 @@ const RangeType& Value::toRange() const
   } else return RangeType::EMPTY;
 }
 
-const FunctionType& Value::toFunction() const { return *std::get<FunctionPtr>(this->value); }
+const FunctionType& Value::toFunction() const
+{
+  return *std::get<FunctionPtr>(this->value);
+}
 
 bool Value::isUncheckedUndef() const
 {
@@ -802,7 +856,10 @@ Value VectorType::operator<(const VectorType& v) const
   return (first1 == last1) && (first2 != last2);
 }
 
-Value VectorType::operator>(const VectorType& v) const { return v.VectorType::operator<(*this); }
+Value VectorType::operator>(const VectorType& v) const
+{
+  return v.VectorType::operator<(*this);
+}
 
 Value VectorType::operator<=(const VectorType& v) const
 {
@@ -950,7 +1007,10 @@ Value Value::operator!=(const Value& v) const
   return std::visit(notequal_visitor(), this->value, v.value);
 }
 
-Value Value::operator<(const Value& v) const { return std::visit(less_visitor(), this->value, v.value); }
+Value Value::operator<(const Value& v) const
+{
+  return std::visit(less_visitor(), this->value, v.value);
+}
 
 Value Value::operator>=(const Value& v) const
 {
@@ -967,7 +1027,10 @@ Value Value::operator<=(const Value& v) const
   return std::visit(lessequal_visitor(), this->value, v.value);
 }
 
-bool Value::cmp_less(const Value& v1, const Value& v2) { return v1.operator<(v2).toBool(); }
+bool Value::cmp_less(const Value& v1, const Value& v2)
+{
+  return v1.operator<(v2).toBool();
+}
 
 class plus_visitor
 {
@@ -995,7 +1058,10 @@ public:
   }
 };
 
-Value Value::operator+(const Value& v) const { return std::visit(plus_visitor(), this->value, v.value); }
+Value Value::operator+(const Value& v) const
+{
+  return std::visit(plus_visitor(), this->value, v.value);
+}
 
 class minus_visitor
 {
@@ -1357,25 +1423,54 @@ std::ostream& operator<<(std::ostream& stream, const RangeType& r)
 }
 
 // called by clone()
-ObjectType::ObjectType(const std::shared_ptr<ObjectObject>& copy) : ptr(copy) {}
+ObjectType::ObjectType(const std::shared_ptr<ObjectObject>& copy) : ptr(copy)
+{
+}
 
 ObjectType::ObjectType(EvaluationSession *session) : ptr(std::make_shared<ObjectObject>())
 {
   ptr->evaluation_session = session;
 }
 
-const Value& ObjectType::get(const std::string& key) const { return ptr->get(key); }
-bool ObjectType::set(const std::string& key, Value value) { return ptr->set(key, std::move(value)); }
-bool ObjectType::del(const std::string& key) { return ptr->del(key) != NOINDEX; }
-bool ObjectType::contains(const std::string& key) const { return ptr->find(key) != NOINDEX; }
-bool ObjectType::empty() const { return ptr->values.empty(); }
-const std::vector<std::string>& ObjectType::keys() const { return ptr->keys; }
-const std::vector<Value>& ObjectType::values() const { return ptr->values; }
+const Value& ObjectType::get(const std::string& key) const
+{
+  return ptr->get(key);
+}
+bool ObjectType::set(const std::string& key, Value value)
+{
+  return ptr->set(key, std::move(value));
+}
+bool ObjectType::del(const std::string& key)
+{
+  return ptr->del(key) != NOINDEX;
+}
+bool ObjectType::contains(const std::string& key) const
+{
+  return ptr->find(key) != NOINDEX;
+}
+bool ObjectType::empty() const
+{
+  return ptr->values.empty();
+}
+const std::vector<std::string>& ObjectType::keys() const
+{
+  return ptr->keys;
+}
+const std::vector<Value>& ObjectType::values() const
+{
+  return ptr->values;
+}
 
-const Value& ObjectType::operator[](const str_utf8_wrapper& v) const { return this->get(v.toString()); }
+const Value& ObjectType::operator[](const str_utf8_wrapper& v) const
+{
+  return this->get(v.toString());
+}
 
 // Copy explicitly only when necessary
-ObjectType ObjectType::clone() const { return ObjectType(this->ptr); }
+ObjectType ObjectType::clone() const
+{
+  return ObjectType(this->ptr);
+}
 
 std::ostream& operator<<(std::ostream& stream, const ObjectType& v)
 {

--- a/src/core/node.cc
+++ b/src/core/node.cc
@@ -39,9 +39,14 @@
 
 size_t AbstractNode::idx_counter;
 
-AbstractNode::AbstractNode(const ModuleInstantiation *mi) : modinst(mi), idx(idx_counter++) {}
+AbstractNode::AbstractNode(const ModuleInstantiation *mi) : modinst(mi), idx(idx_counter++)
+{
+}
 
-std::string AbstractNode::toString() const { return this->name() + "()"; }
+std::string AbstractNode::toString() const
+{
+  return this->name() + "()";
+}
 
 std::shared_ptr<const AbstractNode> AbstractNode::getNodeByID(
   int idx, std::deque<std::shared_ptr<const AbstractNode>>& path) const
@@ -118,15 +123,30 @@ void AbstractNode::findNodesWithSameMod(const std::shared_ptr<const AbstractNode
   }
 }
 
-std::string GroupNode::name() const { return "group"; }
+std::string GroupNode::name() const
+{
+  return "group";
+}
 
-std::string GroupNode::verbose_name() const { return this->_name; }
+std::string GroupNode::verbose_name() const
+{
+  return this->_name;
+}
 
-std::string ListNode::name() const { return "list"; }
+std::string ListNode::name() const
+{
+  return "list";
+}
 
-std::string RootNode::name() const { return "root"; }
+std::string RootNode::name() const
+{
+  return "root";
+}
 
-std::string AbstractIntersectionNode::toString() const { return this->name() + "()"; }
+std::string AbstractIntersectionNode::toString() const
+{
+  return this->name() + "()";
+}
 
 std::string AbstractIntersectionNode::name() const
 {
@@ -142,7 +162,10 @@ void AbstractNode::progress_prepare()
   this->progress_mark = ++progress_report_count;
 }
 
-void AbstractNode::progress_report() const { progress_update(shared_from_this(), this->progress_mark); }
+void AbstractNode::progress_report() const
+{
+  progress_update(shared_from_this(), this->progress_mark);
+}
 
 std::ostream& operator<<(std::ostream& stream, const AbstractNode& node)
 {

--- a/src/core/parsersettings.cc
+++ b/src/core/parsersettings.cc
@@ -14,9 +14,15 @@ namespace fs = std::filesystem;
 
 std::vector<std::string> librarypath;
 
-static void add_librarydir(const std::string& libdir) { librarypath.push_back(libdir); }
+static void add_librarydir(const std::string& libdir)
+{
+  librarypath.push_back(libdir);
+}
 
-const std::vector<std::string>& get_library_path() { return librarypath; }
+const std::vector<std::string>& get_library_path()
+{
+  return librarypath;
+}
 
 /*!
    Searces for the given file in library paths and returns the full path if found.

--- a/src/geometry/ClipperUtils.cc
+++ b/src/geometry/ClipperUtils.cc
@@ -120,7 +120,10 @@ int scaleBitsFromBounds(const BoundingBox& bounds, int total_bits)
   return (actual_bits - 1) - exp;
 }
 
-int scaleBitsFromPrecision(int precision) { return std::ilogb(std::pow(10, precision)) + 1; }
+int scaleBitsFromPrecision(int precision)
+{
+  return std::ilogb(std::pow(10, precision)) + 1;
+}
 
 Clipper2Lib::Paths64 fromPolygon2d(const Polygon2d& poly, int scale_bits)
 {

--- a/src/geometry/Geometry.cc
+++ b/src/geometry/Geometry.cc
@@ -8,9 +8,14 @@
 #include <string>
 #include <utility>
 
-GeometryList::GeometryList(Geometry::Geometries geometries) : children(std::move(geometries)) {}
+GeometryList::GeometryList(Geometry::Geometries geometries) : children(std::move(geometries))
+{
+}
 
-std::unique_ptr<Geometry> GeometryList::copy() const { return std::make_unique<GeometryList>(*this); }
+std::unique_ptr<Geometry> GeometryList::copy() const
+{
+  return std::make_unique<GeometryList>(*this);
+}
 
 size_t GeometryList::memsize() const
 {

--- a/src/geometry/Geometry.h
+++ b/src/geometry/Geometry.h
@@ -73,8 +73,11 @@ public:
   virtual ~GeometryVisitor() = default;
 };
 
-#define VISITABLE_GEOMETRY() \
-  void accept(GeometryVisitor& visitor) const override { visitor.visit(*this); }
+#define VISITABLE_GEOMETRY()                           \
+  void accept(GeometryVisitor& visitor) const override \
+  {                                                    \
+    visitor.visit(*this);                              \
+  }
 
 class GeometryList : public Geometry
 {

--- a/src/geometry/GeometryCache.cc
+++ b/src/geometry/GeometryCache.cc
@@ -35,13 +35,25 @@ bool GeometryCache::insert(const std::string& id, const std::shared_ptr<const Ge
   return inserted;
 }
 
-size_t GeometryCache::size() const { return cache.size(); }
+size_t GeometryCache::size() const
+{
+  return cache.size();
+}
 
-size_t GeometryCache::totalCost() const { return cache.totalCost(); }
+size_t GeometryCache::totalCost() const
+{
+  return cache.totalCost();
+}
 
-size_t GeometryCache::maxSizeMB() const { return this->cache.maxCost() / (1024ul * 1024ul); }
+size_t GeometryCache::maxSizeMB() const
+{
+  return this->cache.maxCost() / (1024ul * 1024ul);
+}
 
-void GeometryCache::setMaxSizeMB(size_t limit) { this->cache.setMaxCost(limit * 1024ul * 1024ul); }
+void GeometryCache::setMaxSizeMB(size_t limit)
+{
+  this->cache.setMaxCost(limit * 1024ul * 1024ul);
+}
 
 void GeometryCache::print()
 {

--- a/src/geometry/GeometryEvaluator.cc
+++ b/src/geometry/GeometryEvaluator.cc
@@ -58,7 +58,9 @@ class Geometry;
 class Polygon2d;
 class Tree;
 
-GeometryEvaluator::GeometryEvaluator(const Tree& tree) : tree(tree) {}
+GeometryEvaluator::GeometryEvaluator(const Tree& tree) : tree(tree)
+{
+}
 
 /*!
    Set allownef to false to force the result to _not_ be a Nef polyhedron

--- a/src/geometry/PolySet.cc
+++ b/src/geometry/PolySet.cc
@@ -52,9 +52,14 @@
 
  */
 
-PolySet::PolySet(unsigned int dim, boost::tribool convex) : dim_(dim), convex_(convex) {}
+PolySet::PolySet(unsigned int dim, boost::tribool convex) : dim_(dim), convex_(convex)
+{
+}
 
-std::unique_ptr<Geometry> PolySet::copy() const { return std::make_unique<PolySet>(*this); }
+std::unique_ptr<Geometry> PolySet::copy() const
+{
+  return std::make_unique<PolySet>(*this);
+}
 
 std::string PolySet::dump() const
 {

--- a/src/geometry/PolySetBuilder.cc
+++ b/src/geometry/PolySetBuilder.cc
@@ -57,19 +57,40 @@ void PolySetBuilder::reserve(int vertices_count, int indices_count)
   if (indices_count != 0) indices_.reserve(indices_count);
 }
 
-void PolySetBuilder::setConvexity(int convexity) { convexity_ = convexity; }
+void PolySetBuilder::setConvexity(int convexity)
+{
+  convexity_ = convexity;
+}
 
-void PolySetBuilder::addColor(const Color4f& color) { colors_.push_back(color); }
+void PolySetBuilder::addColor(const Color4f& color)
+{
+  colors_.push_back(color);
+}
 
-void PolySetBuilder::addColorIndex(const int32_t idx) { color_indices_.push_back(idx); }
+void PolySetBuilder::addColorIndex(const int32_t idx)
+{
+  color_indices_.push_back(idx);
+}
 
-int PolySetBuilder::numVertices() const { return vertices_.size(); }
+int PolySetBuilder::numVertices() const
+{
+  return vertices_.size();
+}
 
-int PolySetBuilder::numPolygons() const { return indices_.size(); }
+int PolySetBuilder::numPolygons() const
+{
+  return indices_.size();
+}
 
-bool PolySetBuilder::isEmpty() const { return vertices_.size() == 0 && indices_.size() == 0; }
+bool PolySetBuilder::isEmpty() const
+{
+  return vertices_.size() == 0 && indices_.size() == 0;
+}
 
-int PolySetBuilder::vertexIndex(const Vector3d& pt) { return vertices_.lookup(pt); }
+int PolySetBuilder::vertexIndex(const Vector3d& pt)
+{
+  return vertices_.lookup(pt);
+}
 
 void PolySetBuilder::appendGeometry(const std::shared_ptr<const Geometry>& geom)
 {
@@ -126,7 +147,10 @@ void PolySetBuilder::addVertex(int ind)
   }
 }
 
-void PolySetBuilder::addVertex(const Vector3d& v) { addVertex(vertexIndex(v)); }
+void PolySetBuilder::addVertex(const Vector3d& v)
+{
+  addVertex(vertexIndex(v));
+}
 
 void PolySetBuilder::endPolygon(const Color4f& color)
 {

--- a/src/geometry/Polygon2d.cc
+++ b/src/geometry/Polygon2d.cc
@@ -17,9 +17,15 @@
 #include "geometry/PolySet.h"
 #include "glview/RenderSettings.h"
 
-Polygon2d::Polygon2d(Outline2d outline) : sanitized(true) { addOutline(std::move(outline)); }
+Polygon2d::Polygon2d(Outline2d outline) : sanitized(true)
+{
+  addOutline(std::move(outline));
+}
 
-std::unique_ptr<Geometry> Polygon2d::copy() const { return std::make_unique<Polygon2d>(*this); }
+std::unique_ptr<Geometry> Polygon2d::copy() const
+{
+  return std::make_unique<Polygon2d>(*this);
+}
 
 BoundingBox Outline2d::getBoundingBox() const
 {
@@ -77,7 +83,10 @@ std::string Polygon2d::dump() const
   return out.str();
 }
 
-bool Polygon2d::isEmpty() const { return this->theoutlines.empty(); }
+bool Polygon2d::isEmpty() const
+{
+  return this->theoutlines.empty();
+}
 
 void Polygon2d::transform(const Transform2d& mat)
 {

--- a/src/geometry/cgal/CGALCache.cc
+++ b/src/geometry/cgal/CGALCache.cc
@@ -16,7 +16,9 @@
 
 CGALCache *CGALCache::inst = nullptr;
 
-CGALCache::CGALCache(size_t limit) : cache(limit) {}
+CGALCache::CGALCache(size_t limit) : cache(limit)
+{
+}
 
 std::shared_ptr<const Geometry> CGALCache::get(const std::string& id) const
 {
@@ -50,15 +52,30 @@ bool CGALCache::insert(const std::string& id, const std::shared_ptr<const Geomet
   return inserted;
 }
 
-size_t CGALCache::size() const { return cache.size(); }
+size_t CGALCache::size() const
+{
+  return cache.size();
+}
 
-size_t CGALCache::totalCost() const { return cache.totalCost(); }
+size_t CGALCache::totalCost() const
+{
+  return cache.totalCost();
+}
 
-size_t CGALCache::maxSizeMB() const { return this->cache.maxCost() / (1024ul * 1024ul); }
+size_t CGALCache::maxSizeMB() const
+{
+  return this->cache.maxCost() / (1024ul * 1024ul);
+}
 
-void CGALCache::setMaxSizeMB(size_t limit) { this->cache.setMaxCost(limit * 1024ul * 1024ul); }
+void CGALCache::setMaxSizeMB(size_t limit)
+{
+  this->cache.setMaxCost(limit * 1024ul * 1024ul);
+}
 
-void CGALCache::clear() { cache.clear(); }
+void CGALCache::clear()
+{
+  cache.clear();
+}
 
 void CGALCache::print()
 {

--- a/src/geometry/cgal/CGALNefGeometry.cc
+++ b/src/geometry/cgal/CGALNefGeometry.cc
@@ -71,7 +71,10 @@ size_t CGALNefGeometry::memsize() const
   return memsize;
 }
 
-bool CGALNefGeometry::isEmpty() const { return !this->p3 || this->p3->is_empty(); }
+bool CGALNefGeometry::isEmpty() const
+{
+  return !this->p3 || this->p3->is_empty();
+}
 
 BoundingBox CGALNefGeometry::getBoundingBox() const
 {
@@ -95,7 +98,10 @@ void CGALNefGeometry::resize(const Vector3d& newsize, const Eigen::Matrix<bool, 
                                               autosize));
 }
 
-std::string CGALNefGeometry::dump() const { return OpenSCAD::dump_svg(*this->p3); }
+std::string CGALNefGeometry::dump() const
+{
+  return OpenSCAD::dump_svg(*this->p3);
+}
 
 void CGALNefGeometry::transform(const Transform3d& matrix)
 {

--- a/src/geometry/manifold/ManifoldGeometry.cc
+++ b/src/geometry/manifold/ManifoldGeometry.cc
@@ -35,7 +35,9 @@ Result vector_convert(V const& v)
 
 }  // namespace
 
-ManifoldGeometry::ManifoldGeometry() : manifold_(manifold::Manifold()) {}
+ManifoldGeometry::ManifoldGeometry() : manifold_(manifold::Manifold())
+{
+}
 
 ManifoldGeometry::ManifoldGeometry(manifold::Manifold mani, const std::set<uint32_t>& originalIDs,
                                    const std::map<uint32_t, Color4f>& originalIDToColor,
@@ -52,13 +54,25 @@ std::unique_ptr<Geometry> ManifoldGeometry::copy() const
   return std::make_unique<ManifoldGeometry>(*this);
 }
 
-const manifold::Manifold& ManifoldGeometry::getManifold() const { return manifold_; }
+const manifold::Manifold& ManifoldGeometry::getManifold() const
+{
+  return manifold_;
+}
 
-bool ManifoldGeometry::isEmpty() const { return getManifold().IsEmpty(); }
+bool ManifoldGeometry::isEmpty() const
+{
+  return getManifold().IsEmpty();
+}
 
-size_t ManifoldGeometry::numFacets() const { return getManifold().NumTri(); }
+size_t ManifoldGeometry::numFacets() const
+{
+  return getManifold().NumTri();
+}
 
-size_t ManifoldGeometry::numVertices() const { return getManifold().NumVert(); }
+size_t ManifoldGeometry::numVertices() const
+{
+  return getManifold().NumVert();
+}
 
 bool ManifoldGeometry::isManifold() const
 {
@@ -70,7 +84,10 @@ bool ManifoldGeometry::isValid() const
   return manifold_.Status() == manifold::Manifold::Error::NoError;
 }
 
-void ManifoldGeometry::clear() { manifold_ = manifold::Manifold(); }
+void ManifoldGeometry::clear()
+{
+  manifold_ = manifold::Manifold();
+}
 
 size_t ManifoldGeometry::memsize() const
 {

--- a/src/geometry/roof_vd.cc
+++ b/src/geometry/roof_vd.cc
@@ -93,9 +93,15 @@ struct segment_traits<roof_vd::Segment> {
 
 namespace roof_vd {
 
-bool operator==(const Point& lhs, const Point& rhs) { return lhs.a == rhs.a && lhs.b == rhs.b; }
+bool operator==(const Point& lhs, const Point& rhs)
+{
+  return lhs.a == rhs.a && lhs.b == rhs.b;
+}
 
-bool operator==(const Segment& lhs, const Segment& rhs) { return lhs.p0 == rhs.p0 && lhs.p1 == rhs.p1; }
+bool operator==(const Segment& lhs, const Segment& rhs)
+{
+  return lhs.p0 == rhs.p0 && lhs.p1 == rhs.p1;
+}
 
 bool segment_has_endpoint(const Segment& segment, const Point& point)
 {

--- a/src/glview/Camera.cc
+++ b/src/glview/Camera.cc
@@ -81,7 +81,10 @@ void Camera::zoom(int zoom, bool relative)
   }
 }
 
-void Camera::setProjection(ProjectionType type) { this->projection = type; }
+void Camera::setProjection(ProjectionType type)
+{
+  this->projection = type;
+}
 
 void Camera::resetView()
 {
@@ -151,9 +154,15 @@ void Camera::updateView(const std::shared_ptr<const FileContext>& context, bool 
   }
 }
 
-Eigen::Vector3d Camera::getVpt() const { return -object_trans; }
+Eigen::Vector3d Camera::getVpt() const
+{
+  return -object_trans;
+}
 
-void Camera::setVpt(double x, double y, double z) { object_trans << -x, -y, -z; }
+void Camera::setVpt(double x, double y, double z)
+{
+  object_trans << -x, -y, -z;
+}
 
 static double wrap(double angle)
 {
@@ -165,15 +174,30 @@ Eigen::Vector3d Camera::getVpr() const
   return {wrap(90 - object_rot.x()), wrap(-object_rot.y()), wrap(-object_rot.z())};
 }
 
-void Camera::setVpr(double x, double y, double z) { object_rot << wrap(90 - x), wrap(-y), wrap(-z); }
+void Camera::setVpr(double x, double y, double z)
+{
+  object_rot << wrap(90 - x), wrap(-y), wrap(-z);
+}
 
-void Camera::setVpd(double d) { viewer_distance = d; }
+void Camera::setVpd(double d)
+{
+  viewer_distance = d;
+}
 
-double Camera::zoomValue() const { return viewer_distance; }
+double Camera::zoomValue() const
+{
+  return viewer_distance;
+}
 
-void Camera::setVpf(double f) { fov = f; }
+void Camera::setVpf(double f)
+{
+  fov = f;
+}
 
-double Camera::fovValue() const { return fov; }
+double Camera::fovValue() const
+{
+  return fov;
+}
 
 std::string Camera::statusText() const
 {

--- a/src/glview/ColorMap.cc
+++ b/src/glview/ColorMap.cc
@@ -81,21 +81,45 @@ RenderColorScheme::RenderColorScheme(const fs::path& path) : _path(path)
   }
 }
 
-bool RenderColorScheme::valid() const { return !_name.empty(); }
+bool RenderColorScheme::valid() const
+{
+  return !_name.empty();
+}
 
-const std::string& RenderColorScheme::name() const { return _name; }
+const std::string& RenderColorScheme::name() const
+{
+  return _name;
+}
 
-int RenderColorScheme::index() const { return _index; }
+int RenderColorScheme::index() const
+{
+  return _index;
+}
 
-bool RenderColorScheme::showInGui() const { return _show_in_gui; }
+bool RenderColorScheme::showInGui() const
+{
+  return _show_in_gui;
+}
 
-std::string RenderColorScheme::path() const { return _path.string(); }
+std::string RenderColorScheme::path() const
+{
+  return _path.string();
+}
 
-std::string RenderColorScheme::error() const { return _error; }
+std::string RenderColorScheme::error() const
+{
+  return _error;
+}
 
-ColorScheme& RenderColorScheme::colorScheme() { return _color_scheme; }
+ColorScheme& RenderColorScheme::colorScheme()
+{
+  return _color_scheme;
+}
 
-const boost::property_tree::ptree& RenderColorScheme::propertyTree() const { return pt; }
+const boost::property_tree::ptree& RenderColorScheme::propertyTree() const
+{
+  return pt;
+}
 
 void RenderColorScheme::addColor(RenderColor colorKey, const std::string& key)
 {
@@ -130,7 +154,10 @@ ColorMap::ColorMap()
   dump();
 }
 
-const char *ColorMap::defaultColorSchemeName() const { return DEFAULT_COLOR_SCHEME_NAME; }
+const char *ColorMap::defaultColorSchemeName() const
+{
+  return DEFAULT_COLOR_SCHEME_NAME;
+}
 
 const ColorScheme& ColorMap::defaultColorScheme() const
 {

--- a/src/glview/GLView.cc
+++ b/src/glview/GLView.cc
@@ -36,7 +36,10 @@ GLView::GLView()
 #endif
 }
 
-GLView::~GLView() { teardownShader(); }
+GLView::~GLView()
+{
+  teardownShader();
+}
 
 void GLView::setupShader()
 {
@@ -70,7 +73,10 @@ void GLView::teardownShader()
   }
 }
 
-void GLView::setRenderer(std::shared_ptr<Renderer> r) { this->renderer = r; }
+void GLView::setRenderer(std::shared_ptr<Renderer> r)
+{
+  this->renderer = r;
+}
 
 /* update the color schemes of the Renderer attached to this GLView
    to match the colorscheme of this GLView.*/
@@ -108,7 +114,10 @@ void GLView::resizeGL(int w, int h)
   setupShader();
 }
 
-void GLView::setCamera(const Camera& cam) { this->cam = cam; }
+void GLView::setCamera(const Camera& cam)
+{
+  this->cam = cam;
+}
 
 void GLView::setupCamera()
 {

--- a/src/glview/NULLGL.cc
+++ b/src/glview/NULLGL.cc
@@ -14,24 +14,71 @@
 #include "glview/OpenGLContext.h"
 #include "glview/system-gl.h"
 
-bool FBO::resize(size_t, size_t) { return false; }
-FBO::FBO(int, int, bool) {}
-GLuint FBO::bind() { return 0; }
+bool FBO::resize(size_t, size_t)
+{
+  return false;
+}
+FBO::FBO(int, int, bool)
+{
+}
+GLuint FBO::bind()
+{
+  return 0;
+}
 GLView::~GLView() = default;
 GLView::GLView() = default;
-std::string gl_dump() { return {"GL Renderer: NULLGL\n"}; }
-std::string gl_extensions_dump() { return {"NULLGL Extensions"}; }
-std::unique_ptr<FBO> createFBO(int, int) { return nullptr; }
-std::vector<uint8_t> OpenGLContext::getFramebuffer() const { return {}; }
-void FBO::destroy() {}
-void FBO::unbind() {}
-void GLView::initializeGL() {}
-void GLView::paintGL() {}
-void GLView::resizeGL(int w, int h) {}
-void GLView::setCamera(const Camera& /*cam*/) { assert(false && "not implemented"); }
-void GLView::setColorScheme(const ColorScheme& /*cs*/) { assert(false && "not implemented"); }
-void GLView::setColorScheme(const std::string& /*cs*/) { assert(false && "not implemented"); }
-void GLView::setRenderer(std::shared_ptr<Renderer>) {}
-void GLView::showAxes(const Color4f& col) {}
-void GLView::showCrosshairs(const Color4f& col) {}
-void GLView::showSmallaxes(const Color4f& col) {}
+std::string gl_dump()
+{
+  return {"GL Renderer: NULLGL\n"};
+}
+std::string gl_extensions_dump()
+{
+  return {"NULLGL Extensions"};
+}
+std::unique_ptr<FBO> createFBO(int, int)
+{
+  return nullptr;
+}
+std::vector<uint8_t> OpenGLContext::getFramebuffer() const
+{
+  return {};
+}
+void FBO::destroy()
+{
+}
+void FBO::unbind()
+{
+}
+void GLView::initializeGL()
+{
+}
+void GLView::paintGL()
+{
+}
+void GLView::resizeGL(int w, int h)
+{
+}
+void GLView::setCamera(const Camera& /*cam*/)
+{
+  assert(false && "not implemented");
+}
+void GLView::setColorScheme(const ColorScheme& /*cs*/)
+{
+  assert(false && "not implemented");
+}
+void GLView::setColorScheme(const std::string& /*cs*/)
+{
+  assert(false && "not implemented");
+}
+void GLView::setRenderer(std::shared_ptr<Renderer>)
+{
+}
+void GLView::showAxes(const Color4f& col)
+{
+}
+void GLView::showCrosshairs(const Color4f& col)
+{
+}
+void GLView::showSmallaxes(const Color4f& col)
+{
+}

--- a/src/glview/OffscreenView.cc
+++ b/src/glview/OffscreenView.cc
@@ -96,10 +96,16 @@ OffscreenView::OffscreenView(uint32_t width, uint32_t height)
   GLView::resizeGL(width, height);
 }
 
-OffscreenView::~OffscreenView() { fbo.reset(); }
+OffscreenView::~OffscreenView()
+{
+  fbo.reset();
+}
 
 #ifdef ENABLE_OPENCSG
-void OffscreenView::display_opencsg_warning() { LOG("OpenSCAD recommended OpenGL version is 2.0."); }
+void OffscreenView::display_opencsg_warning()
+{
+  LOG("OpenSCAD recommended OpenGL version is 2.0.");
+}
 #endif
 
 bool OffscreenView::save(const char *filename) const

--- a/src/glview/Renderer.cc
+++ b/src/glview/Renderer.cc
@@ -174,7 +174,9 @@ std::vector<SelectedObject> Renderer::findModelObject(const Vector3d& /*near_pt*
 }
 #else  // NULLGL
 
-Renderer::Renderer() : colorscheme_(nullptr) {}
+Renderer::Renderer() : colorscheme_(nullptr)
+{
+}
 bool Renderer::getColorSchemeColor(Renderer::ColorMode colormode, Color4f& outcolor) const
 {
   return false;
@@ -184,8 +186,13 @@ bool Renderer::getShaderColor(Renderer::ColorMode colormode, const Color4f& obje
 {
   return false;
 }
-std::string ShaderUtils::loadShaderSource(const std::string& name) { return ""; }
-void Renderer::setColorScheme(const ColorScheme& cs) {}
+std::string ShaderUtils::loadShaderSource(const std::string& name)
+{
+  return "";
+}
+void Renderer::setColorScheme(const ColorScheme& cs)
+{
+}
 std::vector<SelectedObject> Renderer::findModelObject(const Vector3d& /*near_pt*/,
                                                       const Vector3d& /*far_pt*/, int /*mouse_x*/,
                                                       int /*mouse_y*/, double /*tolerance*/)

--- a/src/glview/VBOBuilder.cc
+++ b/src/glview/VBOBuilder.cc
@@ -32,7 +32,9 @@ Vector3d uniqueMultiply(std::unordered_map<Vector3d, Vector3d>& vert_mult_map, c
 
 }  // namespace
 
-void addAttributeValues(IAttributeData&) {}
+void addAttributeValues(IAttributeData&)
+{
+}
 
 void VertexData::getLastVertex(std::vector<GLbyte>& interleaved_buffer) const
 {

--- a/src/glview/VBORenderer.cc
+++ b/src/glview/VBORenderer.cc
@@ -59,7 +59,9 @@ void shader_attribs_disable(const ShaderUtils::ShaderInfo& shaderinfo)
 
 }  // namespace VBOUtils
 
-VBORenderer::VBORenderer() : Renderer() {}
+VBORenderer::VBORenderer() : Renderer()
+{
+}
 
 size_t VBORenderer::calcNumVertices(const std::shared_ptr<CSGProducts>& products,
                                     bool unique_geometry) const

--- a/src/glview/cgal/CGALRenderer.cc
+++ b/src/glview/cgal/CGALRenderer.cc
@@ -98,7 +98,9 @@ void CGALRenderer::addGeometry(const std::shared_ptr<const Geometry>& geom)
   }
 }
 
-CGALRenderer::~CGALRenderer() {}
+CGALRenderer::~CGALRenderer()
+{
+}
 
 #ifdef ENABLE_CGAL
 void CGALRenderer::createPolyhedrons()

--- a/src/glview/system-gl.h
+++ b/src/glview/system-gl.h
@@ -116,7 +116,9 @@ namespace {
 #define GLint int
 #define GLuint unsigned int
 #define GLdouble unsigned int
-inline void glColor4fv(float *c) {}
+inline void glColor4fv(float *c)
+{
+}
 
 #endif  // NULLGL
 

--- a/src/gui/Animate.cc
+++ b/src/gui/Animate.cc
@@ -233,7 +233,10 @@ void Animate::animateUpdate()
   }
 }
 
-bool Animate::dumpPictures() { return this->e_dump->isChecked() && this->animateTimer->isActive(); }
+bool Animate::dumpPictures()
+{
+  return this->e_dump->isChecked() && this->animateTimer->isActive();
+}
 
 int Animate::nextFrame()
 {
@@ -273,7 +276,10 @@ void Animate::resizeEvent(QResizeEvent *event)
   QWidget::resizeEvent(event);
 }
 
-const QList<QAction *>& Animate::actions() { return actionList; }
+const QList<QAction *>& Animate::actions()
+{
+  return actionList;
+}
 
 void Animate::onActionEvent(InputEventAction *event)
 {
@@ -286,7 +292,10 @@ void Animate::onActionEvent(InputEventAction *event)
   }
 }
 
-double Animate::getAnimTval() { return animTVal; }
+double Animate::getAnimTval()
+{
+  return animTVal;
+}
 
 void Animate::on_pushButton_MoveToBeginning_clicked()
 {

--- a/src/gui/CGALWorker.cc
+++ b/src/gui/CGALWorker.cc
@@ -26,7 +26,10 @@ CGALWorker::CGALWorker()
   moveToThread(this->thread);
 }
 
-CGALWorker::~CGALWorker() { delete this->thread; }
+CGALWorker::~CGALWorker()
+{
+  delete this->thread;
+}
 
 void CGALWorker::start(const Tree& tree)
 {

--- a/src/gui/Dock.cc
+++ b/src/gui/Dock.cc
@@ -12,9 +12,15 @@ Dock::Dock(QWidget *parent) : QDockWidget(parent)
   dockTitleWidget = new QWidget();
 }
 
-Dock::~Dock() { delete dockTitleWidget; }
+Dock::~Dock()
+{
+  delete dockTitleWidget;
+}
 
-void Dock::disableSettingsUpdate() { updateSettings = false; }
+void Dock::disableSettingsUpdate()
+{
+  updateSettings = false;
+}
 
 void Dock::onVisibilityChanged(bool isDockVisible)
 {
@@ -29,7 +35,10 @@ void Dock::setTitleBarVisibility(bool isVisible)
   setTitleBarWidget(isVisible ? dockTitleWidget : nullptr);
 }
 
-void Dock::setConfigKey(const QString& configKey) { this->configKey = configKey; }
+void Dock::setConfigKey(const QString& configKey)
+{
+  this->configKey = configKey;
+}
 
 void Dock::updateTitle()
 {
@@ -46,7 +55,10 @@ void Dock::setName(const QString& name_)
   updateTitle();
 }
 
-QString Dock::getName() const { return name; }
+QString Dock::getName() const
+{
+  return name;
+}
 
 void Dock::setNameSuffix(const QString& namesuffix_)
 {

--- a/src/gui/ErrorLog.cc
+++ b/src/gui/ErrorLog.cc
@@ -98,7 +98,10 @@ void ErrorLog::showtheErrorInGUI(const Message& logMsg)
   }
 }
 
-void ErrorLog::resize() { logTable->resizeRowsToContents(); }
+void ErrorLog::resize()
+{
+  logTable->resizeRowsToContents();
+}
 
 void ErrorLog::onSectionResized(int /*logicalIndex*/, int /*oldSize*/, int /*newSize*/)
 {
@@ -118,7 +121,10 @@ void ErrorLog::clearModel()
   lastMessages.clear();
 }
 
-int ErrorLog::getLine(int row, int col) { return logTable->model()->index(row, col).data().toInt(); }
+int ErrorLog::getLine(int row, int col)
+{
+  return logTable->model()->index(row, col).data().toInt();
+}
 
 void ErrorLog::on_errorLogComboBox_currentTextChanged(const QString& group)
 {
@@ -132,7 +138,10 @@ void ErrorLog::on_errorLogComboBox_currentTextChanged(const QString& group)
   }
 }
 
-void ErrorLog::on_logTable_doubleClicked(const QModelIndex& index) { onIndexSelected(index); }
+void ErrorLog::on_logTable_doubleClicked(const QModelIndex& index)
+{
+  onIndexSelected(index);
+}
 
 void ErrorLog::on_actionRowSelected_triggered(bool)
 {

--- a/src/gui/ExportPdfDialog.cc
+++ b/src/gui/ExportPdfDialog.cc
@@ -190,6 +190,12 @@ void ExportPdfDialog::on_toolButtonStrokeWidthReset_clicked()
   this->doubleSpinBoxStrokeWidth->setValue(this->defaultStrokeWidth);
 }
 
-void ExportPdfDialog::on_checkBoxEnableFill_toggled(bool checked) { updateFillControlsEnabled(); }
+void ExportPdfDialog::on_checkBoxEnableFill_toggled(bool checked)
+{
+  updateFillControlsEnabled();
+}
 
-void ExportPdfDialog::on_checkBoxEnableStroke_toggled(bool checked) { updateStrokeControlsEnabled(); }
+void ExportPdfDialog::on_checkBoxEnableStroke_toggled(bool checked)
+{
+  updateStrokeControlsEnabled();
+}

--- a/src/gui/ExportSvgDialog.cc
+++ b/src/gui/ExportSvgDialog.cc
@@ -17,17 +17,35 @@ ExportSvgDialog::ExportSvgDialog()
   connect(pushButtonCancel, &QPushButton::clicked, this, &ExportSvgDialog::reject);
 }
 
-int ExportSvgDialog::exec() { return QDialog::exec(); }
+int ExportSvgDialog::exec()
+{
+  return QDialog::exec();
+}
 
-QColor ExportSvgDialog::getFillColor() const { return fillColor; }
+QColor ExportSvgDialog::getFillColor() const
+{
+  return fillColor;
+}
 
-bool ExportSvgDialog::isFillEnabled() const { return checkBoxEnableFill->isChecked(); }
+bool ExportSvgDialog::isFillEnabled() const
+{
+  return checkBoxEnableFill->isChecked();
+}
 
-QColor ExportSvgDialog::getStrokeColor() const { return strokeColor; }
+QColor ExportSvgDialog::getStrokeColor() const
+{
+  return strokeColor;
+}
 
-bool ExportSvgDialog::isStrokeEnabled() const { return checkBoxEnableStroke->isChecked(); }
+bool ExportSvgDialog::isStrokeEnabled() const
+{
+  return checkBoxEnableStroke->isChecked();
+}
 
-double ExportSvgDialog::getStrokeWidth() const { return doubleSpinBoxStrokeWidth->value(); }
+double ExportSvgDialog::getStrokeWidth() const
+{
+  return doubleSpinBoxStrokeWidth->value();
+}
 
 ExportSvgOptions ExportSvgDialog::getOptions() const
 {
@@ -48,9 +66,15 @@ void ExportSvgDialog::on_toolButtonFillColor_clicked()
   }
 }
 
-void ExportSvgDialog::on_toolButtonFillColorReset_clicked() { updateFillColor(QColor(Qt::white)); }
+void ExportSvgDialog::on_toolButtonFillColorReset_clicked()
+{
+  updateFillColor(QColor(Qt::white));
+}
 
-void ExportSvgDialog::on_checkBoxEnableFill_toggled(bool checked) { updateFillControlsEnabled(); }
+void ExportSvgDialog::on_checkBoxEnableFill_toggled(bool checked)
+{
+  updateFillControlsEnabled();
+}
 
 void ExportSvgDialog::on_toolButtonStrokeColor_clicked()
 {
@@ -60,9 +84,15 @@ void ExportSvgDialog::on_toolButtonStrokeColor_clicked()
   }
 }
 
-void ExportSvgDialog::on_toolButtonStrokeColorReset_clicked() { updateStrokeColor(QColor(Qt::black)); }
+void ExportSvgDialog::on_toolButtonStrokeColorReset_clicked()
+{
+  updateStrokeColor(QColor(Qt::black));
+}
 
-void ExportSvgDialog::on_checkBoxEnableStroke_toggled(bool checked) { updateStrokeControlsEnabled(); }
+void ExportSvgDialog::on_checkBoxEnableStroke_toggled(bool checked)
+{
+  updateStrokeControlsEnabled();
+}
 
 void ExportSvgDialog::on_toolButtonStrokeWidthReset_clicked()
 {

--- a/src/gui/FontList.cc
+++ b/src/gui/FontList.cc
@@ -34,15 +34,29 @@
 #include "FontCache.h"
 #include "utils/printutils.h"
 
-FontItemDelegate::FontItemDelegate(QObject *parent) : QStyledItemDelegate(parent) {}
+FontItemDelegate::FontItemDelegate(QObject *parent) : QStyledItemDelegate(parent)
+{
+}
 
-int FontItemDelegate::fontSize() const { return _fontSize; }
+int FontItemDelegate::fontSize() const
+{
+  return _fontSize;
+}
 
-void FontItemDelegate::setFontSize(int fontSize) { _fontSize = fontSize; }
+void FontItemDelegate::setFontSize(int fontSize)
+{
+  _fontSize = fontSize;
+}
 
-QString FontItemDelegate::text() const { return _text; }
+QString FontItemDelegate::text() const
+{
+  return _text;
+}
 
-void FontItemDelegate::setText(const QString& text) { _text = text; }
+void FontItemDelegate::setText(const QString& text)
+{
+  _text = text;
+}
 
 void FontItemDelegate::initStyleOption(QStyleOptionViewItem *opt, const QModelIndex& idx) const
 {
@@ -90,9 +104,14 @@ void FontItemDelegate::paint(QPainter *painter, const QStyleOptionViewItem& opti
   QStyledItemDelegate::paint(painter, opt, idx);
 }
 
-FontSortFilterProxyModel::FontSortFilterProxyModel(QObject *parent) : QSortFilterProxyModel(parent) {}
+FontSortFilterProxyModel::FontSortFilterProxyModel(QObject *parent) : QSortFilterProxyModel(parent)
+{
+}
 
-void FontSortFilterProxyModel::clearFilter() { filterHashes.clear(); }
+void FontSortFilterProxyModel::clearFilter()
+{
+  filterHashes.clear();
+}
 
 void FontSortFilterProxyModel::appendFilterHashes(const std::vector<uint32_t>& hashes)
 {
@@ -241,20 +260,35 @@ void FontList::showColumn(int column, bool show)
   }
 }
 
-void FontList::on_actionShowFontNameColumn_toggled(bool show) { showColumn(COL_FONT_NAME, show); }
+void FontList::on_actionShowFontNameColumn_toggled(bool show)
+{
+  showColumn(COL_FONT_NAME, show);
+}
 
 void FontList::on_actionShowStyledFontNameColumn_toggled(bool show)
 {
   showColumn(COL_STYLED_FONT_NAME, show);
 }
 
-void FontList::on_actionShowFontStyleColumn_toggled(bool show) { showColumn(COL_FONT_STYLE, show); }
+void FontList::on_actionShowFontStyleColumn_toggled(bool show)
+{
+  showColumn(COL_FONT_STYLE, show);
+}
 
-void FontList::on_actionShowFontSampleColumn_toggled(bool show) { showColumn(COL_SAMPLE, show); }
+void FontList::on_actionShowFontSampleColumn_toggled(bool show)
+{
+  showColumn(COL_SAMPLE, show);
+}
 
-void FontList::on_actionShowFileNameColumn_toggled(bool show) { showColumn(COL_FILE_NAME, show); }
+void FontList::on_actionShowFileNameColumn_toggled(bool show)
+{
+  showColumn(COL_FILE_NAME, show);
+}
 
-void FontList::on_actionShowFilePathColumn_toggled(bool show) { showColumn(COL_FILE_PATH, show); }
+void FontList::on_actionShowFilePathColumn_toggled(bool show)
+{
+  showColumn(COL_FILE_PATH, show);
+}
 
 void FontList::on_actionResetColumns_triggered()
 {
@@ -285,7 +319,10 @@ void FontList::on_tableView_customContextMenuRequested(const QPoint& pos)
   menu->popup(tableView->viewport()->mapToGlobal(pos));
 }
 
-const QModelIndex FontList::currentIndex() const { return tableView->selectionModel()->currentIndex(); }
+const QModelIndex FontList::currentIndex() const
+{
+  return tableView->selectionModel()->currentIndex();
+}
 
 void FontList::on_actionCopyFontName_triggered()
 {
@@ -428,7 +465,10 @@ void FontList::update_font_list()
   delete list;
 }
 
-void FontList::resizeEvent(QResizeEvent *event) { QWidget::resizeEvent(event); }
+void FontList::resizeEvent(QResizeEvent *event)
+{
+  QWidget::resizeEvent(event);
+}
 
 /**
  * Quote a string according to the requirements of font-config.

--- a/src/gui/FontListTableView.cc
+++ b/src/gui/FontListTableView.cc
@@ -34,9 +34,14 @@
 #include <QMimeData>
 #include <QTableView>
 
-FontListTableView::FontListTableView(QWidget *parent) : QTableView(parent) {}
+FontListTableView::FontListTableView(QWidget *parent) : QTableView(parent)
+{
+}
 
-void FontListTableView::setDragText(const QString& text) { this->text = text.trimmed(); }
+void FontListTableView::setDragText(const QString& text)
+{
+  this->text = text.trimmed();
+}
 
 void FontListTableView::startDrag(Qt::DropActions supportedActions)
 {

--- a/src/gui/IgnoreWheelWhenNotFocused.cc
+++ b/src/gui/IgnoreWheelWhenNotFocused.cc
@@ -35,7 +35,9 @@ void installIgnoreWheelWhenNotFocused(QWidget *parent)
 
 }  // NOLINT(clang-analyzer-cplusplus.NewDeleteLeaks): False positive
 
-IgnoreWheelWhenNotFocused::IgnoreWheelWhenNotFocused(QWidget *parent) : QObject(parent) {}
+IgnoreWheelWhenNotFocused::IgnoreWheelWhenNotFocused(QWidget *parent) : QObject(parent)
+{
+}
 
 // https://stackoverflow.com/questions/5821802/qspinbox-inside-a-qscrollarea-how-to-prevent-spin-box-from-stealing-focus-when
 bool IgnoreWheelWhenNotFocused::eventFilter(QObject *obj, QEvent *event)

--- a/src/gui/InitConfigurator.cc
+++ b/src/gui/InitConfigurator.cc
@@ -17,7 +17,10 @@
 
 #include <string>
 
-void InitConfigurator::writeSettings() { Settings::Settings::visit(SettingsWriter()); }
+void InitConfigurator::writeSettings()
+{
+  Settings::Settings::visit(SettingsWriter());
+}
 
 void InitConfigurator::initUpdateCheckBox(const BlockSignals<QCheckBox *>& checkBox,
                                           const Settings::SettingsEntryBool& entry)

--- a/src/gui/LaunchingScreen.cc
+++ b/src/gui/LaunchingScreen.cc
@@ -16,7 +16,10 @@
 
 LaunchingScreen *LaunchingScreen::inst = nullptr;
 
-LaunchingScreen *LaunchingScreen::getDialog() { return LaunchingScreen::inst; }
+LaunchingScreen *LaunchingScreen::getDialog()
+{
+  return LaunchingScreen::inst;
+}
 
 // Called (possibly multiple times) by EventFilter on MacOS, e.g.
 // when the user opens files from Finder.
@@ -79,9 +82,15 @@ LaunchingScreen::LaunchingScreen(QWidget *parent) : QDialog(parent)
   connect(this->checkBox, &QCheckBox::toggled, this, &LaunchingScreen::checkboxState);
 }
 
-LaunchingScreen::~LaunchingScreen() { LaunchingScreen::inst = nullptr; }
+LaunchingScreen::~LaunchingScreen()
+{
+  LaunchingScreen::inst = nullptr;
+}
 
-QStringList LaunchingScreen::selectedFiles() const { return this->files; }
+QStringList LaunchingScreen::selectedFiles() const
+{
+  return this->files;
+}
 
 bool LaunchingScreen::isForceShowEditor() const
 {
@@ -149,4 +158,7 @@ void LaunchingScreen::checkboxState(bool state) const
   settings.setValue("launcher/showOnStartup", !state);
 }
 
-void LaunchingScreen::openUserManualURL() const { UIUtils::openUserManualURL(); }
+void LaunchingScreen::openUserManualURL() const
+{
+  UIUtils::openUserManualURL();
+}

--- a/src/gui/MainWindow.cc
+++ b/src/gui/MainWindow.cc
@@ -852,9 +852,15 @@ void MainWindow::setAllMouseViewActions()
                                    Settings::Settings::inputMouseCtrlShiftRightClick.value())));
 }
 
-void MainWindow::onNavigationOpenContextMenu() { navigationMenu->exec(QCursor::pos()); }
+void MainWindow::onNavigationOpenContextMenu()
+{
+  navigationMenu->exec(QCursor::pos());
+}
 
-void MainWindow::onNavigationCloseContextMenu() { rubberBandManager.hide(); }
+void MainWindow::onNavigationCloseContextMenu()
+{
+  rubberBandManager.hide();
+}
 
 void MainWindow::onNavigationTriggerContextMenuEntry()
 {
@@ -955,9 +961,13 @@ void MainWindow::updateWindowSettings(bool isEditorToolbarVisible, bool isViewTo
   hide3DViewToolbar();
 }
 
-void MainWindow::onAxisChanged(InputEventAxisChanged *) {}
+void MainWindow::onAxisChanged(InputEventAxisChanged *)
+{
+}
 
-void MainWindow::onButtonChanged(InputEventButtonChanged *) {}
+void MainWindow::onButtonChanged(InputEventButtonChanged *)
+{
+}
 
 void MainWindow::onTranslateEvent(InputEventTranslate *event)
 {
@@ -1000,7 +1010,10 @@ void MainWindow::onActionEvent(InputEventAction *event)
   }
 }
 
-void MainWindow::onZoomEvent(InputEventZoom *event) { qglview->zoom(event->zoom, event->relative); }
+void MainWindow::onZoomEvent(InputEventZoom *event)
+{
+  qglview->zoom(event->zoom, event->relative);
+}
 
 void MainWindow::loadViewSettings()
 {
@@ -1116,7 +1129,10 @@ MainWindow::~MainWindow()
   }
 }
 
-void MainWindow::showProgress() { updateStatusBar(qobject_cast<ProgressWidget *>(sender())); }
+void MainWindow::showProgress()
+{
+  updateStatusBar(qobject_cast<ProgressWidget *>(sender()));
+}
 
 void MainWindow::report_func(const std::shared_ptr<const AbstractNode>&, void *vp, int mark)
 {
@@ -1284,7 +1300,10 @@ void MainWindow::waitAfterReload()
   this->waitAfterReloadTimer->start();
 }
 
-void MainWindow::on_toolButtonCompileResultClose_clicked() { frameCompileResult->hide(); }
+void MainWindow::on_toolButtonCompileResultClose_clicked()
+{
+  frameCompileResult->hide();
+}
 
 void MainWindow::updateCompileResult()
 {
@@ -1568,7 +1587,10 @@ void MainWindow::actionOpen()
   }
 }
 
-void MainWindow::actionNewWindow() { new MainWindow(QStringList()); }
+void MainWindow::actionNewWindow()
+{
+  new MainWindow(QStringList());
+}
 
 void MainWindow::actionOpenWindow()
 {
@@ -1695,9 +1717,15 @@ void MainWindow::saveBackup()
   return writeBackup(this->tempFile);
 }
 
-void MainWindow::actionSave() { tabManager->save(activeEditor); }
+void MainWindow::actionSave()
+{
+  tabManager->save(activeEditor);
+}
 
-void MainWindow::actionSaveAs() { tabManager->saveAs(activeEditor); }
+void MainWindow::actionSaveAs()
+{
+  tabManager->saveAs(activeEditor);
+}
 
 void MainWindow::actionPythonRevokeTrustedFiles()
 {
@@ -1771,7 +1799,10 @@ void MainWindow::actionPythonSelectVenv()
 #endif  // ifdef ENABLE_PYTHON
 }
 
-void MainWindow::actionSaveACopy() { tabManager->saveACopy(activeEditor); }
+void MainWindow::actionSaveACopy()
+{
+  tabManager->saveACopy(activeEditor);
+}
 
 void MainWindow::actionShowLibraryFolder()
 {
@@ -1884,7 +1915,10 @@ void MainWindow::showFind(bool doFindAndReplace)
   findInputField->selectAll();
 }
 
-void MainWindow::actionShowFind() { showFind(false); }
+void MainWindow::actionShowFind()
+{
+  showFind(false);
+}
 
 void MainWindow::findString(const QString& textToFind)
 {
@@ -1893,7 +1927,10 @@ void MainWindow::findString(const QString& textToFind)
   activeEditor->find(textToFind);
 }
 
-void MainWindow::actionShowFindAndReplace() { showFind(true); }
+void MainWindow::actionShowFindAndReplace()
+{
+  showFind(true);
+}
 
 void MainWindow::actionSelectFind(int type)
 {
@@ -1935,11 +1972,20 @@ void MainWindow::convertTabsToSpaces()
   activeEditor->setText(converted);
 }
 
-void MainWindow::findNext() { activeEditor->find(this->findInputField->text(), true); }
+void MainWindow::findNext()
+{
+  activeEditor->find(this->findInputField->text(), true);
+}
 
-void MainWindow::findPrev() { activeEditor->find(this->findInputField->text(), true, true); }
+void MainWindow::findPrev()
+{
+  activeEditor->find(this->findInputField->text(), true, true);
+}
 
-void MainWindow::useSelectionForFind() { findInputField->setText(activeEditor->selectedText()); }
+void MainWindow::useSelectionForFind()
+{
+  findInputField->setText(activeEditor->selectedText());
+}
 
 void MainWindow::updateFindBuffer(const QString& s)
 {
@@ -2151,7 +2197,10 @@ void MainWindow::parseTopLevelDocument()
   this->parsedFile = this->rootFile;
 }
 
-void MainWindow::changeParameterWidget() { parameterDock->setVisible(true); }
+void MainWindow::changeParameterWidget()
+{
+  parameterDock->setVisible(true);
+}
 
 void MainWindow::checkAutoReload()
 {
@@ -2571,7 +2620,10 @@ void MainWindow::measureFinished()
   if (didSomething) resetMeasurementsState(true, "Click to start measuring");
 }
 
-void MainWindow::clearAllSelectionIndicators() { this->activeEditor->clearAllSelectionIndicators(); }
+void MainWindow::clearAllSelectionIndicators()
+{
+  this->activeEditor->clearAllSelectionIndicators();
+}
 
 void MainWindow::setSelectionIndicatorStatus(EditorInterface *editor, int nodeIndex,
                                              EditorSelectionIndicatorStatus status)
@@ -2674,7 +2726,10 @@ void MainWindow::onHoveredObjectInSelectionMenu()
   setSelection(action->property("id").toInt());
 }
 
-void MainWindow::setLastFocus(QWidget *widget) { this->lastFocus = widget; }
+void MainWindow::setLastFocus(QWidget *widget)
+{
+  this->lastFocus = widget;
+}
 
 /**
  * Switch version label and progress widget. When switching to the progress
@@ -3104,7 +3159,10 @@ void MainWindow::viewModeShowScaleProportional()
   this->qglview->update();
 }
 
-bool MainWindow::isEmpty() { return activeEditor->toPlainText().isEmpty(); }
+bool MainWindow::isEmpty()
+{
+  return activeEditor->toPlainText().isEmpty();
+}
 
 void MainWindow::editorContentChanged()
 {
@@ -3179,9 +3237,15 @@ void MainWindow::setProjectionType(ProjectionType mode)
   qglview->update();
 }
 
-void MainWindow::viewPerspective() { setProjectionType(ProjectionType::PERSPECTIVE); }
+void MainWindow::viewPerspective()
+{
+  setProjectionType(ProjectionType::PERSPECTIVE);
+}
 
-void MainWindow::viewOrthogonal() { setProjectionType(ProjectionType::ORTHOGONAL); }
+void MainWindow::viewOrthogonal()
+{
+  setProjectionType(ProjectionType::ORTHOGONAL);
+}
 
 void MainWindow::viewTogglePerspective()
 {
@@ -3382,9 +3446,15 @@ void MainWindow::onWindowShortcutExport3DActivated()
   }
 }
 
-void MainWindow::on_editActionInsertTemplate_triggered() { activeEditor->displayTemplates(); }
+void MainWindow::on_editActionInsertTemplate_triggered()
+{
+  activeEditor->displayTemplates();
+}
 
-void MainWindow::on_editActionFoldAll_triggered() { activeEditor->foldUnfold(); }
+void MainWindow::on_editActionFoldAll_triggered()
+{
+  activeEditor->foldUnfold();
+}
 
 QString MainWindow::getCurrentFileName() const
 {
@@ -3556,15 +3626,30 @@ void MainWindow::helpAbout()
   dialog->deleteLater();
 }
 
-void MainWindow::helpHomepage() { UIUtils::openHomepageURL(); }
+void MainWindow::helpHomepage()
+{
+  UIUtils::openHomepageURL();
+}
 
-void MainWindow::helpManual() { UIUtils::openUserManualURL(); }
+void MainWindow::helpManual()
+{
+  UIUtils::openUserManualURL();
+}
 
-void MainWindow::helpOfflineManual() { UIUtils::openOfflineUserManual(); }
+void MainWindow::helpOfflineManual()
+{
+  UIUtils::openOfflineUserManual();
+}
 
-void MainWindow::helpCheatSheet() { UIUtils::openCheatSheetURL(); }
+void MainWindow::helpCheatSheet()
+{
+  UIUtils::openCheatSheetURL();
+}
 
-void MainWindow::helpOfflineCheatSheet() { UIUtils::openOfflineCheatSheet(); }
+void MainWindow::helpOfflineCheatSheet()
+{
+  UIUtils::openOfflineCheatSheet();
+}
 
 void MainWindow::helpLibrary()
 {
@@ -3662,7 +3747,10 @@ void MainWindow::errorLogOutput(const Message& log_msg, void *userdata)
   QMetaObject::invokeMethod(thisp, "errorLogOutput", Q_ARG(Message, log_msg));
 }
 
-void MainWindow::errorLogOutput(const Message& log_msg) { this->errorLogWidget->toErrorLog(log_msg); }
+void MainWindow::errorLogOutput(const Message& log_msg)
+{
+  this->errorLogWidget->toErrorLog(log_msg);
+}
 
 void MainWindow::setCurrentOutput()
 {
@@ -3674,7 +3762,10 @@ void MainWindow::hideCurrentOutput()
   set_output_handler(&MainWindow::noOutputConsole, &MainWindow::noOutputErrorLog, this);
 }
 
-void MainWindow::clearCurrentOutput() { set_output_handler(nullptr, nullptr, nullptr); }
+void MainWindow::clearCurrentOutput()
+{
+  set_output_handler(nullptr, nullptr, nullptr);
+}
 
 void MainWindow::openCSGSettingsChanged()
 {
@@ -3707,7 +3798,10 @@ QString MainWindow::exportPath(const QString& suffix)
   return QString("%1/%2.%3").arg(dir, basename, suffix);
 }
 
-void MainWindow::jumpToLine(int line, int col) { this->activeEditor->setCursorPosition(line, col); }
+void MainWindow::jumpToLine(int line, int col)
+{
+  this->activeEditor->setCursorPosition(line, col);
+}
 
 void MainWindow::resetMeasurementsState(bool enable, const QString& tooltipMessage)
 {

--- a/src/gui/OctoPrint.cc
+++ b/src/gui/OctoPrint.cc
@@ -47,7 +47,10 @@ const QString OctoPrint::url() const
   return QString::fromStdString(Settings::Settings::octoPrintUrl.value());
 }
 
-const std::string OctoPrint::apiKey() const { return Settings::Settings::octoPrintApiKey.value(); }
+const std::string OctoPrint::apiKey() const
+{
+  return Settings::Settings::octoPrintApiKey.value();
+}
 
 const QJsonDocument OctoPrint::getJsonData(const QString& endpoint) const
 {

--- a/src/gui/OctoPrintApiKeyDialog.cc
+++ b/src/gui/OctoPrintApiKeyDialog.cc
@@ -116,9 +116,15 @@ int OctoPrintApiKeyDialog::exec()
   return QDialog::exec();
 }
 
-void OctoPrintApiKeyDialog::on_pushButtonRetry_clicked() { startRequest(); }
+void OctoPrintApiKeyDialog::on_pushButtonRetry_clicked()
+{
+  startRequest();
+}
 
-void OctoPrintApiKeyDialog::on_pushButtonOk_clicked() { accept(); }
+void OctoPrintApiKeyDialog::on_pushButtonOk_clicked()
+{
+  accept();
+}
 
 void OctoPrintApiKeyDialog::on_pushButtonCancel_clicked()
 {

--- a/src/gui/OpenCSGWarningDialog.cc
+++ b/src/gui/OpenCSGWarningDialog.cc
@@ -13,4 +13,7 @@ OpenCSGWarningDialog::OpenCSGWarningDialog(QWidget *)
           &Preferences::on_openCSGWarningBox_toggled);
 }
 
-void OpenCSGWarningDialog::setText(const QString& text) { this->warningText->setPlainText(text); }
+void OpenCSGWarningDialog::setText(const QString& text)
+{
+  this->warningText->setPlainText(text);
+}

--- a/src/gui/OpenSCADApp.cc
+++ b/src/gui/OpenSCADApp.cc
@@ -31,7 +31,10 @@ OpenSCADApp::OpenSCADApp(int& argc, char **argv) : QApplication(argc, argv)
           &OpenSCADApp::setRenderBackend3D);
 }
 
-OpenSCADApp::~OpenSCADApp() { delete this->fontCacheDialog; }
+OpenSCADApp::~OpenSCADApp()
+{
+  delete this->fontCacheDialog;
+}
 
 #include <QMessageBox>
 

--- a/src/gui/Preferences.cc
+++ b/src/gui/Preferences.cc
@@ -296,7 +296,10 @@ void Preferences::init()
   emit editorConfigChanged();
 }
 
-Preferences::~Preferences() { removeDefaultSettings(); }
+Preferences::~Preferences()
+{
+  removeDefaultSettings();
+}
 
 void Preferences::update()
 {
@@ -1235,7 +1238,10 @@ void Preferences::writeSettings()
   fireEditorConfigChanged();
 }
 
-void Preferences::fireEditorConfigChanged() const { emit editorConfigChanged(); }
+void Preferences::fireEditorConfigChanged() const
+{
+  emit editorConfigChanged();
+}
 
 void Preferences::keyPressEvent(QKeyEvent *e)
 {

--- a/src/gui/PrintInitDialog.cc
+++ b/src/gui/PrintInitDialog.cc
@@ -246,7 +246,10 @@ void PrintInitDialog::on_pushButtonOk_clicked()
   accept();
 }
 
-void PrintInitDialog::on_pushButtonCancel_clicked() { reject(); }
+void PrintInitDialog::on_pushButtonCancel_clicked()
+{
+  reject();
+}
 
 int PrintInitDialog::exec()
 {
@@ -273,8 +276,17 @@ int PrintInitDialog::exec()
   return result;
 }
 
-print_service_t PrintInitDialog::getServiceType() const { return this->selectedPrintService; }
+print_service_t PrintInitDialog::getServiceType() const
+{
+  return this->selectedPrintService;
+}
 
-QString PrintInitDialog::getServiceName() const { return this->selectedServiceName; }
+QString PrintInitDialog::getServiceName() const
+{
+  return this->selectedServiceName;
+}
 
-FileFormat PrintInitDialog::getFileFormat() const { return this->selectedFileFormat; }
+FileFormat PrintInitDialog::getFileFormat() const
+{
+  return this->selectedFileFormat;
+}

--- a/src/gui/ProgressWidget.cc
+++ b/src/gui/ProgressWidget.cc
@@ -14,20 +14,35 @@ ProgressWidget::ProgressWidget(QWidget *parent) : QWidget(parent)
   QTimer::singleShot(1000, this, &ProgressWidget::requestShow);
 }
 
-bool ProgressWidget::wasCanceled() const { return this->wascanceled; }
+bool ProgressWidget::wasCanceled() const
+{
+  return this->wascanceled;
+}
 
 /*!
    Returns milliseconds since this widget was created
  */
-int ProgressWidget::elapsedTime() const { return this->starttime.elapsed(); }
+int ProgressWidget::elapsedTime() const
+{
+  return this->starttime.elapsed();
+}
 
-void ProgressWidget::cancel() { this->wascanceled = true; }
+void ProgressWidget::cancel()
+{
+  this->wascanceled = true;
+}
 
 void ProgressWidget::setRange(int minimum, int maximum)
 {
   this->progressBar->setRange(minimum, maximum);
 }
 
-void ProgressWidget::setValue(int progress) { this->progressBar->setValue(progress); }
+void ProgressWidget::setValue(int progress)
+{
+  this->progressBar->setValue(progress);
+}
 
-int ProgressWidget::value() const { return this->progressBar->value(); }
+int ProgressWidget::value() const
+{
+  return this->progressBar->value();
+}

--- a/src/gui/QGLView.cc
+++ b/src/gui/QGLView.cc
@@ -69,7 +69,10 @@
 #include "gui/qt-obsolete.h"
 #include "gui/Measurement.h"
 
-QGLView::QGLView(QWidget *parent) : QOpenGLWidget(parent) { init(); }
+QGLView::QGLView(QWidget *parent) : QOpenGLWidget(parent)
+{
+  init();
+}
 
 QGLView::~QGLView()
 {
@@ -87,7 +90,10 @@ void QGLView::init()
   setMouseTracking(true);
 }
 
-void QGLView::resetView() { cam.resetView(); }
+void QGLView::resetView()
+{
+  cam.resetView();
+}
 
 void QGLView::viewAll()
 {
@@ -427,7 +433,10 @@ const QImage& QGLView::grabFrame()
   return this->frame;
 }
 
-bool QGLView::save(const char *filename) const { return this->frame.save(filename, "PNG"); }
+bool QGLView::save(const char *filename) const
+{
+  return this->frame.save(filename, "PNG");
+}
 
 void QGLView::wheelEvent(QWheelEvent *event)
 {
@@ -442,9 +451,15 @@ void QGLView::wheelEvent(QWheelEvent *event)
   }
 }
 
-void QGLView::ZoomIn() { zoom(120, true); }
+void QGLView::ZoomIn()
+{
+  zoom(120, true);
+}
 
-void QGLView::ZoomOut() { zoom(-120, true); }
+void QGLView::ZoomOut()
+{
+  zoom(-120, true);
+}
 
 void QGLView::zoom(double v, bool relative)
 {

--- a/src/gui/QGLView2.cc
+++ b/src/gui/QGLView2.cc
@@ -34,7 +34,10 @@
  */
 #include <QOpenGLContext>
 
-QOpenGLContext *getGLContext() { return (QOpenGLContext::currentContext()); }
+QOpenGLContext *getGLContext()
+{
+  return (QOpenGLContext::currentContext());
+}
 
 void setGLContext(QOpenGLContext *ctx)
 {

--- a/src/gui/QWordSearchField.cc
+++ b/src/gui/QWordSearchField.cc
@@ -25,7 +25,10 @@ QWordSearchField::QWordSearchField(QFrame *parent) : QLineEdit(parent)
   fieldLabel->setAlignment(Qt::AlignRight);
 }
 
-void QWordSearchField::resizeEvent(QResizeEvent *) { resizeSearchField(); }
+void QWordSearchField::resizeEvent(QResizeEvent *)
+{
+  resizeSearchField();
+}
 
 void QWordSearchField::resizeSearchField()
 {

--- a/src/gui/RubberBandManager.cc
+++ b/src/gui/RubberBandManager.cc
@@ -20,7 +20,10 @@ bool RubberBandManager::isEmphasized(Dock *dock)
   return rubberBand.isVisible() && emphasizedDock == dock;
 }
 
-bool RubberBandManager::isVisible() { return rubberBand.isVisible(); }
+bool RubberBandManager::isVisible()
+{
+  return rubberBand.isVisible();
+}
 
 void RubberBandManager::emphasize(Dock *dock)
 {

--- a/src/gui/ScadApi.cc
+++ b/src/gui/ScadApi.cc
@@ -130,7 +130,9 @@ void ScadApi::autoCompleteFunctions(const QStringList& context, QStringList& lis
   }
 }
 
-void ScadApi::autoCompletionSelected(const QString& /*selection*/) {}
+void ScadApi::autoCompletionSelected(const QString& /*selection*/)
+{
+}
 
 QStringList ScadApi::callTips(const QStringList& context, int /*commas*/,
                               QsciScintilla::CallTipsStyle /*style*/, QList<int>& /*shifts*/)

--- a/src/gui/ScadLexer.cc
+++ b/src/gui/ScadLexer.cc
@@ -45,7 +45,10 @@ ScadLexer::ScadLexer(QObject *parent) : QsciLexerCPP(parent)
   setFoldAtElse(true);
 }
 
-const char *ScadLexer::language() const { return "SCAD"; }
+const char *ScadLexer::language() const
+{
+  return "SCAD";
+}
 
 void ScadLexer::setKeywords(int set, const std::string& keywords)
 {
@@ -225,7 +228,10 @@ ScadLexer2::ScadLexer2(QObject *parent) : QsciLexerCustom(parent), LexInterface(
   my_lexer->default_rules();
 }
 
-ScadLexer2::~ScadLexer2() { delete my_lexer; }
+ScadLexer2::~ScadLexer2()
+{
+  delete my_lexer;
+}
 
 void ScadLexer2::styleText(int start, int end)
 {
@@ -371,7 +377,10 @@ QString ScadLexer2::description(int style) const
   return {QString::number(style)};
 }
 
-const char *ScadLexer2::language() const { return "SCAD"; }
+const char *ScadLexer2::language() const
+{
+  return "SCAD";
+}
 
 QStringList ScadLexer2::autoCompletionWordSeparators() const
 {

--- a/src/gui/ScintillaEditor.cc
+++ b/src/gui/ScintillaEditor.cc
@@ -114,13 +114,25 @@ EditorColorScheme::EditorColorScheme(const fs::path& path) : path(path)
   }
 }
 
-bool EditorColorScheme::valid() const { return !_name.isEmpty(); }
+bool EditorColorScheme::valid() const
+{
+  return !_name.isEmpty();
+}
 
-const QString& EditorColorScheme::name() const { return _name; }
+const QString& EditorColorScheme::name() const
+{
+  return _name;
+}
 
-int EditorColorScheme::index() const { return _index; }
+int EditorColorScheme::index() const
+{
+  return _index;
+}
 
-const boost::property_tree::ptree& EditorColorScheme::propertyTree() const { return pt; }
+const boost::property_tree::ptree& EditorColorScheme::propertyTree() const
+{
+  return pt;
+}
 
 ScintillaEditor::ScintillaEditor(QWidget *parent) : EditorInterface(parent)
 {
@@ -263,9 +275,15 @@ ScintillaEditor::ScintillaEditor(QWidget *parent) : EditorInterface(parent)
   qsci->SendScintilla(QsciScintillaBase::SCI_SETBUFFEREDDRAW, false);
 }
 
-QPoint ScintillaEditor::mapToGlobal(const QPoint& pos) { return qsci->mapToGlobal(pos); }
+QPoint ScintillaEditor::mapToGlobal(const QPoint& pos)
+{
+  return qsci->mapToGlobal(pos);
+}
 
-QMenu *ScintillaEditor::createStandardContextMenu() { return qsci->createStandardContextMenu(); }
+QMenu *ScintillaEditor::createStandardContextMenu()
+{
+  return qsci->createStandardContextMenu();
+}
 
 void ScintillaEditor::addTemplate()
 {
@@ -302,9 +320,15 @@ void ScintillaEditor::addTemplate(const fs::path& path)
   }
 }
 
-void ScintillaEditor::displayTemplates() { qsci->showUserList(1, userList); }
+void ScintillaEditor::displayTemplates()
+{
+  qsci->showUserList(1, userList);
+}
 
-void ScintillaEditor::foldUnfold() { qsci->foldAll(); }
+void ScintillaEditor::foldUnfold()
+{
+  qsci->foldAll();
+}
 
 /**
  * Apply the settings that are changeable in the preferences. This is also
@@ -371,7 +395,10 @@ void ScintillaEditor::setupAutoComplete(const bool forceOff)
   qsci->setAutoCompletionThreshold(val <= 0 ? 1 : val);
 }
 
-void ScintillaEditor::fireModificationChanged() { emit modificationChanged(this); }
+void ScintillaEditor::fireModificationChanged()
+{
+  emit modificationChanged(this);
+}
 
 void ScintillaEditor::setPlainText(const QString& text)
 {
@@ -379,7 +406,10 @@ void ScintillaEditor::setPlainText(const QString& text)
   setContentModified(false);
 }
 
-QString ScintillaEditor::toPlainText() { return qsci->text(); }
+QString ScintillaEditor::toPlainText()
+{
+  return qsci->text();
+}
 
 void ScintillaEditor::setContentModified(bool modified)
 {
@@ -388,7 +418,10 @@ void ScintillaEditor::setContentModified(bool modified)
   qsci->setModified(modified);
 }
 
-bool ScintillaEditor::isContentModified() { return qsci->isModified(); }
+bool ScintillaEditor::isContentModified()
+{
+  return qsci->isModified();
+}
 
 void ScintillaEditor::highlightError(int error_pos)
 {
@@ -751,7 +784,10 @@ QStringList ScintillaEditor::colorSchemes()
   return colorSchemes;
 }
 
-bool ScintillaEditor::canUndo() { return qsci->isUndoAvailable(); }
+bool ScintillaEditor::canUndo()
+{
+  return qsci->isUndoAvailable();
+}
 
 void ScintillaEditor::setHighlightScheme(const QString& name)
 {
@@ -766,7 +802,10 @@ void ScintillaEditor::setHighlightScheme(const QString& name)
   noColor();
 }
 
-void ScintillaEditor::insert(const QString& text) { qsci->insert(text); }
+void ScintillaEditor::insert(const QString& text)
+{
+  qsci->insert(text);
+}
 
 void ScintillaEditor::setText(const QString& text)
 {
@@ -774,19 +813,40 @@ void ScintillaEditor::setText(const QString& text)
   qsci->replaceSelectedText(text);
 }
 
-void ScintillaEditor::undo() { qsci->undo(); }
+void ScintillaEditor::undo()
+{
+  qsci->undo();
+}
 
-void ScintillaEditor::redo() { qsci->redo(); }
+void ScintillaEditor::redo()
+{
+  qsci->redo();
+}
 
-void ScintillaEditor::cut() { qsci->cut(); }
+void ScintillaEditor::cut()
+{
+  qsci->cut();
+}
 
-void ScintillaEditor::copy() { qsci->copy(); }
+void ScintillaEditor::copy()
+{
+  qsci->copy();
+}
 
-void ScintillaEditor::paste() { qsci->paste(); }
+void ScintillaEditor::paste()
+{
+  qsci->paste();
+}
 
-void ScintillaEditor::zoomIn() { qsci->zoomIn(); }
+void ScintillaEditor::zoomIn()
+{
+  qsci->zoomIn();
+}
 
-void ScintillaEditor::zoomOut() { qsci->zoomOut(); }
+void ScintillaEditor::zoomOut()
+{
+  qsci->zoomOut();
+}
 
 void ScintillaEditor::initFont(const QString& fontName, uint size)
 {
@@ -983,7 +1043,10 @@ void ScintillaEditor::uncommentSelection()
   }
 }
 
-QString ScintillaEditor::selectedText() { return qsci->selectedText(); }
+QString ScintillaEditor::selectedText()
+{
+  return qsci->selectedText();
+}
 
 bool ScintillaEditor::eventFilter(QObject *obj, QEvent *e)
 {

--- a/src/gui/TabManager.cc
+++ b/src/gui/TabManager.cc
@@ -236,41 +236,95 @@ void TabManager::createTab(const QString& filename)
   emit tabCountChanged(editorList.size());
 }
 
-size_t TabManager::count() { return tabWidget->count(); }
+size_t TabManager::count()
+{
+  return tabWidget->count();
+}
 
-void TabManager::highlightError(int i) { editor->highlightError(i); }
+void TabManager::highlightError(int i)
+{
+  editor->highlightError(i);
+}
 
-void TabManager::unhighlightLastError() { editor->unhighlightLastError(); }
+void TabManager::unhighlightLastError()
+{
+  editor->unhighlightLastError();
+}
 
-void TabManager::undo() { editor->undo(); }
+void TabManager::undo()
+{
+  editor->undo();
+}
 
-void TabManager::redo() { editor->redo(); }
+void TabManager::redo()
+{
+  editor->redo();
+}
 
-void TabManager::cut() { editor->cut(); }
+void TabManager::cut()
+{
+  editor->cut();
+}
 
-void TabManager::copy() { editor->copy(); }
+void TabManager::copy()
+{
+  editor->copy();
+}
 
-void TabManager::paste() { editor->paste(); }
+void TabManager::paste()
+{
+  editor->paste();
+}
 
-void TabManager::indentSelection() { editor->indentSelection(); }
+void TabManager::indentSelection()
+{
+  editor->indentSelection();
+}
 
-void TabManager::unindentSelection() { editor->unindentSelection(); }
+void TabManager::unindentSelection()
+{
+  editor->unindentSelection();
+}
 
-void TabManager::commentSelection() { editor->commentSelection(); }
+void TabManager::commentSelection()
+{
+  editor->commentSelection();
+}
 
-void TabManager::uncommentSelection() { editor->uncommentSelection(); }
+void TabManager::uncommentSelection()
+{
+  editor->uncommentSelection();
+}
 
-void TabManager::toggleBookmark() { editor->toggleBookmark(); }
+void TabManager::toggleBookmark()
+{
+  editor->toggleBookmark();
+}
 
-void TabManager::nextBookmark() { editor->nextBookmark(); }
+void TabManager::nextBookmark()
+{
+  editor->nextBookmark();
+}
 
-void TabManager::prevBookmark() { editor->prevBookmark(); }
+void TabManager::prevBookmark()
+{
+  editor->prevBookmark();
+}
 
-void TabManager::jumpToNextError() { editor->jumpToNextError(); }
+void TabManager::jumpToNextError()
+{
+  editor->jumpToNextError();
+}
 
-void TabManager::setFocus() { editor->setFocus(); }
+void TabManager::setFocus()
+{
+  editor->setFocus();
+}
 
-void TabManager::updateActionUndoState() { par->editActionUndo->setEnabled(editor->canUndo()); }
+void TabManager::updateActionUndoState()
+{
+  par->editActionUndo->setEnabled(editor->canUndo());
+}
 
 void TabManager::onHyperlinkIndicatorClicked(int val)
 {

--- a/src/gui/UIUtils.cc
+++ b/src/gui/UIUtils.cc
@@ -203,7 +203,10 @@ QStringList UIUtils::recentFiles()
   return files;
 }
 
-const QList<UIUtils::ExampleCategory>& UIUtils::exampleCategories() { return readExamples(); }
+const QList<UIUtils::ExampleCategory>& UIUtils::exampleCategories()
+{
+  return readExamples();
+}
 
 QFileInfoList UIUtils::exampleFiles(const QString& category)
 {
@@ -217,9 +220,15 @@ QFileInfoList UIUtils::exampleFiles(const QString& category)
   return examples;
 }
 
-void UIUtils::openURL(const QString& url) { QDesktopServices::openUrl(QUrl(url)); }
+void UIUtils::openURL(const QString& url)
+{
+  QDesktopServices::openUrl(QUrl(url));
+}
 
-void UIUtils::openHomepageURL() { QDesktopServices::openUrl(QUrl("https://www.openscad.org/")); }
+void UIUtils::openHomepageURL()
+{
+  QDesktopServices::openUrl(QUrl("https://www.openscad.org/"));
+}
 
 static void openVersionedURL(const QString& url)
 {

--- a/src/gui/WindowManager.cc
+++ b/src/gui/WindowManager.cc
@@ -2,8 +2,17 @@
 #include <QSet>
 #include "gui/MainWindow.h"
 
-void WindowManager::add(MainWindow *mainwin) { this->windows.insert(mainwin); }
+void WindowManager::add(MainWindow *mainwin)
+{
+  this->windows.insert(mainwin);
+}
 
-void WindowManager::remove(MainWindow *mainwin) { this->windows.remove(mainwin); }
+void WindowManager::remove(MainWindow *mainwin)
+{
+  this->windows.remove(mainwin);
+}
 
-const QSet<MainWindow *>& WindowManager::getWindows() const { return this->windows; }
+const QSet<MainWindow *>& WindowManager::getWindows() const
+{
+  return this->windows;
+}

--- a/src/gui/input/AxisConfigWidget.cc
+++ b/src/gui/input/AxisConfigWidget.cc
@@ -42,7 +42,10 @@
 #include "gui/InitConfigurator.h"
 #include "gui/input/InputEventMapper.h"
 
-AxisConfigWidget::AxisConfigWidget(QWidget *parent) : QWidget(parent) { setupUi(this); }
+AxisConfigWidget::AxisConfigWidget(QWidget *parent) : QWidget(parent)
+{
+  setupUi(this);
+}
 
 void AxisConfigWidget::AxesChanged(int nr, double val) const
 {
@@ -507,7 +510,10 @@ void AxisConfigWidget::applyComboBox(QComboBox * /*comboBox*/, int val,
   writeSettings();
 }
 
-void AxisConfigWidget::writeSettings() { Settings::Settings::visit(SettingsWriter()); }
+void AxisConfigWidget::writeSettings()
+{
+  Settings::Settings::visit(SettingsWriter());
+}
 
 void AxisConfigWidget::updateStates()
 {

--- a/src/gui/input/ButtonConfigWidget.cc
+++ b/src/gui/input/ButtonConfigWidget.cc
@@ -38,7 +38,10 @@
 #include "gui/IgnoreWheelWhenNotFocused.h"
 #include "gui/input/InputEventMapper.h"
 
-ButtonConfigWidget::ButtonConfigWidget(QWidget *parent) : QWidget(parent) { setupUi(this); }
+ButtonConfigWidget::ButtonConfigWidget(QWidget *parent) : QWidget(parent)
+{
+  setupUi(this);
+}
 
 void ButtonConfigWidget::updateButtonState(int nr, bool pressed) const
 {
@@ -226,7 +229,10 @@ void ButtonConfigWidget::updateComboBox(QComboBox *comboBox, const Settings::Set
   }
 }
 
-void ButtonConfigWidget::writeSettings() { Settings::Settings::visit(SettingsWriter()); }
+void ButtonConfigWidget::writeSettings()
+{
+  Settings::Settings::visit(SettingsWriter());
+}
 
 void ButtonConfigWidget::initActionComboBox(QComboBox *comboBox,
                                             const Settings::SettingsEntryString& entry)

--- a/src/gui/input/DBusInputDriver.cc
+++ b/src/gui/input/DBusInputDriver.cc
@@ -32,13 +32,24 @@
 #include "openscad_adaptor.h"
 #include "openscad_interface.h"
 
-void DBusInputDriver::run() {}
+void DBusInputDriver::run()
+{
+}
 
-DBusInputDriver::DBusInputDriver() { name = "DBusInputDriver"; }
+DBusInputDriver::DBusInputDriver()
+{
+  name = "DBusInputDriver";
+}
 
-bool DBusInputDriver::openOnce() const { return true; }
+bool DBusInputDriver::openOnce() const
+{
+  return true;
+}
 
-bool DBusInputDriver::isOpen() const { return is_open; }
+bool DBusInputDriver::isOpen() const
+{
+  return is_open;
+}
 
 bool DBusInputDriver::open()
 {
@@ -62,7 +73,9 @@ bool DBusInputDriver::open()
   return true;
 }
 
-void DBusInputDriver::close() {}
+void DBusInputDriver::close()
+{
+}
 
 void DBusInputDriver::zoom(double zoom) const
 {
@@ -129,7 +142,10 @@ const QList<double> DBusInputDriver::getTranslation() const
   return InputDriverManager::instance()->getTranslation();
 }
 
-const std::string& DBusInputDriver::get_name() const { return this->name; }
+const std::string& DBusInputDriver::get_name() const
+{
+  return this->name;
+}
 
 std::string DBusInputDriver::get_info() const
 {

--- a/src/gui/input/HidApiInputDriver.cc
+++ b/src/gui/input/HidApiInputDriver.cc
@@ -144,9 +144,15 @@ static const device_id *match_device(const struct hid_device_info *info)
   return nullptr;
 }
 
-HidApiInputDriver::HidApiInputDriver() { name = "HidApiInputDriver"; }
+HidApiInputDriver::HidApiInputDriver()
+{
+  name = "HidApiInputDriver";
+}
 
-void HidApiInputDriver::run() { hidapi_input(hid_dev); }
+void HidApiInputDriver::run()
+{
+  hidapi_input(hid_dev);
+}
 
 void HidApiInputDriver::hidapi_decode_axis(const unsigned char *buf, unsigned int len)
 {
@@ -304,7 +310,10 @@ void HidApiInputDriver::close()
   logstream.close();
 }
 
-const std::string& HidApiInputDriver::get_name() const { return name; }
+const std::string& HidApiInputDriver::get_name() const
+{
+  return name;
+}
 
 std::string HidApiInputDriver::get_info() const
 {

--- a/src/gui/input/InputDriver.cc
+++ b/src/gui/input/InputDriver.cc
@@ -29,8 +29,16 @@
 
 const QEvent::Type InputEvent::eventType = static_cast<QEvent::Type>(QEvent::registerEventType());
 
-InputEvent::InputEvent(const bool activeOnly) : QEvent(eventType), activeOnly(activeOnly) {}
+InputEvent::InputEvent(const bool activeOnly) : QEvent(eventType), activeOnly(activeOnly)
+{
+}
 
-bool InputDriver::isOpen() const { return isRunning(); }
+bool InputDriver::isOpen() const
+{
+  return isRunning();
+}
 
-bool InputDriver::openOnce() const { return false; }
+bool InputDriver::openOnce() const
+{
+  return false;
+}

--- a/src/gui/input/InputDriverManager.cc
+++ b/src/gui/input/InputDriverManager.cc
@@ -54,9 +54,15 @@ InputDriverManager *InputDriverManager::instance()
   return self;
 }
 
-void InputDriverManager::registerDriver(InputDriver *driver) { this->drivers.push_back(driver); }
+void InputDriverManager::registerDriver(InputDriver *driver)
+{
+  this->drivers.push_back(driver);
+}
 
-void InputDriverManager::unregisterDriver(InputDriver *driver) { this->drivers.remove(driver); }
+void InputDriverManager::unregisterDriver(InputDriver *driver)
+{
+  this->drivers.remove(driver);
+}
 
 void InputDriverManager::registerActions(const QList<QAction *>& actions, const QString& parent,
                                          const QString& target)
@@ -159,7 +165,10 @@ void InputDriverManager::closeDrivers()
   }
 }
 
-void InputDriverManager::sendEvent(InputEvent *event) { event->deliver(&mapper); }
+void InputDriverManager::sendEvent(InputEvent *event)
+{
+  event->deliver(&mapper);
+}
 
 void InputDriverManager::postEvent(InputEvent *event)
 {
@@ -169,7 +178,10 @@ void InputDriverManager::postEvent(InputEvent *event)
   }
 }
 
-const std::list<ActionStruct>& InputDriverManager::getActions() const { return actions; }
+const std::list<ActionStruct>& InputDriverManager::getActions() const
+{
+  return actions;
+}
 
 QList<double> InputDriverManager::getTranslation() const
 {
@@ -196,11 +208,20 @@ void InputDriverManager::onFocusChanged(QWidget *, QWidget *current)
   }
 }
 
-void InputDriverManager::onInputMappingUpdated() { mapper.onInputMappingUpdated(); }
+void InputDriverManager::onInputMappingUpdated()
+{
+  mapper.onInputMappingUpdated();
+}
 
-void InputDriverManager::onInputCalibrationUpdated() { mapper.onInputCalibrationUpdated(); }
+void InputDriverManager::onInputCalibrationUpdated()
+{
+  mapper.onInputCalibrationUpdated();
+}
 
-void InputDriverManager::onInputGainUpdated() { mapper.onInputGainUpdated(); }
+void InputDriverManager::onInputGainUpdated()
+{
+  mapper.onInputGainUpdated();
+}
 
 size_t InputDriverManager::getButtonCount() const
 {

--- a/src/gui/input/JoystickInputDriver.cc
+++ b/src/gui/input/JoystickInputDriver.cc
@@ -89,7 +89,10 @@ bool JoystickInputDriver::open()
   return true;
 }
 
-void JoystickInputDriver::close() { stopRequest = true; }
+void JoystickInputDriver::close()
+{
+  stopRequest = true;
+}
 
 const std::string& JoystickInputDriver::get_name() const
 {
@@ -103,4 +106,7 @@ std::string JoystickInputDriver::get_info() const
              "Axis: ", (int)axes, " ", "Buttons: ", (int)buttons, " ");
 }
 
-void JoystickInputDriver::setJoystickNr(std::string jnr) { this->nr = std::move(jnr); }
+void JoystickInputDriver::setJoystickNr(std::string jnr)
+{
+  this->nr = std::move(jnr);
+}

--- a/src/gui/input/MouseConfigWidget.cc
+++ b/src/gui/input/MouseConfigWidget.cc
@@ -39,7 +39,10 @@
 #include "gui/IgnoreWheelWhenNotFocused.h"
 #include "gui/Preferences.h"
 
-MouseConfigWidget::MouseConfigWidget(QWidget *parent) : QWidget(parent) { setupUi(this); }
+MouseConfigWidget::MouseConfigWidget(QWidget *parent) : QWidget(parent)
+{
+  setupUi(this);
+}
 
 void MouseConfigWidget::updateMouseState(int nr, bool pressed) const
 {
@@ -234,7 +237,10 @@ void MouseConfigWidget::applyComboBox(QComboBox *comboBox, int val, Settings::Se
   writeSettings();
 }
 
-void MouseConfigWidget::writeSettings() { Settings::Settings::visit(SettingsWriter()); }
+void MouseConfigWidget::writeSettings()
+{
+  Settings::Settings::visit(SettingsWriter());
+}
 
 void MouseConfigWidget::initActionComboBox(QComboBox *comboBox, Settings::SettingsEntryInt& entry)
 {

--- a/src/gui/input/QGamepadInputDriver.cc
+++ b/src/gui/input/QGamepadInputDriver.cc
@@ -30,9 +30,13 @@
 
 #include <string>
 
-void QGamepadInputDriver::run() {}
+void QGamepadInputDriver::run()
+{
+}
 
-QGamepadInputDriver::QGamepadInputDriver() : gamepad(nullptr) {}
+QGamepadInputDriver::QGamepadInputDriver() : gamepad(nullptr)
+{
+}
 
 bool QGamepadInputDriver::open()
 {
@@ -119,7 +123,10 @@ bool QGamepadInputDriver::open()
   return true;
 }
 
-void QGamepadInputDriver::close() { gamepad.reset(); }
+void QGamepadInputDriver::close()
+{
+  gamepad.reset();
+}
 
 const std::string& QGamepadInputDriver::get_name() const
 {
@@ -127,7 +134,10 @@ const std::string& QGamepadInputDriver::get_name() const
   return name;
 }
 
-bool QGamepadInputDriver::isOpen() const { return this->gamepad ? this->gamepad->isConnected() : false; }
+bool QGamepadInputDriver::isOpen() const
+{
+  return this->gamepad ? this->gamepad->isConnected() : false;
+}
 
 std::string QGamepadInputDriver::get_info() const
 {

--- a/src/gui/input/SpaceNavInputDriver.cc
+++ b/src/gui/input/SpaceNavInputDriver.cc
@@ -180,9 +180,14 @@ bool SpaceNavInputDriver::open()
   return true;
 }
 
-void SpaceNavInputDriver::close() {}
+void SpaceNavInputDriver::close()
+{
+}
 
-void SpaceNavInputDriver::setDominantAxisOnly(bool var) { this->dominantAxisOnly = var; }
+void SpaceNavInputDriver::setDominantAxisOnly(bool var)
+{
+  this->dominantAxisOnly = var;
+}
 
 const std::string& SpaceNavInputDriver::get_name() const
 {

--- a/src/gui/parameter/GroupWidget.cc
+++ b/src/gui/parameter/GroupWidget.cc
@@ -31,7 +31,10 @@ GroupWidget::GroupWidget(const QString& title, QWidget *parent) : QWidget(parent
   QObject::connect(&toggleButton, &QToolButton::toggled, this, &GroupWidget::setExpanded);
 }
 
-void GroupWidget::addWidget(QWidget *widget) { contentLayout.addWidget(widget); }
+void GroupWidget::addWidget(QWidget *widget)
+{
+  contentLayout.addWidget(widget);
+}
 
 void GroupWidget::setExpanded(bool expanded)
 {

--- a/src/gui/parameter/ParameterCheckBox.cc
+++ b/src/gui/parameter/ParameterCheckBox.cc
@@ -24,4 +24,7 @@ void ParameterCheckBox::onChanged()
   emit changed(true);
 }
 
-void ParameterCheckBox::setValue() { checkBox->setChecked(parameter->value); }
+void ParameterCheckBox::setValue()
+{
+  checkBox->setChecked(parameter->value);
+}

--- a/src/gui/parameter/ParameterComboBox.cc
+++ b/src/gui/parameter/ParameterComboBox.cc
@@ -29,4 +29,7 @@ void ParameterComboBox::onChanged(int index)
   }
 }
 
-void ParameterComboBox::setValue() { comboBox->setCurrentIndex(parameter->valueIndex); }
+void ParameterComboBox::setValue()
+{
+  comboBox->setCurrentIndex(parameter->valueIndex);
+}

--- a/src/gui/parameter/ParameterSlider.cc
+++ b/src/gui/parameter/ParameterSlider.cc
@@ -59,13 +59,21 @@ ParameterSlider::ParameterSlider(QWidget *parent, NumberParameter *parameter,
   ParameterSlider::setValue();
 }
 
-void ParameterSlider::valueApplied() { lastApplied = lastSent; }
+void ParameterSlider::valueApplied()
+{
+  lastApplied = lastSent;
+}
 
 // slider handle grabbed
-void ParameterSlider::onSliderPressed() {}
+void ParameterSlider::onSliderPressed()
+{
+}
 
 // slider handle released
-void ParameterSlider::onSliderReleased() { this->commitChange(true); }
+void ParameterSlider::onSliderReleased()
+{
+  this->commitChange(true);
+}
 
 // slider handle dragged
 void ParameterSlider::onSliderMoved(int position)
@@ -98,7 +106,10 @@ void ParameterSlider::onSpinBoxChanged(double value)
 }
 
 // Enter key pressed or spinbox focus lost
-void ParameterSlider::onSpinBoxEditingFinished() { commitChange(true); }
+void ParameterSlider::onSpinBoxEditingFinished()
+{
+  commitChange(true);
+}
 
 void ParameterSlider::commitChange(bool immediate)
 {

--- a/src/gui/parameter/ParameterSpinBox.cc
+++ b/src/gui/parameter/ParameterSpinBox.cc
@@ -51,7 +51,10 @@ ParameterSpinBox::ParameterSpinBox(QWidget *parent, NumberParameter *parameter,
   ParameterSpinBox::setValue();
 }
 
-void ParameterSpinBox::valueApplied() { lastApplied = lastSent; }
+void ParameterSpinBox::valueApplied()
+{
+  lastApplied = lastSent;
+}
 
 void ParameterSpinBox::onChanged(double value)
 {

--- a/src/gui/parameter/ParameterText.cc
+++ b/src/gui/parameter/ParameterText.cc
@@ -20,7 +20,10 @@ ParameterText::ParameterText(QWidget *parent, StringParameter *parameter,
   ParameterText::setValue();
 }
 
-void ParameterText::valueApplied() { lastApplied = lastSent; }
+void ParameterText::valueApplied()
+{
+  lastApplied = lastSent;
+}
 
 void ParameterText::onEdit(const QString& text)
 {

--- a/src/gui/parameter/ParameterVector.cc
+++ b/src/gui/parameter/ParameterVector.cc
@@ -88,7 +88,10 @@ ParameterVector::ParameterVector(QWidget *parent, VectorParameter *parameter,
   ParameterVector::setValue();
 }
 
-void ParameterVector::valueApplied() { lastApplied = lastSent; }
+void ParameterVector::valueApplied()
+{
+  lastApplied = lastSent;
+}
 
 void ParameterVector::onChanged()
 {

--- a/src/gui/parameter/ParameterWidget.cc
+++ b/src/gui/parameter/ParameterWidget.cc
@@ -143,7 +143,10 @@ void ParameterWidget::setParameters(const SourceFile *sourceFile, const std::str
   loadSet(comboBoxPreset->currentIndex());
 }
 
-void ParameterWidget::applyParameters(SourceFile *sourceFile) { this->parameters.apply(sourceFile); }
+void ParameterWidget::applyParameters(SourceFile *sourceFile)
+{
+  this->parameters.apply(sourceFile);
+}
 
 bool ParameterWidget::childHasFocus()
 {

--- a/src/guitests/TestTabManager.cc
+++ b/src/guitests/TestTabManager.cc
@@ -3,7 +3,9 @@
 #include "platform/PlatformUtils.h"
 #include "TestTabManager.h"
 
-void TestTabManager::initTestCase() {}
+void TestTabManager::initTestCase()
+{
+}
 
 void TestTabManager::checkOpenClose()
 {

--- a/src/guitests/UXTest.cc
+++ b/src/guitests/UXTest.cc
@@ -1,7 +1,10 @@
 #include "UXTest.h"
 #include "platform/PlatformUtils.h"
 
-void UXTest::setWindow(MainWindow *window_) { window = window_; }
+void UXTest::setWindow(MainWindow *window_)
+{
+  window = window_;
+}
 
 void UXTest::restoreWindowInitialState()
 {

--- a/src/io/export.cc
+++ b/src/io/export.cc
@@ -140,7 +140,10 @@ std::vector<FileFormat> all3D()
   return all3DFormats;
 }
 
-const FileFormatInfo& info(FileFormat fileFormat) { return containers().fileFormatToInfo[fileFormat]; }
+const FileFormatInfo& info(FileFormat fileFormat)
+{
+  return containers().fileFormatToInfo[fileFormat];
+}
 
 bool fromIdentifier(const std::string& identifier, FileFormat& format)
 {
@@ -150,7 +153,10 @@ bool fromIdentifier(const std::string& identifier, FileFormat& format)
   return true;
 }
 
-const std::string& toSuffix(FileFormat format) { return containers().fileFormatToInfo[format].suffix; }
+const std::string& toSuffix(FileFormat format)
+{
+  return containers().fileFormatToInfo[format].suffix;
+}
 
 bool canPreview(FileFormat format)
 {
@@ -266,7 +272,10 @@ bool exportFileByName(const std::shared_ptr<const Geometry>& root_geom, const st
 
 namespace {
 
-double remove_negative_zero(double x) { return x == -0 ? 0 : x; }
+double remove_negative_zero(double x)
+{
+  return x == -0 ? 0 : x;
+}
 
 Vector3d remove_negative_zero(const Vector3d& pt)
 {

--- a/src/io/export_3mf_v2.cc
+++ b/src/io/export_3mf_v2.cc
@@ -84,7 +84,10 @@ uint32_t lib3mf_seek_callback(uint64_t pos, std::ostream *stream)
   return !(*stream);
 }
 
-void export_3mf_error(std::string msg) { LOG(message_group::Export_Error, std::move(msg)); }
+void export_3mf_error(std::string msg)
+{
+  LOG(message_group::Export_Error, std::move(msg));
+}
 
 int count_mesh_objects(const Lib3MF::PModel& model)
 {

--- a/src/io/export_pdf.cc
+++ b/src/io/export_pdf.cc
@@ -55,9 +55,15 @@ void draw_text(const char *text, cairo_t *cr, double x, double y, double fontSiz
   cairo_show_text(cr, text);
 }
 
-double mm_to_points(double mm) { return mm * PTS_IN_MM; }
+double mm_to_points(double mm)
+{
+  return mm * PTS_IN_MM;
+}
 
-double points_to_mm(double pts) { return pts / PTS_IN_MM; }
+double points_to_mm(double pts)
+{
+  return pts / PTS_IN_MM;
+}
 
 void draw_grid(cairo_t *cr, double left, double right, double bottom, double top, double gridSize)
 {

--- a/src/io/export_png.cc
+++ b/src/io/export_png.cc
@@ -137,6 +137,9 @@ std::unique_ptr<OffscreenView> prepare_preview(Tree& tree, const ViewOptions& op
 {
   return nullptr;
 }
-bool export_png(const OffscreenView& glview, std::ostream& output) { return false; }
+bool export_png(const OffscreenView& glview, std::ostream& output)
+{
+  return false;
+}
 
 #endif  // NULLGL

--- a/src/io/import_3mf_dummy.cc
+++ b/src/io/import_3mf_dummy.cc
@@ -32,7 +32,10 @@
 #include "geometry/PolySet.h"
 #include "io/lib3mf_utils.h"
 
-std::string get_lib3mf_version() { return "(not enabled)"; }
+std::string get_lib3mf_version()
+{
+  return "(not enabled)";
+}
 
 std::unique_ptr<class PolySet> import_3mf(const std::string&, const Location& loc)
 {

--- a/src/io/import_amf.cc
+++ b/src/io/import_amf.cc
@@ -104,7 +104,9 @@ public:
   virtual xmlTextReaderPtr createXmlReader(const char *filename);
 };
 
-AmfImporter::AmfImporter(const Location& loc) : loc(loc) {}
+AmfImporter::AmfImporter(const Location& loc) : loc(loc)
+{
+}
 
 void AmfImporter::set_x(AmfImporter *importer, const xmlChar *value)
 {
@@ -301,7 +303,9 @@ public:
   xmlTextReaderPtr createXmlReader(const char *filename) override;
 };
 
-AmfImporterZIP::AmfImporterZIP(const Location& loc) : AmfImporter(loc) {}
+AmfImporterZIP::AmfImporterZIP(const Location& loc) : AmfImporter(loc)
+{
+}
 
 int AmfImporterZIP::read_callback(void *context, char *buffer, int len)
 {

--- a/src/io/import_stl.cc
+++ b/src/io/import_stl.cc
@@ -55,7 +55,10 @@ static void uint32_byte_swap(unsigned char *p)
 #endif
 }
 
-static void uint32_byte_swap(uint32_t& x) { uint32_byte_swap(reinterpret_cast<unsigned char *>(&x)); }
+static void uint32_byte_swap(uint32_t& x)
+{
+  uint32_byte_swap(reinterpret_cast<unsigned char *>(&x));
+}
 #endif  // if BOOST_ENDIAN_BIG_BYTE
 
 static void read_stl_facet(std::ifstream& f, stl_facet& facet)

--- a/src/libsvg/group.cc
+++ b/src/libsvg/group.cc
@@ -33,7 +33,10 @@ namespace libsvg {
 
 const std::string group::name("g");
 
-void group::set_attrs(attr_map_t& attrs, void *context) { shape::set_attrs(attrs, context); }
+void group::set_attrs(attr_map_t& attrs, void *context)
+{
+  shape::set_attrs(attrs, context);
+}
 
 const std::string group::dump() const
 {

--- a/src/libsvg/libsvg.cc
+++ b/src/libsvg/libsvg.cc
@@ -221,6 +221,9 @@ shapes_list_t *libsvg_read_file(const char *filename, void *context)
   return shape_list;
 }
 
-void libsvg_free(shapes_list_t *shapes) { delete shapes; }
+void libsvg_free(shapes_list_t *shapes)
+{
+  delete shapes;
+}
 
 }  // namespace libsvg

--- a/src/libsvg/svgpage.cc
+++ b/src/libsvg/svgpage.cc
@@ -33,7 +33,9 @@ namespace libsvg {
 
 const std::string svgpage::name("svg");
 
-svgpage::svgpage() : width({0.0, unit_t::UNDEFINED}), height({0.0, unit_t::UNDEFINED}) {}
+svgpage::svgpage() : width({0.0, unit_t::UNDEFINED}), height({0.0, unit_t::UNDEFINED})
+{
+}
 
 void svgpage::set_attrs(attr_map_t& attrs, void *context)
 {

--- a/src/libsvg/transformation.cc
+++ b/src/libsvg/transformation.cc
@@ -50,7 +50,9 @@ const std::string transformation::get_args() const
   return str.str();
 }
 
-matrix::matrix() : transformation("m", "matrix") {}
+matrix::matrix() : transformation("m", "matrix")
+{
+}
 
 /**
  * matrix(<a> <b> <c> <d> <e> <f>), which specifies a transformation in
@@ -76,7 +78,9 @@ std::vector<Eigen::Matrix3d> matrix::get_matrices()
   return result;
 }
 
-translate::translate() : transformation("t", "translate") {}
+translate::translate() : transformation("t", "translate")
+{
+}
 
 /**
  * translate(<tx> [<ty>]), which specifies a translation by tx and ty.
@@ -104,7 +108,9 @@ std::vector<Eigen::Matrix3d> translate::get_matrices()
   return result;
 }
 
-scale::scale() : transformation("s", "scale") {}
+scale::scale() : transformation("s", "scale")
+{
+}
 
 /**
  * scale(<sx> [<sy>]), which specifies a scale operation by sx and sy.
@@ -132,7 +138,9 @@ std::vector<Eigen::Matrix3d> scale::get_matrices()
   return result;
 }
 
-rotate::rotate() : transformation("r", "rotate") {}
+rotate::rotate() : transformation("r", "rotate")
+{
+}
 
 /**
  * rotate(<rotate-angle> [<cx> <cy>]), which specifies a rotation by
@@ -185,7 +193,9 @@ std::vector<Eigen::Matrix3d> rotate::get_matrices()
   return result;
 }
 
-skew_x::skew_x() : transformation("x", "skew_x") {}
+skew_x::skew_x() : transformation("x", "skew_x")
+{
+}
 
 /**
  * skewX(<skew-angle>), which specifies a skew transformation along the x-axis.
@@ -211,7 +221,9 @@ std::vector<Eigen::Matrix3d> skew_x::get_matrices()
   return result;
 }
 
-skew_y::skew_y() : transformation("y", "skew_y") {}
+skew_y::skew_y() : transformation("y", "skew_y")
+{
+}
 
 /**
  * skewY(<skew-angle>), which specifies a skew transformation along the y-axis.

--- a/src/openscad_gui.cc
+++ b/src/openscad_gui.cc
@@ -123,7 +123,10 @@ QString assemblePath(const std::filesystem::path& absoluteBaseDir, const std::st
   return fileInfo.absoluteFilePath();
 }
 
-void dialogThreadFunc(FontCacheInitializer *initializer) { initializer->run(); }
+void dialogThreadFunc(FontCacheInitializer *initializer)
+{
+  initializer->run();
+}
 
 void dialogInitHandler(FontCacheInitializer *initializer, void *)
 {
@@ -157,7 +160,9 @@ void registerDefaultIcon(QString applicationFilePath)
                        QVariant(appPath));
 }
 #else
-void registerDefaultIcon(const QString&) {}
+void registerDefaultIcon(const QString&)
+{
+}
 #endif
 
 }  // namespace

--- a/src/openscad_mimalloc.h
+++ b/src/openscad_mimalloc.h
@@ -17,9 +17,15 @@ inline void *gmp_realloc(void *ptr, size_t /*oldsize*/, size_t newsize)
 {
   return mi_realloc(ptr, newsize);
 }
-inline void gmp_free(void *ptr, size_t /*oldsize*/) { mi_free(ptr); }
+inline void gmp_free(void *ptr, size_t /*oldsize*/)
+{
+  mi_free(ptr);
+}
 #include <gmp.h>
-inline void init_mimalloc() { mp_set_memory_functions(mi_malloc, gmp_realloc, gmp_free); }
+inline void init_mimalloc()
+{
+  mp_set_memory_functions(mi_malloc, gmp_realloc, gmp_free);
+}
 #endif  // ENABLE_CGAL
 
 #endif  // USE_MIMALLOC

--- a/src/platform/PlatformUtils-posix.cc
+++ b/src/platform/PlatformUtils-posix.cc
@@ -66,7 +66,10 @@ static std::string getXdgUserDir(const std::string& dir)
   return "";
 }
 
-std::string PlatformUtils::pathSeparatorChar() { return ":"; }
+std::string PlatformUtils::pathSeparatorChar()
+{
+  return ":";
+}
 
 std::string PlatformUtils::userDocumentsPath()
 {
@@ -271,4 +274,6 @@ const std::string PlatformUtils::sysinfo(bool extended)
   return result;
 }
 
-void PlatformUtils::ensureStdIO() {}
+void PlatformUtils::ensureStdIO()
+{
+}

--- a/src/platform/PlatformUtils-win.cc
+++ b/src/platform/PlatformUtils-win.cc
@@ -24,7 +24,10 @@
 
 #include "version.h"
 
-std::string PlatformUtils::pathSeparatorChar() { return ";"; }
+std::string PlatformUtils::pathSeparatorChar()
+{
+  return ";";
+}
 
 // see http://msdn.microsoft.com/en-us/library/windows/desktop/bb762494%28v=vs.85%29.aspx
 static const std::string getFolderPath(int nFolder)
@@ -49,7 +52,10 @@ static const std::string getFolderPath(int nFolder)
   return "";
 }
 
-std::string PlatformUtils::userDocumentsPath() { return documentsPath(); }
+std::string PlatformUtils::userDocumentsPath()
+{
+  return documentsPath();
+}
 
 // retrieve the path to 'My Documents' for the current user under windows
 // In XP this is 'c:\documents and settings\username\my documents'
@@ -74,7 +80,10 @@ std::string PlatformUtils::userConfigPath()
   return retval + std::string("/") + PlatformUtils::OPENSCAD_FOLDER_NAME;
 }
 
-unsigned long PlatformUtils::stackLimit() { return STACK_LIMIT_DEFAULT; }
+unsigned long PlatformUtils::stackLimit()
+{
+  return STACK_LIMIT_DEFAULT;
+}
 
 // NOLINTNEXTLINE(modernize-use-using)
 typedef BOOL(WINAPI *LPFN_ISWOW64PROCESS)(HANDLE, PBOOL);
@@ -173,7 +182,10 @@ const std::string PlatformUtils::sysinfo(bool extended)
 #ifdef USE_MIMALLOC
 #include <mimalloc.h>
 // mimalloc needs an output handler that references stderr after we mess with it.
-static void mi_output(const char *msg, void *arg) { fputs(msg, stderr); }
+static void mi_output(const char *msg, void *arg)
+{
+  fputs(msg, stderr);
+}
 #endif
 
 // attach to parent console if standard IO handles not available

--- a/src/platform/PlatformUtils.cc
+++ b/src/platform/PlatformUtils.cc
@@ -137,9 +137,15 @@ std::string PlatformUtils::userPath(const std::string& name)
   return path.generic_string();
 }
 
-std::string PlatformUtils::userLibraryPath() { return userPath("libraries"); }
+std::string PlatformUtils::userLibraryPath()
+{
+  return userPath("libraries");
+}
 
-std::string PlatformUtils::userExamplesPath() { return userPath("examples"); }
+std::string PlatformUtils::userExamplesPath()
+{
+  return userPath("examples");
+}
 
 std::string PlatformUtils::backupPath()
 {

--- a/src/python/pyopenscad.cc
+++ b/src/python/pyopenscad.cc
@@ -38,7 +38,10 @@ extern "C" PyObject *PyInit_openscad(void);
 bool python_active;
 bool python_trusted;
 
-void PyObjectDeleter(PyObject *pObject) { Py_XDECREF(pObject); };
+void PyObjectDeleter(PyObject *pObject)
+{
+  Py_XDECREF(pObject);
+};
 
 PyObjectUniquePtr pythonInitDict(nullptr, PyObjectDeleter);
 PyObjectUniquePtr pythonMainModule(nullptr, PyObjectDeleter);
@@ -442,7 +445,9 @@ void initPython(const std::string& binDir, double time)
   PyRun_String(stream.str().c_str(), Py_file_input, pythonInitDict.get(), pythonInitDict.get());
 }
 
-void finishPython(void) {}
+void finishPython(void)
+{
+}
 
 std::string evaluatePython(const std::string& code, bool dry_run)
 {
@@ -589,7 +594,10 @@ static PyModuleDef OpenSCADModule = {PyModuleDef_HEAD_INIT,
                                      NULL,
                                      NULL};
 
-extern "C" PyObject *PyInit_openscad(void) { return PyModule_Create(&OpenSCADModule); }
+extern "C" PyObject *PyInit_openscad(void)
+{
+  return PyModule_Create(&OpenSCADModule);
+}
 
 PyMODINIT_FUNC PyInit_PyOpenSCAD(void)
 {

--- a/src/utils/calc.cc
+++ b/src/utils/calc.cc
@@ -33,4 +33,7 @@
 #include "utils/degree_trig.h"
 
 // Linear interpolate.  Can replace with std::lerp in C++20
-double Calc::lerp(double a, double b, double t) { return (1 - t) * a + t * b; }
+double Calc::lerp(double a, double b, double t)
+{
+  return (1 - t) * a + t * b;
+}

--- a/src/utils/degree_trig.cc
+++ b/src/utils/degree_trig.cc
@@ -36,9 +36,15 @@
 // Trigonometry function taking degrees, accurate for 30, 45, 60 and 90, etc.
 //
 
-static inline double rad2deg(double x) { return x * M_RAD2DEG; }
+static inline double rad2deg(double x)
+{
+  return x * M_RAD2DEG;
+}
 
-static inline double deg2rad(double x) { return x * M_DEG2RAD; }
+static inline double deg2rad(double x)
+{
+  return x * M_DEG2RAD;
+}
 
 // this limit assumes 26+26=52 bits mantissa
 // comment/undefine it to disable domain check

--- a/src/utils/hash.cc
+++ b/src/utils/hash.cc
@@ -8,9 +8,18 @@
 #include "geometry/linalg.h"
 
 namespace std {
-std::size_t hash<Vector3f>::operator()(const Vector3f& s) const { return Eigen::hash_value(s); }
-std::size_t hash<Vector3d>::operator()(const Vector3d& s) const { return Eigen::hash_value(s); }
-std::size_t hash<Vector3l>::operator()(const Vector3l& s) const { return Eigen::hash_value(s); }
+std::size_t hash<Vector3f>::operator()(const Vector3f& s) const
+{
+  return Eigen::hash_value(s);
+}
+std::size_t hash<Vector3d>::operator()(const Vector3d& s) const
+{
+  return Eigen::hash_value(s);
+}
+std::size_t hash<Vector3l>::operator()(const Vector3l& s) const
+{
+  return Eigen::hash_value(s);
+}
 }  // namespace std
 
 namespace Eigen {

--- a/src/utils/printutils.cc
+++ b/src/utils/printutils.cc
@@ -62,7 +62,10 @@ bool would_have_thrown()
   return would_throw;
 }
 
-void print_messages_push() { print_messages_stack.emplace_back(); }
+void print_messages_push()
+{
+  print_messages_stack.emplace_back();
+}
 
 void print_messages_pop()
 {
@@ -163,7 +166,10 @@ std::string two_digit_exp_format(std::string doublestr)
   return doublestr;
 }
 
-std::string two_digit_exp_format(double x) { return two_digit_exp_format(std::to_string(x)); }
+std::string two_digit_exp_format(double x)
+{
+  return two_digit_exp_format(std::to_string(x));
+}
 
 void resetSuppressedMessages()
 {
@@ -211,4 +217,7 @@ bool getGroupTextPlain(const enum message_group& group)
   return group == message_group::NONE || group == message_group::Echo;
 }
 
-std::string quoteVar(const std::string& varname) { return '"' + varname + '"'; }
+std::string quoteVar(const std::string& varname)
+{
+  return '"' + varname + '"';
+}

--- a/src/utils/printutils.h
+++ b/src/utils/printutils.h
@@ -31,7 +31,10 @@
 // Not wanting to risk breaking translations by changing every usage of this,
 // I've opted to just disable the check in this case. - Hans L
 // NOLINTBEGIN(bugprone-reserved-identifier)
-inline char *_(const char *msgid) { return gettext(msgid); }
+inline char *_(const char *msgid)
+{
+  return gettext(msgid);
+}
 inline const char *_(const char *msgid, const char *msgctxt)
 {
   /* The separator between msgctxt and msgid in a .mo file.  */

--- a/src/utils/svg.cc
+++ b/src/utils/svg.cc
@@ -202,7 +202,10 @@ std::string point_dump(const CGAL::Sphere_point<CGAL_Kernel3>& p)
   return out.str();
 }
 
-std::string vert_dump(CGAL_Nef_polyhedron3::Vertex_const_handle vch) { return point_dump(vch->point()); }
+std::string vert_dump(CGAL_Nef_polyhedron3::Vertex_const_handle vch)
+{
+  return point_dump(vch->point());
+}
 
 std::string vert_dump(CGAL_Nef_polyhedron3::Nef_polyhedron_S2::SVertex_const_handle vch)
 {


### PR DESCRIPTION
How this was done:

* Lookup clang-format docs at https://clang.llvm.org/docs/ClangFormatStyleOptions.html
* Our format is based on the "Google" style. To inspect the Google style: `clang-format -style=Google -dump-config`
* Edit https://github.com/openscad/openscad/blob/master/.clang-format
* Run `./scripts/beautify.sh --all`, inspect the result and iterate as needed.