### PR TITLE
Candidate export_dxf_R14 function

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1284,6 +1284,7 @@ set(GUI_SOURCES
   src/gui/ErrorLog.cc
   src/gui/EventFilter.h
   src/gui/Export3mfDialog.cc
+  src/gui/ExportDxfDialog.cc
   src/gui/ExportPdfDialog.cc
   src/gui/ExportSvgDialog.cc
   src/gui/OctoPrintApiKeyDialog.cc
@@ -1359,6 +1360,7 @@ set(GUI_HEADERS
     src/gui/ErrorLog.h
     src/gui/EventFilter.h
     src/gui/Export3mfDialog.h
+    src/gui/ExportDxfDialog.h
     src/gui/ExportPdfDialog.h
     src/gui/ExportSvgDialog.h
     src/gui/OctoPrintApiKeyDialog.h
@@ -1417,6 +1419,7 @@ set(GUI_UIS
     src/gui/Console.ui
     src/gui/ErrorLog.ui
     src/gui/Export3mfDialog.ui
+    src/gui/ExportDxfDialog.ui
     src/gui/ExportPdfDialog.ui
     src/gui/ExportSvgDialog.ui
     src/gui/OctoPrintApiKeyDialog.ui

--- a/src/core/Settings.cc
+++ b/src/core/Settings.cc
@@ -489,6 +489,18 @@ SettingsEntryString SettingsExportSvg::exportSvgStrokeColor(SECTION_EXPORT_SVG, 
 SettingsEntryDouble SettingsExportSvg::exportSvgStrokeWidth(SECTION_EXPORT_SVG, "stroke-width", 0, 0.01,
                                                             999, 0.35);
 
+SettingsEntryBool SettingsExportDxf::exportDxfAlwaysShowDialog(SECTION_EXPORT_DXF, "always-show-dialog",
+                                                               true);
+SettingsEntryEnum<DxfVersion> SettingsExportDxf::exportDxfVersion(
+  SECTION_EXPORT_DXF, "version",
+  {
+    {DxfVersion::Legacy, "legacy", _("Legacy (original OpenSCAD behaviour)")},
+    {DxfVersion::R10, "R10", _("R10 (AC1006, maximum compatibility)")},
+    {DxfVersion::R12, "R12", _("R12 (AC1009, handles)")},
+    {DxfVersion::R14, "R14", _("R14 (AC1014, full object model)")},
+  },
+  DxfVersion::Legacy);
+
 SettingsEntryEnum<ColorListFilterType> SettingsColorList::colorListFilterType(
   SECTION_COLOR_LIST, "filter-type",
   {

--- a/src/core/Settings.h
+++ b/src/core/Settings.h
@@ -29,6 +29,7 @@ constexpr inline auto SECTION_PYTHON = "python";
 constexpr inline auto SECTION_EXPORT_PDF = "export-pdf";
 constexpr inline auto SECTION_EXPORT_3MF = "export-3mf";
 constexpr inline auto SECTION_EXPORT_SVG = "export-svg";
+constexpr inline auto SECTION_EXPORT_DXF = "export-dxf";
 constexpr inline auto SECTION_COLOR_LIST = "color-list";
 
 class SettingsEntryBase
@@ -611,6 +612,20 @@ public:
 
   static constexpr std::array<const SettingsEntryBase *, 5> cmdline{
     &exportSvgFill, &exportSvgFillColor, &exportSvgStroke, &exportSvgStrokeColor, &exportSvgStrokeWidth,
+  };
+};
+
+class SettingsExportDxf
+{
+public:
+  // The DXF version to export. Default is Legacy (original OpenSCAD behaviour).
+  // When a GUI dialog is added, exportDxfAlwaysShowDialog controls whether it
+  // appears automatically, following the same pattern as PDF, 3MF, and SVG.
+  static SettingsEntryBool exportDxfAlwaysShowDialog;
+  static SettingsEntryEnum<DxfVersion> exportDxfVersion;
+
+  static constexpr std::array<const SettingsEntryBase *, 1> cmdline{
+    &exportDxfVersion,
   };
 };
 

--- a/src/gui/ExportDxfDialog.cc
+++ b/src/gui/ExportDxfDialog.cc
@@ -1,0 +1,62 @@
+#include "ExportDxfDialog.h"
+#include <QPushButton>
+#include "core/Settings.h"
+#include "gui/SettingsWriter.h"
+
+using S = Settings::SettingsExportDxf;
+
+ExportDxfDialog::ExportDxfDialog()
+{
+  setupUi(this);
+  this->checkBoxAlwaysShowDialog->setChecked(S::exportDxfAlwaysShowDialog.value());
+
+  // Populate combo box from settings entry (fills items + selects persisted value)
+  initComboBox(comboBoxVersion, Settings::SettingsExportDxf::exportDxfVersion);
+
+  connect(pushButtonOk, &QPushButton::clicked, this, &ExportDxfDialog::accept);
+  connect(pushButtonCancel, &QPushButton::clicked, this, &ExportDxfDialog::reject);
+}
+
+int ExportDxfDialog::exec()
+{
+  bool showDialog = this->checkBoxAlwaysShowDialog->isChecked();
+  if ((QApplication::keyboardModifiers() & Qt::ShiftModifier) != 0) {
+    showDialog = true;
+  }
+
+  const auto result = showDialog ? QDialog::exec() : QDialog::Accepted;
+
+  if (result == QDialog::Accepted) {
+    S::exportDxfAlwaysShowDialog.setValue(this->checkBoxAlwaysShowDialog->isChecked());
+    Settings::Settings::visit(SettingsWriter());
+  }
+
+  return result;
+  // return QDialog::exec();
+}
+
+void ExportDxfDialog::accept()
+{
+  // Persist the chosen version before closing so the next export starts
+  // from the same value (GUI fromSettings() and command-line both benefit).
+  const int idx = comboBoxVersion->currentIndex();
+  const auto& items = Settings::SettingsExportDxf::exportDxfVersion.items();
+  if (idx >= 0 && idx < static_cast<int>(items.size())) {
+    Settings::SettingsExportDxf::exportDxfVersion.setValue(items[idx].value);
+  }
+  writeSettings();
+  QDialog::accept();
+}
+
+ExportDxfOptions ExportDxfDialog::getOptions() const
+{
+  const int idx = comboBoxVersion->currentIndex();
+  const auto& items = Settings::SettingsExportDxf::exportDxfVersion.items();
+
+  DxfVersion version = DxfVersion::Legacy;
+  if (idx >= 0 && idx < static_cast<int>(items.size())) {
+    version = items[idx].value;
+  }
+
+  return ExportDxfOptions{.version = version};
+}

--- a/src/gui/ExportDxfDialog.h
+++ b/src/gui/ExportDxfDialog.h
@@ -1,0 +1,21 @@
+#pragma once
+
+#include <QDialog>
+
+#include "gui/qtgettext.h"  // IWYU pragma: keep
+#include "ui_ExportDxfDialog.h"
+#include "gui/InitConfigurator.h"
+#include "io/export.h"
+
+class ExportDxfDialog : public QDialog, public Ui::ExportDxfDialog, public InitConfigurator
+{
+  Q_OBJECT;
+
+public:
+  ExportDxfDialog();
+
+  int exec() override;
+  void accept() override;
+
+  ExportDxfOptions getOptions() const;
+};

--- a/src/gui/ExportDxfDialog.ui
+++ b/src/gui/ExportDxfDialog.ui
@@ -1,0 +1,110 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>ExportDxfDialog</class>
+ <widget class="QDialog" name="ExportDxfDialog">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>320</width>
+    <height>120</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>Export DXF Options</string>
+  </property>
+  <layout class="QVBoxLayout" name="verticalLayout">
+   <item>
+    <widget class="QGroupBox" name="groupBoxVersion">
+     <property name="title">
+      <string>DXF Format Version</string>
+     </property>
+     <layout class="QHBoxLayout" name="horizontalLayoutVersion">
+      <item>
+       <widget class="QLabel" name="labelVersion">
+        <property name="text">
+         <string>Version:</string>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QComboBox" name="comboBoxVersion">
+        <property name="toolTip">
+         <string>Select the DXF format version to export. Legacy preserves the original OpenSCAD output.</string>
+        </property>
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+          <horstretch>1</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+       </widget>
+      </item>
+     </layout>
+    </widget>
+   </item>
+   <item>
+    <layout class="QHBoxLayout" name="horizontalLayoutDialogButtons">
+     <item>
+      <widget class="QCheckBox" name="checkBoxAlwaysShowDialog">
+       <property name="text">
+        <string>Always show dialog</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <spacer name="horizontalSpacerDialogButtons">
+       <property name="orientation">
+        <enum>Qt::Horizontal</enum>
+       </property>
+       <property name="sizeHint" stdset="0">
+        <size>
+         <width>40</width>
+         <height>20</height>
+        </size>
+       </property>
+      </spacer>
+     </item>
+     <item>
+      <widget class="QPushButton" name="pushButtonCancel">
+       <property name="text">
+        <string>Cancel</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QPushButton" name="pushButtonOk">
+       <property name="text">
+        <string>OK</string>
+       </property>
+       <property name="default">
+        <bool>true</bool>
+       </property>
+      </widget>
+     </item>
+    </layout>
+   </item>
+  </layout>
+ </widget>
+ <tabstops>
+  <tabstop>comboBoxVersion</tabstop>
+  <tabstop>checkBoxAlwaysShowDialog</tabstop>  
+  <tabstop>pushButtonCancel</tabstop>
+  <tabstop>pushButtonOk</tabstop>
+ </tabstops>
+ <resources/>
+ <connections>
+  <connection>
+   <sender>pushButtonOk</sender>
+   <signal>clicked()</signal>
+   <receiver>ExportDxfDialog</receiver>
+   <slot>accept()</slot>
+  </connection>
+  <connection>
+   <sender>pushButtonCancel</sender>
+   <signal>clicked()</signal>
+   <receiver>ExportDxfDialog</receiver>
+   <slot>reject()</slot>
+  </connection>
+ </connections>
+</ui>

--- a/src/gui/MainWindow.cc
+++ b/src/gui/MainWindow.cc
@@ -116,6 +116,7 @@
 #include "gui/Dock.h"
 #include "gui/Editor.h"
 #include "gui/Export3mfDialog.h"
+#include "gui/ExportDxfDialog.h"
 #include "gui/ExportPdfDialog.h"
 #include "gui/ExportSvgDialog.h"
 #include "gui/ExternalToolInterface.h"
@@ -2538,6 +2539,14 @@ void MainWindow::actionExportFileFormat(int fmt)
       return;
     }
     exportInfo.optionsSvg = std::make_shared<ExportSvgOptions>(exportSvgDialog.getOptions());
+    actionExport(2, exportInfo);
+  } break;
+  case FileFormat::DXF: {
+    ExportDxfDialog exportDxfDialog;
+    if (exportDxfDialog.exec() == QDialog::Rejected) {
+      return;
+    }
+    exportInfo.optionsDxf = std::make_shared<ExportDxfOptions>(exportDxfDialog.getOptions());
     actionExport(2, exportInfo);
   } break;
   default: actionExport(fileformat::is3D(format) ? 3 : fileformat::is2D(format) ? 2 : 0, exportInfo);

--- a/src/gui/Preferences.cc
+++ b/src/gui/Preferences.cc
@@ -318,6 +318,8 @@ void Preferences::update()
     Settings::SettingsExportPdf::exportPdfAlwaysShowDialog.value());
   this->checkBoxAlwaysShowExport3mfDialog->setChecked(
     Settings::SettingsExport3mf::export3mfAlwaysShowDialog.value());
+  this->checkBoxAlwaysShowExportDXFDialog->setChecked(
+    Settings::SettingsExportDxf::exportDxfAlwaysShowDialog.value());
   this->checkBoxAlwaysShowPrintServiceDialog->setChecked(
     Settings::Settings::printServiceAlwaysShowDialog.value());
 }
@@ -1234,6 +1236,12 @@ void Preferences::on_checkBoxAlwaysShowExportPdfDialog_toggled(bool state)
 void Preferences::on_checkBoxAlwaysShowExport3mfDialog_toggled(bool state)
 {
   Settings::SettingsExport3mf::export3mfAlwaysShowDialog.setValue(state);
+  writeSettings();
+}
+
+void Preferences::on_checkBoxAlwaysShowExportDXFDialog_toggled(bool state)
+{
+  Settings::SettingsExportDxf::exportDxfAlwaysShowDialog.setValue(state);
   writeSettings();
 }
 

--- a/src/gui/Preferences.h
+++ b/src/gui/Preferences.h
@@ -152,6 +152,7 @@ public slots:
   // Dialogs
   void on_checkBoxAlwaysShowExportPdfDialog_toggled(bool);
   void on_checkBoxAlwaysShowExport3mfDialog_toggled(bool);
+  void on_checkBoxAlwaysShowExportDXFDialog_toggled(bool);
   void on_checkBoxAlwaysShowPrintServiceDialog_toggled(bool);
 
 signals:

--- a/src/gui/Preferences.ui
+++ b/src/gui/Preferences.ui
@@ -2844,6 +2844,13 @@
             </widget>
            </item>
            <item>
+            <widget class="QCheckBox" name="checkBoxAlwaysShowExportDXFDialog">
+             <property name="text">
+              <string>Always show DXF export dialog</string>
+             </property>
+            </widget>
+           </item>
+           <item>
             <widget class="QCheckBox" name="checkBoxAlwaysShowPrintServiceDialog">
              <property name="text">
               <string>Always show Print Service dialog</string>

--- a/src/io/export.h
+++ b/src/io/export.h
@@ -19,6 +19,7 @@
 #include "glview/Camera.h"
 #include "glview/ColorMap.h"
 #include "io/export_enums.h"
+#include "io/export_dxf.h"
 
 using SPDF = Settings::SettingsExportPdf;
 using S3MF = Settings::SettingsExport3mf;
@@ -285,6 +286,27 @@ struct ExportSvgOptions {
   }
 };
 
