### PR TITLE
Add "em" parameter to text functions to set the size of an em-square.

### DIFF
--- a/src/core/Parameters.h
+++ b/src/core/Parameters.h
@@ -48,6 +48,7 @@ public:
   boost::optional<const Value&> lookup(const std::string& name) const;
 
   void set_caller(const std::string& caller);
+  const std::string& get_caller() const { return caller; }
   const Value& get(const std::string& name) const;
   const Value& get(const std::initializer_list<std::string> names) const;
   double get(const std::string& name, double default_value) const;

--- a/src/core/TextNode.cc
+++ b/src/core/TextNode.cc
@@ -44,7 +44,7 @@ static std::shared_ptr<AbstractNode> builtin_text(const ModuleInstantiation *ins
   auto *session = arguments.session();
   Parameters parameters =
     Parameters::parse(std::move(arguments), inst->location(), {"text", "size", "font"},
-                      {"direction", "language", "script", "halign", "valign", "spacing"});
+                      {"direction", "language", "script", "halign", "valign", "spacing", "em"});
   parameters.set_caller("text");
 
   auto p = FreetypeRenderer::Params(parameters);
@@ -72,6 +72,8 @@ void register_builtin_text()
   Builtins::init(
     "text", new BuiltinModule(builtin_text),
     {
-      R"(text(text = "", size = 10, font = "", direction = "ltr", language = "en", script = "latin", halign = "left", valign = "baseline", spacing = 1 [, $fn]))",
+      // Why em=13.9?  Because that's the em size that you get with size=10.
+      // See the commentary in FreetypeRenderer.cc.
+      R"(text(text = "", size = 10, font = "", direction = "ltr", language = "en", script = "latin", halign = "left", valign = "baseline", spacing = 1, em = 13.9 [, $fn]))",
     });
 }

--- a/src/core/builtin_functions.cc
+++ b/src/core/builtin_functions.cc
@@ -948,7 +948,7 @@ Value builtin_textmetrics(Arguments arguments, const Location& loc)
   auto *session = arguments.session();
   Parameters parameters =
     Parameters::parse(std::move(arguments), loc, {"text", "size", "font"},
-                      {"direction", "language", "script", "halign", "valign", "spacing"});
+                      {"direction", "language", "script", "halign", "valign", "spacing", "em"});
   parameters.set_caller("textmetrics");
 
   FreetypeRenderer::Params ftparams(parameters);
@@ -998,7 +998,7 @@ Value builtin_textmetrics(Arguments arguments, const Location& loc)
 Value builtin_fontmetrics(Arguments arguments, const Location& loc)
 {
   auto *session = arguments.session();
-  Parameters parameters = Parameters::parse(std::move(arguments), loc, {"size", "font"});
+  Parameters parameters = Parameters::parse(std::move(arguments), loc, {"size", "font", "em"});
   parameters.set_caller("fontmetrics");
 
   FreetypeRenderer::Params ftparams(parameters);
@@ -1228,16 +1228,17 @@ void register_builtin_functions()
                    "chr(range) -> string",
                  });
 
-  Builtins::init(
-    "textmetrics", new BuiltinFunction(&builtin_textmetrics, &Feature::ExperimentalTextMetricsFunctions),
-    {
-      "textmetrics(text, size, font, direction, language, script, halign, valign, spacing) -> object",
-    });
+  Builtins::init("textmetrics",
+                 new BuiltinFunction(&builtin_textmetrics, &Feature::ExperimentalTextMetricsFunctions),
+                 {
+                   "textmetrics(text, size, font, direction, language, script, halign, valign, spacing, "
+                   "em) -> object",
+                 });
 
   Builtins::init("fontmetrics",
                  new BuiltinFunction(&builtin_fontmetrics, &Feature::ExperimentalTextMetricsFunctions),
                  {
-                   "fontmetrics(size, font) -> object",
+                   "fontmetrics(size, font, em) -> object",
                  });
 
   Builtins::init("ord", new BuiltinFunction(&builtin_ord),


### PR DESCRIPTION
Fixes #4304.

This PR takes a simpler approach than #4306 did.  #4306 would record how the size was specified, and would conditionally fix or not-fix the scaling error at the lower level.  Here we accept the same `em` parameter, but simply use it to set the `size` parameter, scaling it to compensate for the error at the lower level... and leaving lots of comments explaining the oddity.

This does not include the "underline" metric discussed in #4306; this topic is already complex enough without adding unrelated changes.  The "underline" metric can be covered in a separate PR.