### PR TITLE
IWYU for some missing headers.

### DIFF
--- a/src/core/CSGNode.cc
+++ b/src/core/CSGNode.cc
@@ -25,6 +25,7 @@
  */
 
 #include "core/CSGNode.h"
+#include "core/enums.h"
 #include "geometry/PolySet.h"
 #include "geometry/linalg.h"
 

--- a/src/core/CSGTreeEvaluator.cc
+++ b/src/core/CSGTreeEvaluator.cc
@@ -1,5 +1,6 @@
 #include "core/CSGTreeEvaluator.h"
 #include "geometry/Geometry.h"
+#include "core/enums.h"
 #include "core/node.h"
 #include "core/BaseVisitable.h"
 #include "geometry/linalg.h"

--- a/src/core/CSGTreeEvaluator.h
+++ b/src/core/CSGTreeEvaluator.h
@@ -6,6 +6,7 @@
 #include <cstddef>
 #include "core/NodeVisitor.h"
 #include <memory>
+#include "core/enums.h"
 #include "core/node.h"
 #include "core/BaseVisitable.h"
 #include "core/ModuleInstantiation.h"

--- a/src/core/ColorUtil.cc
+++ b/src/core/ColorUtil.cc
@@ -1,4 +1,6 @@
 #include <boost/spirit/home/support/common_terminals.hpp>
+#include <cctype>
+#include <cmath>
 #include <algorithm>
 #include <optional>
 #include <string>

--- a/src/core/CsgOpNode.cc
+++ b/src/core/CsgOpNode.cc
@@ -26,6 +26,7 @@
 
 #include "core/CsgOpNode.h"
 
+#include "core/enums.h"
 #include "core/Builtins.h"
 #include "core/Children.h"
 #include "core/module.h"

--- a/src/core/FreetypeRenderer.cc
+++ b/src/core/FreetypeRenderer.cc
@@ -25,6 +25,7 @@
  */
 #include "core/FreetypeRenderer.h"
 
+#include <iterator>
 #include <ostream>
 #include <algorithm>
 #include <limits>

--- a/src/core/Settings.cc
+++ b/src/core/Settings.cc
@@ -2,6 +2,7 @@
 
 #include "core/MouseConfig.h"
 
+#include <algorithm>
 #include <ostream>
 #include <cassert>
 #include <cstddef>

--- a/src/geometry/GeometryEvaluator.cc
+++ b/src/geometry/GeometryEvaluator.cc
@@ -1,6 +1,7 @@
 #include "geometry/GeometryEvaluator.h"
 
 #include "Feature.h"
+#include "core/enums.h"
 #include "core/node.h"
 #include "core/BaseVisitable.h"
 #include "geometry/boolean_utils.h"

--- a/src/geometry/cgal/cgalutils-applyops-minkowski.cc
+++ b/src/geometry/cgal/cgalutils-applyops-minkowski.cc
@@ -1,5 +1,7 @@
 #include "geometry/cgal/cgalutils.h"
 
+#include <iterator>
+#include <list>
 #include <cassert>
 #include <cstddef>
 #include <utility>
@@ -10,6 +12,7 @@
 #include <CGAL/convex_hull_3.h>
 
 #include "core/node.h"
