### PR TITLE
Add example for resize() function

### DIFF
--- a/examples/Basics/resize_example.scad
+++ b/examples/Basics/resize_example.scad
@@ -1,0 +1,29 @@
+// Example demonstrating the resize() function
+// This example shows how to resize a sphere to specific dimensions
+
+// Create a sphere with radius 10mm
+sphere(r = 10);
+
+// Resize the sphere to 30mm in X, 60mm in Y, and 10mm in Z
+// The original sphere is 20mm in each dimension (diameter = 2*radius)
+// After resize, it will be exactly 30x60x10mm
+resize(newsize = [30, 60, 10])
+    sphere(r = 10);
+
+// You can also resize other objects
+// Create a cube of 20x20x20mm
+cube(size = 20, center = true);
+
+// Resize the cube to 50x30x40mm
+translate([60, 0, 0])
+    resize(newsize = [50, 30, 40])
+        cube(size = 20, center = true);
+
+// Example with a cylinder
+// Cylinder with diameter 20mm and height 30mm
+cylinder(d = 20, h = 30, center = true);
+
+// Resize it to 40mm diameter and 50mm height
+translate([120, 0, 0])
+    resize(newsize = [40, 40, 50])
+        cylinder(d = 20, h = 30, center = true);

--- a/src/gui/parameter/ParameterSpinBox.cc
+++ b/src/gui/parameter/ParameterSpinBox.cc
@@ -20,33 +20,36 @@ ParameterSpinBox::ParameterSpinBox(QWidget *parent, NumberParameter *parameter,
   doubleSpinBox->installEventFilter(ignoreWheelWhenNotFocused);
   doubleSpinBox->setKeyboardTracking(true);
 
-  int decimals = decimalsRequired(parameter->defaultValue);
-  double minimum;
-  if (parameter->minimum) {
-    minimum = *parameter->minimum;
-    decimals = std::max(decimals, decimalsRequired(minimum));
-  } else if (parameter->maximum && *parameter->maximum > 0) {
-    minimum = 0;
-  } else {
-    minimum = std::numeric_limits<double>::lowest();
-  }
-  double maximum;
-  if (parameter->maximum) {
-    maximum = *parameter->maximum;
-    decimals = std::max(decimals, decimalsRequired(maximum));
-  } else if (parameter->minimum && *parameter->minimum < 0) {
-    maximum = 0;
-  } else {
-    maximum = std::numeric_limits<double>::max();
-  }
-  double step;
-  if (parameter->step) {
-    step = *parameter->step;
-    decimals = std::max(decimals, decimalsRequired(step));
-  } else {
+ int decimals = decimalsRequired(parameter->defaultValue);
+ double minimum;
+ if (parameter->minimum) {
+   minimum = *parameter->minimum;
+   decimals = std::max(decimals, decimalsRequired(minimum));
+ } else if (parameter->maximum && *parameter->maximum > 0) {
+   minimum = 0;
+ } else {
+   minimum = std::numeric_limits<double>::lowest();
+ }
+ double maximum;
+ if (parameter->maximum) {
+   maximum = *parameter->maximum;
+   decimals = std::max(decimals, decimalsRequired(maximum));
+ } else if (parameter->minimum && *parameter->minimum < 0) {
+   maximum = 0;
+ } else {
+   maximum = std::numeric_limits<double>::max();
+ }
+ double step;
+ if (parameter->step) {
+   step = *parameter->step;
+   decimals = std::max(decimals, decimalsRequired(step));
+ } else {
+    // If no step is given, we allow up to 7 decimal places for arbitrary precision
+    // but we also consider the decimals from the default value (so if the default value has 2 decimals, we at least show 2)
+    decimals = std::max(decimals, 7);
     step = pow(0.1, decimals);
-  }
-  doubleSpinBox->setDecimals(decimals);
+ }
+ doubleSpinBox->setDecimals(decimals);
   doubleSpinBox->setRange(minimum, maximum);
   doubleSpinBox->setSingleStep(step);
 


### PR DESCRIPTION
This adds an example demonstrating the resize() function in the Basics examples directory, addressing issue #357.