### PR TITLE
FIX: Skip compilation initially when editor is empty

### DIFF
--- a/src/gui/MainWindow.cc
+++ b/src/gui/MainWindow.cc
@@ -3560,8 +3560,7 @@ void MainWindow::onTabManagerEditorChanged(EditorInterface *newEditor)
 
   // If there is no renderedEditor we request for a new preview if the
   // auto-reload is enabled.
-  if (renderedEditor == nullptr && designActionAutoReload->isChecked() &&
-      !MainWindow::isEmpty()) {
+  if (renderedEditor == nullptr && designActionAutoReload->isChecked() && !MainWindow::isEmpty()) {
     actionRenderPreview();
   }
 }


### PR DESCRIPTION
Only trigger actionRenderPreview when auto-reload is enabled and the active editor contains non-whitespace text. Previously the preview was requested whenever renderedEditor was null and auto-reload was on, which could cause unnecessary preview requests or attempts to render empty content. This adds a trimmed non-empty check on the active editor before requesting a preview.

Fixes #6580