### PR TITLE
chore: clickable link in local test results

### DIFF
--- a/tests/test_pretty_print.py
+++ b/tests/test_pretty_print.py
@@ -459,7 +459,15 @@ def main():
     html_filename = os.path.join(builddir, 'Testing', 'Temporary', html_basename)
     debug('saving ' + html_filename + ' ' + str(len(html)) + ' bytes')
     trysave(html_filename, html)
-    print("report saved:\n", html_filename.replace(os.getcwd()+os.path.sep,''))
+    if os.environ.get("CI"):
+        # relative path because this ultimately this file will end up inside a zip archive
+        report_path = html_filename.replace(os.getcwd() + os.path.sep, "")
+        print("report saved:\n", report_path)
+    else:
+        report_path = os.path.abspath(html_filename)
+        report_uri = pathlib.Path(report_path).as_uri()
+        report_link = f"\033]8;;{report_uri}\033\\{report_path}\033]8;;\033\\"
+        print("report saved:\n", report_link)
 
     debug('test_pretty_print complete')
 


### PR DESCRIPTION
When running, for example, `ctest -V -R '^render-manifold_surface_image$'`, the path printed would be a relative path. It takes a small amount of effort to look up the PWD and concatenate the strings in the browser.

With this change, there are two options when running this locally:

- select and copy-paste the absolute path into the browser to access results
- click the URL in compatible terminals

Incompatible terminals will just show the text by itself: https://gist.github.com/egmontkob/eb114294efbcd5adb1944c9f3cb5feda#backward-compatibility

<img width="1414" height="227" alt="image" src="https://github.com/user-attachments/assets/766bdee8-7fca-4c12-963f-0e64a2bd825d" />
