### PR TITLE
Dynamic dark mode switching

### DIFF
--- a/src/gui/Animate.cc
+++ b/src/gui/Animate.cc
@@ -24,6 +24,17 @@ Animate::Animate(QWidget *parent) : QWidget(parent)
   setupUi(this);
   initGUI();
 
+  auto *stepsValidator = new QIntValidator(this);
+  stepsValidator->setBottom(0);
+  e_fsteps->setValidator(stepsValidator);
+
+  auto *fpsValidator = new QDoubleValidator(this);
+  fpsValidator->setBottom(0.0);
+  e_fps->setValidator(fpsValidator);
+
+  auto *tvalValidator = new QDoubleValidator(0.0, 1.0, -1, this);
+  e_tval->setValidator(tvalValidator);
+
   const auto width = groupBoxParameter->minimumSizeHint().width();
   const auto margins = layout()->contentsMargins();
   const auto scrollMargins = scrollAreaWidgetContents->layout()->contentsMargins();
@@ -111,22 +122,6 @@ void Animate::updatedAnimFpsAndAnimSteps()
     animateTimer->setSingleShot(false);
     animateTimer->setInterval(int(1000 / fps));
     animateTimer->start();
-  }
-
-  QPalette defaultPalette;
-  const auto bgColor = defaultPalette.base().color().toRgb();
-  QString redStyleSheet = UIUtils::blendForBackgroundColorStyleSheet(bgColor, errorBlendColor);
-
-  if (this->steps_ok || this->e_fsteps->text() == "") {
-    this->e_fsteps->setStyleSheet("");
-  } else {
-    this->e_fsteps->setStyleSheet(redStyleSheet);
-  }
-
-  if (this->fpsOK || this->e_fps->text() == "") {
-    this->e_fps->setStyleSheet("");
-  } else {
-    this->e_fps->setStyleSheet(redStyleSheet);
   }
 
   updatePauseButtonIcon();

--- a/src/gui/ColorList.cc
+++ b/src/gui/ColorList.cc
@@ -286,7 +286,6 @@ void ColorList::sortByLightness(const bool descending)
 void ColorList::updateSelectedColor()
 {
   QPalette defaultPalette;
-  const auto styleSheet = QString("QLineEdit { color: %1; background-color: %2; }");
   const auto name = selectedColorLabel ? selectedColorLabel->text() : "";
   const auto colorRgb = selectedColorLabel ? selectedColorLabel->backgroundColor().name() : "";
   const auto colorRgbR =
@@ -295,21 +294,41 @@ void ColorList::updateSelectedColor()
     selectedColorLabel ? QString::number(selectedColorLabel->backgroundColor().green()) : "";
   const auto colorRgbB =
     selectedColorLabel ? QString::number(selectedColorLabel->backgroundColor().blue()) : "";
-  const auto color =
-    selectedColorLabel ? selectedColorLabel->backgroundColor() : defaultPalette.text().color();
+  const auto color = selectedColorLabel ? selectedColorLabel->backgroundColor() : QColor();
   ui->lineEditColorNameSelected->setText(name);
   ui->lineEditColorRgbSelected->setText(colorRgb);
   ui->lineEditColorRgbSelectedR->setText(colorRgbR);
   ui->lineEditColorRgbSelectedG->setText(colorRgbG);
   ui->lineEditColorRgbSelectedB->setText(colorRgbB);
-  ui->lineEditAsForeground->setStyleSheet(styleSheet.arg(color.name(), asForeground.name()));
-  ui->lineEditAsBackground->setStyleSheet(styleSheet.arg(asBackground.name(), color.name()));
+  // Bug:  the "reset sample text" icon is fixed by the theme (light or dark) and can be
+  // impossible to see if the selected background is close to the theme's icon color.
+  // This applies to both boxes; for "as foreground" it applies if you selected a "bad"
+  // background color, and for "as background" it applies if the selected color is "bad".
+  // https://stackoverflow.com/questions/24943711/qt-drawing-icons-using-color-and-alpha-map
+  // may be helpful.
+  setWidgetColor(ui->lineEditAsForeground, color, asForeground);
+  setWidgetColor(ui->lineEditAsBackground, asBackground, color);
+}
+
+void ColorList::setWidgetColor(QWidget *w, const QColor& fg, const QColor& bg) const
+{
+  // Transcribe the parent's palette onto the widget, updating the foreground and background
+  // colors as requested.  If the supplied color is invalid, don't update it.
+  QPalette p = w->parentWidget()->palette();
+  if (fg.isValid()) {
+    p.setColor(w->foregroundRole(), fg);
+  }
+  if (bg.isValid()) {
+    p.setColor(w->backgroundRole(), bg);
+    // Work around https://qt-project.atlassian.net/browse/QTBUG-145776
+    p.setColor(QPalette::Button, bg);
+  }
+  w->setPalette(p);
 }
 
 void ColorList::on_toolButtonAsForegroundReset_clicked()
 {
-  QPalette defaultPalette;
-  asForeground = defaultPalette.base().color().toRgb();
+  asForeground = QColor();
   updateSelectedColor();
 }
 
