### PR TITLE
Adds a font.version string to fontmetrics().  Fixes #6668.

### DIFF
--- a/src/core/FreetypeRenderer.cc
+++ b/src/core/FreetypeRenderer.cc
@@ -47,6 +47,9 @@
 #include "utils/printutils.h"
 
 #include FT_OUTLINE_H
+#include FT_TRUETYPE_IDS_H
+#include FT_SFNT_NAMES_H
+
 // NOLINTNEXTLINE(bugprone-macro-parentheses)
 #define SCRIPT_UNTAG(tag) \
   ((uint8_t)((tag) >> 24)) % ((uint8_t)((tag) >> 16)) % ((uint8_t)((tag) >> 8)) % ((uint8_t)(tag))
@@ -545,8 +548,90 @@ FreetypeRenderer::FontMetrics::FontMetrics(const FreetypeRenderer::Params& param
   interline = FT_MulFix(face->face_->height, size_metrics->y_scale) / scale * params.size;
   family_name = face->face_->family_name;
   style_name = face->face_->style_name;
+  version = getFontVersion(face->face_);
 
   ok = true;
+}
+
+// Freetype docs are not crystal clear about the encoding used for SFNT names.  The following version
+// support is based on observed behavior, for the platform and encoding values observed.  It is
+// conservative: it accepts only ASCII characters, and if the string appears to contain any non-ASCII
+// characters then it is rejected.
+std::string FreetypeRenderer::FontMetrics::getASCII(FT_Byte *string, int len)
+{
+  for (int j = 0; j < len; j += 2) {
+    // Accept only ASCII.
+    if (!isascii(string[j]) || !isprint(string[j])) {
+      return "";
+    }
+  }
+  return std::string((char *)string, len);
+}
+
+std::string FreetypeRenderer::FontMetrics::getUTF16BE(FT_Byte *string, int len)
+{
+  if (len % 2 != 0) {
+    return "";
+  }
+
+  std::string s = "";
+
+  for (int j = 0; j < len; j += 2) {
+    // Accept only ASCII.
+    if (string[j] != 0) {
+      return "";
+    }
+    char c = string[j + 1];
+    if (!isascii(c) || !isprint(c)) {
+      return "";
+    }
+    s += c;
+  }
+  return s;
+}
+
+// Returns a version string for the specified face, or "".
+std::string FreetypeRenderer::FontMetrics::getFontVersion(FT_Face face_)
+{
+  unsigned int n = FT_Get_Sfnt_Name_Count(face_);
+  // Note that error yields n==0, which falls through the loop to the "not found" handling.
+  for (unsigned int i = 0; i < n; i++) {
+    FT_SfntName sfnt;
+    auto error = FT_Get_Sfnt_Name(face_, i, &sfnt);
+    if (error != 0) {
+      // Maybe we should report this.
+      continue;
+    }
+    if (sfnt.name_id != TT_NAME_ID_VERSION_STRING) {
+      continue;
+    }
+    auto pid = sfnt.platform_id;
+    auto eid = sfnt.encoding_id;
+    std::string s = "";
+    // You really want to switch on the combination, so that you can have multiple combinations get
+    // the same handling.  One way to do that would be to arithmetically combine the platform and
+    // encoding IDs, and switch on the result.
+    if ((pid == TT_PLATFORM_APPLE_UNICODE && eid == TT_APPLE_ID_UNICODE_2_0) ||
+        (pid == TT_PLATFORM_MICROSOFT && eid == TT_MS_ID_UNICODE_CS)) {
+      // UCS-2 / UTF-16?
+      s = getUTF16BE(sfnt.string, sfnt.string_len);
+    } else if (pid == TT_PLATFORM_MACINTOSH && eid == TT_MAC_ID_ROMAN) {
+      // ASCII / UTF-8?
+      s = getASCII(sfnt.string, sfnt.string_len);
+    }
+    if (s != "") {
+      return s;
+    }
+    // Dump anything we didn't like to stdout.
+    printf("Unknown version string encoding:\n");
+    printf("platform %u encoding %u\n", sfnt.platform_id, sfnt.encoding_id);
+    for (int j = 0; j < sfnt.string_len; j++) {
+      printf(" %2.2x", (unsigned char)sfnt.string[j]);
+    }
+    printf("\n");
+    fflush(stdout);
+  }
+  return "";
 }
 
 FreetypeRenderer::TextMetrics::TextMetrics(const FreetypeRenderer::Params& params)

