### PR TITLE
feat(gui): add trackpad pinch-to-zoom and two-finger scroll to pan

### DIFF
--- a/src/gui/QGLView.cc
+++ b/src/gui/QGLView.cc
@@ -459,10 +459,47 @@ bool QGLView::save(const char *filename) const
   return this->frame.save(filename, "PNG");
 }
 
+bool QGLView::event(QEvent *event)
+{
+  if (event->type() == QEvent::NativeGesture) {
+    auto *nge = static_cast<QNativeGestureEvent *>(event);
+    if (nge->gestureType() == Qt::ZoomNativeGesture) {
+      const double zoomFactor = nge->value();
+#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
+      const auto pos = nge->position();
+#else
+      const auto pos = nge->pos();
+#endif
+      if (this->mouseCentricZoom) {
+        zoomCursor(pos.x(), pos.y(), zoomFactor * 1200);
+      } else {
+        zoom(zoomFactor * 1200, true);
+      }
+      return true;
+    }
+  }
+  return QOpenGLWidget::event(event);
+}
+
 void QGLView::wheelEvent(QWheelEvent *event)
 {
   const auto pos = Q_WHEEL_EVENT_POSITION(event);
   const int v = event->angleDelta().y();
+
+  // Trackpad two-finger scrolling reports scroll phases;
+  // traditional mouse scroll wheel reports NoScrollPhase.
+  if (event->phase() != Qt::NoScrollPhase) {
+    // Trackpad scroll -> pan
+    const auto pd = event->pixelDelta();
+    if (!pd.isNull()) {
+      double mx = -pd.x() / (double)QWidget::width() * 1.0 * cam.zoomValue();
+      double mz = -pd.y() / (double)QWidget::height() * 1.0 * cam.zoomValue();
+      translate(mx, 0, mz, true);
+    }
+    return;
+  }
+
+  // Mouse wheel -> zoom (original behavior)
   if (QApplication::keyboardModifiers() & Qt::ShiftModifier) {
     zoomFov(v);
   } else if (this->mouseCentricZoom) {

--- a/src/gui/QGLView.h
+++ b/src/gui/QGLView.h
@@ -8,6 +8,7 @@
 #include <array>
 #include <QImage>
 #include <QMouseEvent>
+#include <QNativeGestureEvent>
 #include <QPoint>
 #include <QWheelEvent>
 #include <QWidget>
@@ -93,6 +94,7 @@ private:
 #endif
   QImage frame;  // Used by grabFrame() and save()
 
+  bool event(QEvent *event) override;
   void wheelEvent(QWheelEvent *event) override;
   void mousePressEvent(QMouseEvent *event) override;
   void mouseMoveEvent(QMouseEvent *event) override;


### PR DESCRIPTION
## Summary

Make OpenSCAD usable on Mac! This really makes a big difference for me but I obviously don't want to break it for anybody else. So please let me know what I should test.

- Add `QNativeGestureEvent` handler for pinch-to-zoom on macOS (and Windows precision touchpads)
- Change `wheelEvent` to pan on trackpad two-finger scroll, while preserving zoom for mouse scroll wheel
- Distinguish trackpad from mouse wheel using `QWheelEvent::phase()` (trackpad events have scroll phases; mouse wheel reports `NoScrollPhase`)

Relates to #4297

## What was tested (macOS 26.2, Qt 6.10.2, Apple Silicon)

- Trackpad two-finger scroll - pans the viewport (was zoom)
- Trackpad pinch - zooms the viewport (was not handled)
- clang-format - passes `./scripts/beautify.sh --check`

## What was NOT tested

- Pinch with mouseCentricZoom enabled - zooms toward gesture center point
- Mouse click-drag - rotate/pan unchanged
- Double-click - center view unchanged
- Right-click - context menu unchanged
- Mouse scroll wheel - should still zoom via `NoScrollPhase` path, but not verified with a physical mouse
- Shift+scroll wheel - FOV zoom path not tested
- Apple Magic Mouse - uses scroll phases like trackpad, so it will pan instead of zoom
- Linux (X11/Wayland) - `phase()` is typically `NoScrollPhase` on X11 so behavior should be unchanged; Wayland with libinput may have phases
- Windows precision touchpad - `QNativeGestureEvent` should work but untested
- Qt 5 build - the `#else` branch for `nge->pos()` was not compiled

## Note on PR #6681

PR #6681 takes a more comprehensive approach (configurable scroll actions, pinch rotation). However, it uses `QPinchGesture` via `grabGesture()` which does not fire on macOS because the OS consumes touch events before Qt can synthesize gestures. This PR uses `QNativeGestureEvent` instead, which receives pinch events reliably on macOS. These two approaches could be combined.