@@ -329,8 +348,7 @@ void ColorList::on_toolButtonAsForegroundColorDialog_clicked()
 
 void ColorList::on_toolButtonAsBackgroundReset_clicked()
 {
-  QPalette defaultPalette;
-  asBackground = defaultPalette.base().color().toRgb();
+  asBackground = QColor();
   updateSelectedColor();
 }
 

--- a/src/gui/ColorList.h
+++ b/src/gui/ColorList.h
@@ -47,6 +47,7 @@ private:
   void sortByLightness(const bool descending = false);
   void updateColorDialog(QColor& target);
   void updateSelectedColor();
+  void setWidgetColor(QWidget *w, const QColor& fg, const QColor& bg) const;
 
 protected slots:
   void updateSort();

--- a/src/gui/Console.cc
+++ b/src/gui/Console.cc
@@ -129,13 +129,7 @@ void Console::addHtml(const QString& html)
 
 void Console::setConsoleFont(const QString& fontFamily, uint ptSize)
 {
-  const auto stylesheet = QString(R"(
-    QPlainTextEdit {
-        font-family: '%1';
-        font-size: %2pt;
-    }
-  )");
-  this->setStyleSheet(stylesheet.arg(fontFamily, QString::number(ptSize)));
+  this->document()->setDefaultFont(QFont(fontFamily, ptSize));
 }
 
 void Console::update()

--- a/src/gui/Export3mfDialog.cc
+++ b/src/gui/Export3mfDialog.cc
@@ -51,8 +51,7 @@ Export3mfDialog::Export3mfDialog()
   this->checkBoxAlwaysShowDialog->setChecked(S::export3mfAlwaysShowDialog.value());
   initButtonGroup(this->buttonGroupColors, S::export3mfColorMode);
   initButtonGroup(this->buttonGroupUnit, S::export3mfUnit);
-  this->color = QColor(QString::fromStdString(S::export3mfColor.value()));
-  this->labelColorsSelected->setStyleSheet(UIUtils::getBackgroundColorStyleSheet(this->color));
+  updateColor(QColor(QString::fromStdString(S::export3mfColor.value())));
   this->spinBoxDecimalPrecision->setValue(S::export3mfDecimalPrecision.value());
   initComboBox(this->comboBoxMaterialType, S::export3mfMaterialType);
 
@@ -84,7 +83,10 @@ Export3mfDialog::Export3mfDialog()
 void Export3mfDialog::updateColor(const QColor& color)
 {
   this->color = color;
-  this->labelColorsSelected->setStyleSheet(UIUtils::getBackgroundColorStyleSheet(this->color));
+  QWidget *w = this->labelColorsSelected;
+  QPalette p = w->palette();
+  p.setColor(w->backgroundRole(), this->color);
+  w->setPalette(p);
 }
 
 int Export3mfDialog::exec()
@@ -123,7 +125,10 @@ int Export3mfDialog::exec()
 
 void Export3mfDialog::on_toolButtonColorsSelected_clicked()
 {
-  updateColor(QColorDialog::getColor(this->color));
+  QColor newColor = QColorDialog::getColor(this->color);
+  if (newColor.isValid()) {
+    updateColor(newColor);
+  }
 }
 
 void Export3mfDialog::on_toolButtonColorsSelectedReset_clicked()

--- a/src/gui/Export3mfDialog.ui
+++ b/src/gui/Export3mfDialog.ui
@@ -236,6 +236,9 @@
               <property name="text">
                <string/>
               </property>
+              <property name="autoFillBackground">
+               <bool>true</bool>
+              </property>
              </widget>
             </item>
             <item>

--- a/src/gui/ExportPdfDialog.cc
+++ b/src/gui/ExportPdfDialog.cc
@@ -130,15 +130,19 @@ double ExportPdfDialog::getGridSize() const
 void ExportPdfDialog::updateFillColor(const QColor& color)
 {
   this->fillColor = color;
-  QString styleSheet = QString("QLabel { background-color: %1; }").arg(color.name());
-  this->labelFillColor->setStyleSheet(styleSheet);
+  QWidget *w = this->labelFillColor;
+  QPalette p = w->palette();
+  p.setColor(w->backgroundRole(), color);
+  w->setPalette(p);
 }
 
 void ExportPdfDialog::updateStrokeColor(const QColor& color)
 {
   this->strokeColor = color;
-  QString styleSheet = QString("QLabel { background-color: %1; }").arg(color.name());
-  this->labelStrokeColor->setStyleSheet(styleSheet);
+  QWidget *w = this->labelStrokeColor;
+  QPalette p = w->palette();
+  p.setColor(w->backgroundRole(), color);
+  w->setPalette(p);
 }
 
 void ExportPdfDialog::updateFillControlsEnabled()

--- a/src/gui/ExportPdfDialog.ui
+++ b/src/gui/ExportPdfDialog.ui
@@ -532,6 +532,9 @@
               <property name="text">
                <string/>
               </property>
+              <property name="autoFillBackground">
+               <bool>true</bool>
+              </property>
              </widget>
             </item>
             <item>
@@ -588,6 +591,9 @@
               </property>
               <property name="text">
                <string/>
+              </property>
+              <property name="autoFillBackground">
+               <bool>true</bool>
               </property>
              </widget>
             </item>

--- a/src/gui/MainWindow.cc
+++ b/src/gui/MainWindow.cc
@@ -91,6 +91,7 @@
 #include <utility>
 #include <vector>
 
