### PR TITLE
fix: prevent font family prefix-matching bug in QFontComboBox

### DIFF
--- a/src/gui/Preferences.cc
+++ b/src/gui/Preferences.cc
@@ -763,9 +763,17 @@ void Preferences::fireApplicationFontChanged() const
 
 void Preferences::on_fontComboBoxApplicationFontFamily_currentFontChanged(const QFont& font)
 {
+  // The global * stylesheet in setApplicationFont() applies font-family to
+  // all widgets including this QFontComboBox.  That can re-trigger this slot
+  // with a wrong match (e.g. "Ubuntu" prefix-matched back to "Ubuntu Mono").
+  // Block signals during the update to prevent the re-entrant cascade, then
+  // restore the correct selection afterwards.
   QSettingsCached settings;
   settings.setValue("advanced/applicationFontFamily", font.family());
+  fontComboBoxApplicationFontFamily->blockSignals(true);
   fireApplicationFontChanged();
+  fontComboBoxApplicationFontFamily->setCurrentFont(font);
+  fontComboBoxApplicationFontFamily->blockSignals(false);
 }
 
 void Preferences::on_comboBoxApplicationFontSize_currentIndexChanged(int index)
@@ -1498,10 +1506,7 @@ void Preferences::createFontSizeMenu(QComboBox *boxarg, const QString& setting)
 void Preferences::updateGUIFontFamily(QFontComboBox *ffSelector, const QString& setting)
 {
   const auto fontfamily = getValue(setting).toString();
-  const auto fidx = ffSelector->findText(fontfamily, Qt::MatchContains);
-  if (fidx >= 0) {
-    BlockSignals<QFontComboBox *>(ffSelector)->setCurrentIndex(fidx);
-  }
+  BlockSignals<QFontComboBox *>(ffSelector)->setCurrentFont(QFont(fontfamily));
 }
 
 void Preferences::updateGUIFontSize(QComboBox *fsSelector, const QString& setting)


### PR DESCRIPTION
## Summary

Fixes #6707

- Block signals on the `QFontComboBox` during `setApplicationFont()` to prevent the global `*` stylesheet from re-triggering `currentFontChanged` with a prefix-matched wrong result (e.g. selecting "Ubuntu" gets reverted back to "Ubuntu Mono")
- Replace `findText(fontfamily, Qt::MatchContains)` with `QFontComboBox::setCurrentFont(QFont(fontfamily))` in `updateGUIFontFamily()` for exact font family matching

## Test plan

1. Set application font to "Ubuntu Mono" in Preferences, close and restart
2. Open Preferences and change font to "Ubuntu" — verify it changes immediately
3. Change font to "Tuffy" — verify it changes
4. Change font to "Ubuntu" — verify it changes
5. Test with other font pairs where one name is a prefix of the other (e.g. "Noto Sans" / "Noto Sans Mono")

Made with [Cursor](https://cursor.com)