### PR TITLE
Print time-to-first-frame on first frame

### DIFF
--- a/src/RenderStatistic.cc
+++ b/src/RenderStatistic.cc
@@ -330,7 +330,7 @@ void LogVisitor::printCacheStatistic()
 void LogVisitor::printRenderingTime(const std::chrono::milliseconds ms)
 {
   // always enabled
-  LOG("Total rendering time: %1$d:%2$02d:%3$02d.%4$03d", (ms.count() / 1000 / 60 / 60),
+  LOG("Time to first image: %1$d:%2$02d:%3$02d.%4$03d", (ms.count() / 1000 / 60 / 60),
       (ms.count() / 1000 / 60 % 60), (ms.count() / 1000 % 60), (ms.count() % 1000));
 }
 

--- a/src/gui/MainWindow.cc
+++ b/src/gui/MainWindow.cc
@@ -1056,10 +1056,18 @@ void MainWindow::compileCSG()
     this->thrownTogetherRenderer = std::make_shared<ThrownTogetherRenderer>(
       this->rootProduct, this->highlightsProducts, this->backgroundProducts);
     LOG("Compile and preview finished.");
-    renderStatistic.printRenderingTime();
+    renderStatistic.printRenderingTime();  // Removed: printRenderingTime()
     this->processEvents();
   } catch (const HardWarningException&) {
     exceptionCleanup();
+  }
+}
+
+void MainWindow::onFrameRendered()
+{
+  if (this->isWaitingForFirstFrame) {
+    this->renderStatistic.printRenderingTime();
+    this->isWaitingForFirstFrame = false;
   }
 }
 
@@ -1776,6 +1784,7 @@ void MainWindow::prepareCompile(const char *afterCompileSlot, bool procevents, b
   this->afterCompileSlot = afterCompileSlot;
   this->procevents = procevents;
   this->isPreview = preview;
+  this->isWaitingForFirstFrame = preview;
 }
 
 void MainWindow::on_designActionPreview_triggered()
@@ -3595,6 +3604,7 @@ void MainWindow::setup3DView()
   connect(this->qglview, &QGLView::doRightClick, this, &MainWindow::rightClick);
   connect(this->qglview, &QGLView::doLeftClick, this, &MainWindow::leftClick);
   connect(this->qglview, &QGLView::initialized, this, &MainWindow::updateViewModeAfterGLInit);
+  connect(this->qglview, &QGLView::frameRendered, this, &MainWindow::onFrameRendered);
 }
 
 /**
@@ -3684,7 +3694,7 @@ void MainWindow::setupMenusAndActions()
 
   //
   // File menu
-  // 
+  //
 
 
   // Recent files

--- a/src/gui/MainWindow.h
+++ b/src/gui/MainWindow.h
@@ -86,6 +86,7 @@ public:
   QTimer *autoReloadTimer;
   QTimer *waitAfterReloadTimer;
   RenderStatistic renderStatistic;
+  bool isWaitingForFirstFrame{false};
 
   std::shared_ptr<SourceFile> rootFile;            // Result of parsing
   std::shared_ptr<SourceFile> parsedFile;          // Last parse for include list
@@ -343,6 +344,7 @@ private slots:
   void on_designActionRender_triggered();
   void actionRenderDone(const std::shared_ptr<const Geometry>&);
   void cgalRender();
+  void onFrameRendered();
   void handleMeasurementClicked(QAction *clickedAction);
   void on_designCheckValidity_triggered();
   void on_designActionDisplayAST_triggered();

--- a/src/gui/QGLView.cc
+++ b/src/gui/QGLView.cc
@@ -205,6 +205,7 @@ void QGLView::paintGL()
                     .arg(size().rheight());
     statusLabel->setText(status);
   }
+  emit frameRendered();
 }
 
 void QGLView::mousePressEvent(QMouseEvent *event)

--- a/src/gui/QGLView.h
+++ b/src/gui/QGLView.h
@@ -115,6 +115,7 @@ signals:
   void doRightClick(QPoint screen_coordinate);
   void doLeftClick(QPoint screen_coordinate);
   void initialized();
+  void frameRendered();
 };
 
 /* These are defined in QLGView2.cc.  See the commentary there. */


### PR DESCRIPTION
Changed the rendering time message to 'Time to first image' and defer printing until the first rendered frame is actually displayed. Added QGLView::frameRendered signal (emitted from paintGL), MainWindow::onFrameRendered slot, and an isWaitingForFirstFrame flag that is set for preview compilations; connect the signal to the slot so renderStatistic.printRenderingTime() runs when the first frame finishes. Removed the immediate print call after compile to ensure timing reflects time-to-first-frame.