### PR TITLE
Fix animate window layout when narrow (fixes #6702)

### DIFF
--- a/src/gui/Animate.cc
+++ b/src/gui/Animate.cc
@@ -24,12 +24,18 @@ Animate::Animate(QWidget *parent) : QWidget(parent)
   setupUi(this);
   initGUI();
 
-  const auto width = groupBoxParameter->minimumSizeHint().width();
   const auto margins = layout()->contentsMargins();
   const auto scrollMargins = scrollAreaWidgetContents->layout()->contentsMargins();
   const auto parameterMargins = groupBoxParameter->layout()->contentsMargins();
-  initMinWidth = width + margins.left() + margins.right() + scrollMargins.left() +
+  const auto buttonsMargins = groupBoxButtons->layout()->contentsMargins();
+
+  const auto paramWidth = groupBoxParameter->minimumSizeHint().width();
+  initMinWidth = paramWidth + margins.left() + margins.right() + scrollMargins.left() +
                  scrollMargins.right() + parameterMargins.left() + parameterMargins.right();
+
+  const auto buttonsWidth = groupBoxButtons->minimumSizeHint().width();
+  initButtonsMinWidth = buttonsWidth + margins.left() + margins.right() + scrollMargins.left() +
+                        scrollMargins.right() + buttonsMargins.left() + buttonsMargins.right();
 }
 
 void Animate::initGUI()
@@ -264,15 +270,33 @@ void Animate::resizeEvent(QResizeEvent *event)
   auto layoutButtons = dynamic_cast<QBoxLayout *>(groupBoxButtons->layout());
 
   if (layoutParameters && layoutButtons) {
+    const int currentWidth = event->size().width();
+
+    // Use a small hysteresis band (20px) to prevent jitter when the window
+    // is dragged near a transition threshold.
+    const int hysteresis = 20;
+
     if (layoutParameters->direction() == QBoxLayout::LeftToRight) {
-      if (event->size().width() < initMinWidth) {
+      if (currentWidth < initMinWidth) {
         layoutParameters->setDirection(QBoxLayout::TopToBottom);
+        scrollAreaWidgetContents->layout()->invalidate();
+      }
+    } else {
+      if (currentWidth > initMinWidth + hysteresis) {
+        layoutParameters->setDirection(QBoxLayout::LeftToRight);
+        scrollAreaWidgetContents->layout()->invalidate();
+      }
+    }
+
+    // The button row contains only fixed-size icon buttons and can stay
+    // horizontal at a narrower width than the parameter row.
+    if (layoutButtons->direction() == QBoxLayout::LeftToRight) {
+      if (currentWidth < initButtonsMinWidth) {
         layoutButtons->setDirection(QBoxLayout::TopToBottom);
         scrollAreaWidgetContents->layout()->invalidate();
       }
     } else {
-      if (event->size().width() > initMinWidth) {
-        layoutParameters->setDirection(QBoxLayout::LeftToRight);
+      if (currentWidth > initButtonsMinWidth + hysteresis) {
         layoutButtons->setDirection(QBoxLayout::LeftToRight);
         scrollAreaWidgetContents->layout()->invalidate();
       }

--- a/src/gui/Animate.h
+++ b/src/gui/Animate.h
@@ -72,6 +72,7 @@ private:
   bool steps_ok;
 
   int initMinWidth;
+  int initButtonsMinWidth;
 
   QIcon iconRun;
   QIcon iconPause;

--- a/src/gui/Animate.ui
+++ b/src/gui/Animate.ui
@@ -100,8 +100,14 @@
            <widget class="QLineEdit" name="e_tval">
             <property name="minimumSize">
              <size>
-              <width>120</width>
+              <width>60</width>
               <height>0</height>
+             </size>
+            </property>
+            <property name="maximumSize">
+             <size>
+              <width>80</width>
+              <height>16777215</height>
              </size>
             </property>
             <property name="alignment">
@@ -139,8 +145,14 @@
            <widget class="QLineEdit" name="e_fps">
             <property name="minimumSize">
              <size>
-              <width>120</width>
+              <width>60</width>
               <height>0</height>
+             </size>
+            </property>
+            <property name="maximumSize">
+             <size>
+              <width>80</width>
+              <height>16777215</height>
              </size>
             </property>
             <property name="alignment">
@@ -178,8 +190,14 @@
            <widget class="QLineEdit" name="e_fsteps">
             <property name="minimumSize">
              <size>
-              <width>120</width>
+              <width>60</width>
               <height>0</height>
+             </size>
+            </property>
+            <property name="maximumSize">
+             <size>
+              <width>80</width>
+              <height>16777215</height>
              </size>
             </property>
             <property name="alignment">


### PR DESCRIPTION
Problem
When the animate dock is made narrower than its default width, 
all controls jump immediately to one-per-line mode, requiring 
the window to be very tall to show everything.

Fix
- Reduced input field minimum widths (120px → 60px) and added 
  maximum widths (80px) in Animate.ui so the parameter row fits 
  in less horizontal space
- Added a separate resize threshold for the button row so buttons 
  stay horizontal at narrower widths than the parameter row requires
- Added 20px hysteresis to prevent layout jitter when dragging 
  near a threshold

Files Changed
src/gui/Animate.ui
src/gui/Animate.h
src/gui/Animate.cc