### PR TITLE
refactor: change get_cairo_version() return type from const std::string to std::string in export_pdf.cc to be consistent

### DIFF
--- a/src/io/export_pdf.cc
+++ b/src/io/export_pdf.cc
@@ -339,7 +339,7 @@ void export_pdf(const std::shared_ptr<const Geometry>& geom, std::ostream& outpu
 
 #else  // ENABLE_CAIRO
 
-const std::string get_cairo_version()
+std::string get_cairo_version()
 {
   const std::string cairo_version = "(not enabled)";
   return cairo_version;


### PR DESCRIPTION
Fixes #6747