### PR TITLE
Avoid saving window state when closing docket widgets

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1300,6 +1300,7 @@ set(GUI_SOURCES
   src/gui/LaunchingScreen.cc
   src/gui/LibraryInfoDialog.cc
   src/gui/MainWindow.cc
+  src/gui/WorkspaceSaver.cc
   src/gui/Measurement.cc
   src/gui/Animate.cc
   src/gui/FontList.cc
@@ -1380,6 +1381,7 @@ set(GUI_HEADERS
     src/gui/LaunchingScreen.h
     src/gui/LibraryInfoDialog.h
     src/gui/MainWindow.h
+    src/gui/WorkspaceSaver.h
     src/gui/MouseSelector.h
     src/gui/Network.h
     src/gui/NetworkSignal.h

--- a/src/gui/MainWindow.cc
+++ b/src/gui/MainWindow.cc
@@ -1521,8 +1521,10 @@ bool MainWindow::eventFilter(QObject *obj, QEvent *event)
   // not defined by Qt, so we may end up closing undocked dock widgets before we've had a chance to save
   // their window state. This overrides close to proactively save the window state.
   if (event->type() == QEvent::Close) {
-    if (qobject_cast<Dock *>(obj) && !static_cast<QCloseEvent *>(event)->spontaneous()) {
-      saveWindowStateOnClose();
+    if (auto dock = qobject_cast<Dock *>(obj)) {
+      if (dock->isFloating() && !static_cast<QCloseEvent *>(event)->spontaneous()) {
+        saveWindowStateOnClose();
+      }
     }
   }
 

--- a/src/gui/MainWindow.cc
+++ b/src/gui/MainWindow.cc
@@ -25,6 +25,7 @@
  */
 
 #include "gui/MainWindow.h"
+#include "gui/WorkspaceSaver.h"
 
 #include <sys/stat.h>
 
@@ -1517,17 +1518,6 @@ bool MainWindow::event(QEvent *event)
 
 bool MainWindow::eventFilter(QObject *obj, QEvent *event)
 {
-  // OpenSCAD quits by closing all top-level windows. However, the order in which top-level are closed is
-  // not defined by Qt, so we may end up closing undocked dock widgets before we've had a chance to save
-  // their window state. This overrides close to proactively save the window state.
-  if (event->type() == QEvent::Close) {
-    if (auto dock = qobject_cast<Dock *>(obj)) {
-      if (dock->isFloating() && !static_cast<QCloseEvent *>(event)->spontaneous()) {
-        saveWindowStateOnClose();
-      }
-    }
-  }
-
   if (rubberBandManager.isVisible()) {
     if (event->type() == QEvent::KeyRelease) {
       auto keyEvent = static_cast<QKeyEvent *>(event);
@@ -3238,23 +3228,12 @@ void MainWindow::on_helpActionLibraryInfo_triggered()
   this->libraryInfoDialog->show();
 }
 
-void MainWindow::saveWindowStateOnClose()
-{
-  if (windowStateSaved) return;
-  windowStateSaved = true;
-
-  QSettingsCached settings;
-  settings.setValue("window/geometry", saveGeometry());
-  auto windowState = saveState();
-  UIUtils::dumpSaveState(windowState);
-  settings.setValue("window/state", windowState);
-}
-
 void MainWindow::closeEvent(QCloseEvent *event)
 {
+  WorkspaceSaver::instance()->captureState(this);
   if (tabManager->shouldClose()) {
+    WorkspaceSaver::instance()->lock();
     isClosing = true;
-    saveWindowStateOnClose();
     progress_report_fin();
 
     // Log to stdout from now on
@@ -3270,6 +3249,7 @@ void MainWindow::closeEvent(QCloseEvent *event)
     hideCurrentOutput();
     event->accept();
   } else {
+    WorkspaceSaver::instance()->unlock();
     event->ignore();
   }
 }

--- a/src/gui/MainWindow.h
+++ b/src/gui/MainWindow.h
@@ -131,8 +131,6 @@ private:
   std::vector<std::pair<Dock *, QString>> docks;
 
   volatile bool isClosing = false;
-  bool windowStateSaved = false;
-  void saveWindowStateOnClose();
   void consoleOutputRaw(const QString& msg);
   void clearAllSelectionIndicators();
   void setSelectionIndicatorStatus(EditorInterface *editor, int nodeIndex,

--- a/src/gui/WorkspaceSaver.cc
+++ b/src/gui/WorkspaceSaver.cc
@@ -1,0 +1,112 @@
+#include "WorkspaceSaver.h"
+#include <QApplication>
+#include <QEvent>
+#include <QSettings>
+#include "gui/QSettingsCached.h"
+#include <QSessionManager>
+
+/**
+ * @class WorkspaceSaver
+ * @brief Singleton class responsible for safely capturing and saving the application's workspace state.
+ *
+ * This class ensures that the layout state (including the state of floating QDockWidgets)
+ * is safely captured and saved to a configuration file upon application exit. It handles
+ * scenarios like multiple windows, quit interruptions, and the arbitrary closing order
+ * of top-level floating docks.
+ */
+
+WorkspaceSaver *WorkspaceSaver::instance()
+{
+  static WorkspaceSaver *inst = nullptr;
+  if (!inst) {
+    inst = new WorkspaceSaver(qApp);
+  }
+  return inst;
+}
+
+WorkspaceSaver::WorkspaceSaver(QObject *parent) : QObject(parent)
+{
+  // aboutToQuit is emitted after closeAllWindows() has been called, so we can be sure that the
+  // geometry/state we capture is the last one before the app quits.
+  connect(qApp, &QCoreApplication::aboutToQuit, this, &WorkspaceSaver::commitToSettings);
+  // commitDataRequest is emitted when the user tries to quit the app, but before closeAllWindows() is
+  // called.
+  connect(qApp, &QGuiApplication::commitDataRequest, this, [this](QSessionManager&) {
+    captureActiveMainWindow();
+    lock();
+  });
+  qApp->installEventFilter(this);
+}
+
+/**
+ * Finds the currently active main window and captures its state.
+ */
+void WorkspaceSaver::captureActiveMainWindow()
+{
+  QMainWindow *activeMainWindow = nullptr;
+  for (QWidget *widget : QApplication::topLevelWidgets()) {
+    if (auto *win = qobject_cast<QMainWindow *>(widget)) {
+      activeMainWindow = win;
+      if (win->isActiveWindow()) {
+        break;
+      }
+    }
+  }
+  if (activeMainWindow) {
+    captureState(activeMainWindow);
+  }
+}
+
+void WorkspaceSaver::captureState(QMainWindow *window)
+{
+  if (locked_) return;
+  saved_geometry_ = window->saveGeometry();
+  saved_state_ = window->saveState();
+}
+
+/**
+ * This should be called once a valid state is guaranteed to be captured,
+ * avoiding subsequent overwrites by partial state destructions during shutdown.
+ */
+void WorkspaceSaver::lock()
+{
+  locked_ = true;
+}
+
+/**
+ *
+ * This is typically used when a quit operation is aborted (e.g., user cancels).
+ */
+void WorkspaceSaver::unlock()
+{
+  locked_ = false;
+}
+
+bool WorkspaceSaver::eventFilter(QObject *obj, QEvent *event)
+{
+  if (event->type() == QEvent::Quit) {
+    // By the time Quit is processed, closeAllWindows() has already hidden docks.
+    // We only capture here if we haven't locked it (i.e. if it wasn't captured in closeEvent).
+    if (!locked_ && saved_geometry_.isEmpty()) {
+      captureActiveMainWindow();
+      lock();
+    }
+  }
+  return QObject::eventFilter(obj, event);
+}
+
+/**
+ * @brief Commits the currently captured state and geometry to persistent settings.
+ */
+void WorkspaceSaver::commitToSettings()
+{
+  if (!saved_geometry_.isEmpty() || !saved_state_.isEmpty()) {
+    QSettingsCached settings;
+    if (!saved_geometry_.isEmpty()) {
+      settings.setValue("window/geometry", saved_geometry_);
+    }
+    if (!saved_state_.isEmpty()) {
+      settings.setValue("window/state", saved_state_);
+    }
+  }
+}

--- a/src/gui/WorkspaceSaver.h
+++ b/src/gui/WorkspaceSaver.h
@@ -1,0 +1,33 @@
+#pragma once
+
+#include <QObject>
+#include <QByteArray>
+#include <QMainWindow>
+
+class WorkspaceSaver : public QObject
+{
+  Q_OBJECT
+
+public:
+  static WorkspaceSaver *instance();
+
+  void captureState(QMainWindow *window);
+  void lock();
+  void unlock();
+
+protected:
+  bool eventFilter(QObject *obj, QEvent *event) override;
+
+public slots:
+  void commitToSettings();
+
+private:
+  WorkspaceSaver(QObject *parent = nullptr);
+  ~WorkspaceSaver() = default;
+
+  void captureActiveMainWindow();
+
+  QByteArray saved_geometry_;
+  QByteArray saved_state_;
+  bool locked_ = false;
+};

--- a/src/openscad_gui.cc
+++ b/src/openscad_gui.cc
@@ -74,6 +74,7 @@
 #include "gui/LaunchingScreen.h"
 #include "gui/MainWindow.h"
 #include "gui/OpenSCADApp.h"
+#include "gui/WorkspaceSaver.h"
 #include "gui/Preferences.h"
 #include "gui/QSettingsCached.h"
 #include "openscad.h"
@@ -200,6 +201,7 @@ int gui(std::vector<std::string>& inputFiles, const std::filesystem::path& origi
 {
   configureOpenGLContext();
   OpenSCADApp app(argc, argv);
+  WorkspaceSaver::instance();
   QIcon::setThemeName(isDarkMode() ? "chokusen-dark" : "chokusen");
 
   // set up groups for QSettings


### PR DESCRIPTION
#6769 introduced a bug: When closing _docked_ widgets, the MainWindow state was saved and remembered, causing a later real exit to _not_ save the state.

Edit - second try:

To avoid dealing with partially closed windows by trying to guess how they were closed, we instead intercept two Qt mechanism:
* Listen for the commitDataRequest signal from QGuiApplication, which feels like what Qt intended
* As a fallback, install ourselves as an event filter listening for the Quit event, in case commitDataRequest didn't pan out
* To avoid re-saving partial contents, lock the state once saved, and only unlock if the quit was rejected by the user.
* Business logic is separated out in a WorkspaceSaver class