### PR TITLE
Refactor editor color scheme

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1295,6 +1295,7 @@ set(GUI_SOURCES
   src/gui/ColorList.cc
   src/gui/ColorLabel.cc
   src/gui/ColorLayout.cc
+  src/gui/EditorColorMap.cc
   src/gui/MouseSelector.cc
   src/gui/OctoPrint.cc
   src/gui/OpenCSGWarningDialog.cc

--- a/src/gui/EditorColorMap.cc
+++ b/src/gui/EditorColorMap.cc
@@ -1,0 +1,81 @@
+#include "gui/EditorColorMap.h"
+#include "platform/PlatformUtils.h"
+#include "utils/printutils.h"
+
+#include <boost/property_tree/json_parser.hpp>
+
+std::shared_ptr<EditorColorScheme> EditorColorScheme::load(const fs::path& path)
+{
+  boost::property_tree::ptree pt;
+  try {
+    boost::property_tree::read_json(path.string(), pt);
+  } catch (const std::exception& e) {
+    LOG("Error reading color scheme file '%1$s': %2$s", path.generic_string(), e.what());
+    return nullptr;
+  }
+
+  auto name = pt.get<std::string>("name", "");
+  if (name.empty()) {
+    return nullptr;
+  }
+  auto index = pt.get<int>("index", 0);
+
+  return std::make_shared<EditorColorScheme>(QString::fromStdString(name), index, std::move(pt));
+}
+
+EditorColorScheme::EditorColorScheme(QString name, int index, boost::property_tree::ptree pt)
+  : name_(std::move(name)), index_(index), pt_(std::move(pt))
+{
+}
+
+EditorColorMap *EditorColorMap::inst()
+{
+  static EditorColorMap instance;
+  return &instance;
+}
+
+EditorColorMap::EditorColorMap()
+{
+  enumerateColorSchemesInPath(color_schemes_, PlatformUtils::resourceBasePath());
+  enumerateColorSchemesInPath(color_schemes_, PlatformUtils::userConfigPath());
+}
+
+void EditorColorMap::enumerateColorSchemesInPath(EditorColorMap::colorscheme_set_t& result_set,
+                                                 const fs::path& path)
+{
+  const auto color_schemes = path / "color-schemes" / "editor";
+
+  if (fs::exists(color_schemes) && fs::is_directory(color_schemes)) {
+    for (const auto& dirEntry : fs::directory_iterator(color_schemes)) {
+      if (!dirEntry.is_regular_file()) continue;
+
+      const auto& entryPath = dirEntry.path();
+      if (entryPath.extension() != ".json") continue;
+
+      auto colorScheme = EditorColorScheme::load(entryPath);
+      if (colorScheme) {
+        result_set.emplace(colorScheme->index(), std::move(colorScheme));
+      }
+    }
+  }
+}
+
+QStringList EditorColorMap::colorSchemeNames() const
+{
+  QStringList names;
+  for (const auto& entry : color_schemes_) {
+    names << entry.second->name();
+  }
+  names << "Off";
+  return names;
+}
+
+std::shared_ptr<EditorColorScheme> EditorColorMap::getColorScheme(const QString& name) const
+{
+  for (const auto& entry : color_schemes_) {
+    if (entry.second->name() == name) {
+      return entry.second;
+    }
+  }
+  return nullptr;
+}

--- a/src/gui/EditorColorMap.h
+++ b/src/gui/EditorColorMap.h
@@ -1,0 +1,45 @@
+#pragma once
+
+#include <QString>
+#include <QStringList>
+#include <filesystem>
+#include <map>
+#include <memory>
+#include <boost/property_tree/ptree.hpp>
+
+namespace fs = std::filesystem;
+
+class EditorColorScheme
+{
+public:
+  static std::shared_ptr<EditorColorScheme> load(const fs::path& path);
+
+  EditorColorScheme(QString name, int index, boost::property_tree::ptree pt);
+  ~EditorColorScheme() = default;
+
+  const QString& name() const { return name_; }
+  int index() const { return index_; }
+  const boost::property_tree::ptree& propertyTree() const { return pt_; }
+
+private:
+  QString name_;
+  int index_;
+  boost::property_tree::ptree pt_;
+};
+
+class EditorColorMap
+{
+public:
+  using colorscheme_set_t = std::multimap<int, std::shared_ptr<EditorColorScheme>, std::less<>>;
+
+  static EditorColorMap *inst();
+
+  QStringList colorSchemeNames() const;
+  std::shared_ptr<EditorColorScheme> getColorScheme(const QString& name) const;
+
+private:
+  EditorColorMap();
+  void enumerateColorSchemesInPath(colorscheme_set_t& result_set, const fs::path& path);
+
+  colorscheme_set_t color_schemes_;
+};

--- a/src/gui/MainWindow.cc
+++ b/src/gui/MainWindow.cc
@@ -3499,12 +3499,6 @@ void MainWindow::setupEditor(const QStringList& filenames)
   connect(this->editActionNextTab, &QAction::triggered, tabManager, &TabManager::nextTab);
   connect(this->editActionPrevTab, &QAction::triggered, tabManager, &TabManager::prevTab);
 
-  // Configure the highlighting color scheme from the active editor one.
-  // This is done only one time at creation of the first MainWindow instance
-  auto preferences = GlobalPreferences::inst();
-  if (!preferences->hasHighlightingColorScheme())
-    preferences->setHighlightingColorSchemes(activeEditor->colorSchemes());
-
   onTabManagerEditorChanged(activeEditor);
   QObject::connect(editorDock, &Dock::visibilityChanged, this,
                    &MainWindow::onEditorDockVisibilityChanged);

--- a/src/gui/Preferences.cc
+++ b/src/gui/Preferences.cc
@@ -65,6 +65,7 @@
 #include "geometry/cgal/CGALCache.h"
 #endif
 #include "glview/ColorMap.h"
+#include "gui/EditorColorMap.h"
 #include "glview/RenderSettings.h"
 #include "gui/QSettingsCached.h"
 #include "gui/SettingsWriter.h"
@@ -103,6 +104,8 @@ Preferences::Preferences(QWidget *parent) : QMainWindow(parent)
   for (const auto& name : names) renderColorSchemes << name.c_str();
 
   syntaxHighlight->clear();
+  syntaxHighlight->addItems(EditorColorMap::inst()->colorSchemeNames());
+
   colorSchemeChooser->clear();
   colorSchemeChooser->addItems(renderColorSchemes);
   init();
@@ -1469,18 +1472,6 @@ void Preferences::apply_win() const
 {
   emit requestRedraw();
   emit openCSGSettingsChanged();
-}
-
-bool Preferences::hasHighlightingColorScheme() const
-{
-  return BlockSignals<QComboBox *>(syntaxHighlight)->count() != 0;
-}
-
-void Preferences::setHighlightingColorSchemes(const QStringList& colorSchemes)
-{
-  auto combobox = BlockSignals<QComboBox *>(syntaxHighlight);
-  combobox->clear();
-  combobox->addItems(colorSchemes);
 }
 
 void Preferences::createFontSizeMenu(QComboBox *boxarg, const QString& setting)

--- a/src/gui/Preferences.h
+++ b/src/gui/Preferences.h
@@ -41,12 +41,6 @@ public:
   void fireApplicationFontChanged() const;
   void insertListItem(QListWidget *listBox, QListWidgetItem *listItem);
 
-  // Returns true if there is an higlightling color scheme configured.
-  bool hasHighlightingColorScheme() const;
-
-  // Set a new colorScheme.
-  void setHighlightingColorSchemes(const QStringList& colorSchemes);
-
 public slots:
   void actionTriggered(class QAction *);
   void featuresCheckBoxToggled(bool);

--- a/src/gui/ScintillaEditor.cc
+++ b/src/gui/ScintillaEditor.cc
@@ -101,39 +101,6 @@ QsciScintilla::WhitespaceVisibility SettingsConverter::toShowWhitespaces(const s
   }
 }
 
