### PR TITLE
perf(geometry): collect 3D hull input from PolySet vertices

### DIFF
--- a/src/geometry/cgal/cgalutils-applyops.cc
+++ b/src/geometry/cgal/cgalutils-applyops.cc
@@ -183,11 +183,9 @@ std::unique_ptr<PolySet> applyHull3D(const Geometry::Geometries& children)
       });
 #endif  // ENABLE_MANIFOLD
     } else if (const auto *ps = dynamic_cast<const PolySet *>(chgeom.get())) {
-      addCapacity(ps->indices.size() * 3);
-      for (const auto& p : ps->indices) {
-        for (const auto& ind : p) {
-          addPoint(CGALUtils::vector_convert<Hull_kernel::Point_3>(ps->vertices[ind]));
-        }
+      addCapacity(ps->vertices.size());
+      for (const auto& v : ps->vertices) {
+        addPoint(CGALUtils::vector_convert<Hull_kernel::Point_3>(v));
       }
     }
   }

--- a/src/geometry/manifold/manifold-applyops.cc
+++ b/src/geometry/manifold/manifold-applyops.cc
@@ -41,12 +41,9 @@ std::shared_ptr<ManifoldGeometry> applyOperator3DManifold(const Geometry::Geomet
           return false;
         });
       } else if (const auto *ps = dynamic_cast<const PolySet *>(chgeom.get())) {
-        pts.reserve(pts.size() + ps->indices.size() * 3);
-        for (const auto& p : ps->indices) {
-          for (const auto& ind : p) {
-            auto& v = ps->vertices[ind];
-            pts.push_back({v[0], v[1], v[2]});
-          }
+        pts.reserve(pts.size() + ps->vertices.size());
+        for (const auto& v : ps->vertices) {
+          pts.push_back({v[0], v[1], v[2]});
         }
       } else {
         auto chN = createManifoldFromGeometry(chgeom);


### PR DESCRIPTION
## Problem

When building the point cloud for `hull()` in 3D, both the Manifold path (`ManifoldUtils::applyOperator3DManifold` with `OpenSCADOperator::HULL`) and the CGAL path (`CGALUtils::applyHull3D`) walked each `PolySet` face and pushed every corner vertex. That repeats shared vertices once per incident triangle and scales with triangle count instead of vertex count.

## Fix

Iterate `PolySet::vertices` directly in both code paths. For a typical closed mesh, the convex hull of all vertices equals the hull of triangle corners; we avoid redundant work and a larger intermediate point list before `Manifold::Hull` / `CGAL::convex_hull_3`.

## Notes

- Related to review feedback on downstream sync work (PythonSCAD); the dead `ManifoldUtils::applyHull` declaration is addressed separately in [#6754](https://github.com/openscad/openscad/pull/6754).
- Built locally with `cmake --build build -j8`.

Made with [Cursor](https://cursor.com)