### PR TITLE
Quick stab at showing FPS on the status line

### DIFF
--- a/src/gui/QGLView.cc
+++ b/src/gui/QGLView.cc
@@ -215,13 +215,21 @@ void QGLView::resizeGL(int w, int h)
 
 void QGLView::paintGL()
 {
+  const std::chrono::steady_clock::time_point begin{std::chrono::steady_clock::now()};
   GLView::paintGL();
+  const std::chrono::steady_clock::time_point end{std::chrono::steady_clock::now()};
+  const std::chrono::microseconds us{std::chrono::duration_cast<std::chrono::microseconds>(end - begin)};
+  double d = us.count();
+  double rawFPS = 1000.0 * 1000.0 / d;
+  const double decay = 0.9;  // weigh previous value at 90%
+  smoothedFPS = smoothedFPS ? (smoothedFPS * decay) + (rawFPS * (1 - decay)) : rawFPS;
 
   if (statusLabel) {
-    auto status = QString("%1 (%2x%3)")
+    auto status = QString("%1 (%2x%3) %4 FPS")
                     .arg(QString::fromStdString(cam.statusText()))
                     .arg(size().rwidth())
-                    .arg(size().rheight());
+                    .arg(size().rheight())
+                    .arg(smoothedFPS, 0, 'g', 4);
     statusLabel->setText(status);
   }
 }

--- a/src/gui/QGLView.h
+++ b/src/gui/QGLView.h
@@ -92,6 +92,7 @@ private:
   QPoint last_mouse;
 #endif
   QImage frame;  // Used by grabFrame() and save()
+  double smoothedFPS = 0;
 
   void wheelEvent(QWheelEvent *event) override;
   void mousePressEvent(QMouseEvent *event) override;


### PR DESCRIPTION
When and if done:  Fixes #6629.

Measures the time for GLView::paintGL(), which seems to be shared across all forms of rendering.  Inverts it to get FPS, then uses an exponential-decay smoother to reduce noise.

<img width="294" height="69" alt="image" src="https://github.com/user-attachments/assets/b186c25e-6ed2-4062-bfb5-0b6bd9dbf0d9" />


Known issues:
* Should reset smoothing on each new preview/render.
* Unrelated to animation FPS, needs clarity in presentation.
* value for smoothing parameter ("decay") is debatable.

More that I thought of after commit:
* Probably interacts very poorly with animation, no matter what you do.
* Measured FPS varies pretty widely even for a single model.  Maybe based on current viewport?
* FPS of rendered image is really high (~6000FPS).  Don't know if that's real or not.
* Currently uses the equivalent of `%.4g`, which is too many digits most of the time.  But having fewer than that pushed rendered-image FPS into exponential notation.