### PR TITLE
Use QT_VERSION_MAJOR as a version for saveState/restoreState 

### DIFF
--- a/src/gui/MainWindow.cc
+++ b/src/gui/MainWindow.cc
@@ -669,7 +669,9 @@ MainWindow::MainWindow(const QStringList& filenames) : rubberBandManager(this)
     setGeometry(screen()->availableGeometry());
   }
 #endif
-  restoreState(windowState);
+  // Use QT_VERSION_MAJOR as the version number to invalidate incompatible states
+  // from older Qt versions (e.g. Qt5 -> Qt6 migration), which can cause a crash.
+  restoreState(windowState, QT_VERSION_MAJOR);
 
   if (windowState.size() == 0) {
     /*
@@ -3705,7 +3707,7 @@ void MainWindow::closeEvent(QCloseEvent *event)
 
     QSettingsCached settings;
     settings.setValue("window/geometry", saveGeometry());
-    settings.setValue("window/state", saveState());
+    settings.setValue("window/state", saveState(QT_VERSION_MAJOR));
     if (this->tempFile) {
       delete this->tempFile;
       this->tempFile = nullptr;


### PR DESCRIPTION
to avoid trying to restore an incompatible state.
Fixes #6503

Theory:
* Upgrading from Qt5 to Qt6 may cause Qt not be unable to restore window state due to an unknown internal bug in Qt failing to associate saved state with existing widgets
* OpenSCAD made a number of changes in the last year related to dockable widgets and editor tabs. There's a chance that this triggers the above mentioned issue even if everything is Qt6.
* Introducing a version makes OpenSCAD ignore any window state saved from previous versions. This will cause people to lose window state once when they updated (or multiple times if they switch between old and new versions).

In the even that this doesn't fix the crash and we're unable to reproduce and troubleshoot further, the next idea is to detect the crash, and wipe he state on the subsequent launch so that it doesn't crash again.