### PR TITLE
Fix wrong colors on multi-mesh 3MF export with lib3mf v1

### DIFF
--- a/src/io/export_3mf_v1.cc
+++ b/src/io/export_3mf_v1.cc
@@ -68,7 +68,6 @@ struct ExportContext {
   int modelcount = 0;
   Color4f defaultColor;
   DWORD defaultColorId = 0;
-  std::vector<DWORD> materialids;
   const ExportInfo& info;
   const std::shared_ptr<const Export3mfOptions> options;
 };
@@ -117,7 +116,8 @@ int count_mesh_objects(PLib3MFModel *& model)
 }
 
 bool handle_triangle_color(PLib3MFPropertyHandler *propertyhandler, const std::unique_ptr<PolySet>& ps,
-                           int triangle_index, int color_index, ExportContext& ctx)
+                           int triangle_index, int color_index, const std::vector<DWORD>& materialids,
+                           ExportContext& ctx)
 {
   if (color_index < 0) {
     return true;
@@ -134,7 +134,7 @@ bool handle_triangle_color(PLib3MFPropertyHandler *propertyhandler, const std::u
 
   if (ctx.basematerial) {
     if (lib3mf_propertyhandler_setbasematerial(propertyhandler, triangle_index, ctx.basematerialid,
-                                               ctx.materialids[color_index]) != LIB3MF_OK) {
+                                               materialids[color_index]) != LIB3MF_OK) {
       export_3mf_error("Can't set triangle base material.", ctx.model);
       return false;
     }
@@ -155,6 +155,14 @@ bool handle_triangle_color(PLib3MFPropertyHandler *propertyhandler, const std::u
  */
 bool append_polyset(const std::shared_ptr<const PolySet>& ps, ExportContext& ctx)
 {
+  // Per-mesh local: each PolySet's `color_indices` are indices into *this*
+  // mesh's `colors`, so the lib3mf-side material IDs registered for those
+  // colors must also be looked up per-mesh. Keeping this in `ctx` (as was
+  // done previously) caused the second mesh's `color_index=0` to resolve
+  // to the FIRST mesh's material ID, silently painting all subsequent
+  // meshes with the first one's color. See #6813.
+  std::vector<DWORD> materialids;
+
   PLib3MFModelMeshObject *mesh = nullptr;
   if (lib3mf_model_addmeshobject(ctx.model, &mesh) != LIB3MF_OK) {
     export_3mf_error("Can't add mesh to 3MF model.", ctx.model);
@@ -239,9 +247,9 @@ bool append_polyset(const std::shared_ptr<const PolySet>& ps, ExportContext& ctx
       }
     }
 
-    ctx.materialids.reserve(sorted_ps->colors.size());
+    materialids.reserve(sorted_ps->colors.size());
     for (size_t i = 0; i < sorted_ps->colors.size(); i++) {
-      ctx.materialids.push_back(materialFunc(materials + i, sorted_ps->colors[i]));
+      materialids.push_back(materialFunc(materials + i, sorted_ps->colors[i]));
     }
   }
 
@@ -253,7 +261,7 @@ bool append_polyset(const std::shared_ptr<const PolySet>& ps, ExportContext& ctx
 
   for (size_t i = 0; i < sorted_ps->color_indices.size(); ++i) {
     const int32_t idx = sorted_ps->color_indices[i];
-    if (!handle_triangle_color(propertyhandler, sorted_ps, i, idx, ctx)) {
+    if (!handle_triangle_color(propertyhandler, sorted_ps, i, idx, materialids, ctx)) {
       return false;
     }
   }


### PR DESCRIPTION
Closes #6813. Continuation of #6159 (which was self-closed by the original reporter 4 minutes after opening with no fix landed; their "fixed in yesterday's version" build was almost certainly linked against `lib3mf >= 2`, which is unaffected — see #6813 for the full reasoning).

## Summary

With `--enable=lazy-union` (or any other path that produces a top-level `GeometryList`), exporting a multi-color scene to 3MF produces a file in which **every mesh after the first** has its triangle properties pointing at the **first** mesh's base material. The visible result is that all but the first object render in the wrong color.

The bug only fires on builds linked against `lib3mf 1.x`. The v2 path is unaffected.

## Root cause

`ExportContext::materialids` is a `std::vector<DWORD>` member of the per-export context. `append_polyset` `push_back`s each new mesh's per-color material IDs into it without ever clearing, while `handle_triangle_color` then indexes it with the per-mesh-relative `color_index`:

```cpp
struct ExportContext {
  ...
  std::vector<DWORD> materialids;   // shared across every mesh
  ...
};

bool append_polyset(...) {
  ...
  for (size_t i = 0; i < sorted_ps->colors.size(); i++) {
    ctx.materialids.push_back(materialFunc(materials + i, sorted_ps->colors[i]));
  }
  ...
}

bool handle_triangle_color(...) {
  ...
  lib3mf_propertyhandler_setbasematerial(propertyhandler, triangle_index,
                                         ctx.basematerialid,
                                         ctx.materialids[color_index]);
  ...
}
```

After the first mesh seeds `ctx.materialids = [first_id]`, the second mesh's triangles -- whose own PolySet has only one color, so all triangles carry `color_index = 0` -- look up `ctx.materialids[0]` and resolve to the **first** mesh's material ID instead of their own newly-registered one.

The `lib3mf v2` path (`export_3mf_v2.cc`) is unaffected because it keys per-color material registration off `ctx.colors` (a `Color4f -> idx` map) instead of a vector indexed by `color_index`.

## Fix

`materialids` is only ever pushed to and read from within a single `append_polyset` call, so move it from `ExportContext` to a local in `append_polyset` and pass it as a parameter to `handle_triangle_color`. Each mesh now starts with an empty `materialids` so its own `color_index = 0` resolves to its own first material ID.

Diff is small and surgical (~14/-6):

- `ExportContext::materialids` field removed.
- `append_polyset` declares a local `std::vector<DWORD> materialids` per call (with an in-code comment explaining the per-mesh scoping).
- `handle_triangle_color` takes `const std::vector<DWORD>& materialids` as a parameter.

## Test plan

Reproducer (the exact script from #6159):

```scad
color("red") cube(10);
color("blue") translate([12, 0, 0]) cube(10);
```

```bash
openscad --enable=lazy-union --enable=predictible-output \
         --export-format 3mf -o out.3mf script.scad
unzip -p out.3mf 3D/3dmodel.model
```

- [x] Verified the bug exists on `master @ b38f68881` linked against `lib3MF.so.1` (second `<object>`'s triangles all reference `p1="1"` = red).
- [x] Verified the fix produces correct output: second object's triangles now reference `p1="2"` (= Color 2 = blue), matching its `color("blue")` source.
- [x] Three-mesh stress (red, blue, red again): each object correctly references its own slot (`p1=1`, `p1=2`, `p1=3`), no cross-mesh aliasing.
- [x] Single-color scene through the same code path is unaffected (no triangle-level properties when no `color()` is set).
- [x] No changes to `src/io/export_3mf_v2.cc` (the lib3mf-v2 path was already correct).

## Notes

- This commit was developed and validated in PythonSCAD, where it has been merged on a branch that triggers the same code path through the in-script `export(dict, ...)` form. Since the PythonSCAD and OpenSCAD `export_3mf_v1.cc` files only diverge in PythonSCAD-specific `ENABLE_PYTHON` / `Export3mfPartInfo` plumbing -- not in the `materialids` logic -- the cherry-pick was clean.
- A regression test (e.g. a multi-mesh `lazy-union` 3MF golden in `tests/regression/dump3mftest/`) is intentionally not included to keep this PR minimal. Happy to add one in a follow-up commit on this branch if you'd like.


Made with [Cursor](https://cursor.com)