### PR TITLE
Rollback header file sorting for spnav driver.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 .cache/
 .vs/
 .vscode/
+*.code-workspace
 .idea/
 .clangd/
 /*.scad

--- a/src/gui/input/SpaceNavInputDriver.cc
+++ b/src/gui/input/SpaceNavInputDriver.cc
@@ -30,16 +30,14 @@
  */
 
 #include "gui/input/SpaceNavInputDriver.h"
-
-#include <spnav.h>
-#include <unistd.h>
-
-#include <QThread>
-#include <string>
-
 #include "gui/input/InputDriverEvent.h"
 #include "gui/input/InputDriverManager.h"
 #include "utils/printutils.h"
+
+#include <QThread>
+#include <spnav.h>
+#include <unistd.h>
+#include <string>
 
 void SpaceNavInputDriver::run()
 {


### PR DESCRIPTION
Temporary revert as spnav.h brings in X11 headers that pollutes the global namespace by #defining Status causing build failure with spnav enabled.