### PR TITLE
Fix sense of Dock::setTitleBarVisibility(isVisible)

### DIFF
--- a/src/gui/Dock.cc
+++ b/src/gui/Dock.cc
@@ -41,7 +41,7 @@ Dock::~Dock()
 
 void Dock::setTitleBarVisibility(bool isVisible)
 {
-  setTitleBarWidget(isVisible ? dockTitleWidget : nullptr);
+  setTitleBarWidget(isVisible ? nullptr : dockTitleWidget);
 }
 
 void Dock::updateTitle()

--- a/src/gui/MainWindow.cc
+++ b/src/gui/MainWindow.cc
@@ -597,7 +597,7 @@ void MainWindow::updateReorderMode(bool reorderMode)
 {
   MainWindow::reorderMode = reorderMode;
   for (auto& [dock, name] : docks) {
-    dock->setTitleBarVisibility(!reorderMode);
+    dock->setTitleBarVisibility(reorderMode);
   }
 }
 


### PR DESCRIPTION
This is an internal cleanup only.

`Dock::setTitleBarVisibility()` has a [simple implementation](https://github.com/openscad/openscad/blob/0e1111771d4c5ebaf2a05342dc28bf6fbc9f6ef5/src/gui/Dock.cc#L42):
```
void Dock::setTitleBarVisibility(bool isVisible)
{
  setTitleBarWidget(isVisible ? dockTitleWidget : nullptr);
}
```
Obvious, right?

Well, no, it's wrong.  `nullptr` leads to using a default title bar, while `dockTitleWidget` is an empty (and therefore invisible) widget.

This is compensated for by [its caller](https://github.com/openscad/openscad/blob/0e1111771d4c5ebaf2a05342dc28bf6fbc9f6ef5/src/gui/MainWindow.cc#L600):
```
    dock->setTitleBarVisibility(!reorderMode);
```
... where `reorderMode` true means that you **are** allowed to to move panes around, and so they **should** have title bars.

So, today, if you're allowed to move panes around, it calls setTitleBarVisibility with isVisible=false, which is then interpreted to mean that there **should** be a title bar.

Oops.  This PR leaves the name `isVisible` alone, and reverses the sense so that `true` means visible.