+// =====================================================================
+// DXF EXPORT OPTIONS
+// =====================================================================
+//
+// Mirrors the pattern used by ExportPdfOptions, Export3mfOptions, and
+// ExportSvgOptions.  Populated from -O export-dxf/version=<R10|R12|R14>
+// on the command line, or from the GUI settings store via fromSettings().
+//
+// Command-line usage:
+//   openscad -o out.dxf -O export-dxf/version=R14 input.scad
+//
+// =====================================================================
+
+struct ExportDxfOptions {
+  DxfVersion version = DxfVersion::Legacy;
+
+  static std::shared_ptr<const ExportDxfOptions> withOptions(const CmdLineExportOptions& cmdLineOptions);
+
+  static std::shared_ptr<const ExportDxfOptions> fromSettings();
+};
+
 struct ExportInfo {
   FileFormat format;
   FileFormatInfo info;
@@ -297,6 +319,7 @@ struct ExportInfo {
   std::shared_ptr<const ExportPdfOptions> optionsPdf;
   std::shared_ptr<const Export3mfOptions> options3mf;
   std::shared_ptr<const ExportSvgOptions> optionsSvg;
+  std::shared_ptr<const ExportDxfOptions> optionsDxf;
 };
 
 ExportInfo createExportInfo(const FileFormat& format, const FileFormatInfo& info,
@@ -315,7 +338,6 @@ void export_obj(const std::shared_ptr<const Geometry>& geom, std::ostream& outpu
 void export_off(const std::shared_ptr<const Geometry>& geom, std::ostream& output);
 void export_wrl(const std::shared_ptr<const Geometry>& geom, std::ostream& output);
 void export_amf(const std::shared_ptr<const Geometry>& geom, std::ostream& output);
-void export_dxf(const std::shared_ptr<const Geometry>& geom, std::ostream& output);
 void export_svg(const std::shared_ptr<const Geometry>& geom, std::ostream& output,
                 const ExportInfo& exportInfo);
 void export_pov(const std::shared_ptr<const Geometry>& geom, std::ostream& output,

--- a/src/io/export_dxf.cc
+++ b/src/io/export_dxf.cc
@@ -23,8 +23,46 @@
  *  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
  *
  */
+
+// =====================================================================
+// DXF EXPORTER: LEGACY / R10 / R12 / R14 RUNTIME SELECTION
+// =====================================================================
+//
+// This file provides DXF export at four modes, selected at runtime via
+// a DxfVersion parameter passed from openscad.cc:
+//
+//   DxfVersion::Legacy  - Original OpenSCAD behaviour (default, no flag)
+//   DxfVersion::R10     - AC1006, spec-correct, POLYLINE entities
+//   DxfVersion::R12     - AC1009, spec-correct, POLYLINE + handles
+//   DxfVersion::R14     - AC1014, spec-correct, LWPOLYLINE + object model
+//
+// ENTITY CHOICE BY MODE:
+//
+//   Legacy:  LWPOLYLINE always (original behaviour, not strictly valid
+//            pre-R14 but accepted by most tools)
+//
+//   R10/R12: POLYLINE / VERTEX / SEQEND  (spec-correct pre-R14 entity)
+//            Each outline = one POLYLINE header + N VERTEX records +
+//            one SEQEND. R12 adds handles on each of these records.
+//
+//   R14:     LWPOLYLINE (correct R14+ entity, compact single record)
+//
+// HANDLE ALLOCATION:
+//
+//   Legacy/R10: No handles
+//   R12:        Handle per POLYLINE + handle per VERTEX + handle per SEQEND
+//               handseed = H_ENT_START_R12 + sum(2 + vertex_count) per outline
+//   R14:        Handle per LWPOLYLINE entity
+//               handseed = H_ENT_START_R14 + outline_count
+//
+// =====================================================================
+
+#include "io/export.h"
+#include "io/export_dxf.h"
+
 #include <cassert>
 #include <clocale>
+#include <iomanip>
 #include <limits>
 #include <memory>
 #include <ostream>
@@ -39,172 +77,576 @@
     Saves the current Polygon2d as DXF to the given absolute filename.
  */
 
-static void export_dxf_header(std::ostream& output, double xMin, double yMin, double xMax, double yMax)
+// =====================================================================
+// HANDLE MANAGEMENT (R12 and R14)
+// =====================================================================
+//
+// R12: Handles are OPTIONAL but enabled here via $HANDLING=1.
+//      POLYLINE, each VERTEX, and SEQEND each get a handle.
+//
+// R14: Handles are MANDATORY. Every table entry, block, entity, and
+//      object must have a unique handle.
+//
+// Handle allocation:
+//   - Sequential hex values starting at 1
+//   - Fixed assignments for tables, blocks, and dictionaries
+//   - Dynamic assignment for entities after fixed region
+// =====================================================================
+
+// R14 handle assignments: fixed layout for entire object model
+static constexpr int H_LTYPE_TABLE_R14 = 0x1;
+static constexpr int H_LTYPE_CONT_R14 = 0x2;
+static constexpr int H_LAYER_TABLE_R14 = 0x3;
+static constexpr int H_LAYER_0_R14 = 0x4;
+static constexpr int H_STYLE_TABLE_R14 = 0x5;
+static constexpr int H_BLOCKREC_TABLE_R14 = 0x6;
+static constexpr int H_BLOCKREC_MODEL_R14 = 0x7;
+static constexpr int H_BLOCKREC_PAPER_R14 = 0x8;
+static constexpr int H_BLOCK_MODEL_R14 = 0x9;
+static constexpr int H_ENDBLK_MODEL_R14 = 0xA;
+static constexpr int H_BLOCK_PAPER_R14 = 0xB;
+static constexpr int H_ENDBLK_PAPER_R14 = 0xC;
+static constexpr int H_DICT_ROOT_R14 = 0xD;
+static constexpr int H_DICT_GROUP_R14 = 0xE;
+static constexpr int H_ENT_START_R14 = 0xF;  // entity handles start here
+
+// R12 handle assignments: simpler layout, no object model
+static constexpr int H_LTYPE_TABLE_R12 = 0x1;
+static constexpr int H_LTYPE_CONT_R12 = 0x2;
+static constexpr int H_LAYER_TABLE_R12 = 0x3;
+static constexpr int H_LAYER_0_R12 = 0x4;
+static constexpr int H_STYLE_TABLE_R12 = 0x5;
+static constexpr int H_ENT_START_R12 = 0x6;  // entity handles start here
+
+// Emit group 5 (handle) as uppercase hex
+static void emit_handle(std::ostream& o, int handle)
 {
-  // https://dxfwrite.readthedocs.io/en/latest/headervars.html
-  // http://paulbourke.net/dataformats/dxf/min3d.html
-
-  // based on: https://github.com/mozman/ezdxf/tree/master/examples_dxf
-  // Minimal_DXF_AC1009.dxf - not working in Adobe Illustrator
-  // Minimal_DXF_AC1006.dxf - not working with LibreCAD (due to 3DFACE?)
-
-  // tested to work on:
-  // - InkScape 1.0.0
-  // - LibreCAD
-  // - Adobe Illustrator
-  // - https://sharecad.org
-  // - generic cutters
-
-  output << "999\n"
-         << "DXF from OpenSCAD\n";
-
-  //
-  // SECTION 1
-  //
-
-  /* --- START --- */
-
-  output << "  0\n"
-         << "SECTION\n"
-         << "  2\n"
-         << "HEADER\n"
-         << "  9\n"
-         << "$ACADVER\n"
-         << "  1\n"
-         << "AC1006\n"
-         << "  9\n"
-         << "$INSBASE\n"
-         << " 10\n"
-         << "0.0\n"
-         << " 20\n"
-         << "0.0\n"
-         << " 30\n"
-         << "0.0\n";
-
-  /* --- LIMITS --- */
-
-  output << "  9\n"
-         << "$EXTMIN\n"
-         << " 10\n"
-         << xMin << "\n"
-         << " 20\n"
-         << yMin << "\n"
-         << "  9\n"
-         << "$EXTMAX\n"
-         << " 10\n"
-         << xMax << "\n"
-         << " 20\n"
-         << yMax << "\n";
-
-  output << "  9\n"
-         << "$LINMIN\n"
-         << " 10\n"
-         << xMin << "\n"
-         << " 20\n"
-         << yMin << "\n"
-         << "  9\n"
-         << "$LINMAX\n"
-         << " 10\n"
-         << xMax << "\n"
-         << " 20\n"
-         << yMax << "\n";
-
-  output << "  0\n"
-         << "ENDSEC\n";
-
-  //
-  // SECTION 2
-  //
-
-  output << "  0\n"
-         << "SECTION\n";
-
-  output << "  2\n"
-         << "TABLES\n";
-
-  /* --- LINETYPE --- */
-
-  output << "  0\n"
-         << "TABLE\n"
-         << "  2\n"
-         << "LTYPE\n"
-         << " 70\n"
-         << "1\n"
-
-         << "  0\n"
-         << "LTYPE\n"
-         << "  2\n"
-         << "CONTINUOUS\n"  // linetype name
-         << " 70\n"
-         << "64\n"
-         << "  3\n"
-         << "Solid line\n"  // descriptive text
-         << " 72\n"
-         << "65\n"  // always 65
-         << " 73\n"
-         << "0\n"  // number of linetype elements
-         << " 40\n"
-         << "0.000000\n"  // total pattern length
-
-         << "  0\n"
-         << "ENDTAB\n";
-
-  /* --- LAYERS --- */
-
-  output << "  0\n"
-         << "TABLE\n"
-         << "  2\n"
-         << "LAYER\n"
-         << " 70\n"
-         << "6\n"
-
-         << "  0\n"
-         << "LAYER\n"
-         << "  2\n"
-         << "0\n"  // layer name
-         << " 70\n"
-         << "64\n"
-         << " 62\n"
-         << "7\n"  // color
-         << "  6\n"
-         << "CONTINUOUS\n"
-
-         << "  0\n"
-         << "ENDTAB\n";
-
-  /* --- STYLE --- */
-
-  output << "  0\n"
-         << "TABLE\n"
-         << "  2\n"
-         << "STYLE\n"
-         << " 70\n"
-         << "0\n"
-         << "  0\n"
-         << "ENDTAB\n";
-
-  output << "  0\n"
-         << "ENDSEC\n";
-
-  //
-  // SECTION 3
-  //
-
-  output << "  0\n"
-         << "SECTION\n"
-         << "  2\n"
-         << "BLOCKS\n"
-         << "  0\n"
-         << "ENDSEC\n";
+  o << "  5\n" << std::uppercase << std::hex << handle << std::dec << "\n";
 }
 
-static void export_dxf(const Polygon2d& poly, std::ostream& output)
+// Emit group 330 (owner handle) as uppercase hex (R14 only)
+static void emit_owner(std::ostream& o, int handle)
 {
-  setlocale(LC_NUMERIC, "C");  // Ensure radix is . (not ,) in output
+  o << "330\n" << std::uppercase << std::hex << handle << std::dec << "\n";
+}
 
-  // find limits
+// Emit a bare hex value (no group code) for soft-pointer and $HANDSEED
+static void emit_hexval(std::ostream& o, int handle)
+{
+  o << std::uppercase << std::hex << handle << std::dec << "\n";
+}
+
+// =====================================================================
+// HEADER SECTION GENERATION
+// =====================================================================
+
+// Legacy header: byte-for-byte reproduction of original OpenSCAD output.
+// Note: $LINMIN/$LINMAX are the original typos (should be $LIMMIN/$LIMMAX)
+// and are preserved here intentionally so that Legacy mode is identical to
+// the output that existing users rely on.
+static void export_dxf_header_Legacy(std::ostream& output, double xMin, double yMin, double xMax,
+                                     double yMax)
+{
+  output << "999\n"
+         << "DXF from OpenSCAD\n"  // original comment (no version tag)
+
+         << "  0\nSECTION\n"
+         << "  2\nHEADER\n"
+
+         << "  9\n$ACADVER\n"
+         << "  1\nAC1006\n"
+
+         << "  9\n$INSBASE\n"
+         << " 10\n0.0\n"
+         << " 20\n0.0\n"
+         << " 30\n0.0\n"
+
+         << "  9\n$EXTMIN\n"
+         << " 10\n"
+         << xMin << "\n"
+         << " 20\n"
+         << yMin << "\n"
+
+         << "  9\n$EXTMAX\n"
+         << " 10\n"
+         << xMax << "\n"
+         << " 20\n"
+         << yMax << "\n"
+
+         << "  9\n$LINMIN\n"  // original typo Ã¢â‚¬â€ preserved
+         << " 10\n"
+         << xMin << "\n"
+         << " 20\n"
+         << yMin << "\n"
+
+         << "  9\n$LINMAX\n"  // original typo Ã¢â‚¬â€ preserved
+         << " 10\n"
+         << xMax << "\n"
+         << " 20\n"
+         << yMax << "\n"
+
+         << "  0\nENDSEC\n";
+
+  // TABLES section
+  output << "  0\nSECTION\n"
+         << "  2\nTABLES\n";
+
+  // LTYPE table
+  output << "  0\nTABLE\n"
+         << "  2\nLTYPE\n"
+         << " 70\n1\n"
+         << "  0\nLTYPE\n"
+         << "  2\nCONTINUOUS\n"
+         << " 70\n64\n"
+         << "  3\nSolid line\n"
+         << " 72\n65\n"
+         << " 73\n0\n"
+         << " 40\n0.000000\n"
+         << "  0\nENDTAB\n";
+
+  // LAYER table
+  output << "  0\nTABLE\n"
+         << "  2\nLAYER\n"
+         << " 70\n6\n"
+         << "  0\nLAYER\n"
+         << "  2\n0\n"
+         << " 70\n64\n"
+         << " 62\n7\n"
+         << "  6\nCONTINUOUS\n"
+         << "  0\nENDTAB\n";
+
+  // STYLE table
+  output << "  0\nTABLE\n"
+         << "  2\nSTYLE\n"
+         << " 70\n0\n"
+         << "  0\nENDTAB\n";
+
+  output << "  0\nENDSEC\n";
+
+  // BLOCKS section (empty)
+  output << "  0\nSECTION\n"
+         << "  2\nBLOCKS\n"
+         << "  0\nENDSEC\n";
+}
+
+static void export_dxf_header_R10(std::ostream& output, double xMin, double yMin, double xMax,
+                                  double yMax)
+{
+  output << "999\n"
+         << "DXF from OpenSCAD (R10)\n"
+
+         << "  0\nSECTION\n"
+         << "  2\nHEADER\n"
+
+         << "  9\n$ACADVER\n"
+         << "  1\nAC1006\n"
+
+         << "  9\n$INSBASE\n"
+         << " 10\n0.0\n"
+         << " 20\n0.0\n"
+         << " 30\n0.0\n"
+
+         << "  9\n$EXTMIN\n"
+         << " 10\n"
+         << xMin << "\n"
+         << " 20\n"
+         << yMin << "\n"
+
+         << "  9\n$EXTMAX\n"
+         << " 10\n"
+         << xMax << "\n"
+         << " 20\n"
+         << yMax << "\n"
+
+         << "  9\n$LIMMIN\n"
+         << " 10\n"
+         << xMin << "\n"
+         << " 20\n"
+         << yMin << "\n"
+
+         << "  9\n$LIMMAX\n"
+         << " 10\n"
+         << xMax << "\n"
+         << " 20\n"
+         << yMax << "\n"
+
+         << "  0\nENDSEC\n";
+
+  // TABLES section
+  output << "  0\nSECTION\n"
+         << "  2\nTABLES\n";
+
+  // LTYPE table
+  output << "  0\nTABLE\n"
+         << "  2\nLTYPE\n"
+         << " 70\n1\n"
+         << "  0\nLTYPE\n"
+         << "  2\nCONTINUOUS\n"
+         << " 70\n64\n"
+         << "  3\nSolid line\n"
+         << " 72\n65\n"
+         << " 73\n0\n"
+         << " 40\n0.000000\n"
+         << "  0\nENDTAB\n";
+
+  // LAYER table
+  output << "  0\nTABLE\n"
+         << "  2\nLAYER\n"
+         << " 70\n1\n"
+         << "  0\nLAYER\n"
+         << "  2\n0\n"
+         << " 70\n64\n"
+         << " 62\n7\n"
+         << "  6\nCONTINUOUS\n"
+         << "  0\nENDTAB\n";
+
+  // STYLE table
+  output << "  0\nTABLE\n"
+         << "  2\nSTYLE\n"
+         << " 70\n0\n"
+         << "  0\nENDTAB\n";
+
+  output << "  0\nENDSEC\n";
+
+  // BLOCKS section (empty)
+  output << "  0\nSECTION\n"
+         << "  2\nBLOCKS\n"
+         << "  0\nENDSEC\n";
+}
+
+static void export_dxf_header_R12(std::ostream& output, double xMin, double yMin, double xMax,
+                                  double yMax, int handseed)
+{
+  output << "999\n"
+         << "DXF from OpenSCAD (R12)\n"
+
+         << "  0\nSECTION\n"
+         << "  2\nHEADER\n"
+
+         << "  9\n$ACADVER\n"
+         << "  1\nAC1009\n"
+
+         << "  9\n$DWGCODEPAGE\n"
+         << "  3\nansi_1252\n"
+
+         << "  9\n$INSBASE\n"
+         << " 10\n0.0\n"
+         << " 20\n0.0\n"
+         << " 30\n0.0\n"
+
+         << "  9\n$EXTMIN\n"
+         << " 10\n"
+         << xMin << "\n"
+         << " 20\n"
+         << yMin << "\n"
+
+         << "  9\n$EXTMAX\n"
+         << " 10\n"
+         << xMax << "\n"
+         << " 20\n"
+         << yMax << "\n"
+
+         << "  9\n$LIMMIN\n"
+         << " 10\n"
+         << xMin << "\n"
+         << " 20\n"
+         << yMin << "\n"
+
+         << "  9\n$LIMMAX\n"
+         << " 10\n"
+         << xMax << "\n"
+         << " 20\n"
+         << yMax << "\n"
+
+         << "  9\n$HANDLING\n"
+         << " 70\n1\n"
+
+         << "  9\n$HANDSEED\n"
+         << "  5\n";
+  emit_hexval(output, handseed);
+
+  output << "  0\nENDSEC\n";
+
+  // TABLES section
+  output << "  0\nSECTION\n"
+         << "  2\nTABLES\n";
+
+  // LTYPE table
+  output << "  0\nTABLE\n"
+         << "  2\nLTYPE\n";
+  emit_handle(output, H_LTYPE_TABLE_R12);
+  output << " 70\n1\n"
+         << "  0\nLTYPE\n";
+  emit_handle(output, H_LTYPE_CONT_R12);
+  output << "  2\nCONTINUOUS\n"
+         << " 70\n64\n"
+         << "  3\nSolid line\n"
+         << " 72\n65\n"
+         << " 73\n0\n"
+         << " 40\n0.000000\n"
+         << "  0\nENDTAB\n";
+
+  // LAYER table
+  output << "  0\nTABLE\n"
+         << "  2\nLAYER\n";
+  emit_handle(output, H_LAYER_TABLE_R12);
+  output << " 70\n1\n"
+         << "  0\nLAYER\n";
+  emit_handle(output, H_LAYER_0_R12);
+  output << "  2\n0\n"
+         << " 70\n64\n"
+         << " 62\n7\n"
+         << "  6\nCONTINUOUS\n"
+         << "  0\nENDTAB\n";
+
+  // STYLE table
+  output << "  0\nTABLE\n"
+         << "  2\nSTYLE\n";
+  emit_handle(output, H_STYLE_TABLE_R12);
+  output << " 70\n0\n"
+         << "  0\nENDTAB\n";
+
+  output << "  0\nENDSEC\n";
+
+  // BLOCKS section (empty)
+  output << "  0\nSECTION\n"
+         << "  2\nBLOCKS\n"
+         << "  0\nENDSEC\n";
+}
+
+static void export_dxf_header_R14(std::ostream& output, double xMin, double yMin, double xMax,
+                                  double yMax, int handseed, int insunits, int lunits)
+{
+  output << "999\n"
+         << "DXF from OpenSCAD (R14)\n"
+
+         << "  0\nSECTION\n"
+         << "  2\nHEADER\n"
+
+         << "  9\n$ACADVER\n"
+         << "  1\nAC1014\n"
+
+         << "  9\n$DWGCODEPAGE\n"
+         << "  3\nansi_1252\n"
+
+         << "  9\n$INSBASE\n"
+         << " 10\n0.0\n"
+         << " 20\n0.0\n"
+         << " 30\n0.0\n"
+
+         << "  9\n$EXTMIN\n"
+         << " 10\n"
+         << xMin << "\n"
+         << " 20\n"
+         << yMin << "\n"
+
+         << "  9\n$EXTMAX\n"
+         << " 10\n"
+         << xMax << "\n"
+         << " 20\n"
+         << yMax << "\n"
+
+         << "  9\n$LIMMIN\n"
+         << " 10\n"
+         << xMin << "\n"
+         << " 20\n"
+         << yMin << "\n"
+
+         << "  9\n$LIMMAX\n"
+         << " 10\n"
+         << xMax << "\n"
+         << " 20\n"
+         << yMax << "\n"
+
+         << "  9\n$HANDSEED\n"
+         << "  5\n";
+  emit_hexval(output, handseed);
+
+  output << "  9\n$MEASUREMENT\n"
+         << " 70\n1\n"
+         << "  9\n$INSUNITS\n"
+         << " 70\n"
+         << insunits << "\n"
+         << "  9\n$LUNITS\n"
+         << " 70\n"
+         << lunits << "\n";
+
+  output << "  0\nENDSEC\n";
+
+  // CLASSES section (required by R14, empty is valid)
+  output << "  0\nSECTION\n"
+         << "  2\nCLASSES\n"
+         << "  0\nENDSEC\n";
+
+  // TABLES section
+  output << "  0\nSECTION\n"
+         << "  2\nTABLES\n";
+
+  // LTYPE table
+  output << "  0\nTABLE\n"
+         << "  2\nLTYPE\n";
+  emit_handle(output, H_LTYPE_TABLE_R14);
+  emit_owner(output, 0);
+  output << "100\nAcDbSymbolTable\n"
+         << " 70\n1\n"
+         << "  0\nLTYPE\n";
+  emit_handle(output, H_LTYPE_CONT_R14);
+  emit_owner(output, H_LTYPE_TABLE_R14);
+  output << "100\nAcDbSymbolTableRecord\n"
+         << "100\nAcDbLinetypeTableRecord\n"
+         << "  2\nCONTINUOUS\n"
+         << " 70\n64\n"
+         << "  3\nSolid line\n"
+         << " 72\n65\n"
+         << " 73\n0\n"
+         << " 40\n0.000000\n"
+         << "  0\nENDTAB\n";
+
+  // LAYER table
+  output << "  0\nTABLE\n"
+         << "  2\nLAYER\n";
+  emit_handle(output, H_LAYER_TABLE_R14);
+  emit_owner(output, 0);
+  output << "100\nAcDbSymbolTable\n"
+         << " 70\n1\n"
+         << "  0\nLAYER\n";
+  emit_handle(output, H_LAYER_0_R14);
+  emit_owner(output, H_LAYER_TABLE_R14);
+  output << "100\nAcDbSymbolTableRecord\n"
+         << "100\nAcDbLayerTableRecord\n"
+         << "  2\n0\n"
+         << " 70\n0\n"
+         << " 62\n7\n"
+         << "  6\nCONTINUOUS\n"
+         << "  0\nENDTAB\n";
+
+  // STYLE table
+  output << "  0\nTABLE\n"
+         << "  2\nSTYLE\n";
+  emit_handle(output, H_STYLE_TABLE_R14);
+  emit_owner(output, 0);
+  output << "100\nAcDbSymbolTable\n"
+         << " 70\n0\n"
+         << "  0\nENDTAB\n";
+
+  // BLOCK_RECORD table (required by R14)
+  output << "  0\nTABLE\n"
+         << "  2\nBLOCK_RECORD\n";
+  emit_handle(output, H_BLOCKREC_TABLE_R14);
+  emit_owner(output, 0);
+  output << "100\nAcDbSymbolTable\n"
+         << " 70\n2\n"
+         << "  0\nBLOCK_RECORD\n";
+  emit_handle(output, H_BLOCKREC_MODEL_R14);
+  emit_owner(output, H_BLOCKREC_TABLE_R14);
+  output << "100\nAcDbSymbolTableRecord\n"
+         << "100\nAcDbBlockTableRecord\n"
+         << "  2\n*Model_Space\n"
+         << "  0\nBLOCK_RECORD\n";
+  emit_handle(output, H_BLOCKREC_PAPER_R14);
+  emit_owner(output, H_BLOCKREC_TABLE_R14);
+  output << "100\nAcDbSymbolTableRecord\n"
+         << "100\nAcDbBlockTableRecord\n"
+         << "  2\n*Paper_Space\n"
+         << "  0\nENDTAB\n";
+
+  output << "  0\nENDSEC\n";
+
+  // BLOCKS section (*Model_Space and *Paper_Space required by R14)
+  output << "  0\nSECTION\n"
+         << "  2\nBLOCKS\n"
+         << "  0\nBLOCK\n";
+  emit_handle(output, H_BLOCK_MODEL_R14);
+  emit_owner(output, H_BLOCKREC_MODEL_R14);
+  output << "100\nAcDbEntity\n"
+         << "  8\n0\n"
+         << "100\nAcDbBlockBegin\n"
+         << "  2\n*Model_Space\n"
+         << " 70\n0\n"
+         << " 10\n0.0\n"
+         << " 20\n0.0\n"
+         << " 30\n0.0\n"
+         << "  3\n*Model_Space\n"
+         << "  0\nENDBLK\n";
+  emit_handle(output, H_ENDBLK_MODEL_R14);
+  emit_owner(output, H_BLOCKREC_MODEL_R14);
+  output << "100\nAcDbEntity\n"
+         << "  8\n0\n"
+         << "100\nAcDbBlockEnd\n"
+         << "  0\nBLOCK\n";
+  emit_handle(output, H_BLOCK_PAPER_R14);
+  emit_owner(output, H_BLOCKREC_PAPER_R14);
+  output << "100\nAcDbEntity\n"
+         << "  8\n0\n"
+         << "100\nAcDbBlockBegin\n"
+         << "  2\n*Paper_Space\n"
+         << " 70\n0\n"
+         << " 10\n0.0\n"
+         << " 20\n0.0\n"
+         << " 30\n0.0\n"
+         << "  3\n*Paper_Space\n"
+         << "  0\nENDBLK\n";
+  emit_handle(output, H_ENDBLK_PAPER_R14);
+  emit_owner(output, H_BLOCKREC_PAPER_R14);
+  output << "100\nAcDbEntity\n"
+         << "  8\n0\n"
+         << "100\nAcDbBlockEnd\n"
+         << "  0\nENDSEC\n";
+}
+
+static void export_dxf_objects_R14(std::ostream& output)
+{
+  output << "  0\nSECTION\n"
+         << "  2\nOBJECTS\n"
+         << "  0\nDICTIONARY\n";
+  emit_handle(output, H_DICT_ROOT_R14);
+  emit_owner(output, 0);
+  output << "100\nAcDbDictionary\n"
+         << "281\n1\n"
+         << "  3\nACAD_GROUP\n"
+         << "350\n";
+  emit_hexval(output, H_DICT_GROUP_R14);
+
+  output << "  0\nDICTIONARY\n";
+  emit_handle(output, H_DICT_GROUP_R14);
+  emit_owner(output, H_DICT_ROOT_R14);
+  output << "100\nAcDbDictionary\n"
+         << "281\n1\n"
+         << "  0\nENDSEC\n";
+}
+
+// =====================================================================
+// ENTITY EXPORT - MAIN FUNCTION
+// =====================================================================
+//
+// Exports a Polygon2d to DXF. Version controls entity format:
+//
+//   Legacy:  LWPOLYLINE always (original OpenSCAD behaviour, no handles)
+//   R10:     POLYLINE/VERTEX/SEQEND (spec-correct, no handles)
+//   R12:     POLYLINE/VERTEX/SEQEND (spec-correct, with handles)
+//   R14:     LWPOLYLINE (spec-correct R14+ entity, with handles)
+//
+// POINT (1 vertex) and LINE (2 vertices) are handled the same in all
+// modes Ã¢â‚¬â€ they are valid in all DXF versions.
+//
+// SEQEND in R12 also receives a handle. The handseed for R12 is
+// calculated as:
+//   H_ENT_START_R12 + sum over outlines of (2 + vertex_count)
+// because each outline consumes: 1 POLYLINE handle + N VERTEX handles
+// + 1 SEQEND handle.
+// =====================================================================
+
+static void export_dxf(const Polygon2d& poly, std::ostream& output, DxfVersion version)
+{
+  setlocale(LC_NUMERIC, "C");  // Force "." decimal separator
+
+  // ---------------------------------------------------------------
+  // Calculate bounding box
+  // ---------------------------------------------------------------
   double xMin, yMin, xMax, yMax;
-  xMin = yMin = std::numeric_limits<double>::max(), xMax = yMax = std::numeric_limits<double>::min();
+  xMin = yMin = std::numeric_limits<double>::max();
+  xMax = yMax = std::numeric_limits<double>::min();
+
   for (const auto& o : poly.outlines()) {
     for (const auto& p : o.vertices) {
       if (xMin > p[0]) xMin = p[0];
@@ -214,107 +656,227 @@ static void export_dxf(const Polygon2d& poly, std::ostream& output)
     }
   }
 
-  export_dxf_header(output, xMin, yMin, xMax, yMax);
-
-  // REFERENCE:
-  // DXF (AutoCAD Drawing Interchange Format) Family, ASCII variant
-  //    https://www.loc.gov/preservation/digital/formats/fdd/fdd000446.shtml#specs
-  // About the DXF Format (DXF)
-  //    https://help.autodesk.com/view/ACD/2017/ENU/?guid=GUID-235B22E0-A567-4CF6-92D3-38A2306D73F3
-  // About ASCII DXF Files
-  //    https://help.autodesk.com/view/ACD/2017/ENU/?guid=GUID-20172853-157D-4024-8E64-32F3BD64F883
-  // DXF Format
-  //    https://documentation.help/AutoCAD-DXF/WSfacf1429558a55de185c428100849a0ab7-5f35.htm
-
-  output << "  0\n"
-         << "SECTION\n"
-         << "  2\n"
-         << "ENTITIES\n";
+  // ---------------------------------------------------------------
+  // Calculate handseed for R12 and R14
+  //
+  // R14: one handle per entity (LWPOLYLINE, POINT, LINE)
+  // R12: POLYLINE=1, VERTEX=N, SEQEND=1 per outline  Ã¢â€ â€™  (2+N) per outline
+  //      POINT and LINE outlines consume 1 handle each (no VERTEX/SEQEND)
+  // ---------------------------------------------------------------
+  int handseed_r12 = H_ENT_START_R12;
+  int handseed_r14 = H_ENT_START_R14;
 
   for (const auto& o : poly.outlines()) {
-    switch (o.vertices.size()) {
-    case 1: {
-      // POINT: just in case it's supported in the future
-      const Vector2d& p = o.vertices[0];
-      output << "  0\n"
-             << "POINT\n"
-             << "100\n"
-             << "AcDbEntity\n"
-             << "  8\n"
-             << "0\n"  // layer 0
-             << "100\n"
-             << "AcDbPoint\n"
-             << " 10\n"
-             << p[0] << "\n"  // x
-             << " 20\n"
-             << p[1] << "\n";  // y
-    } break;
-    case 2: {
-      // LINE: just in case it's supported in the future
-      // The [X1 Y1 X2 Y2] order is the most common and can be parsed linearly.
-      // Some libraries, like the python libraries dxfgrabber and ezdxf, cannot open [X1 X2 Y1 Y2] order.
-      const Vector2d& p1 = o.vertices[0];
-      const Vector2d& p2 = o.vertices[1];
-      output << "  0\n"
-             << "LINE\n"
-             << "100\n"
-             << "AcDbEntity\n"
-             << "  8\n"
-             << "0\n"  // layer 0
-             << "100\n"
-             << "AcDbLine\n"
-             << " 10\n"
-             << p1[0] << "\n"  // x1
-             << " 20\n"
-             << p1[1] << "\n"  // y1
-             << " 11\n"
-             << p2[0] << "\n"  // x2
-             << " 21\n"
-             << p2[1] << "\n";  // y2
-    } break;
-    default:
-      // LWPOLYLINE
-      output << "  0\n"
-             << "LWPOLYLINE\n"
-             << "100\n"
-             << "AcDbEntity\n"
-             << "  8\n"
-             << "0\n"  // layer 0
-             << "100\n"
-             << "AcDbPolyline\n"
-             << " 90\n"
-             << o.vertices.size() << "\n"  // number of vertices
-             << " 70\n"
-             << "1\n";  // closed = 1
-      for (const auto& p : o.vertices) {
-        output << " 10\n"
-               << p[0] << "\n"
-               << " 20\n"
-               << p[1] << "\n";
-      }
-      break;
+    const int n = static_cast<int>(o.vertices.size());
+    if (n <= 2) {
+      // POINT or LINE: 1 handle in both R12 and R14
+      handseed_r12 += 1;
+      handseed_r14 += 1;
+    } else {
+      // R12: POLYLINE(1) + VERTEX(n) + SEQEND(1) = n+2
+      handseed_r12 += n + 2;
+      // R14: LWPOLYLINE(1)
+      handseed_r14 += 1;
     }
   }
 
-  output << "  0\n"
-         << "ENDSEC\n";
-  output << "  0\n"
-         << "EOF\n";
+  // ---------------------------------------------------------------
+  // Write header (version-specific)
+  // ---------------------------------------------------------------
+  switch (version) {
+  case DxfVersion::Legacy:
+    // Legacy uses its own header that exactly reproduces original OpenSCAD
+    // output, including the $LINMIN/$LINMAX typos and plain comment string.
+    export_dxf_header_Legacy(output, xMin, yMin, xMax, yMax);
+    break;
+  case DxfVersion::R10: export_dxf_header_R10(output, xMin, yMin, xMax, yMax); break;
+  case DxfVersion::R12: export_dxf_header_R12(output, xMin, yMin, xMax, yMax, handseed_r12); break;
+  case DxfVersion::R14:
+    export_dxf_header_R14(output, xMin, yMin, xMax, yMax, handseed_r14, 4, 2);
+    //                                                                    ^  ^
+    //                                                          insunits=4(mm) lunits=2(decimal)
+    break;
+  }
 
-  setlocale(LC_NUMERIC, "");  // set default locale
+  // ---------------------------------------------------------------
+  // ENTITIES SECTION
+  // ---------------------------------------------------------------
+  output << "  0\nSECTION\n"
+         << "  2\nENTITIES\n";
+
+  int ent_handle = (version == DxfVersion::R14)   ? H_ENT_START_R14
+                   : (version == DxfVersion::R12) ? H_ENT_START_R12
+                                                  : 0;
+
+  for (const auto& o : poly.outlines()) {
+    const int n = static_cast<int>(o.vertices.size());
+
+    if (n == 1) {
+      // -----------------------------------------------------------
+      // POINT entity Ã¢â‚¬â€ single vertex (valid in all versions)
+      // -----------------------------------------------------------
+      const Vector2d& p = o.vertices[0];
+      output << "  0\nPOINT\n";
+      if (version == DxfVersion::R12 || version == DxfVersion::R14) {
+        emit_handle(output, ent_handle++);
+      }
+      // Legacy and R14 both emit subclass markers Ã¢â‚¬" the original OpenSCAD
+      // code always emitted these for all entity types.
+      if (version == DxfVersion::Legacy || version == DxfVersion::R14) {
+        output << "100\nAcDbEntity\n";
+      }
+      output << "  8\n0\n";
+      if (version == DxfVersion::R14) {
+        output << "  6\nByLayer\n"
+               << " 62\n256\n";
+      }
+      if (version == DxfVersion::Legacy || version == DxfVersion::R14) {
+        output << "100\nAcDbPoint\n";
+      }
+      output << " 10\n"
+             << p[0] << "\n"
+             << " 20\n"
+             << p[1] << "\n";
+
+    } else if (n == 2) {
+      // -----------------------------------------------------------
+      // LINE entity Ã¢â‚¬â€ two vertices (valid in all versions)
+      // -----------------------------------------------------------
+      const Vector2d& p1 = o.vertices[0];
+      const Vector2d& p2 = o.vertices[1];
+      output << "  0\nLINE\n";
+      if (version == DxfVersion::R12 || version == DxfVersion::R14) {
+        emit_handle(output, ent_handle++);
+      }
+      // Legacy and R14 both emit subclass markers Ã¢â‚¬" the original OpenSCAD
+      // code always emitted these for all entity types.
+      if (version == DxfVersion::Legacy || version == DxfVersion::R14) {
+        output << "100\nAcDbEntity\n";
+      }
+      output << "  8\n0\n";
+      if (version == DxfVersion::R14) {
+        output << "  6\nByLayer\n"
+               << " 62\n256\n";
+      }
+      if (version == DxfVersion::Legacy || version == DxfVersion::R14) {
+        output << "100\nAcDbLine\n";
+      }
+      output << " 10\n"
+             << p1[0] << "\n"
+             << " 20\n"
+             << p1[1] << "\n"
+             << " 11\n"
+             << p2[0] << "\n"
+             << " 21\n"
+             << p2[1] << "\n";
+
+    } else {
+      // -----------------------------------------------------------
+      // Polyline entity Ã¢â‚¬â€ three or more vertices (most common)
+      //
+      // Legacy/R14: LWPOLYLINE (single compact record)
+      // R10/R12:    POLYLINE + VERTEX*N + SEQEND (pre-R14 spec)
+      // -----------------------------------------------------------
+      if (version == DxfVersion::Legacy || version == DxfVersion::R14) {
+        // LWPOLYLINE Ã¢â‚¬â€ compact single-record form
+        output << "  0\nLWPOLYLINE\n";
+        if (version == DxfVersion::R14) {
+          emit_handle(output, ent_handle++);
+        }
+        // Both Legacy and R14 emit subclass markers Ã¢â‚¬â€ the original OpenSCAD
+        // code always emitted these even though they are technically R14-only.
+        output << "100\nAcDbEntity\n";
+        output << "  8\n0\n";
+        if (version == DxfVersion::R14) {
+          output << "  6\nByLayer\n"
+                 << " 62\n256\n";
+        }
+        output << "100\nAcDbPolyline\n";
+        output << " 90\n"
+               << n << "\n"
+               << " 70\n1\n";  // closed polyline flag
+        if (version == DxfVersion::R14) {
+          output << " 43\n0\n";  // constant width = 0
+        }
+        for (const auto& p : o.vertices) {
+          output << " 10\n"
+                 << p[0] << "\n"
+                 << " 20\n"
+                 << p[1] << "\n";
+        }
+
+      } else {
+        // POLYLINE / VERTEX / SEQEND Ã¢â‚¬â€ spec-correct for R10 and R12
+        output << "  0\nPOLYLINE\n";
+        if (version == DxfVersion::R12) {
+          emit_handle(output, ent_handle++);
+        }
+        output << "  8\n0\n"
+               << " 66\n1\n"   // vertices-follow flag
+               << " 70\n1\n";  // closed polyline flag
+
+        for (const auto& p : o.vertices) {
+          output << "  0\nVERTEX\n";
+          if (version == DxfVersion::R12) {
+            emit_handle(output, ent_handle++);
+          }
+          output << "  8\n0\n"
+                 << " 10\n"
+                 << p[0] << "\n"
+                 << " 20\n"
+                 << p[1] << "\n";
+        }
+
+        output << "  0\nSEQEND\n";
+        if (version == DxfVersion::R12) {
+          emit_handle(output, ent_handle++);
+        }
+      }
+    }
+  }
+
+  output << "  0\nENDSEC\n";
+
+  // OBJECTS section (R14 only)
+  if (version == DxfVersion::R14) {
+    export_dxf_objects_R14(output);
+  }
+
+  output << "  0\nEOF\n";
+
+  setlocale(LC_NUMERIC, "");  // Restore locale
 }
 
-void export_dxf(const std::shared_ptr<const Geometry>& geom, std::ostream& output)
+// =====================================================================
+// PUBLIC API FUNCTIONS
+// =====================================================================
+//
+// Entry points called by OpenSCAD's export system.
+// Dispatch to appropriate handler based on geometry type.
+//
+// Supported geometry types:
+//   - Polygon2d:    2D polygon (the primary use case)
+//   - GeometryList: Recursively export each child
+//   - PolySet:      Not supported (3D mesh, would need projection)
+// =====================================================================
+
+void export_dxf(const std::shared_ptr<const Geometry>& geom, std::ostream& output, DxfVersion version)
 {
   if (const auto geomlist = std::dynamic_pointer_cast<const GeometryList>(geom)) {
     for (const auto& item : geomlist->getChildren()) {
-      export_dxf(item.second, output);
+      export_dxf(item.second, output, version);
     }
   } else if (const auto poly = std::dynamic_pointer_cast<const Polygon2d>(geom)) {
-    export_dxf(*poly, output);
-  } else if (std::dynamic_pointer_cast<const PolySet>(geom)) {  // NOLINT(bugprone-branch-clone)
+    export_dxf(*poly, output, version);
+  } else if (std::dynamic_pointer_cast<const PolySet>(geom)) {
     assert(false && "Unsupported file format");
-  } else {  // NOLINT(bugprone-branch-clone)
+  } else {
     assert(false && "Export as DXF for this geometry type is not supported");
   }
+}
+
+// Overload without version parameter Ã¢â‚¬â€ defaults to Legacy (original behaviour)
+void export_dxf(const std::shared_ptr<const Geometry>& geom, std::ostream& output)
+{
+  export_dxf(geom, output, DxfVersion::Legacy);
 }

--- a/src/io/export_dxf.h
+++ b/src/io/export_dxf.h
@@ -1,0 +1,43 @@
+/*
+ *  OpenSCAD (www.openscad.org)
+ *  Copyright (C) 2009-2011 Clifford Wolf <clifford@clifford.at> and
+ *                          Marius Kintel <marius@kintel.net>
+ *
+ *  This program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  As a special exception, you have permission to link this program
+ *  with the CGAL library and distribute executables, as long as you
+ *  follow the requirements of the GNU GPL in regard to all of the
+ *  software in the executable aside from CGAL.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program; if not, write to the Free Software
+ *  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ *
+ */
+
+#pragma once
+
+#include <memory>
+#include <ostream>
+
+#include "io/export_enums.h"
+
+// DxfVersion enum is defined in export_enums.h alongside the other
+// export format enums (ExportPdfPaperSize, Export3mfColorMode, etc.)
+
+class Geometry;
+
+// Export DXF with explicit version selection
+void export_dxf(const std::shared_ptr<const Geometry>& geom, std::ostream& output, DxfVersion version);
+
+// Export DXF with default version (Legacy - preserves original behaviour)
+void export_dxf(const std::shared_ptr<const Geometry>& geom, std::ostream& output);

--- a/src/io/export_enums.h
+++ b/src/io/export_enums.h
@@ -39,3 +39,10 @@ enum class Export3mfMaterialType : std::uint8_t {
   color,
   basematerial,
 };
+
+enum class DxfVersion : std::uint8_t {
+  Legacy,  // Original OpenSCAD behaviour: LWPOLYLINE for all (DEFAULT)
+  R10,     // AC1006 - POLYLINE/VERTEX/SEQEND, no handles, spec-correct
+  R12,     // AC1009 - POLYLINE/VERTEX/SEQEND with handles, spec-correct
+  R14,     // AC1014 - LWPOLYLINE, full object model, spec-correct
+};

--- a/src/openscad.cc
+++ b/src/openscad.cc
@@ -245,6 +245,7 @@ void help_export()
   help_export(Settings::SettingsExportPdf::cmdline);
   help_export(Settings::SettingsExport3mf::cmdline);
   help_export(Settings::SettingsExportSvg::cmdline);
+  help_export(Settings::SettingsExportDxf::cmdline);
   exit(0);
 }
 
@@ -512,10 +513,10 @@ int do_export(const CommandLine& cmd, const RenderVariables& render_variables, F
     const int dim = fileformat::is3D(export_format) ? 3 : fileformat::is2D(export_format) ? 2 : 0;
     ExportInfo exportInfo = createExportInfo(export_format, fileformat::info(export_format),
                                              input_filename, &cmd.camera, cmd.exportOptions);
+
     if (dim > 0 && !checkAndExport(root_geom, dim, exportInfo, cmd.is_stdout, filename_str)) {
       return 1;
     }
-
     if (export_format == FileFormat::PNG) {
       bool success = true;
       bool const wrote = with_output(
@@ -911,6 +912,7 @@ int openscad_main(int argc, char **argv)
                     }) +
            "\n")
             .c_str())
+
     ("d,d", po::value<std::string>(), "deps_file -generate a dependency file for make")
     ("m,m", po::value<std::string>(), "make_cmd -runs make_cmd file if file is missing")
     ("quiet,q", "quiet mode (don't print anything *except* errors)")


### PR DESCRIPTION
Candidate function to create dxf output that has improved compatibility with the R14 version (versus current hybrid of R10/R14/R14).

I wanted to have it enabled or toggled under experimental, but couldn't see a way to do that quickly.  So this has a complier flag of ENABLE_R14 which I think works.

Developed with Claude.ai. Tested on local install with dxfs then imported into LibreCad, VariCAD and FreeCAD.  If other tests can be suggested, I'll explore.

mconsidine 

Reference: #6594