### PR TITLE
setupInput() must be called before setupPreferences().  Fixes #6795.

### DIFF
--- a/src/gui/MainWindow.cc
+++ b/src/gui/MainWindow.cc
@@ -296,9 +296,8 @@ MainWindow::MainWindow(const QStringList& filenames) : rubberBandManager(this)
 
   setup3DView();
   setupViewportControl();
-  setupPreferences();
-
   setupInput();
+  setupPreferences();
 
   restoreWindowState();
 


### PR DESCRIPTION
Like the title says.  It doesn't work so good when you go to build a menu, and the list that you're building the menu from hasn't been built yet.

Fixes #6795.