### PR TITLE
Bump OpenCSG to 1.8.2

### DIFF
--- a/scripts/macosx-build-dependencies.sh
+++ b/scripts/macosx-build-dependencies.sh
@@ -95,7 +95,7 @@ PACKAGES=(
     "qt6 6.8.3"
 
     # https://opencsg.org/news.html
-    "opencsg 1.8.1"
+    "opencsg 1.8.2"
 
     # https://riverbankcomputing.com/software/qscintilla/download
     "qscintilla 2.14.1"

--- a/submodules/OpenCSG.txt
+++ b/submodules/OpenCSG.txt
@@ -1,2 +1,4 @@
 7b24d76 OpenCSG 1.5.1
 059a173 OpenCSG 1.6.0
+9bf1227 OpenCSG 1.8.2
+


### PR DESCRIPTION
Updating macOS build and submodule. See #6784.