### PR TITLE
Do *not* set the window type to Qt::Window.  Fixes #6667 (shortcuts don't work in undocked windows)

### DIFF
--- a/src/gui/Dock.cc
+++ b/src/gui/Dock.cc
@@ -79,15 +79,16 @@ void Dock::setNameSuffix(const QString& namesuffix_)
 
 void Dock::onTopLevelStatusChanged(bool isTopLevel)
 {
+  // CAUTION:  A previous incarnation of this set the window type of an undocked window to Qt::Window
+  // (rather than its default Qt::Tool) in an attempt to enable undocked windows to float behind the
+  // main window.  That didn't work (or at least not on all platforms), and caused #6667, breaking
+  // shortcuts when undocked.  See #6765 for more discussion.
+
   // update the title of the window so it contains the title suffix (in general filename)
-  // also update the flags and visibility to provide interactive feedback on the user action
-  // while it is moving the dock in topLevel=true state. The purpose of such setting
-  // on Qt::Window flag is to allow the dock to be floating behind the main window,
-  // something which isn't supported for regular QDockWidgets.
-  Qt::WindowFlags flags = (windowFlags() & ~Qt::WindowType_Mask) | Qt::Window;
+  // also update the visibility to provide interactive feedback on the user action
+  // while it is moving the dock in topLevel=true state.
   if (isTopLevel) {
-    setWindowFlags(flags);
-    // show() rmits an innocuous "Already setting window visible!" warning on macOS
+    // show() emits an innocuous "Already setting window visible!" warning on macOS
     ScopedMessageSilencer silencer;
     show();
   }


### PR DESCRIPTION
(But means that undocked windows can't be under the main window.)

I don't see a combination of window flags that would obviously both treat the window as a secondary window (so it inherits shortcuts?) and allows it to be underneath the parent window.  But maybe I'm just not seeing something.