### PR TITLE
Switch msys2-install-dependencies.sh to Qt6 by default.  Fixes #6565.

### DIFF
--- a/scripts/msys2-install-dependencies.sh
+++ b/scripts/msys2-install-dependencies.sh
@@ -25,10 +25,10 @@ if [[ -z "${GITHUB_RUN_ID}" ]]; then
     #            name:  disables any translation for name
 fi
 
-if [[ "$QT" == "qt6" ]]; then
-  QT_PACKAGES="qscintilla-qt6:p qt6-5compat:p qt6-multimedia:p qt6-svg:p"
-else
+if [[ "$QT" == "qt5" ]]; then
   QT_PACKAGES="qscintilla-qt5:p qt5-multimedia:p qt5-svg:p"
+else
+  QT_PACKAGES="qscintilla-qt6:p qt6-5compat:p qt6-multimedia:p qt6-svg:p"
 fi
 
 PACKAGE_LIST=(


### PR DESCRIPTION
Before, the default was to install Qt5 components, and install Qt6 components instead if $1 is "qt6".
With this change, the default is to install Qt6 components, and install Qt5 components instead if $1 is "qt5".

Perhaps the default (and maybe only) behavior should be to install both, to be a superset of the old behavior, but it seemed simpler to track the build default... no reason to install Qt5 components for default builds.

Fixes #6565.