### PR TITLE
Restore window state after show()

### DIFF
--- a/src/gui/MainWindow.cc
+++ b/src/gui/MainWindow.cc
@@ -294,10 +294,9 @@ MainWindow::MainWindow(const QStringList& filenames) : rubberBandManager(this)
 
   setupInput();
 
-  restoreWindowState();
-
   this->hideFind();
   show();
+  restoreWindowState();  // Restore needs to happen after show()
   openRemainingFiles(filenames);
 }
 


### PR DESCRIPTION
Fixes an issue where restoring Window state was sometimes not working correctly on macOS