### PR TITLE
Change text popup arguments to match the order actually accepted.

### DIFF
--- a/src/core/TextNode.cc
+++ b/src/core/TextNode.cc
@@ -72,6 +72,6 @@ void register_builtin_text()
   Builtins::init(
     "text", new BuiltinModule(builtin_text),
     {
-      R"(text(text = "", size = 10, font = "", halign = "left", valign = "baseline", spacing = 1, direction = "ltr", language = "en", script = "latin"[, $fn]))",
+      R"(text(text = "", size = 10, font = "", direction = "ltr", language = "en", script = "latin", halign = "left", valign = "baseline", spacing = 1 [, $fn]))",
     });
 }


### PR DESCRIPTION
Like the title says.  The popup has never matched the actual implementation.  (Nor have the cheat sheet, nor the Wikibooks page.)