### PR TITLE
Don't show customizer on experimental feature changes.

### DIFF
--- a/src/gui/MainWindow.cc
+++ b/src/gui/MainWindow.cc
@@ -413,8 +413,6 @@ MainWindow::MainWindow(const QStringList& filenames) : rubberBandManager(this)
   waitAfterReloadTimer->setSingleShot(true);
   waitAfterReloadTimer->setInterval(autoReloadPollingPeriodMS);
   connect(waitAfterReloadTimer, &QTimer::timeout, this, &MainWindow::waitAfterReload);
-  connect(GlobalPreferences::inst(), &Preferences::ExperimentalChanged, this,
-          &MainWindow::changeParameterWidget);
 
   progressThrottle->start();
 
@@ -2212,11 +2210,6 @@ void MainWindow::parseTopLevelDocument()
   activeEditor->resetHighlighting();
   this->rootFile = parseDocument(activeEditor);
   this->parsedFile = this->rootFile;
-}
-
-void MainWindow::changeParameterWidget()
-{
-  parameterDock->setVisible(true);
 }
 
 void MainWindow::checkAutoReload()

--- a/src/gui/MainWindow.h
+++ b/src/gui/MainWindow.h
@@ -253,7 +253,6 @@ private slots:
   void instantiateRoot();
   void compileDone(bool didchange);
   void compileEnded();
-  void changeParameterWidget();
 
 private slots:
   void copyViewportTranslation();


### PR DESCRIPTION
Customizer is no longer experimental and doesn't need to be hooked up to the experimental features.

Fixes #6547