### PR TITLE
Add underline position and thickness as font metrics.

### DIFF
--- a/src/core/FreetypeRenderer.cc
+++ b/src/core/FreetypeRenderer.cc
@@ -513,6 +513,19 @@ FreetypeRenderer::FontMetrics::FontMetrics(const FreetypeRenderer::Params& param
   family_name = face->face_->family_name;
   style_name = face->face_->style_name;
 
+  underline_thickness =
+    FT_MulFix(face->face_->underline_thickness, size_metrics->y_scale) / scale * params.size;
+  // FreeType defines underline position as the vertical center of the underline.
+  // That's inconvenient for our user, who probably wants to call square()
+  // to generate the underline and would need to translate it down to
+  // center it.  Rather than making our user do that, *we* define the
+  // underline position as being the position of the bottom of the underline,
+  // so that translate([0,position,0]) square(length, thickness) will do
+  // the right thing.
+  underline_position =
+    FT_MulFix(face->face_->underline_position, size_metrics->y_scale) / scale * params.size -
+    underline_thickness / 2;
+
   ok = true;
 }
 

--- a/src/core/FreetypeRenderer.h
+++ b/src/core/FreetypeRenderer.h
@@ -132,6 +132,8 @@ public:
     double max_ascent;
     double max_descent;
     double interline;
+    double underline_position;
+    double underline_thickness;
     std::string family_name;
     std::string style_name;
     FontMetrics(const FreetypeRenderer::Params& params);

--- a/src/core/builtin_functions.cc
+++ b/src/core/builtin_functions.cc
@@ -1019,20 +1019,20 @@ Value builtin_fontmetrics(Arguments arguments, const Location& loc)
   max.set("ascent", metrics.max_ascent);
   max.set("descent", metrics.max_descent);
 
-  ObjectType font(session);
-  font.set("family", metrics.family_name);
-  font.set("style", metrics.style_name);
-
   ObjectType underline(arguments.session());
   underline.set("position", metrics.underline_position);
   underline.set("thickness", metrics.underline_thickness);
+
+  ObjectType font(session);
+  font.set("family", metrics.family_name);
+  font.set("style", metrics.style_name);
 
   ObjectType font_metrics(session);
   font_metrics.set("nominal", nominal);
   font_metrics.set("max", max);
   font_metrics.set("interline", metrics.interline);
-  font_metrics.set("font", font);
   font_metrics.set("underline", underline);
+  font_metrics.set("font", font);
 
   return std::move(font_metrics);
 }

--- a/src/core/builtin_functions.cc
+++ b/src/core/builtin_functions.cc
@@ -1023,11 +1023,16 @@ Value builtin_fontmetrics(Arguments arguments, const Location& loc)
   font.set("family", metrics.family_name);
   font.set("style", metrics.style_name);
 
+  ObjectType underline(arguments.session());
+  underline.set("position", metrics.underline_position);
+  underline.set("thickness", metrics.underline_thickness);
+
   ObjectType font_metrics(session);
   font_metrics.set("nominal", nominal);
   font_metrics.set("max", max);
   font_metrics.set("interline", metrics.interline);
   font_metrics.set("font", font);
+  font_metrics.set("underline", underline);
 
   return std::move(font_metrics);
 }

--- a/tests/regression/echo/text-metrics-test-expected.echo
+++ b/tests/regression/echo/text-metrics-test-expected.echo
@@ -1,8 +1,8 @@
 ECHO: "Normal..."
 ECHO: { position = [0.96, -0.1408]; size = [27.8024, 10.208]; ascent = 10.0672; descent = -0.1408; offset = [0, 0]; advance = [29.3443, 0]; }
 ECHO: { position = [-116.212, -10.208]; size = [98.96, 20.416]; ascent = 20.1344; descent = -0.2816; offset = [-117.377, -9.9264]; advance = [117.377, 0]; }
-ECHO: { nominal = { ascent = 12.5733; descent = -2.9433; }; max = { ascent = 13.6109; descent = -4.2114; }; interline = 15.9709; font = { family = "Liberation Sans"; style = "Regular"; }; }
-ECHO: { nominal = { ascent = 25.1466; descent = -5.8866; }; max = { ascent = 27.2218; descent = -8.4228; }; interline = 31.9418; font = { family = "Liberation Sans"; style = "Regular"; }; }
+ECHO: { nominal = { ascent = 12.5733; descent = -2.9433; }; max = { ascent = 13.6109; descent = -4.2114; }; interline = 15.9709; font = { family = "Liberation Sans"; style = "Regular"; }; underline = { position = -2.48895; thickness = 1.0173; }; }
+ECHO: { nominal = { ascent = 25.1466; descent = -5.8866; }; max = { ascent = 27.2218; descent = -8.4228; }; interline = 31.9418; font = { family = "Liberation Sans"; style = "Regular"; }; underline = { position = -4.9779; thickness = 2.0346; }; }
 ECHO: "Errors..."
 WARNING: textmetrics(..., size=[]) Invalid type: expected number, found vector in file text-metrics-test.scad, line 20
 WARNING: textmetrics(..., text=123) Invalid type: expected string, found number in file text-metrics-test.scad, line 20