+#include "openscad_gui.h"
 #include "core/AST.h"
 #include "core/BuiltinContext.h"
 #include "core/Builtins.h"
@@ -3990,4 +3991,12 @@ void MainWindow::openRemainingFiles(const QStringList& filenames)
   for (int i = 1; i < filenames.size(); ++i) tabManager->createTab(filenames[i]);
 
   activeEditor->setFocus();
+}
+
+void MainWindow::changeEvent(QEvent *event)
+{
+  if (event->type() == QEvent::ThemeChange) {
+    setGlobalTheme();
+  }
+  QMainWindow::changeEvent(event);
 }

--- a/src/gui/MainWindow.cc
+++ b/src/gui/MainWindow.cc
@@ -804,19 +804,17 @@ void MainWindow::updateCompileResult()
       const QFileInfo fileInfo(activeEditor->filepath);
       msg = QString(_("Error while compiling '%1'.")).arg(fileInfo.fileName());
     }
-    toolButtonCompileResultIcon->setIcon(
-      QIcon(QString::fromUtf8(":/icons/information-icons-error.png")));
+    labelCompileResultIcon->setPixmap(QPixmap(QString(":/icons/information-icons-error.png")));
   } else {
     const char *fmt = ngettext("Compilation generated %1 warning.", "Compilation generated %1 warnings.",
                                compileWarnings);
     msg = QString(fmt).arg(compileWarnings);
-    toolButtonCompileResultIcon->setIcon(
-      QIcon(QString::fromUtf8(":/icons/information-icons-warning.png")));
+    labelCompileResultIcon->setPixmap(QPixmap(QString(":/icons/information-icons-warning.png")));
   }
   const QFontMetrics fm(labelCompileResultMessage->font());
   const int sizeIcon = std::max(12, std::min(32, fm.height()));
   const int sizeClose = std::max(10, std::min(32, fm.height()) - 4);
-  toolButtonCompileResultIcon->setIconSize(QSize(sizeIcon, sizeIcon));
+  labelCompileResultIcon->setFixedSize(QSize(sizeIcon, sizeIcon));
   toolButtonCompileResultClose->setIconSize(QSize(sizeClose, sizeClose));
 
   msg += _(

--- a/src/gui/MainWindow.cc
+++ b/src/gui/MainWindow.cc
@@ -60,6 +60,7 @@
 #include <QSoundEffect>
 #include <QSplitter>
 #include <QStatusBar>
+#include <QSizeGrip>
 #include <QStringList>
 #include <QTemporaryFile>
 #include <QTextEdit>
@@ -613,11 +614,6 @@ MainWindow::~MainWindow()
   }
 }
 
-void MainWindow::showProgress()
-{
-  updateStatusBar(qobject_cast<ProgressWidget *>(sender()));
-}
-
 void MainWindow::report_func(const std::shared_ptr<const AbstractNode>&, void *vp, int mark)
 {
   // limit to progress bar update calls to 5 per second
@@ -628,22 +624,22 @@ void MainWindow::report_func(const std::shared_ptr<const AbstractNode>&, void *v
     auto thisp = static_cast<MainWindow *>(vp);
     auto v = static_cast<int>((mark * 1000.0) / progress_report_count);
     auto permille = v < 1000 ? v : 999;
-    if (permille > thisp->progresswidget->value()) {
-      QMetaObject::invokeMethod(thisp->progresswidget, "setValue", Qt::QueuedConnection,
+    if (permille > thisp->progressWidget->value()) {
+      QMetaObject::invokeMethod(thisp->progressWidget, "setValue", Qt::QueuedConnection,
                                 Q_ARG(int, permille));
       QApplication::processEvents();
     }
 
     // FIXME: Check if cancel was requested by e.g. Application quit
-    if (thisp->progresswidget->wasCanceled()) throw ProgressCancelException();
+    if (thisp->progressWidget->wasCanceled()) throw ProgressCancelException();
   }
 }
 
 bool MainWindow::network_progress_func(const double permille)
 {
-  QMetaObject::invokeMethod(this->progresswidget, "setValue", Qt::QueuedConnection,
+  QMetaObject::invokeMethod(this->progressWidget, "setValue", Qt::QueuedConnection,
                             Q_ARG(int, (int)permille));
-  return (progresswidget && progresswidget->wasCanceled());
+  return (progressWidget && progressWidget->wasCanceled());
 }
 
 void MainWindow::updateRecentFiles(const QString& FileSavedOrOpened)
@@ -962,8 +958,7 @@ void MainWindow::compileCSG()
     this->processEvents();
 
     // Main CSG evaluation
-    this->progresswidget = new ProgressWidget(this);
-    connect(this->progresswidget, &ProgressWidget::requestShow, this, &MainWindow::showProgress);
+    updateStatusBar(true);
 
     GeometryEvaluator geomevaluator(this->tree);
 #ifdef ENABLE_OPENCSG
@@ -985,7 +980,7 @@ void MainWindow::compileCSG()
       LOG("CSG generation cancelled due to hardwarning being enabled.");
     }
     progress_report_fin();
-    updateStatusBar(nullptr);
+    updateStatusBar(false);
 
     LOG("Compiling design (CSG Products normalization)...");
     this->processEvents();
@@ -1857,12 +1852,11 @@ void MainWindow::sendToExternalTool(ExternalToolInterface& externalToolService)
     return;
   }
 
-  this->progresswidget = new ProgressWidget(this);
-  connect(this->progresswidget, &ProgressWidget::requestShow, this, &MainWindow::showProgress);
+  updateStatusBar(true);
 
   const bool process_status = externalToolService.process(
     activeFileName.toStdString(), [this](double permille) { return network_progress_func(permille); });
-  updateStatusBar(nullptr);
+  updateStatusBar(false);
   if (!process_status) {
     return;
   }
@@ -1927,8 +1921,7 @@ void MainWindow::cgalRender()
   LOG("Rendering Polygon Mesh using %1$s...",
       renderBackend3DToString(RenderSettings::inst()->backend3D).c_str());
 
-  this->progresswidget = new ProgressWidget(this);
-  connect(this->progresswidget, &ProgressWidget::requestShow, this, &MainWindow::showProgress);
+  updateStatusBar(true);
 
   if (!isClosing) progress_report_prep(this->rootNode, report_func, this);
   else return;
@@ -1979,7 +1972,7 @@ void MainWindow::actionRenderDone(const std::shared_ptr<const Geometry>& root_ge
     LOG(message_group::UI_Warning, "No top level geometry to render");
   }
 
-  updateStatusBar(nullptr);
+  updateStatusBar(false);
 
   const bool renderSoundEnabled =
     GlobalPreferences::inst()->getValue("advanced/enableSoundNotification").toBool();
@@ -2277,37 +2270,15 @@ void MainWindow::setLastFocus(QWidget *widget)
   this->lastFocus = widget;
 }
 
