### PR TITLE
Switch icons when light/dark mode changes, not just at startup.

### DIFF
--- a/src/gui/MainWindow.cc
+++ b/src/gui/MainWindow.cc
@@ -91,6 +91,7 @@
 #include <utility>
 #include <vector>
 
+#include "openscad_gui.h"
 #include "core/AST.h"
 #include "core/BuiltinContext.h"
 #include "core/Builtins.h"
@@ -3990,4 +3991,12 @@ void MainWindow::openRemainingFiles(const QStringList& filenames)
   for (int i = 1; i < filenames.size(); ++i) tabManager->createTab(filenames[i]);
 
   activeEditor->setFocus();
+}
+
+void MainWindow::changeEvent(QEvent *event)
+{
+  if (event->type() == QEvent::ThemeChange) {
+    setGlobalTheme();
+  }
+  QMainWindow::changeEvent(event);
 }

--- a/src/gui/MainWindow.h
+++ b/src/gui/MainWindow.h
@@ -159,6 +159,7 @@ private:
 
 protected:
   void closeEvent(QCloseEvent *event) override;
+  void changeEvent(QEvent *event) override;
 
 private slots:
   void updateUndockMode(bool undockMode);

--- a/src/openscad_gui.cc
+++ b/src/openscad_gui.cc
@@ -132,6 +132,11 @@ void configureOpenGLContext()
 
 }  // namespace
 
+void setGlobalTheme()
+{
+  QIcon::setThemeName(isDarkMode() ? "chokusen-dark" : "chokusen");
+}
+
 namespace {
 
 // Only if "fileName" is not absolute, prepend the "absoluteBase".
@@ -200,7 +205,7 @@ int gui(std::vector<std::string>& inputFiles, const std::filesystem::path& origi
 {
   configureOpenGLContext();
   OpenSCADApp app(argc, argv);
-  QIcon::setThemeName(isDarkMode() ? "chokusen-dark" : "chokusen");
+  setGlobalTheme();
 
   // set up groups for QSettings
   QCoreApplication::setOrganizationName("OpenSCAD");

--- a/src/openscad_gui.h
+++ b/src/openscad_gui.h
@@ -32,3 +32,4 @@
 
 int gui(std::vector<std::string>& inputFiles, const std::filesystem::path& original_path, int argc,
         char **argv, const std::string&, const bool);
+void setGlobalTheme();


### PR DESCRIPTION
At startup time, we select either a black-on-white icon set (for light mode) or a white-on-black icon set (for dark mode).

However, if you change modes while the program is running, we don't reconsider the icon set.  Worse, the background *does* get changed, and so you can end up with black-on-black icons if you switch to dark mode:
<img width="511" height="70" alt="image" src="https://github.com/user-attachments/assets/cd5e0559-e849-41d6-baec-7a98c323c6bd" />
or white-on-white icons if you switch to light mode:
<img width="513" height="72" alt="image" src="https://github.com/user-attachments/assets/9a3c5f64-b6bc-45b2-81f9-3dfcec70122e" />

This change makes the icon set selection be dynamic:  when the theme changes, we reconsider which icon set to use.

Note:  There are still other problems with dynamic switching, mostly having to do with style sheets interfering with automatic switching logic.  But those are separable issues.