@@ -17,4 +17,4 @@ ECHO: { position = [0, 0]; size = [0, 0]; ascent = 0; descent = 0; offset = [0, 
 WARNING: variable "text" not specified as parameter in file text-metrics-test.scad, line 25
 WARNING: fontmetrics(..., size=true) Invalid type: expected number, found bool in file text-metrics-test.scad, line 25
 WARNING: fontmetrics(..., font=0) Invalid type: expected string, found number in file text-metrics-test.scad, line 25
-ECHO: { nominal = { ascent = 12.5733; descent = -2.9433; }; max = { ascent = 13.6109; descent = -4.2114; }; interline = 15.9709; font = { family = "Liberation Sans"; style = "Regular"; }; }
+ECHO: { nominal = { ascent = 12.5733; descent = -2.9433; }; max = { ascent = 13.6109; descent = -4.2114; }; interline = 15.9709; font = { family = "Liberation Sans"; style = "Regular"; }; underline = { position = -2.48895; thickness = 1.0173; }; }

--- a/tests/regression/echo/text-metrics-test-expected.echo
+++ b/tests/regression/echo/text-metrics-test-expected.echo
@@ -1,8 +1,8 @@
 ECHO: "Normal..."
 ECHO: { position = [0.96, -0.1408]; size = [27.8024, 10.208]; ascent = 10.0672; descent = -0.1408; offset = [0, 0]; advance = [29.3443, 0]; }
 ECHO: { position = [-116.212, -10.208]; size = [98.96, 20.416]; ascent = 20.1344; descent = -0.2816; offset = [-117.377, -9.9264]; advance = [117.377, 0]; }
-ECHO: { nominal = { ascent = 12.5733; descent = -2.9433; }; max = { ascent = 13.6109; descent = -4.2114; }; interline = 15.9709; font = { family = "Liberation Sans"; style = "Regular"; }; underline = { position = -2.48895; thickness = 1.0173; }; }
-ECHO: { nominal = { ascent = 25.1466; descent = -5.8866; }; max = { ascent = 27.2218; descent = -8.4228; }; interline = 31.9418; font = { family = "Liberation Sans"; style = "Regular"; }; underline = { position = -4.9779; thickness = 2.0346; }; }
+ECHO: { nominal = { ascent = 12.5733; descent = -2.9433; }; max = { ascent = 13.6109; descent = -4.2114; }; interline = 15.9709; underline = { position = -2.48895; thickness = 1.0173; }; font = { family = "Liberation Sans"; style = "Regular"; }; }
+ECHO: { nominal = { ascent = 25.1466; descent = -5.8866; }; max = { ascent = 27.2218; descent = -8.4228; }; interline = 31.9418; underline = { position = -4.9779; thickness = 2.0346; }; font = { family = "Liberation Sans"; style = "Regular"; }; }
 ECHO: "Errors..."
 WARNING: textmetrics(..., size=[]) Invalid type: expected number, found vector in file text-metrics-test.scad, line 20
 WARNING: textmetrics(..., text=123) Invalid type: expected string, found number in file text-metrics-test.scad, line 20
@@ -17,4 +17,4 @@ ECHO: { position = [0, 0]; size = [0, 0]; ascent = 0; descent = 0; offset = [0, 
 WARNING: variable "text" not specified as parameter in file text-metrics-test.scad, line 25
 WARNING: fontmetrics(..., size=true) Invalid type: expected number, found bool in file text-metrics-test.scad, line 25
 WARNING: fontmetrics(..., font=0) Invalid type: expected string, found number in file text-metrics-test.scad, line 25
-ECHO: { nominal = { ascent = 12.5733; descent = -2.9433; }; max = { ascent = 13.6109; descent = -4.2114; }; interline = 15.9709; font = { family = "Liberation Sans"; style = "Regular"; }; underline = { position = -2.48895; thickness = 1.0173; }; }
+ECHO: { nominal = { ascent = 12.5733; descent = -2.9433; }; max = { ascent = 13.6109; descent = -4.2114; }; interline = 15.9709; underline = { position = -2.48895; thickness = 1.0173; }; font = { family = "Liberation Sans"; style = "Regular"; }; }


### PR DESCRIPTION
Adds an underline object with position and thickness to the return from fontmetrics(), e.g.:

```
echo(fontmetrics());
```
```
ECHO: {
    ...
    underline = { position = -2.48895; thickness = 1.0173; };
}
```

Sample use case:
```
size = 10;
text="Hello";
tm = textmetrics(text, size=size);
fm = fontmetrics(size=size);

text(text, size=size);
translate([tm.position.x, fm.underline.position])
    square([tm.size.x, fm.underline.thickness]);
```

<img width="332" height="154" alt="image" src="https://github.com/user-attachments/assets/6e37fdd4-deee-41e5-8300-1ffe8f0d0988" />

Note that the new metric controls only the vertical position and thickness of the underline; the X position and width is derived from the metrics of the text to be underlined.

Application note:  if you want spacing around descenders, offset the text a little and subtract it from the underline.