### PR TITLE
Linear extrude argument error handling

### DIFF
--- a/src/core/LinearExtrudeNode.cc
+++ b/src/core/LinearExtrudeNode.cc
@@ -56,14 +56,16 @@ std::shared_ptr<AbstractNode> builtin_linear_extrude(const ModuleInstantiation *
 
   if (parameters["v"].isDefined()) {
     if (!parameters["v"].getVec3(node->height[0], node->height[1], node->height[2])) {
-      LOG(message_group::Error, "v when specified should be a 3d vector.");
+      LOG(message_group::Warning, inst->location(), parameters.documentRoot(),
+          "v when specified should be a 3d vector");
     }
     height = 1.0;
   }
   const Value& heightValue = parameters[{"height", "h"}];
   if (heightValue.isDefined()) {
     if (!heightValue.getFiniteDouble(height)) {
-      LOG(message_group::Error, "height when specified should be a number.");
+      LOG(message_group::Warning, inst->location(), parameters.documentRoot(),
+          "height when specified should be a number");
       height = 100.0;
     }
     node->height.normalize();

--- a/tests/regression/echo/linear_extrude-parameter-tests-expected.echo
+++ b/tests/regression/echo/linear_extrude-parameter-tests-expected.echo
@@ -32,8 +32,8 @@ WARNING: linear_extrude(..., scale=true) could not be converted in file linear_e
 WARNING: Specified both "height" and "h" in file linear_extrude-parameter-tests.scad, line 24
 WARNING: linear_extrude(..., scale=[1 : 1 : 3]) could not be converted in file linear_extrude-parameter-tests.scad, line 24
 WARNING: Specified both "height" and "h" in file linear_extrude-parameter-tests.scad, line 24
-ERROR: height when specified should be a number.
-ERROR: height when specified should be a number.
-ERROR: height when specified should be a number.
-ERROR: height when specified should be a number.
-ERROR: height when specified should be a number.
+WARNING: height when specified should be a number in file linear_extrude-parameter-tests.scad, line 27
+WARNING: height when specified should be a number in file linear_extrude-parameter-tests.scad, line 27
+WARNING: height when specified should be a number in file linear_extrude-parameter-tests.scad, line 27
+WARNING: height when specified should be a number in file linear_extrude-parameter-tests.scad, line 27
+WARNING: height when specified should be a number in file linear_extrude-parameter-tests.scad, line 27


### PR DESCRIPTION
Fixes #6742 points 1 through 3:

1. Include location in `v` and `height` errors.
2. Switch `v` and `height` errors to be message_group::Warning.
3. Move `center` to the second argument.

Point 4 is a cheat sheet update to match, to follow when this merges.