### PR TITLE
Linux uni dependency installer script improvements

### DIFF
--- a/scripts/uni-get-dependencies.sh
+++ b/scripts/uni-get-dependencies.sh
@@ -55,7 +55,7 @@ get_netbsd_deps()
 get_opensuse_deps()
 {
  zypper install mpfr-devel gmp-devel boost-devel \
-  glew-devel cmake git bison flex catch2-devel cgal-devel curl \
+  glew-devel cmake git bison flex cgal-devel curl \
   glib2-devel gettext freetype-devel harfbuzz-devel  \
   qscintilla-qt5-devel libqt5-qtbase-devel libQt5OpenGL-devel \
   xvfb-run libzip-devel libqt5-qtmultimedia-devel libqt5-qtsvg-devel \
@@ -63,24 +63,20 @@ get_opensuse_deps()
   libboost_program_options-devel tbb-devel
  # qscintilla-qt5-devel replaces libqscintilla_qt5-devel
  # but openscad compiles with both
- zypper install libeigen3-devel
- if [ $? -ne 0 ]; then
-  zypper install libeigen3
- fi
- zypper install ImageMagick
- if [ $? -ne 0 ]; then
-  zypper install imagemagick
- fi
- zypper install opencsg-devel
- if [ $? -ne 0 ]; then
-  pver=`cat /etc/os-release | grep -i pretty_name | sed s/PRETTY_NAME=//g`
-  pver=`echo $pver | sed s/\"//g | sed s/\ /_/g `
-  echo attempting to add graphics repository for opencsg...
-  set +x
-  zypper ar -f http://download.opensuse.org/repositories/graphics/$pver graphics
+ zypper install libeigen3-devel || zypper install libeigen3
+
+ zypper install ImageMagick || zypper install imagemagick
+
+ zypper install catch2-devel || zypper install Catch2-devel
+
+ install_opencsg_and_repo() {
+  pver=$(grep -i pretty_name /etc/os-release | sed 's/PRETTY_NAME=//g; s/"//g; s/ /_/g')
+  echo "attempting to add graphics repository for opencsg..."
+  zypper ar -f "http://download.opensuse.org/repositories/graphics/${pver}" graphics
   zypper install opencsg-devel
-  set -x
- fi
+ }
+
+ zypper install opencsg-devel || install_opencsg_and_repo
 }
 
 get_mageia_deps()


### PR DESCRIPTION
This PR adds a step to check `/etc/os-release` for distro information, which is the modern system most distros are using now. 

Some distros with os-release have removed /etc/issue (fedora and opensuse both have to my knowledge), so the current logic will bail if it detects os-release info but fails to get a match, instead of falling back to the other checks. The idea being that any missing modern distros can be added to the new check, but I'm not sure if this is the preferred logic, so I'd appreciate an opinion here.

Other things altered:
- Added `set -eu` (per t-pauls comment on the linked issue)
- Removed old fedora version logic (and other redundant logic). 
    - Removed solus's os-release check, and the copied in os-release check that was just for debian.  
    - Removed `get_fedora_deps_yum` (only used by old fedora versions).
    - Renamed `get_fedora_deps_dnf` to `get_fedora_deps` as `get_qomo_deps` and the red hat check both were referring to it this way (a bug from splitting it into a dnf/yum check?).
- Added `Catch2-devel` check to opensuse installer, and reworked its logic due to `set -e` clobbering the old exit code logic.

This is my first PR to any OSS project, so ALL feedback is greatly appreciated. 

Closes #6701 