### PR TITLE
Fine tune Animate pane layout.  Fixes #6702.

### DIFF
--- a/src/gui/Animate.cc
+++ b/src/gui/Animate.cc
@@ -24,10 +24,10 @@ Animate::Animate(QWidget *parent) : QWidget(parent)
   setupUi(this);
   initGUI();
 
-  const auto width = groupBoxParameter->minimumSizeHint().width();
+  const auto width = animateParameters->minimumSizeHint().width();
   const auto margins = layout()->contentsMargins();
   const auto scrollMargins = scrollAreaWidgetContents->layout()->contentsMargins();
-  const auto parameterMargins = groupBoxParameter->layout()->contentsMargins();
+  const auto parameterMargins = animateParameters->layout()->contentsMargins();
   initMinWidth = width + margins.left() + margins.right() + scrollMargins.left() +
                  scrollMargins.right() + parameterMargins.left() + parameterMargins.right();
 }
@@ -260,8 +260,8 @@ int Animate::nextFrame()
 
 void Animate::resizeEvent(QResizeEvent *event)
 {
-  auto layoutParameters = dynamic_cast<QBoxLayout *>(groupBoxParameter->layout());
-  auto layoutButtons = dynamic_cast<QBoxLayout *>(groupBoxButtons->layout());
+  auto layoutParameters = dynamic_cast<QBoxLayout *>(animateParameters->layout());
+  auto layoutButtons = dynamic_cast<QBoxLayout *>(animateButtons->layout());
 
   if (layoutParameters && layoutButtons) {
     if (layoutParameters->direction() == QBoxLayout::LeftToRight) {

--- a/src/gui/Animate.ui
+++ b/src/gui/Animate.ui
@@ -33,16 +33,16 @@
     <enum>QLayout::SetDefaultConstraint</enum>
    </property>
    <property name="leftMargin">
-    <number>10</number>
+    <number>0</number>
    </property>
    <property name="topMargin">
-    <number>10</number>
+    <number>0</number>
    </property>
    <property name="rightMargin">
-    <number>10</number>
+    <number>0</number>
    </property>
    <property name="bottomMargin">
-    <number>10</number>
+    <number>0</number>
    </property>
    <item>
     <widget class="QScrollArea" name="scrollArea">
@@ -75,17 +75,30 @@
       </property>
       <layout class="QVBoxLayout" name="verticalLayout_2">
        <item>
-        <widget class="QGroupBox" name="groupBoxParameter">
+        <widget class="QWidget" name="animateParameters">
          <property name="sizePolicy">
           <sizepolicy hsizetype="Preferred" vsizetype="Minimum">
            <horstretch>0</horstretch>
            <verstretch>0</verstretch>
           </sizepolicy>
          </property>
-         <property name="title">
-          <string/>
-         </property>
          <layout class="QHBoxLayout" name="horizontalLayout">
+          <item>
+           <spacer name="horizontalSpacer_1">
+            <property name="orientation">
+             <enum>Qt::Horizontal</enum>
+            </property>
+            <property name="sizeType">
+             <enum>QSizePolicy::Expanding</enum>
+            </property>
+            <property name="sizeHint" stdset="0">
+             <size>
+              <width>0</width>
+              <height>0</height>
+             </size>
+            </property>
+           </spacer>
+          </item>
           <item>
            <widget class="QLabel" name="label_time">
             <property name="text">
@@ -100,8 +113,14 @@
            <widget class="QLineEdit" name="e_tval">
             <property name="minimumSize">
              <size>
-              <width>120</width>
+              <width>50</width>
               <height>0</height>
+             </size>
+            </property>
+            <property name="maximumSize">
+             <size>
+              <width>50</width>
+              <height>100</height>
              </size>
             </property>
             <property name="alignment">
@@ -110,12 +129,12 @@
            </widget>
           </item>
           <item>
-           <spacer name="horizontalSpacer_1">
+           <spacer name="horizontalSpacer_2">
             <property name="orientation">
              <enum>Qt::Horizontal</enum>
             </property>
             <property name="sizeType">
-             <enum>QSizePolicy::Fixed</enum>
+             <enum>QSizePolicy::Expanding</enum>
             </property>
             <property name="sizeHint" stdset="0">
              <size>
@@ -139,8 +158,14 @@
            <widget class="QLineEdit" name="e_fps">
             <property name="minimumSize">
              <size>
-              <width>120</width>
+              <width>30</width>
               <height>0</height>
+             </size>
+            </property>
+            <property name="maximumSize">
+             <size>
+              <width>50</width>
+              <height>100</height>
              </size>
             </property>
             <property name="alignment">
@@ -149,12 +174,12 @@
            </widget>
           </item>
           <item>
-           <spacer name="horizontalSpacer_2">
+           <spacer name="horizontalSpacer_3">
             <property name="orientation">
              <enum>Qt::Horizontal</enum>
             </property>
             <property name="sizeType">
-             <enum>QSizePolicy::Fixed</enum>
+             <enum>QSizePolicy::Expanding</enum>
             </property>
             <property name="sizeHint" stdset="0">
              <size>
@@ -178,8 +203,14 @@
            <widget class="QLineEdit" name="e_fsteps">
             <property name="minimumSize">
              <size>
-              <width>120</width>
+              <width>30</width>
               <height>0</height>
+             </size>
+            </property>
+            <property name="maximumSize">
+             <size>
+              <width>50</width>
+              <height>100</height>
              </size>
             </property>
             <property name="alignment">
@@ -188,12 +219,12 @@
            </widget>
           </item>
           <item>
-           <spacer name="horizontalSpacer_3">
+           <spacer name="horizontalSpacer_4">
             <property name="orientation">
              <enum>Qt::Horizontal</enum>
             </property>
             <property name="sizeType">
-             <enum>QSizePolicy::Fixed</enum>
+             <enum>QSizePolicy::Expanding</enum>
             </property>
             <property name="sizeHint" stdset="0">
              <size>
@@ -211,13 +242,16 @@
            </widget>
           </item>
           <item>
-           <spacer name="horizontalSpacer_4">
+           <spacer name="horizontalSpacer_5">
             <property name="orientation">
              <enum>Qt::Horizontal</enum>
             </property>
+            <property name="sizeType">
+             <enum>QSizePolicy::Expanding</enum>
+            </property>
             <property name="sizeHint" stdset="0">
              <size>
-              <width>40</width>
+              <width>0</width>
               <height>0</height>
              </size>
             </property>
@@ -227,15 +261,12 @@
         </widget>
        </item>
        <item>
-        <widget class="QGroupBox" name="groupBoxButtons">
+        <widget class="QWidget" name="animateButtons">
          <property name="sizePolicy">
           <sizepolicy hsizetype="Preferred" vsizetype="Minimum">
            <horstretch>0</horstretch>
            <verstretch>0</verstretch>
           </sizepolicy>
-         </property>
-         <property name="title">
-          <string/>
          </property>
          <layout class="QHBoxLayout" name="horizontalLayout_2">
           <item>
@@ -259,6 +290,18 @@
             <property name="icon">
              <iconset theme="chokusen-vcr-control-start"/>
             </property>
+            <property name="maximumSize">
+             <size>
+              <width>48</width>
+              <height>48</height>
+             </size>
+            </property>
+            <property name="minimumSize">
+             <size>
+              <width>48</width>
+              <height>48</height>
+             </size>
+            </property>
             <property name="iconSize">
              <size>
               <width>32</width>
@@ -274,6 +317,18 @@
             </property>
             <property name="icon">
              <iconset theme="chokusen-vcr-control-step-back"/>
+            </property>
+            <property name="maximumSize">
+             <size>
+              <width>48</width>
+              <height>48</height>
+             </size>
+            </property>
+            <property name="minimumSize">
+             <size>
+              <width>48</width>
+              <height>48</height>
+             </size>
             </property>
             <property name="iconSize">
              <size>
@@ -291,6 +346,18 @@
             <property name="icon">
              <iconset theme="chokusen-vcr-control-play"/>
             </property>
+            <property name="maximumSize">
+             <size>
+              <width>48</width>
+              <height>48</height>
+             </size>
+            </property>
+            <property name="minimumSize">
+             <size>
+              <width>48</width>
+              <height>48</height>
+             </size>
+            </property>
             <property name="iconSize">
              <size>
               <width>32</width>
@@ -306,6 +373,18 @@
             </property>
             <property name="icon">
              <iconset theme="chokusen-vcr-control-step-forward"/>
+            </property>
+            <property name="maximumSize">
+             <size>
+              <width>48</width>
+              <height>48</height>
+             </size>
+            </property>
+            <property name="minimumSize">
+             <size>
+              <width>48</width>
+              <height>48</height>
+             </size>
             </property>
             <property name="iconSize">
              <size>
@@ -323,6 +402,18 @@
             <property name="icon">
              <iconset theme="chokusen-vcr-control-end"/>
             </property>
+            <property name="maximumSize">
+             <size>
+              <width>48</width>
+              <height>48</height>
+             </size>
+            </property>
+            <property name="minimumSize">
+             <size>
+              <width>48</width>
+              <height>48</height>
+             </size>
+            </property>
             <property name="iconSize">
              <size>
               <width>32</width>
@@ -335,7 +426,7 @@
            </widget>
           </item>
           <item>
-           <spacer name="horizontalSpacer_5">
+           <spacer name="horizontalSpacer_6">
             <property name="orientation">
              <enum>Qt::Horizontal</enum>
             </property>


### PR DESCRIPTION
I looked at #6735, but I thought that it should be possible to address the problem using metadata rather than adding logic.

I was partially wrong - there is no "word wrap" layout scheme, which is what I would have thought of.  (There is a sample "flow layout" scheme, but it seemed heavyweight for the need.) However, it does seem like tuning the metadata helps a great deal.  The only C++ change here is to change the names of some of the components because of changes in the widgets used.

Here's a stock OpenSCAD 2026.04.16 resized to a 200-pixel-tall viewport and otherwise sized to the smallest it can be and still keep the animate pane horizontal:
<img width="1046" height="757" alt="image" src="https://github.com/user-attachments/assets/6eda1f34-4e2c-420d-8145-f9fc13e544d9" />

Here's the stock one, with a ~500px-wide viewport, with the animate toolbar vertical and made as small as it can be without losing anything - in particular, without numbers falling off the right side.
<img width="1038" height="957" alt="image" src="https://github.com/user-attachments/assets/d6fbba4e-eeb9-40ff-8124-3f2a246323ed" />

Here's mine with the sizes fine tuned.

200px tall viewport, as small as it will go with the animate toolbar horizontal:
<img width="524" height="671" alt="image" src="https://github.com/user-attachments/assets/9bf282f8-032c-4872-a9b0-79e6d27fd72d" />

About 500px wide, as small as it will go with the animate toolbar vertical:
<img width="992" height="930" alt="image" src="https://github.com/user-attachments/assets/06314ec5-fe92-4d9b-a021-ab8abb466153" />

Pasting those into github conveniently gives me the overall dimensions:
| | Old | New |
|--------|--------|--------|
| Horizontal | 1046x757 | 524x671 |
| Vertical | 1038x957 | 992x930 |

So the new version is significantly smaller and, I believe, looks better.  (It looks like I actually increased the size of the buttons.  Also, it looks like vertical mode has more vertical space above and below the buttons than it really needs.  Both of those suggest that a bit more tuning might be appropriate.)

Here's what the old one looks like with a very wide window:
<img width="1914" height="265" alt="image" src="https://github.com/user-attachments/assets/fa535f82-43d9-4f2a-9587-2fd47b789551" />

and here's what the new one looks like at that width:
<img width="1919" height="194" alt="image" src="https://github.com/user-attachments/assets/7c9ae24e-3b3e-4cc1-9515-13ef96f73d92" />

At that width, we might want to change to yet another layout, with the parameters and the buttons on the same line.  That **would** take logic, probably switching the orientation on the top-level QVBoxLayout.  But not today.

Here's the old one, just barely too narrow to be horizontal:
<img width="1039" height="832" alt="image" src="https://github.com/user-attachments/assets/695f9839-5b2f-42b7-964e-9acb02f76755" />

And the new one:
<img width="506" height="974" alt="image" src="https://github.com/user-attachments/assets/2af9c823-e9ab-4c95-86ad-19439113c70d" />

Here's the new one in a sidebar, in horizontal mode:
<img width="530" height="962" alt="image" src="https://github.com/user-attachments/assets/cd0b8310-68ad-4336-9ecf-20b06f1dd68c" />
