### PR TITLE
Fix mi-malloc version in Library info

### DIFF
--- a/src/LibraryInfo.cc
+++ b/src/LibraryInfo.cc
@@ -66,8 +66,8 @@
 
 #ifdef USE_MIMALLOC
 #include <mimalloc.h>
-const std::string mimalloc_version = std::to_string(MI_MALLOC_VERSION / 10000) + "." +
-                                     std::to_string((MI_MALLOC_VERSION / 100) % 100) + "." +
+const std::string mimalloc_version = std::to_string(MI_MALLOC_VERSION / 1000) + "." +
+                                     std::to_string((MI_MALLOC_VERSION % 1000) / 100) + "." +
                                      std::to_string(MI_MALLOC_VERSION % 100);
 #else
 const std::string mimalloc_version = "<not enabled>";


### PR DESCRIPTION
Adjust calculation to match mimalloc src/options.c.

---

MI_MALLOC_VERSION changed to 5 digits no later than v1.9.8:
https://github.com/microsoft/mimalloc/commit/8602b5f538028a47e23abdb2300b42aeb39a9235

With `-DUSE_MIMALLOC=yes` and a system copy of mimalloc-3.2.8 Library info was reporting:
mi-malloc version: 0.32.8
