### PR TITLE
Fix #6703 Wayland viewport OpenGL context selection

### DIFF
--- a/src/gui/QGLView.cc
+++ b/src/gui/QGLView.cc
@@ -42,6 +42,7 @@
 
 #include <QImage>
 #include <QOpenGLWidget>
+#include <QSurfaceFormat>
 #include <QWidget>
 #include <iostream>
 #include <QApplication>
@@ -72,8 +73,23 @@
 #include "gui/qt-obsolete.h"
 #include "gui/Measurement.h"
 
+namespace {
+
+QSurfaceFormat compatibleWidgetFormat()
+{
+  auto format = QSurfaceFormat::defaultFormat();
+  format.setRenderableType(QSurfaceFormat::OpenGL);
+  format.setProfile(QSurfaceFormat::CompatibilityProfile);
+  if (format.depthBufferSize() < 24) format.setDepthBufferSize(24);
+  if (format.stencilBufferSize() < 8) format.setStencilBufferSize(8);
+  return format;
+}
+
+}  // namespace
+
 QGLView::QGLView(QWidget *parent) : QOpenGLWidget(parent)
 {
+  setFormat(compatibleWidgetFormat());
   init();
 }
 

--- a/src/openscad_gui.cc
+++ b/src/openscad_gui.cc
@@ -36,6 +36,7 @@
 #include <QIcon>
 #include <QObject>
 #include <QPalette>
+#include <QSurfaceFormat>
 #include <QStringList>
 #include <QStyleHints>
 #include <Qt>
@@ -110,6 +111,25 @@ bool isDarkMode()
 #endif  // QT_VERSION
 }
 
+void configureOpenGLContext()
+{
+#if defined(Q_OS_UNIX) && !defined(Q_OS_MACOS)
+  // OpenSCAD still relies on legacy OpenGL compatibility features and GLSL 1.20
+  // shaders, so a GLES context is not currently usable. On Wayland/EGL setups Qt
+  // can otherwise pick OpenGL ES by default.
+  if (qEnvironmentVariableIsEmpty("QT_OPENGL")) {
+    QCoreApplication::setAttribute(Qt::AA_UseDesktopOpenGL);
+  }
+
+  auto format = QSurfaceFormat::defaultFormat();
+  format.setRenderableType(QSurfaceFormat::OpenGL);
+  format.setProfile(QSurfaceFormat::CompatibilityProfile);
+  if (format.depthBufferSize() < 24) format.setDepthBufferSize(24);
+  if (format.stencilBufferSize() < 8) format.setStencilBufferSize(8);
+  QSurfaceFormat::setDefaultFormat(format);
+#endif
+}
+
 }  // namespace
 
 namespace {
@@ -178,6 +198,7 @@ void registerDefaultIcon(const QString&)
 int gui(std::vector<std::string>& inputFiles, const std::filesystem::path& original_path, int argc,
         char **argv, const std::string& gui_test, const bool reset_window_settings)
 {
+  configureOpenGLContext();
   OpenSCADApp app(argc, argv);
   QIcon::setThemeName(isDarkMode() ? "chokusen-dark" : "chokusen");
 


### PR DESCRIPTION
## Summary
- request a desktop OpenGL compatibility surface format before creating the Qt application
- request the same compatibility format for the QOpenGLWidget viewport
- avoid Wayland creating a GLES-style context for the viewport

## Testing
- launch under Wayland
- confirm the previous GLSL #version 120 / GLES shader errors no longer appear and viewport renders

Fixes #6703