### PR TITLE
Remove & from dock titles; remove menu shortcut from jump-to-window menu.

### DIFF
--- a/src/gui/Dock.cc
+++ b/src/gui/Dock.cc
@@ -1,8 +1,8 @@
 #include "gui/Dock.h"
 
-#include <QDockWidget>
 #include <QWidget>
-#include "gui/QSettingsCached.h"
+#include <QDockWidget>
+#include <QRegularExpression>
 
 namespace {
 
@@ -56,6 +56,10 @@ void Dock::updateTitle()
 void Dock::setName(const QString& name_)
 {
   name = name_;
+  // On Linux and Qt6.10 this is not needed, but older Qt versions
+  // show the & mnemonic marker in the dock title. Allow keeping
+  // single & characters not directly followed by a letter.
+  name.replace(QRegularExpression("&([a-zA-Z])"), "\\1");
   updateTitle();
 }
 

--- a/src/gui/MainWindow.cc
+++ b/src/gui/MainWindow.cc
@@ -3649,7 +3649,6 @@ void MainWindow::setupDocks()
     menuWindow->addAction(dock->toggleViewAction());
 
     auto dockAction = navigationMenu->addAction(title);
-    dockAction->setShortcut(QKeySequence::mnemonic(title));
     dockAction->setProperty("id", QVariant::fromValue(dock));
     connect(dockAction, &QAction::triggered, this, &MainWindow::onNavigationTriggerContextMenuEntry);
     connect(dockAction, &QAction::hovered, this, &MainWindow::onNavigationHoveredContextMenuEntry);
@@ -3684,7 +3683,7 @@ void MainWindow::setupMenusAndActions()
 
   //
   // File menu
-  // 
+  //
 
 
   // Recent files


### PR DESCRIPTION
Fixes #6576.