-EditorColorScheme::EditorColorScheme(const fs::path& path) : path(path)
-{
-  try {
-    boost::property_tree::read_json(path.generic_string(), pt);
-    _name = QString::fromStdString(pt.get<std::string>("name"));
-    _index = pt.get<int>("index");
-  } catch (const std::exception& e) {
-    LOG("Error reading color scheme file '%1$s': %2$s", path.generic_string(), e.what());
-    _name = "";
-    _index = 0;
-  }
-}
-
-bool EditorColorScheme::valid() const
-{
-  return !_name.isEmpty();
-}
-
-const QString& EditorColorScheme::name() const
-{
-  return _name;
-}
-
-int EditorColorScheme::index() const
-{
-  return _index;
-}
-
-const boost::property_tree::ptree& EditorColorScheme::propertyTree() const
-{
-  return pt;
-}
-
 ScintillaEditor::ScintillaEditor(QWidget *parent) : EditorInterface(parent)
 {
   api = nullptr;
@@ -743,45 +710,9 @@ void ScintillaEditor::noColor()
   qsci->setEdgeColor(Qt::black);
 }
 
-void ScintillaEditor::enumerateColorSchemesInPath(ScintillaEditor::colorscheme_set_t& result_set,
-                                                  const fs::path& path)
-{
-  const auto color_schemes = path / "color-schemes" / "editor";
-
-  if (fs::exists(color_schemes) && fs::is_directory(color_schemes)) {
-    for (const auto& dirEntry : boost::make_iterator_range(fs::directory_iterator{color_schemes}, {})) {
-      if (!fs::is_regular_file(dirEntry.status())) continue;
-
-      const auto& path = dirEntry.path();
-      if (!(path.extension() == ".json")) continue;
-
-      auto colorScheme = std::make_shared<EditorColorScheme>(path);
-      if (colorScheme->valid()) {
-        result_set.emplace(colorScheme->index(), colorScheme);
-      }
-    }
-  }
-}
-
-ScintillaEditor::colorscheme_set_t ScintillaEditor::enumerateColorSchemes()
-{
-  colorscheme_set_t result_set;
-
-  enumerateColorSchemesInPath(result_set, PlatformUtils::resourceBasePath());
-  enumerateColorSchemesInPath(result_set, PlatformUtils::userConfigPath());
-
-  return result_set;
-}
-
 QStringList ScintillaEditor::colorSchemes()
 {
-  QStringList colorSchemes;
-  for (const auto& colorSchemeEntry : enumerateColorSchemes()) {
-    colorSchemes << colorSchemeEntry.second.get()->name();
-  }
-  colorSchemes << "Off";
-
-  return colorSchemes;
+  return EditorColorMap::inst()->colorSchemeNames();
 }
 
 bool ScintillaEditor::canUndo()