+#include "core/enums.h"
 #include "utils/printutils.h"
 
 namespace CGALUtils {

--- a/src/geometry/cgal/cgalutils-applyops.cc
+++ b/src/geometry/cgal/cgalutils-applyops.cc
@@ -1,6 +1,7 @@
 // this file is split into many separate cgalutils* files
 // in order to workaround gcc 4.9.1 crashing on systems with only 2GB of RAM
 #include "geometry/cgal/cgal.h"
+#include "core/enums.h"
 #include "geometry/Geometry.h"
 #include "geometry/cgal/cgalutils.h"
 #include "Feature.h"

--- a/src/geometry/linalg.h
+++ b/src/geometry/linalg.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <algorithm>
 #include <cstddef>
 #include <functional>
 #include <Eigen/Core>

--- a/src/geometry/manifold/manifold-applyops-minkowski.cc
+++ b/src/geometry/manifold/manifold-applyops-minkowski.cc
@@ -13,6 +13,7 @@
 #include <CGAL/Surface_mesh/Surface_mesh.h>
 
 #include "geometry/cgal/cgal.h"
+#include "core/enums.h"
 #include "geometry/Geometry.h"
 #include "geometry/cgal/cgalutils.h"
 #include "geometry/PolySet.h"

--- a/src/geometry/manifold/manifold-applyops.cc
+++ b/src/geometry/manifold/manifold-applyops.cc
@@ -5,6 +5,7 @@
 
 #include <memory>
 #include "geometry/manifold/manifoldutils.h"
+#include "core/enums.h"
 #include "geometry/Geometry.h"
 #include "core/AST.h"
 #include "geometry/manifold/ManifoldGeometry.h"

--- a/src/glview/preview/CSGTreeNormalizer.cc
+++ b/src/glview/preview/CSGTreeNormalizer.cc
@@ -6,6 +6,7 @@
 #include <stack>
 
 #include "core/CSGNode.h"
+#include "core/enums.h"
 #include "utils/printutils.h"
 
 // Helper function to debug normalization bugs

--- a/src/gui/Animate.cc
+++ b/src/gui/Animate.cc
@@ -1,5 +1,6 @@
 #include "gui/Animate.h"
 
+#include <QPalette>
 #include <string>
 #include <QAction>
 #include <QBoxLayout>

--- a/src/gui/ColorLayout.cc
+++ b/src/gui/ColorLayout.cc
@@ -16,6 +16,8 @@
  *  License along with this program; if not, see
  *  <https://www.gnu.org/licenses/>.
  */
+#include <utility>
+#include <cmath>
 #include <QWidget>
 #include <functional>
 #include <algorithm>

--- a/src/gui/ColorLayout.h
+++ b/src/gui/ColorLayout.h
@@ -18,6 +18,7 @@
  */
 #pragma once
 
+#include <QList>
 #include <QWidget>
 #include <functional>
 

--- a/src/gui/ColorList.cc
+++ b/src/gui/ColorList.cc
@@ -19,6 +19,7 @@
 
 #include "gui/ColorList.h"
 
+#include <QObject>
 #include <QApplication>
 #include <QWidget>
 #include <QColor>

--- a/src/gui/ColorList.h
+++ b/src/gui/ColorList.h
@@ -20,6 +20,7 @@
 
 #include "gui/ColorList.h"
 
+#include <QList>
 #include <QWidget>
 #include <QString>
 #include <QColor>

--- a/src/gui/EditorColorMap.cc
+++ b/src/gui/EditorColorMap.cc
@@ -2,6 +2,7 @@
 #include "platform/PlatformUtils.h"
 #include "utils/printutils.h"
 
+#include <exception>
 #include <QStringList>
 #include <filesystem>
 #include <memory>

--- a/src/gui/EditorColorMap.h
+++ b/src/gui/EditorColorMap.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <functional>
 #include <QString>
 #include <QStringList>
 #include <filesystem>

--- a/src/gui/ExportSvgDialog.cc
+++ b/src/gui/ExportSvgDialog.cc
@@ -1,4 +1,5 @@
 #include "ExportSvgDialog.h"
+#include <QPalette>
 #include <QColorDialog>
 #include <QPushButton>
 

--- a/src/gui/ExternalToolInterface.cc
+++ b/src/gui/ExternalToolInterface.cc
@@ -35,6 +35,7 @@
 #include <QStringList>
 #include <QTemporaryFile>
 
+#include "glview/Camera.h"
 #include "utils/printutils.h"
 #include "core/Settings.h"
 #include "gui/OctoPrint.h"

--- a/src/gui/ExternalToolInterface.h
+++ b/src/gui/ExternalToolInterface.h
@@ -34,6 +34,7 @@
 #include <QString>
 
 #include "gui/PrintService.h"
+#include "glview/Camera.h"
 #include "geometry/Geometry.h"
 #include "core/Settings.h"
 #include "io/export.h"

--- a/src/gui/MainWindow.h
+++ b/src/gui/MainWindow.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <utility>
 #include <ctime>
 #include <tuple>
 #include <unordered_map>
@@ -34,6 +35,7 @@
 #include <QSignalMapper>
 #include <QShortcut>
 #include "core/Context.h"
+#include "glview/Camera.h"
 #include "glview/Renderer.h"
 #include "core/SourceFile.h"
 #ifdef STATIC_QT_SVG_PLUGIN

--- a/src/gui/OctoPrintApiKeyDialog.cc
+++ b/src/gui/OctoPrintApiKeyDialog.cc
@@ -26,6 +26,7 @@
 
 #include "gui/OctoPrintApiKeyDialog.h"
 
+#include <QObject>
 #include <QString>
 #include <QCheckBox>
 #include <QColor>

--- a/src/gui/RubberBandManager.h
+++ b/src/gui/RubberBandManager.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <QObject>
 #include <QRubberBand>
 
 class Dock;

--- a/src/gui/UIUtils.h
+++ b/src/gui/UIUtils.h
@@ -25,6 +25,7 @@
  */
 #pragma once
 
+#include <QList>
 #include <QColor>
 #include <QString>
 #include <QWidget>

--- a/src/gui/ViewportControl.cc
+++ b/src/gui/ViewportControl.cc
@@ -1,5 +1,6 @@
 #include "gui/ViewportControl.h"
 
+#include <QPalette>
 #include <QBoxLayout>
 #include <QGridLayout>
 #include <QLayoutItem>

--- a/src/io/import_3mf_v2.cc
+++ b/src/io/import_3mf_v2.cc
@@ -25,6 +25,8 @@
  */
 #include "io/import.h"
 
+#include <iomanip>
+#include <list>
 #include <algorithm>
 #include <cstdint>
 #include <memory>
@@ -35,6 +37,7 @@
 
 #include <lib3mf_implicit.hpp>
 
+#include "core/enums.h"
 #include "core/AST.h"
 #include "geometry/Geometry.h"
 #include "geometry/linalg.h"

--- a/src/io/import_stl.cc
+++ b/src/io/import_stl.cc
@@ -1,5 +1,6 @@
 #include "io/import.h"
 
+#include <iostream>
 #include <filesystem>
 #include <array>
 #include <cstddef>

--- a/src/python/pyfunctions.cc
+++ b/src/python/pyfunctions.cc
@@ -24,12 +24,14 @@
  *
  */
 
+#include <sstream>
 #include <cstddef>
 #include <memory>
 #include <optional>
 #include <string>
 #include <Python.h>
 #include "python/pyopenscad.h"
+#include "core/enums.h"
 #include "core/node.h"
 #include "core/primitives.h"
 #include "core/CsgOpNode.h"

--- a/src/python/pymod.cc
+++ b/src/python/pymod.cc
@@ -23,6 +23,7 @@
  *  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
  *
  */
+#include <system_error>
 #include <Python.h>
 
 #include <string>

--- a/src/python/pyopenscad.cc
+++ b/src/python/pyopenscad.cc
@@ -23,6 +23,7 @@
  *  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
  *
  */
+#include <sstream>
 #include <array>
 #include <memory>
 #include <optional>
@@ -31,6 +32,7 @@
 #include <filesystem>
 
 #include "pyopenscad.h"
+#include "core/enums.h"
 #include "core/node.h"
 #include "utils/printutils.h"
 #include "core/CsgOpNode.h"


### PR DESCRIPTION
Breakdown:

```
src/core/CSGNode.cc:                     #include "core/enums.h" for OpenSCADOperator
src/core/CsgOpNode.cc:                   #include "core/enums.h" for OpenSCADOperator
src/core/CSGTreeEvaluator.cc:            #include "core/enums.h" for OpenSCADOperator
src/core/CSGTreeEvaluator.h:             #include "core/enums.h" for OpenSCADOperator
src/geometry/cgal/cgalutils-applyops.cc: #include "core/enums.h" for OpenSCADOperator
src/geometry/cgal/cgalutils-applyops-minkowski.cc: #include "core/enums.h" for OpenSCADOperator
src/geometry/GeometryEvaluator.cc:       #include "core/enums.h" for OpenSCADOperator
src/geometry/manifold/manifold-applyops.cc: #include "core/enums.h" for OpenSCADOperator
src/geometry/manifold/manifold-applyops-minkowski.cc: #include "core/enums.h" for OpenSCADOperator
src/glview/preview/CSGTreeNormalizer.cc: #include "core/enums.h" for OpenSCADOperator
src/io/import_3mf_v2.cc:                 #include "core/enums.h" for OpenSCADOperator
src/python/pyfunctions.cc:               #include "core/enums.h" for OpenSCADOperator
src/python/pyopenscad.cc:                #include "core/enums.h" for OpenSCADOperator
src/gui/ColorList.cc:                    #include <QObject> for QObject
src/gui/OctoPrintApiKeyDialog.cc:        #include <QObject> for QObject
src/gui/RubberBandManager.h:             #include <QObject> for QObject
src/gui/Animate.cc:                      #include <QPalette> for QPalette
src/gui/ExportSvgDialog.cc:              #include <QPalette> for QPalette
src/gui/ViewportControl.cc:              #include <QPalette> for QPalette
src/gui/ColorLayout.h:                   #include <QList> for QList
src/gui/ColorList.h:                     #include <QList> for QList
src/gui/UIUtils.h:                       #include <QList> for QList
src/gui/MainWindow.cc:                   #include <QtTypes> for qint64
src/gui/Network.h:                       #include <QtTypes> for qint64
src/gui/NetworkSignal.h:                 #include <QtTypes> for qint64
src/gui/ColorLayout.cc:                  #include <cmath> for std::floor
src/core/ColorUtil.cc:                   #include <cmath> for std::fabs
src/gui/ExternalToolInterface.cc:        #include "glview/Camera.h" for Camera
src/gui/ExternalToolInterface.h:         #include "glview/Camera.h" for Camera
src/gui/MainWindow.h:                    #include "glview/Camera.h" for Camera
src/geometry/cgal/cgalutils-applyops-minkowski.cc: #include <list> for std::list
src/io/import_3mf_v2.cc:                 #include <list> for std::list
src/python/pyfunctions.cc:               #include <sstream> for std::ostringstream
src/python/pyopenscad.cc:                #include <sstream> for std::ostringstream
src/geometry/linalg.h:                   #include <algorithm> for std::clamp
src/core/FreetypeRenderer.cc:            #include <iterator> for std::back_inserter
src/core/Settings.cc:                    #include <algorithm> for std::transform
src/io/import_stl.cc:                    #include <iostream> for std::streampos
src/gui/MainWindow.h:                    #include <utility> for std::pair
src/geometry/cgal/cgalutils-applyops-minkowski.cc: #include <iterator> for std::next
src/core/ColorUtil.cc:                   #include <cctype> for (std::)?isxdigit
src/gui/EditorColorMap.h:                #include <functional> for std::less
src/io/import_3mf_v2.cc:                 #include <iomanip> for std::setw
src/gui/EditorColorMap.cc:               #include <exception> for std::exception
src/python/pymod.cc:                     #include <system_error> for std::error_code
src/gui/ColorLayout.cc:                  #include <utility> for std::as_const
```