-/**
- * Switch version label and progress widget. When switching to the progress
- * widget, the new instance is passed by the caller.
- * In case of resetting back to the version label, nullptr will be passed and
- * multiple calls can happen. So this method must guard against adding the
- * version label multiple times.
- *
- * @param progressWidget a pointer to the progress widget to show or nullptr in
- * case the display should switch back to the version label.
- */
-void MainWindow::updateStatusBar(ProgressWidget *progressWidget)
+void MainWindow::updateStatusBar(bool isProgress)
 {
-  auto sb = this->statusBar();
-  if (progressWidget == nullptr) {
-    if (this->progresswidget != nullptr) {
-      sb->removeWidget(this->progresswidget);
-      delete this->progresswidget;
-      this->progresswidget = nullptr;
-    }
-    if (versionLabel == nullptr) {
-      versionLabel =
-        new QLabel("OpenSCAD " + QString::fromStdString(std::string(openscad_displayversionnumber)));
-      sb->addPermanentWidget(this->versionLabel);
-    }
+  if (isProgress) {
+    progressWidget->reset();
+    versionLabel->hide();
+    progressWidget->show();
   } else {
-    if (this->versionLabel != nullptr) {
-      sb->removeWidget(this->versionLabel);
-      delete this->versionLabel;
-      this->versionLabel = nullptr;
-    }
-    sb->addPermanentWidget(progressWidget);
+    progressWidget->hide();
+    versionLabel->show();
   }
 }
 
@@ -3498,8 +3469,35 @@ void MainWindow::setupPreferences()
  */
 void MainWindow::setupStatusBar()
 {
-  this->versionLabel = nullptr;  // must be initialized before calling updateStatusBar()
-  updateStatusBar(nullptr);
+  statusBar()->setSizeGripEnabled(false);
+
+  QWidget *w = new QWidget();
+  w->setObjectName("statusBox");
+  statusBar()->addPermanentWidget(w, 1);
+
+  QHBoxLayout *hbox = new QHBoxLayout(w);
+  hbox->setContentsMargins(QMargins());
+
+  statusLabel = new QLabel("");
+  statusLabel->setObjectName("statusLabel");
+  statusLabel->setMinimumWidth(100);
+  hbox->addWidget(statusLabel);
+
+  hbox->addStretch(0);
+
+  versionLabel =
+    new QLabel("OpenSCAD " + QString::fromStdString(std::string(openscad_displayversionnumber)));
+  versionLabel->setObjectName("versionLabel");
+  hbox->addWidget(versionLabel);
+
+  progressWidget = new ProgressWidget(nullptr);
+  hbox->addWidget(progressWidget);
+
+  QWidget *sizeGrip = new QSizeGrip(w);
+  sizeGrip->setObjectName("sizeGrip");
+  hbox->addWidget(sizeGrip, 0, Qt::AlignBottom);
+
+  updateStatusBar(false);
 }
 
 /**
@@ -3640,9 +3638,7 @@ void MainWindow::setupViewportControl()
  */
 void MainWindow::setup3DView()
 {
-  this->qglview->statusLabel = new QLabel(this);
-  this->qglview->statusLabel->setMinimumWidth(100);
-  statusBar()->addWidget(this->qglview->statusLabel);
+  this->qglview->statusLabel = statusLabel;
 
   const QSettingsCached settings;
   this->qglview->setMouseCentricZoom(Settings::Settings::mouseCentricZoom.value());

--- a/src/gui/MainWindow.h
+++ b/src/gui/MainWindow.h
@@ -115,8 +115,6 @@ public:
   QShortcut *shortcutNextWindow{nullptr};
   QShortcut *shortcutPreviousWindow{nullptr};
 
-  QLabel *versionLabel;
-
   Measurement::Measurement meas;
 
   int compileErrors;
@@ -137,6 +135,12 @@ private:
   void clearAllSelectionIndicators();
   void setSelectionIndicatorStatus(EditorInterface *editor, int nodeIndex,
                                    EditorSelectionIndicatorStatus status);
+
+  QLabel *statusLabel;
+  QLabel *versionLabel;
+  ProgressWidget *progressWidget;
+
+  void updateStatusBar(bool isProgress);
 
   void setupWindow();
   void setupCoreSubsystems();
@@ -166,7 +170,6 @@ private slots:
   void updateReorderMode(bool reorderMode);
   void setFont(const QString& family, uint size);
   void setColorScheme(const QString& cs);
-  void showProgress();
   void openCSGSettingsChanged();
   void consoleOutput(const Message& msgObj);
   void setSelection(int index);
@@ -238,7 +241,6 @@ private:
   void writeBackup(QFile *file);
   void show_examples();
   void addKeyboardShortCut(const QList<QAction *>& actions);
-  void updateStatusBar(ProgressWidget *progressWidget);
   void activateDock(Dock *);
   Dock *findVisibleDockToActivate(int offset) const;
   Dock *getNextDockFromSender(QObject *sender);
@@ -453,7 +455,6 @@ private:
   char const *afterCompileSlot;
   bool procevents{false};
   QTemporaryFile *tempFile{nullptr};
-  ProgressWidget *progresswidget{nullptr};
   CGALWorker *cgalworker;
   QMutex consolemutex;
   EditorInterface *renderedEditor;  // stores pointer to editor which has been most recently rendered

--- a/src/gui/MainWindow.h
+++ b/src/gui/MainWindow.h
@@ -159,6 +159,7 @@ private:
 
 protected:
   void closeEvent(QCloseEvent *event) override;
+  void changeEvent(QEvent *event) override;
 
 private slots:
   void updateUndockMode(bool undockMode);

--- a/src/gui/MainWindow.ui
+++ b/src/gui/MainWindow.ui
@@ -98,9 +98,6 @@
           </item>
           <item row="0" column="2">
            <widget class="QToolButton" name="toolButtonCompileResultClose">
-            <property name="styleSheet">
-             <string notr="true"/>
-            </property>
             <property name="text">
              <string/>
             </property>
@@ -114,34 +111,21 @@
               <height>22</height>
              </size>
             </property>
-            <property name="toolButtonStyle">
-             <enum>Qt::ToolButtonStyle::ToolButtonIconOnly</enum>
-            </property>
             <property name="autoRaise">
              <bool>true</bool>
             </property>
            </widget>
           </item>
           <item row="0" column="0">
-           <widget class="QToolButton" name="toolButtonCompileResultIcon">
-            <property name="styleSheet">
-             <string notr="true">QToolButton { border: none; }</string>
-            </property>
+           <widget class="QLabel" name="labelCompileResultIcon">
             <property name="text">
              <string/>
             </property>
-            <property name="icon">
-             <iconset resource="../../resources/common.qrc">
-              <normaloff>:/icons/information-icons-error.png</normaloff>:/icons/information-icons-error.png</iconset>
+            <property name="pixmap">
+             <pixmap resource="../../resources/common.qrc">:/icons/information-icons-error.png</pixmap>
             </property>
-            <property name="iconSize">
-             <size>
-              <width>22</width>
-              <height>22</height>
-             </size>
-            </property>
-            <property name="autoRaise">
-             <bool>false</bool>
+            <property name="scaledContents">
+             <bool>true</bool>
             </property>
            </widget>
           </item>

--- a/src/gui/OpenSCADApp.cc
+++ b/src/gui/OpenSCADApp.cc
@@ -100,19 +100,7 @@ void OpenSCADApp::setRenderBackend3D(RenderBackend3D backend)
 
 void OpenSCADApp::setApplicationFont(const QString& family, uint size)
 {
-  // Trigger style sheet refresh to update the application font
-  // (hopefully) everywhere. Also remove ugly frames in the QStatusBar
-  // when using additional widgets
-  const auto stylesheet = QString(R"(
-    * {
-        font-family: '%1';
-        font-size: %2pt;
-    }
-    QStatusBar::item {
-        border: 0px solid black;
-    }
-  )");
-  scadApp->setStyleSheet(stylesheet.arg(family, QString::number(size)));
+  QApplication::setFont(QFont(family, size));
 }
 
 #if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)

--- a/src/gui/Preferences.cc
+++ b/src/gui/Preferences.cc
@@ -44,7 +44,6 @@
 #include <QSettings>
 #include <QSizePolicy>
 #include <QSpacerItem>
-#include <QStatusBar>
 #include <QString>
 #include <QStringList>
 #include <QTextDocument>
@@ -763,7 +762,7 @@ void Preferences::fireApplicationFontChanged() const
 
 void Preferences::on_fontComboBoxApplicationFontFamily_currentFontChanged(const QFont& font)
 {
-  // The global * stylesheet in setApplicationFont() applies font-family to
+  // The global setting in setApplicationFont() applies font-family to
   // all widgets including this QFontComboBox.  That can re-trigger this slot
   // with a wrong match (e.g. "Ubuntu" prefix-matched back to "Ubuntu Mono").
   // Block signals during the update to prevent the re-entrant cascade, then

--- a/src/gui/ProgressWidget.cc
+++ b/src/gui/ProgressWidget.cc
@@ -6,12 +6,15 @@
 ProgressWidget::ProgressWidget(QWidget *parent) : QWidget(parent)
 {
   setupUi(this);
+  reset();
+}
+
+void ProgressWidget::reset()
+{
   setRange(0, 1000);
   setValue(0);
   this->wascanceled = false;
   this->starttime.start();
-
-  QTimer::singleShot(1000, this, &ProgressWidget::requestShow);
 }
 
 bool ProgressWidget::wasCanceled() const

--- a/src/gui/ProgressWidget.h
+++ b/src/gui/ProgressWidget.h
@@ -15,6 +15,7 @@ public:
   ProgressWidget(QWidget *parent = nullptr);
   bool wasCanceled() const;
   int elapsedTime() const;
+  void reset();
 
 public slots:
   void setRange(int minimum, int maximum);
@@ -24,9 +25,6 @@ public slots:
 
 private slots:
   void on_stopButton_clicked();
-
-signals:
-  void requestShow();
 
 private:
   bool wascanceled;

--- a/src/gui/UIUtils.cc
+++ b/src/gui/UIUtils.cc
@@ -490,3 +490,21 @@ void UIUtils::dumpSaveState(const QByteArray&)
 {
 }
 #endif  // QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
+
+void UIUtils::dumpPalette(const QPalette& p)
+{
+  for (int ri = 0; ri < QPalette::NColorRoles; ri++) {
+    QPalette::ColorRole r = (QPalette::ColorRole)ri;
+    printf("%2d", r);
+    for (int gi = 0; gi < QPalette::NColorGroups; gi++) {
+      QPalette::ColorGroup g = (QPalette::ColorGroup)gi;
+      if (p.isBrushSet(g, r)) {
+        printf("  %s ", qPrintable(p.color(g, r).name()));
+      } else {
+        printf(" (%s)", qPrintable(p.color(g, r).name()));
+      }
+    }
+    printf("\n");
+  }
+  fflush(stdout);
+}

--- a/src/gui/UIUtils.cc
+++ b/src/gui/UIUtils.cc
@@ -306,16 +306,6 @@ QString UIUtils::getBackgroundColorStyleSheet(const QColor& color)
   return QString("background-color:%1;").arg(color.toRgb().name());
 }
 
-QString UIUtils::blendForBackgroundColorStyleSheet(const QColor& input, const QColor& blend,
-                                                   float transparency)
-{
-  const auto result =
-    QColor(255.0 * (transparency * blend.redF() + (1 - transparency) * input.redF()),
-           255.0 * (transparency * blend.greenF() + (1 - transparency) * input.greenF()),
-           255.0 * (transparency * blend.blueF() + (1 - transparency) * input.blueF()));
-  return getBackgroundColorStyleSheet(result);
-}
-
 #if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
 static bool dumpDockAreaLayoutInfo(QDataStream& stream)
 {

--- a/src/gui/UIUtils.cc
+++ b/src/gui/UIUtils.cc
@@ -301,11 +301,6 @@ void UIUtils::openOfflineCheatSheet()
   }
 }
 
-QString UIUtils::getBackgroundColorStyleSheet(const QColor& color)
-{
-  return QString("background-color:%1;").arg(color.toRgb().name());
-}
-
 #if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
 static bool dumpDockAreaLayoutInfo(QDataStream& stream)
 {

--- a/src/gui/UIUtils.h
+++ b/src/gui/UIUtils.h
@@ -87,9 +87,6 @@ void openOfflineCheatSheet();
 
 QString getBackgroundColorStyleSheet(const QColor& color);
 
-QString blendForBackgroundColorStyleSheet(const QColor& input, const QColor& blend,
-                                          float transparency = 0.2);
-
 void dumpSaveState(const QByteArray& data);
 
 void dumpPalette(const QPalette& p);

--- a/src/gui/UIUtils.h
+++ b/src/gui/UIUtils.h
@@ -92,4 +92,6 @@ QString blendForBackgroundColorStyleSheet(const QColor& input, const QColor& ble
 
 void dumpSaveState(const QByteArray& data);
 
+void dumpPalette(const QPalette& p);
+
 }  // namespace UIUtils

--- a/src/gui/UIUtils.h
+++ b/src/gui/UIUtils.h
@@ -85,8 +85,6 @@ bool hasOfflineCheatSheet();
 
 void openOfflineCheatSheet();
 
-QString getBackgroundColorStyleSheet(const QColor& color);
-
 void dumpSaveState(const QByteArray& data);
 
 void dumpPalette(const QPalette& p);

--- a/src/gui/ViewportControl.cc
+++ b/src/gui/ViewportControl.cc
@@ -47,14 +47,6 @@ void ViewportControl::setMainWindow(MainWindow *mainWindow)
   this->qglview = mainWindow->qglview;
 }
 
-QString ViewportControl::yellowHintBackground()
-{
-  QPalette defaultPalette;
-  const auto bgColor = defaultPalette.base().color().toRgb();
-  QString styleSheet = UIUtils::blendForBackgroundColorStyleSheet(bgColor, warnBlendColor);
-  return styleSheet;
-}
-
 void ViewportControl::resizeEvent(QResizeEvent *event)
 {
   auto layoutAspectRatio = dynamic_cast<QBoxLayout *>(groupBoxAspectRatio->layout());
@@ -156,26 +148,49 @@ void ViewportControl::updateCamera()
   inputMutex.unlock();
 }
 
+// Given a widget and a color, set the widget's background to be tinted that color, allowing the
+// parent's background to show through.
+void ViewportControl::setBackgroundTint(QWidget *w, QColor color) const
+{
+  // Make the color translucent.
+  color.setAlphaF(tintAlpha);
+
+  // Get the parent's palette (which, note, we haven't mucked with.)
+  QPalette p = palette();
+
+  // I don't find documentation saying which of the various background-like roles a spinbox
+  // uses for its background, and it appears to be somewhat platform-specific, so set them all.
+  //
+  // Note:
+  // QWindow11Style::inputFillBrush uses the Button role for the background *if* the background
+  // role (which defaults to Window) is set.  I think this is a bug.
+  p.setColor(QPalette::Button, color);
+  p.setColor(QPalette::Window, color);
+  p.setColor(QPalette::Base, color);
+
+  w->setPalette(p);
+}
+
 void ViewportControl::updateViewportControlHints()
 {
   // viewport camera field of view
   double fov = doubleSpinBox_fov->value();
   if (fov < 5 || fov > 175) {
     doubleSpinBox_fov->setToolTip(_("extreme values might may lead to strange behavior"));
-    doubleSpinBox_fov->setStyleSheet(yellowHintBackground());
+    setBackgroundTint(doubleSpinBox_fov, warnTint);
   } else {
     doubleSpinBox_fov->setToolTip("");
-    doubleSpinBox_fov->setStyleSheet("");
+    doubleSpinBox_fov->setPalette(palette());  // reset to parent's palette
   }
 
   // camera distance
   double d = doubleSpinBox_d->value();
   if (d < 5) {
     doubleSpinBox_d->setToolTip(_("extreme values might may lead to strange behavior"));
-    doubleSpinBox_d->setStyleSheet(yellowHintBackground());
+    setBackgroundTint(doubleSpinBox_d, warnTint);
   } else {
     doubleSpinBox_d->setToolTip("");
-    doubleSpinBox_d->setStyleSheet("");
+    doubleSpinBox_d->setPalette(palette());  // reset to parent's palette
   }
 }
 

--- a/src/gui/ViewportControl.cc
+++ b/src/gui/ViewportControl.cc
@@ -32,16 +32,10 @@ void ViewportControl::initGUI()
 {
   auto spinDoubleBoxes = this->groupBoxAbsoluteCamera->findChildren<QDoubleSpinBox *>();
   for (auto spinDoubleBox : spinDoubleBoxes) {
-    spinDoubleBox->setMinimum(-DBL_MAX);
-    spinDoubleBox->setMaximum(+DBL_MAX);
     connect(spinDoubleBox, QOverload<double>::of(&QDoubleSpinBox::valueChanged), this,
             &ViewportControl::updateCamera);
   }
 
-  spinBoxWidth->setMinimum(1);
-  spinBoxHeight->setMinimum(1);
-  spinBoxWidth->setMaximum(8192);
-  spinBoxHeight->setMaximum(8192);
   connect(spinBoxWidth, QOverload<int>::of(&QSpinBox::valueChanged), this,
           &ViewportControl::requestResize);
   connect(spinBoxHeight, QOverload<int>::of(&QSpinBox::valueChanged), this,
@@ -58,14 +52,6 @@ QString ViewportControl::yellowHintBackground()
   QPalette defaultPalette;
   const auto bgColor = defaultPalette.base().color().toRgb();
   QString styleSheet = UIUtils::blendForBackgroundColorStyleSheet(bgColor, warnBlendColor);
-  return styleSheet;
-}
-
-QString ViewportControl::redHintBackground()
-{
-  QPalette defaultPalette;
-  const auto bgColor = defaultPalette.base().color().toRgb();
-  QString styleSheet = UIUtils::blendForBackgroundColorStyleSheet(bgColor, errorBlendColor);
   return styleSheet;
 }
 
@@ -174,10 +160,7 @@ void ViewportControl::updateViewportControlHints()
 {
   // viewport camera field of view
   double fov = doubleSpinBox_fov->value();
-  if (fov < 0 || fov > 180) {
-    doubleSpinBox_fov->setToolTip(_("extreme values might may lead to strange behavior"));
-    doubleSpinBox_fov->setStyleSheet(redHintBackground());
-  } else if (fov < 5 || fov > 175) {
+  if (fov < 5 || fov > 175) {
     doubleSpinBox_fov->setToolTip(_("extreme values might may lead to strange behavior"));
     doubleSpinBox_fov->setStyleSheet(yellowHintBackground());
   } else {
@@ -187,10 +170,7 @@ void ViewportControl::updateViewportControlHints()
 
   // camera distance
   double d = doubleSpinBox_d->value();
-  if (d < 0) {
-    doubleSpinBox_d->setToolTip(_("negative distances are not supported"));
-    doubleSpinBox_d->setStyleSheet(redHintBackground());
-  } else if (d < 5) {
+  if (d < 5) {
     doubleSpinBox_d->setToolTip(_("extreme values might may lead to strange behavior"));
     doubleSpinBox_d->setStyleSheet(yellowHintBackground());
   } else {

--- a/src/gui/ViewportControl.h
+++ b/src/gui/ViewportControl.h
@@ -43,8 +43,10 @@ private:
   QGLView *qglview;
   std::mutex inputMutex;
   std::mutex resizeMutex;
-  QString yellowHintBackground();
-  QColor warnBlendColor{"yellow"};
+  const QColor warnTint{"yellow"};
+  const double tintAlpha{0.2};
+
+  void setBackgroundTint(QWidget *w, QColor color) const;
 
 signals:
   void openFile(const QString, int);

--- a/src/gui/ViewportControl.h
+++ b/src/gui/ViewportControl.h
@@ -44,9 +44,7 @@ private:
   std::mutex inputMutex;
   std::mutex resizeMutex;
   QString yellowHintBackground();
-  QString redHintBackground();
   QColor warnBlendColor{"yellow"};
-  QColor errorBlendColor{"red"};
 
 signals:
   void openFile(const QString, int);

--- a/src/gui/ViewportControl.ui
+++ b/src/gui/ViewportControl.ui
@@ -170,10 +170,13 @@
              <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
             </property>
             <property name="minimum">
-             <double>-1000000000000000.000000000000000</double>
+             <double>0</double>
             </property>
             <property name="maximum">
-             <double>1000000000000000.000000000000000</double>
+             <double>360</double>
+            </property>
+            <property name="wrapping">
+             <bool>true</bool>
             </property>
            </widget>
           </item>
@@ -183,10 +186,13 @@
              <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
             </property>
             <property name="minimum">
-             <double>-1000000000000000.000000000000000</double>
+             <double>0</double>
             </property>
             <property name="maximum">
-             <double>1000000000000000.000000000000000</double>
+             <double>360</double>
+            </property>
+            <property name="wrapping">
+             <bool>true</bool>
             </property>
            </widget>
           </item>
@@ -197,6 +203,9 @@
             </property>
             <property name="maximum">
              <double>1000000000000000.000000000000000</double>
+            </property>
+            <property name="minimum">
+             <double>1</double>
             </property>
            </widget>
           </item>
@@ -215,6 +224,9 @@
             <property name="maximum">
              <double>180.000000000000000</double>
             </property>
+            <property name="minimum">
+             <double>0</double>
+            </property>
            </widget>
           </item>
           <item row="1" column="0">
@@ -230,10 +242,13 @@
              <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
             </property>
             <property name="minimum">
-             <double>-1000000000000000.000000000000000</double>
+             <double>0</double>
             </property>
             <property name="maximum">
-             <double>1000000000000000.000000000000000</double>
+             <double>360</double>
+            </property>
+            <property name="wrapping">
+             <bool>true</bool>
             </property>
            </widget>
           </item>

--- a/src/gui/parameter/ParameterWidget.cc
+++ b/src/gui/parameter/ParameterWidget.cc
@@ -471,6 +471,5 @@ void ParameterWidget::cleanSets()
 
 void ParameterWidget::setFontFamilySize(const QString& fontFamily, uint fontSize)
 {
-  scrollArea->setStyleSheet(
-    QString("font-family: \"%1\"; font-size: %2pt;").arg(fontFamily).arg(fontSize));
+  scrollArea->setFont(QFont(fontFamily, fontSize));
 }

--- a/src/openscad_gui.cc
+++ b/src/openscad_gui.cc
@@ -132,6 +132,11 @@ void configureOpenGLContext()
 
 }  // namespace
 
+void setGlobalTheme()
+{
+  QIcon::setThemeName(isDarkMode() ? "chokusen-dark" : "chokusen");
+}
+
 namespace {
 
 // Only if "fileName" is not absolute, prepend the "absoluteBase".
@@ -200,7 +205,7 @@ int gui(std::vector<std::string>& inputFiles, const std::filesystem::path& origi
 {
   configureOpenGLContext();
   OpenSCADApp app(argc, argv);
-  QIcon::setThemeName(isDarkMode() ? "chokusen-dark" : "chokusen");
+  setGlobalTheme();
 
   // set up groups for QSettings
   QCoreApplication::setOrganizationName("OpenSCAD");

--- a/src/openscad_gui.cc
+++ b/src/openscad_gui.cc
@@ -93,11 +93,6 @@ namespace {
 
 // Check if running with light or dark theme. This should really just be used
 // to switch the icon theme globally.
-//
-// For applying a color change, e.g. highlighting the background of an input
-// field, see:
-// UIUtils::blendForBackgroundColorStyleSheet(const QColor& input, const QColor& blend)
-
 bool isDarkMode()
 {
 #if QT_VERSION >= QT_VERSION_CHECK(6, 5, 0)

--- a/src/openscad_gui.h
+++ b/src/openscad_gui.h
@@ -32,3 +32,4 @@
 
 int gui(std::vector<std::string>& inputFiles, const std::filesystem::path& original_path, int argc,
         char **argv, const std::string&, const bool);
+void setGlobalTheme();


### PR DESCRIPTION
Various changes to properly handle switching to and from dark mode while the application is running.

Mostly Qt6 does all of the work, but... it does it using palette inheritance, and style sheets break palette inheritance.
