### PR TITLE
docs(README): add syntax highlighting to in-line SCAD

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,25 +55,31 @@ frame is where you'll see the 3D rendering of your model.
 
 Let's make a tree! Type the following code into the left frame:
 
-    cylinder(h = 30, r = 8);
+```scad
+cylinder(h = 30, r = 8);
+```
 
 Then render the 3D model by hitting F5. Now you can see a cylinder for
 the trunk in our tree. Now let's add the bushy/leafy part of the tree
 represented by a sphere. To do so, we will union a cylinder and a
 sphere.
 
-    union() {
-      cylinder(h = 30, r = 8);
-      sphere(20);
-    }
+```scad
+union() {
+    cylinder(h = 30, r = 8);
+    sphere(20);
+}
+```
 
 But, it's not quite right! The bushy/leafy are around the base of the
 tree. We need to move the sphere up the z-axis.
 
-    union() {
-      cylinder(h = 30, r = 8);
-      translate([0, 0, 40]) sphere(20);
-    }
+```scad
+union() {
+    cylinder(h = 30, r = 8);
+    translate([0, 0, 40]) sphere(20);
+}
+```
 
 And that's it! You made your first 3D model! There are other primitive
 shapes that you can combine with other set operations (union,


### PR DESCRIPTION
## Summary

Add SCAD syntax highlighting to in-line README examples

## Details

- GitHub [can syntax highlight OpenSCAD code](https://github.com/github-linguist/linguist/blob/738a27e1e2f26f061a24e94f85cd37ae9be71105/lib/linguist/languages.yml#L5436) (also visible if you look at the [examples on GitHub](https://github.com/openscad/openscad/blob/10cc3aa86098068f663e496ebf9742e670f5bab6/examples/Basics/CSG.scad#))
  - so use that for the in-line README examples too for nicer readability
  
## Validation

- Tested the rendered markdown in the [PR commit](https://github.com/agilgur5/openscad/blob/849393159ab5e2a121aa3720c44d325ff93ebd4f/README.md#getting-started)