### PR TITLE
fix: use Cmd instead of Ctrl in hyperlink tooltip on macOS

### DIFF
--- a/src/gui/ScintillaEditor.cc
+++ b/src/gui/ScintillaEditor.cc
@@ -1471,8 +1471,13 @@ void ScintillaEditor::onIndicatorReleased(int line, int col, Qt::KeyboardModifie
       val <= hyperlinkIndicatorOffset + static_cast<int>(indicatorData.size())) {
     if (!indicatorsActive) {
       QTimer::singleShot(0, this, [this] {
+#ifdef Q_OS_MACOS
+        QToolTip::showText(QCursor::pos(), "Use <b>Cmd + Click</b> to open the file", this, rect(),
+                           toolTipDuration());
+#else
         QToolTip::showText(QCursor::pos(), "Use <b>CTRL + Click</b> to open the file", this, rect(),
                            toolTipDuration());
+#endif
       });
     }
   }


### PR DESCRIPTION
## Summary

Fixes the hyperlink tooltip to show "Cmd + Click" instead of "CTRL + Click" on macOS, where Cmd is the correct modifier key for opening links.

## Problem

The tooltip text `"Use CTRL + Click to open the file"` is shown on all platforms, but on macOS:
- **Ctrl+Click** opens the context menu (right-click behavior)
- **Cmd+Click** is the standard way to open links/files

This was reported in #4725.

## Solution

Use `#ifdef Q_OS_MACOS` to show the platform-appropriate key label. This follows the same pattern already used in the same file (e.g. line 158-162 for modifier key selection).

## Changes

`src/gui/ScintillaEditor.cc`: Added platform guard around the tooltip text to show "Cmd" on macOS and "CTRL" on other platforms.

## Related

Fixes #4725