### PR TITLE
Notify parent when file reopened from disk

### DIFF
--- a/src/gui/TabManager.cc
+++ b/src/gui/TabManager.cc
@@ -564,6 +564,9 @@ bool TabManager::refreshDocument()
       file_opened = true;
     }
   }
+  if (file_opened) {
+    parent->fileChangedOnDisk();
+  }
   return file_opened;
 }
 


### PR DESCRIPTION
Call parent->fileChangedOnDisk() when refreshDocument successfully reopens a file. Previously refreshDocument set file_opened but did not notify the parent, which could leave the UI or parent state out of sync after an on-disk reload.