### PR TITLE
Ensure dock window actions are available via DBus

### DIFF
--- a/src/gui/MainWindow.cc
+++ b/src/gui/MainWindow.cc
@@ -2994,6 +2994,23 @@ QString MainWindow::getCurrentFileName() const
   return fname.replace("&", "&&");
 }
 
+/**
+ * Convert a dock title to a base name for action naming.
+ * Removes mnemonic markers (&) and hyphens, creating a camelCase name.
+ * Examples: "&Editor" -> "Editor", "Error-&Log" -> "ErrorLog"
+ */
+QString MainWindow::getDockBaseName(const QString& title) const
+{
+  QString baseName = title;
+  // Remove mnemonic marker
+  baseName.remove('&');
+  // Remove hyphens
+  baseName.remove('-');
+  // Remove spaces
+  baseName.remove(' ');
+  return baseName;
+}
+
 void MainWindow::onTabManagerAboutToCloseEditor(EditorInterface *closingEditor)
 {
   // This slots is in charge of closing properly the preview when the
@@ -3646,7 +3663,11 @@ void MainWindow::setupDocks()
     // correctly processed when the dock are floating (is in a different window that the mainwindow)
     dock->installEventFilter(this);
 
-    menuWindow->addAction(dock->toggleViewAction());
+    // Get the toggle action from Qt and set an objectName for DBus accessibility
+    QAction *toggleAction = dock->toggleViewAction();
+    QString baseName = getDockBaseName(title);
+    toggleAction->setObjectName("windowActionToggle" + baseName);
+    menuWindow->addAction(toggleAction);
 
     auto dockAction = navigationMenu->addAction(title);
     dockAction->setShortcut(QKeySequence::mnemonic(title));

--- a/src/gui/MainWindow.h
+++ b/src/gui/MainWindow.h
@@ -240,6 +240,7 @@ private:
   Dock *getNextDockFromSender(QObject *sender);
   void addExportActions(QToolBar *toolbar, QAction *action) const;
   QAction *formatIdentifierToAction(const std::string& identifier) const;
+  QString getDockBaseName(const QString& title) const;
 
   LibraryInfoDialog *libraryInfoDialog{nullptr};
   FontListDialog *fontListDialog{nullptr};


### PR DESCRIPTION
Actions that have no objectname do not get registered as DBus actions, and a previous refactor converted the window actions to qt native dock toggle actions, breaking DBus accessibility.

We explicitly set an ObjectName for each dock action.

Fixes: #6618 
