### PR TITLE
WIP: GPU compute acceleration for Manifold geometry engine (Metal)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1203,6 +1203,15 @@ if(ENABLE_MANIFOLD)
 
   set(MANIFOLD_PYBIND OFF)
   set(MANIFOLD_TEST OFF)
+
+  # Enable GPU compute acceleration if requested.
+  if(ENABLE_METAL_GPU AND APPLE)
+    enable_language(OBJCXX)
+    set(MANIFOLD_GPU ON CACHE BOOL "GPU compute" FORCE)
+    set(MANIFOLD_GPU_METAL ON CACHE BOOL "Metal backend" FORCE)
+    message(STATUS "Manifold GPU compute: Metal")
+  endif()
+
   if(USE_BUILTIN_MANIFOLD)
     if(CMAKE_UNITY_BUILD)
       set(CMAKE_UNITY_BUILD OFF)


### PR DESCRIPTION
> **Status: Work in Progress — seeking review and discussion before further development.**

## Benchmark Results (Apple M5 Pro, 200 spheres @ $fn=128)

| Metric | CPU (TBB) | GPU (Metal) | Improvement |
|--------|-----------|-------------|-------------|
| Per-mesh SortGeometry | 35ms | 1.6ms | **21x** |
| Total sort pipeline (200 meshes) | ~7,000ms | ~660ms | **10.6x** |
| End-to-end render time | 7.75s | 7.14s | **8%** |
| Output correctness | — | byte-identical | verified via MD5 |

## What this PR does

Adds optional GPU compute acceleration for the Manifold geometry engine's `SortGeometry` pipeline using Metal on macOS. The GPU handles the radix sort (O(n log n) bottleneck), while fp64-dependent operations (Morton codes, bounding boxes, Collider box unions) remain on CPU for correctness.

### Architecture

- **GPU HAL** (`src/gpu/gpu_hal.h`): Thin abstraction over Metal with `GpuContext`, `GpuBuffer`, `GpuCommandBatch`, `GpuPipeline`. Null backend compiles on all platforms.
- **Multi-workgroup radix sort** (`kernels/sort.metal`): Based on [VkRadixSort](https://github.com/MircoWerner/VkRadixSort) / Intel Embree approach. Uses per-bin flag arrays + `popcount` for race-free stable scatter — no atomics in the scatter path.
- **GPU BVH tree construction** (`kernels/collider.metal`): `CreateRadixTree` kernel (pure integer CLZ operations). `BuildInternalBoxes` stays on CPU (requires fp64 Box unions).
- **Integration**: `SortGeometry()` dispatches to GPU when triangle count exceeds threshold (8K). Falls back to CPU transparently if Metal is unavailable.

### Build

```bash
cmake .. -DENABLE_METAL_GPU=ON -DCMAKE_BUILD_TYPE=Release
```

Requires macOS with Metal support. No additional dependencies. The Metal shaders are compiled at runtime from source (pre-compilation via `xcrun metal` is optional).

### Limitations and open questions

1. **Apple Silicon lacks fp64 on GPU** — both Metal and OpenCL report `fp64: NO`. Morton code computation, bounding boxes, and boolean intersection math must stay on CPU. This limits the GPU's role to integer-only operations (sort, BVH tree structure).

2. **Unified memory** — Apple Silicon's CPU and GPU share the same memory bus. The GPU doesn't have a bandwidth advantage for memory-bound operations. The speedup comes from the GPU's massively parallel ALUs on compute-bound work (radix sort).

3. **End-to-end improvement is modest (8%)** — The sort is ~10-20% of total render time depending on the workload. Boolean intersection math (fp64), mesh assembly (Compose), and I/O dominate for most real-world models.

4. **Single-platform** — Metal only (macOS). The HAL is designed for an OpenCL backend which would enable Linux/Windows support and fp64 GPU math on discrete GPUs with `cl_khr_fp64`.

5. **Maintenance surface** — ~1,200 lines of new code including Metal shaders. The GPU path replaces `SortGeometry` at the function level, not individual parallel primitives, so changes to `parallel.h` don't require GPU-side updates.

### What's NOT in this PR

- OpenCL backend (planned — would enable fp64 GPU math on discrete GPUs)
- GPU collision detection (`FindCollision`)
- GPU boolean intersection kernels (requires fp64)
- GPU-accelerated Compose (vertex transform + halfedge assembly)

### Files changed

**Manifold submodule** (DatanoiseTV/manifold@feature/gpu-compute-rework):
- `src/gpu/gpu_hal.h` — HAL interfaces
- `src/gpu/gpu_hal_metal.mm` — Metal backend
- `src/gpu/gpu_hal_null.cpp` — Null fallback
- `src/gpu/gpu_sort.h/cpp` — GPU SortGeometry orchestration
- `src/gpu/kernels/sort.metal` — Radix sort + BVH tree kernels
- `src/gpu/CMakeLists.txt` — Build system
- `src/sort.cpp` — GPU fast path dispatch
- `src/collider.h` — Friend declaration for GPU BVH builder
- `CMakeLists.txt` — `MANIFOLD_GPU` option

**OpenSCAD**:
- `CMakeLists.txt` — `ENABLE_METAL_GPU` option, OBJCXX, manifold GPU flags