### PR TITLE
refactor: remove unused applyHull function declaration from manifoldutils.h

### DIFF
--- a/src/geometry/manifold/manifoldutils.h
+++ b/src/geometry/manifold/manifoldutils.h
@@ -24,7 +24,6 @@ std::shared_ptr<SurfaceMesh> createSurfaceMeshFromManifold(const manifold::Manif
 
 std::shared_ptr<ManifoldGeometry> applyOperator3DManifold(const Geometry::Geometries& children,
                                                           OpenSCADOperator op);
-std::shared_ptr<ManifoldGeometry> applyHull(const Geometry::Geometries& children);
 
 Polygon2d polygonsToPolygon2d(const manifold::Polygons& polygons);
 


### PR DESCRIPTION
I was syncing recent changes from OpenSCAD to PythonSCAD and found this abandoned function declaration.

It's jusrt a minor cleanup task though,