--- a/src/core/FreetypeRenderer.h
+++ b/src/core/FreetypeRenderer.h
@@ -134,7 +134,13 @@ public:
     double interline;
     std::string family_name;
     std::string style_name;
+    std::string version;
     FontMetrics(const FreetypeRenderer::Params& params);
+
+  private:
+    static std::string getFontVersion(FT_Face face_);
+    static std::string getUTF16BE(uint8_t *string, int len);
+    static std::string getASCII(uint8_t *string, int len);
   };
   FreetypeRenderer();
   virtual ~FreetypeRenderer() = default;

--- a/src/core/builtin_functions.cc
+++ b/src/core/builtin_functions.cc
@@ -1022,6 +1022,7 @@ Value builtin_fontmetrics(Arguments arguments, const Location& loc)
   ObjectType font(session);
   font.set("family", metrics.family_name);
   font.set("style", metrics.style_name);
+  font.set("version", metrics.version);
 
   ObjectType font_metrics(session);
   font_metrics.set("nominal", nominal);

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1238,6 +1238,7 @@ add_cmdline_test(echo           EXPERIMENTAL OPENSCAD SUFFIX echo FILES ${EXPERI
 
 #
 # --enable=textmetrics tests
+# (Also enables object-function; see #6774.)
 #
 list(APPEND EXPERIMENTAL_TEXTMETRICS_ECHO_FILES
   ${TEST_SCAD_DIR}/misc/isobject-test.scad
@@ -1246,14 +1247,14 @@ list(APPEND EXPERIMENTAL_TEXTMETRICS_ECHO_FILES
 list(APPEND EXPERIMENTAL_TEXTMETRICS_FILES
   ${TEST_SCAD_DIR}/2D/features/text-metrics.scad
 )
-add_cmdline_test(echo           EXPERIMENTAL OPENSCAD SUFFIX echo FILES ${EXPERIMENTAL_TEXTMETRICS_ECHO_FILES} ARGS --enable=textmetrics)
-add_cmdline_test(dump           EXPERIMENTAL OPENSCAD SUFFIX csg  FILES ${EXPERIMENTAL_TEXTMETRICS_FILES} ARGS --enable=textmetrics)
-add_cmdline_test(preview-cgal   EXPERIMENTAL OPENSCAD SUFFIX png  FILES ${EXPERIMENTAL_TEXTMETRICS_FILES} EXPECTEDDIR preview ARGS --enable=textmetrics --backend=cgal)
-add_cmdline_test(throwntogether EXPERIMENTAL OPENSCAD SUFFIX png  FILES ${EXPERIMENTAL_TEXTMETRICS_FILES} ARGS --preview=throwntogether --enable=textmetrics)
-add_cmdline_test(render-csg-cgal      EXPERIMENTAL SCRIPT ${EXPORT_IMPORT_PNGTEST_PY} SUFFIX png FILES ${EXPERIMENTAL_TEXTMETRICS_FILES} EXPECTEDDIR render ARGS ${OPENSCAD_EXE_ARG} --format=csg --render --enable=textmetrics)
-add_cmdline_test(render-cgal    EXPERIMENTAL OPENSCAD SUFFIX png FILES ${EXPERIMENTAL_TEXTMETRICS_FILES} EXPECTEDDIR render ARGS --render --enable=textmetrics --backend=cgal)
-add_cmdline_test(render-dxf      EXPERIMENTAL SCRIPT ${EXPORT_IMPORT_PNGTEST_PY} SUFFIX png ARGS ${OPENSCAD_EXE_ARG} --format=DXF --render=force --enable=textmetrics EXPECTEDDIR render FILES ${EXPERIMENTAL_TEXTMETRICS_FILES})
-add_cmdline_test(render-svg      EXPERIMENTAL SCRIPT ${EXPORT_IMPORT_PNGTEST_PY} SUFFIX png ARGS ${OPENSCAD_EXE_ARG} --format=SVG --render=force --enable=textmetrics EXPECTEDDIR render FILES ${EXPERIMENTAL_TEXTMETRICS_FILES})
+add_cmdline_test(echo           EXPERIMENTAL OPENSCAD SUFFIX echo FILES ${EXPERIMENTAL_TEXTMETRICS_ECHO_FILES} ARGS --enable=textmetrics --enable=object-function)
+add_cmdline_test(dump           EXPERIMENTAL OPENSCAD SUFFIX csg  FILES ${EXPERIMENTAL_TEXTMETRICS_FILES} ARGS --enable=textmetrics --enable=object-function)
+add_cmdline_test(preview-cgal   EXPERIMENTAL OPENSCAD SUFFIX png  FILES ${EXPERIMENTAL_TEXTMETRICS_FILES} EXPECTEDDIR preview ARGS --enable=textmetrics --enable=object-function --backend=cgal)
+add_cmdline_test(throwntogether EXPERIMENTAL OPENSCAD SUFFIX png  FILES ${EXPERIMENTAL_TEXTMETRICS_FILES} ARGS --preview=throwntogether --enable=textmetrics --enable=object-function)
+add_cmdline_test(render-csg-cgal      EXPERIMENTAL SCRIPT ${EXPORT_IMPORT_PNGTEST_PY} SUFFIX png FILES ${EXPERIMENTAL_TEXTMETRICS_FILES} EXPECTEDDIR render ARGS ${OPENSCAD_EXE_ARG} --format=csg --render --enable=textmetrics --enable=object-function)
+add_cmdline_test(render-cgal    EXPERIMENTAL OPENSCAD SUFFIX png FILES ${EXPERIMENTAL_TEXTMETRICS_FILES} EXPECTEDDIR render ARGS --render --enable=textmetrics --enable=object-function --backend=cgal)
+add_cmdline_test(render-dxf      EXPERIMENTAL SCRIPT ${EXPORT_IMPORT_PNGTEST_PY} SUFFIX png ARGS ${OPENSCAD_EXE_ARG} --format=DXF --render=force --enable=textmetrics --enable=object-function EXPECTEDDIR render FILES ${EXPERIMENTAL_TEXTMETRICS_FILES})
+add_cmdline_test(render-svg      EXPERIMENTAL SCRIPT ${EXPORT_IMPORT_PNGTEST_PY} SUFFIX png ARGS ${OPENSCAD_EXE_ARG} --format=SVG --render=force --enable=textmetrics --enable=object-function EXPECTEDDIR render FILES ${EXPERIMENTAL_TEXTMETRICS_FILES})
 
 #
 # --enable=vector-swizzle tests

--- a/tests/data/scad/misc/text-metrics-test.scad
+++ b/tests/data/scad/misc/text-metrics-test.scad
@@ -1,5 +1,8 @@
 use <../../ttf/liberation-2.00.1/LiberationSans-Regular.ttf>
 
+// Redact the font version information, ref #6774.
+function fontmetrics_redact(fm) = object(fm, font=object(fm.font, version="<redacted>"));
+
 echo("Normal...");
 
 // Force Liberation Sans since it's present on all platforms.
@@ -11,8 +14,10 @@ echo(textmetrics("hello", font="Liberation Sans", size=20, direction="rtl",
     language="en", script="latin", halign="right", valign="center", spacing=2));
 
 // fontmetrics()
-echo(fontmetrics(font="Liberation Sans"));
-echo(fontmetrics(font="Liberation Sans", size=20));
+fm1 = fontmetrics(font="Liberation Sans");
+assert(fm1.font.version);   // Assert that we do get a version, though we're going to redact it.
+echo(fontmetrics_redact(fm1));
+echo(fontmetrics_redact(fontmetrics(font="Liberation Sans", size=20)));
 
 echo("Errors...");
 
@@ -22,4 +27,4 @@ echo(textmetrics(text=123, font=true, size=[], direction=0, language=[0:10],
 
 // Exercise type checks on all arguments, and that "text" isn't allowed as
 // an argument even though it's in the common argument processing.
-echo(fontmetrics(text="bad", size=true, font=0));
+echo(fontmetrics_redact(fontmetrics(text="bad", size=true, font=0)));

--- a/tests/regression/echo/text-metrics-test-expected.echo
+++ b/tests/regression/echo/text-metrics-test-expected.echo
@@ -1,20 +1,20 @@
 ECHO: "Normal..."
 ECHO: { position = [0.96, -0.1408]; size = [27.8024, 10.208]; ascent = 10.0672; descent = -0.1408; offset = [0, 0]; advance = [29.3443, 0]; }
 ECHO: { position = [-116.212, -10.208]; size = [98.96, 20.416]; ascent = 20.1344; descent = -0.2816; offset = [-117.377, -9.9264]; advance = [117.377, 0]; }
-ECHO: { nominal = { ascent = 12.5733; descent = -2.9433; }; max = { ascent = 13.6109; descent = -4.2114; }; interline = 15.9709; font = { family = "Liberation Sans"; style = "Regular"; }; }
-ECHO: { nominal = { ascent = 25.1466; descent = -5.8866; }; max = { ascent = 27.2218; descent = -8.4228; }; interline = 31.9418; font = { family = "Liberation Sans"; style = "Regular"; }; }
+ECHO: { nominal = { ascent = 12.5733; descent = -2.9433; }; max = { ascent = 13.6109; descent = -4.2114; }; interline = 15.9709; font = { family = "Liberation Sans"; style = "Regular"; version = "<redacted>"; }; }
+ECHO: { nominal = { ascent = 25.1466; descent = -5.8866; }; max = { ascent = 27.2218; descent = -8.4228; }; interline = 31.9418; font = { family = "Liberation Sans"; style = "Regular"; version = "<redacted>"; }; }
 ECHO: "Errors..."
-WARNING: textmetrics(..., size=[]) Invalid type: expected number, found vector in file text-metrics-test.scad, line 20
-WARNING: textmetrics(..., text=123) Invalid type: expected string, found number in file text-metrics-test.scad, line 20
-WARNING: textmetrics(..., spacing="") Invalid type: expected number, found string in file text-metrics-test.scad, line 20
-WARNING: textmetrics(..., font=true) Invalid type: expected string, found bool in file text-metrics-test.scad, line 20
-WARNING: textmetrics(..., direction=0) Invalid type: expected string, found number in file text-metrics-test.scad, line 20
-WARNING: textmetrics(..., language=[0 : 1 : 10]) Invalid type: expected string, found range in file text-metrics-test.scad, line 20
-WARNING: textmetrics(..., script=0) Invalid type: expected string, found number in file text-metrics-test.scad, line 20
-WARNING: textmetrics(..., halign=0) Invalid type: expected string, found number in file text-metrics-test.scad, line 20
-WARNING: textmetrics(..., valign=0) Invalid type: expected string, found number in file text-metrics-test.scad, line 20
+WARNING: textmetrics(..., size=[]) Invalid type: expected number, found vector in file text-metrics-test.scad, line 25
+WARNING: textmetrics(..., text=123) Invalid type: expected string, found number in file text-metrics-test.scad, line 25
+WARNING: textmetrics(..., spacing="") Invalid type: expected number, found string in file text-metrics-test.scad, line 25
+WARNING: textmetrics(..., font=true) Invalid type: expected string, found bool in file text-metrics-test.scad, line 25
+WARNING: textmetrics(..., direction=0) Invalid type: expected string, found number in file text-metrics-test.scad, line 25
+WARNING: textmetrics(..., language=[0 : 1 : 10]) Invalid type: expected string, found range in file text-metrics-test.scad, line 25
+WARNING: textmetrics(..., script=0) Invalid type: expected string, found number in file text-metrics-test.scad, line 25
+WARNING: textmetrics(..., halign=0) Invalid type: expected string, found number in file text-metrics-test.scad, line 25
+WARNING: textmetrics(..., valign=0) Invalid type: expected string, found number in file text-metrics-test.scad, line 25
 ECHO: { position = [0, 0]; size = [0, 0]; ascent = 0; descent = 0; offset = [0, 0]; advance = [0, 0]; }
-WARNING: variable "text" not specified as parameter in file text-metrics-test.scad, line 25
-WARNING: fontmetrics(..., size=true) Invalid type: expected number, found bool in file text-metrics-test.scad, line 25
-WARNING: fontmetrics(..., font=0) Invalid type: expected string, found number in file text-metrics-test.scad, line 25
-ECHO: { nominal = { ascent = 12.5733; descent = -2.9433; }; max = { ascent = 13.6109; descent = -4.2114; }; interline = 15.9709; font = { family = "Liberation Sans"; style = "Regular"; }; }
+WARNING: variable "text" not specified as parameter in file text-metrics-test.scad, line 30
+WARNING: fontmetrics(..., size=true) Invalid type: expected number, found bool in file text-metrics-test.scad, line 30
+WARNING: fontmetrics(..., font=0) Invalid type: expected string, found number in file text-metrics-test.scad, line 30
+ECHO: { nominal = { ascent = 12.5733; descent = -2.9433; }; max = { ascent = 13.6109; descent = -4.2114; }; interline = 15.9709; font = { family = "Liberation Sans"; style = "Regular"; version = "<redacted>"; }; }


### PR DESCRIPTION
Well, sort of.  The FreeType documentation is somewhat opaque on encoding of these strings, so the interpretation here is very limited and conservative.

A quick look at Font List suggests that it gets its information from Fontconfig.  Fontconfig does have a "version" attribute, but (a) it's an integer, not a string, and (b) it's not present on any font on my Windows 11 system.