@@ -791,15 +722,12 @@ bool ScintillaEditor::canUndo()
 
 void ScintillaEditor::setHighlightScheme(const QString& name)
 {
-  for (const auto& colorSchemeEntry : enumerateColorSchemes()) {
-    const auto colorScheme = colorSchemeEntry.second.get();
-    if (colorScheme->name() == name) {
-      setColormap(colorScheme);
-      return;
-    }
+  auto scheme = EditorColorMap::inst()->getColorScheme(name);
+  if (scheme) {
+    setColormap(scheme.get());
+  } else {
+    noColor();
   }
-
-  noColor();
 }
 
 void ScintillaEditor::insert(const QString& text)

--- a/src/gui/ScintillaEditor.h
+++ b/src/gui/ScintillaEditor.h
@@ -20,6 +20,7 @@
 
 #include "gui/Editor.h"
 #include "gui/ScadApi.h"
+#include "gui/EditorColorMap.h"
 
 // don't need the full definition, because it confuses Qt
 class ScadLexer;
@@ -27,30 +28,9 @@ class ScadLexer2;
 
 #define ENABLE_LEXERTL 1
 
-class EditorColorScheme
-{
-private:
-  const fs::path path;
-
-  boost::property_tree::ptree pt;
-  QString _name;
-  int _index;
-
-public:
-  EditorColorScheme(const fs::path& path);
-  virtual ~EditorColorScheme() = default;
-
-  const QString& name() const;
-  int index() const;
-  bool valid() const;
-  const boost::property_tree::ptree& propertyTree() const;
-};
-
 class ScintillaEditor : public EditorInterface
 {
   Q_OBJECT;
-
-  using colorscheme_set_t = std::multimap<int, std::shared_ptr<EditorColorScheme>, std::less<>>;
 
 public:
   ScintillaEditor(QWidget *parent);
@@ -90,8 +70,6 @@ private:
                          const std::string& defaultValue);
   QColor readColor(const boost::property_tree::ptree& pt, const std::string& name,
                    const QColor& defaultColor);
-  void enumerateColorSchemesInPath(colorscheme_set_t& result_set, const fs::path& path);
-  colorscheme_set_t enumerateColorSchemes();
 
   bool eventFilter(QObject *obj, QEvent *event) override;
   bool handleKeyEventNavigateNumber(QKeyEvent *);


### PR DESCRIPTION
This decouples color scheme creation from ScintillaEditor, and resolves the initialization order forcing us to create an editor before initializing preferences.