### PR TITLE
Set the compiler definition to enable Manifold Minkowski

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1221,6 +1221,9 @@ if(ENABLE_MANIFOLD)
   if (USE_MANIFOLD_TRIANGULATOR)
     target_compile_definitions(OpenSCADLibInternal PUBLIC USE_MANIFOLD_TRIANGULATOR)
   endif()
+  if (USE_MANIFOLD_MINKOWSKI)
+    target_compile_definitions(OpenSCADLibInternal PUBLIC USE_MANIFOLD_MINKOWSKI)
+  endif()
 endif()
 
 #


### PR DESCRIPTION
Somehow I missed that you need to explicitly set the compiler definition based on the option, otherwise it doesn't do anything.