### PR TITLE
Correctly manage changes to perspective/orthogonal actions

### DIFF
--- a/src/gui/MainWindow.cc
+++ b/src/gui/MainWindow.cc
@@ -2768,14 +2768,18 @@ void MainWindow::setProjectionType(ProjectionType mode)
   qglview->update();
 }
 
-void MainWindow::on_viewActionPerspective_triggered()
+void MainWindow::on_viewActionPerspective_toggled(bool checked)
 {
-  setProjectionType(ProjectionType::PERSPECTIVE);
+  if (checked) {
+    setProjectionType(ProjectionType::PERSPECTIVE);
+  }
 }
 
-void MainWindow::on_viewActionOrthogonal_triggered()
+void MainWindow::on_viewActionOrthogonal_toggled(bool checked)
 {
-  setProjectionType(ProjectionType::ORTHOGONAL);
+  if (checked) {
+    setProjectionType(ProjectionType::ORTHOGONAL);
+  }
 }
 
 void MainWindow::viewTogglePerspective()

--- a/src/gui/MainWindow.h
+++ b/src/gui/MainWindow.h
@@ -409,8 +409,8 @@ public slots:
   void on_viewActionBack_triggered();
   void on_viewActionDiagonal_triggered();
   void on_viewActionCenter_triggered();
-  void on_viewActionPerspective_triggered();
-  void on_viewActionOrthogonal_triggered();
+  void on_viewActionPerspective_toggled(bool checked);
+  void on_viewActionOrthogonal_toggled(bool checked);
   void viewTogglePerspective();
   void on_viewActionResetView_triggered();
   void on_viewActionViewAll_triggered();


### PR DESCRIPTION
The existing "triggered" approach only fires on user clicks, while the new "toggled" approach also fires when state is applied from saved settings.

Fixes #6705