### PR TITLE
Change window close sequencing yet again

### DIFF
--- a/src/gui/Dock.cc
+++ b/src/gui/Dock.cc
@@ -1,5 +1,6 @@
 #include "gui/Dock.h"
 
+#include <QCloseEvent>
 #include <QDockWidget>
 #include <QRegularExpression>
 #include <QWidget>

--- a/src/gui/MainWindow.cc
+++ b/src/gui/MainWindow.cc
@@ -615,6 +615,57 @@ MainWindow::~MainWindow()
   delete this->cgalworker;
 }
 
+void MainWindow::closeEvent(QCloseEvent *event)
+{
+  if (!tabManager->shouldClose()) {
+    event->ignore();
+    return;
+  }
+  event->accept();
+
+  // Only save when this is the last MainWindow (or there are none left,
+  // which covers the edge case where closeEvent fires after another
+  // MainWindow has already been destroyed).
+  if (scadApp->windowManager.getWindows().size() == 1) {
+    saveWindowState();
+  }
+
+  isClosing = true;
+  progress_report_fin();
+
+  if (this->tempFile) {
+    delete this->tempFile;
+    this->tempFile = nullptr;
+  }
+
+  // Log to stdout from now on
+  clearCurrentOutput();
+  // Disable invokeMethod calls for consoleOutput during shutdown,
+  // otherwise will segfault if echos are in progress.
+  hideCurrentOutput();
+  for (auto& [dock, title] : docks) {
+    if (dock->isFloating()) {
+      dock->close();
+    }
+  }
+
+  scadApp->windowManager.remove(this);
+  if (scadApp->windowManager.getWindows().empty()) {
+    // Quit application even in case some other windows like
+    // Preferences are still open.
+    QApplication::quit();
+  }
+}
+
+void MainWindow::saveWindowState()
+{
+  QSettingsCached settings;
+  settings.setValue("window/geometry", saveGeometry());
+  auto windowState = saveState();
+  UIUtils::dumpSaveState(windowState);
+  settings.setValue("window/state", windowState);
+}
+
 void MainWindow::showProgress()
 {
   updateStatusBar(qobject_cast<ProgressWidget *>(sender()));
@@ -3276,57 +3327,6 @@ void MainWindow::on_helpActionLibraryInfo_triggered()
     this->libraryInfoDialog = dialog;
   }
   this->libraryInfoDialog->show();
-}
-
-void MainWindow::saveWindowState()
-{
-  QSettingsCached settings;
-  settings.setValue("window/geometry", saveGeometry());
-  auto windowState = saveState();
-  UIUtils::dumpSaveState(windowState);
-  settings.setValue("window/state", windowState);
-}
-
-void MainWindow::closeEvent(QCloseEvent *event)
-{
-  if (!tabManager->shouldClose()) {
-    event->ignore();
-    return;
-  }
-  event->accept();
-
-  // Only save when this is the last MainWindow (or there are none left,
-  // which covers the edge case where closeEvent fires after another
-  // MainWindow has already been destroyed).
-  if (scadApp->windowManager.getWindows().size() == 1) {
-    saveWindowState();
-  }
-
-  isClosing = true;
-  progress_report_fin();
-
-  if (this->tempFile) {
-    delete this->tempFile;
-    this->tempFile = nullptr;
-  }
-
-  // Log to stdout from now on
-  clearCurrentOutput();
-  // Disable invokeMethod calls for consoleOutput during shutdown,
-  // otherwise will segfault if echos are in progress.
-  hideCurrentOutput();
-  for (auto& [dock, title] : docks) {
-    if (dock->isFloating()) {
-      dock->close();
-    }
-  }
-
-  scadApp->windowManager.remove(this);
-  if (scadApp->windowManager.getWindows().empty()) {
-    // Quit application even in case some other windows like
-    // Preferences are still open.
-    QApplication::quit();
-  }
 }
 
 void MainWindow::on_editActionPreferences_triggered()

--- a/src/gui/MainWindow.cc
+++ b/src/gui/MainWindow.cc
@@ -3993,13 +3993,7 @@ void MainWindow::setupMenusAndActions()
 void MainWindow::restoreWindowState()
 {
   const QSettingsCached settings;
-  // fetch window states to be restored after restoreState() call
-  const bool isEditorToolbarVisible = !settings.value("view/hideEditorToolbar").toBool();
-  const bool is3DViewToolbarVisible = !settings.value("view/hide3DViewToolbar").toBool();
-
-  // make sure it looks nice..
   const auto windowState = settings.value("window/state", QByteArray()).toByteArray();
-  // Log to stdout
   clearCurrentOutput();
   UIUtils::dumpSaveState(windowState);
   setCurrentOutput();

--- a/src/gui/MainWindow.cc
+++ b/src/gui/MainWindow.cc
@@ -623,9 +623,7 @@ void MainWindow::closeEvent(QCloseEvent *event)
   }
   event->accept();
 
-  // Only save when this is the last MainWindow (or there are none left,
-  // which covers the edge case where closeEvent fires after another
-  // MainWindow has already been destroyed).
+  // Only save when this is the last MainWindow.
   if (scadApp->windowManager.getWindows().size() == 1) {
     saveWindowState();
   }
@@ -643,6 +641,11 @@ void MainWindow::closeEvent(QCloseEvent *event)
   // Disable invokeMethod calls for consoleOutput during shutdown,
   // otherwise will segfault if echos are in progress.
   hideCurrentOutput();
+
+  // Make sure all the floating docks are closed too as those
+  // would stick around otherwise if the application keeps
+  // running (after closing just a single window, or when
+  // aborting the close process because of user cancellation).
   for (auto& [dock, title] : docks) {
     if (dock->isFloating()) {
       dock->close();

--- a/src/gui/MainWindow.cc
+++ b/src/gui/MainWindow.cc
@@ -613,12 +613,6 @@ void MainWindow::updateReorderMode(bool reorderMode)
 MainWindow::~MainWindow()
 {
   delete this->cgalworker;
-  scadApp->windowManager.remove(this);
-  if (scadApp->windowManager.getWindows().empty()) {
-    // Quit application even in case some other windows like
-    // Preferences are still open.
-    scadApp->quit();
-  }
 }
 
 void MainWindow::showProgress()
@@ -1552,15 +1546,6 @@ bool MainWindow::event(QEvent *event)
 
 bool MainWindow::eventFilter(QObject *obj, QEvent *event)
 {
-  // OpenSCAD quits by closing all top-level windows. However, the order in which top-level are closed is
-  // not defined by Qt, so we may end up closing undocked dock widgets before we've had a chance to save
-  // their window state. This overrides close to proactively save the window state.
-  if (event->type() == QEvent::Close) {
-    if (qobject_cast<Dock *>(obj) && !static_cast<QCloseEvent *>(event)->spontaneous()) {
-      saveWindowStateOnClose();
-    }
-  }
-
   if (rubberBandManager.isVisible()) {
     if (event->type() == QEvent::KeyRelease) {
       auto keyEvent = static_cast<QKeyEvent *>(event);
@@ -3293,11 +3278,8 @@ void MainWindow::on_helpActionLibraryInfo_triggered()
   this->libraryInfoDialog->show();
 }
 
-void MainWindow::saveWindowStateOnClose()
+void MainWindow::saveWindowState()
 {
-  if (windowStateSaved) return;
-  windowStateSaved = true;
-
   QSettingsCached settings;
   settings.setValue("window/geometry", saveGeometry());
   auto windowState = saveState();
@@ -3307,25 +3289,43 @@ void MainWindow::saveWindowStateOnClose()
 
 void MainWindow::closeEvent(QCloseEvent *event)
 {
-  if (tabManager->shouldClose()) {
-    isClosing = true;
-    saveWindowStateOnClose();
-    progress_report_fin();
-
-    // Log to stdout from now on
-    clearCurrentOutput();
-
-    if (this->tempFile) {
-      delete this->tempFile;
-      this->tempFile = nullptr;
-    }
-
-    // Disable invokeMethod calls for consoleOutput during shutdown,
-    // otherwise will segfault if echos are in progress.
-    hideCurrentOutput();
-    event->accept();
-  } else {
+  if (!tabManager->shouldClose()) {
     event->ignore();
+    return;
+  }
+  event->accept();
+
+  // Only save when this is the last MainWindow (or there are none left,
+  // which covers the edge case where closeEvent fires after another
+  // MainWindow has already been destroyed).
+  if (scadApp->windowManager.getWindows().size() == 1) {
+    saveWindowState();
+  }
+
+  isClosing = true;
+  progress_report_fin();
+
+  if (this->tempFile) {
+    delete this->tempFile;
+    this->tempFile = nullptr;
+  }
+
+  // Log to stdout from now on
+  clearCurrentOutput();
+  // Disable invokeMethod calls for consoleOutput during shutdown,
+  // otherwise will segfault if echos are in progress.
+  hideCurrentOutput();
+  for (auto& [dock, title] : docks) {
+    if (dock->isFloating()) {
+      dock->close();
+    }
+  }
+
+  scadApp->windowManager.remove(this);
+  if (scadApp->windowManager.getWindows().empty()) {
+    // Quit application even in case some other windows like
+    // Preferences are still open.
+    QApplication::quit();
   }
 }
 
@@ -3855,7 +3855,7 @@ void MainWindow::setupMenusAndActions()
 #endif
 
 
-  connect(this->fileActionQuit, &QAction::triggered, scadApp, &OpenSCADApp::quit, Qt::QueuedConnection);
+  connect(this->fileActionQuit, &QAction::triggered, scadApp, &OpenSCADApp::closeApp, Qt::QueuedConnection);
 
 #ifdef ENABLE_PYTHON
 #else
@@ -4033,6 +4033,7 @@ void MainWindow::restoreWindowState()
     tabifyDockWidget(errorLogDock, fontListDock);
     tabifyDockWidget(fontListDock, colorListDock);
     tabifyDockWidget(colorListDock, animateDock);
+    tabifyDockWidget(animateDock, aiDock);
     parameterDock->hide();
     viewportControlDock->hide();
     consoleDock->show();

--- a/src/gui/MainWindow.cc
+++ b/src/gui/MainWindow.cc
@@ -4027,8 +4027,14 @@ void MainWindow::restoreWindowState()
     tabifyDockWidget(errorLogDock, fontListDock);
     tabifyDockWidget(fontListDock, colorListDock);
     tabifyDockWidget(colorListDock, animateDock);
-    tabifyDockWidget(animateDock, aiDock);
+    tabifyDockWidget(animateDock, viewportControlDock);
+    tabifyDockWidget(parameterDock, aiDock);
     parameterDock->hide();
+    aiDock->hide();
+    errorLogDock->hide();
+    fontListDock->hide();
+    colorListDock->hide();
+    animateDock->hide();
     viewportControlDock->hide();
     consoleDock->show();
     consoleDock->raise();

--- a/src/gui/MainWindow.h
+++ b/src/gui/MainWindow.h
@@ -133,8 +133,7 @@ private:
   std::vector<std::pair<Dock *, QString>> docks;
 
   volatile bool isClosing = false;
-  bool windowStateSaved = false;
-  void saveWindowStateOnClose();
+  void saveWindowState();
   void consoleOutputRaw(const QString& msg);
   void clearAllSelectionIndicators();
   void setSelectionIndicatorStatus(EditorInterface *editor, int nodeIndex,

--- a/src/gui/OpenSCADApp.cc
+++ b/src/gui/OpenSCADApp.cc
@@ -135,5 +135,8 @@ void OpenSCADApp::closeApp()
       return;
     }
   }
+  // Should not be reached, when closing the last MainWindow,
+  // the quit() call would already happen in the close event
+  // handler MainWindow::closeEvent().
   QApplication::quit();
 }

--- a/src/gui/OpenSCADApp.cc
+++ b/src/gui/OpenSCADApp.cc
@@ -115,7 +115,8 @@ void OpenSCADApp::setApplicationFont(const QString& family, uint size)
   scadApp->setStyleSheet(stylesheet.arg(family, QString::number(size)));
 }
 
-#if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
+// For Qt5, simulate the Qt6 behavior.
+//
 // https://doc.qt.io/qt-6/qtcore-changes-qt6.html#other-classes
 //
 //     In Qt 5, QCoreApplication::quit() was equivalent to calling QCoreApplication::exit().
@@ -124,8 +125,10 @@ void OpenSCADApp::setApplicationFont(const QString& family, uint size)
 //     In Qt 6, the method will instead try to close all top-level windows by posting a close
 //     event. The windows are free to cancel the shutdown process by ignoring the event.
 //
-// For Qt5, simulate the Qt6 behavior.
-void OpenSCADApp::quit()
+// But this implements a slightly modified Qt6 behavior as that triggers
+// deletion of all widget windows before calling MainWindow::closeEvent.
+// We really just call close on our own list of main windows.
+void OpenSCADApp::closeApp()
 {
   for (MainWindow *mw : scadApp->windowManager.getWindows()) {
     if (!mw->close()) {
@@ -134,4 +137,3 @@ void OpenSCADApp::quit()
   }
   QApplication::quit();
 }
-#endif

--- a/src/gui/OpenSCADApp.h
+++ b/src/gui/OpenSCADApp.h
@@ -20,10 +20,9 @@ public:
 
   bool notify(QObject *object, QEvent *event) override;
   void requestOpenFile(const QString& filename);
-#if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
+
   // See comments in OpenSCADApp.cc.
-  static void quit();
-#endif
+  static void closeApp();
 
 public slots:
   void showFontCacheDialog();

--- a/src/gui/ai/AIDock.cc
+++ b/src/gui/ai/AIDock.cc
@@ -4,6 +4,7 @@
 
 AIDock::AIDock(QWidget *parent) : Dock(parent)
 {
+  this->setObjectName("aiDock");
   this->chatWidget = new ChatWidget(this);
   setWidget(this->chatWidget);
 }


### PR DESCRIPTION
Change window close sequencing yet again (fixes #6817) (hopefully?).

- Always rely on our own list of top-level windows (Qt5 and Qt6). This removes the need of messing with close events in the event filter.
- Don't use Qt::closeAllWindows() as that closes all top-levels including docks that are floating.
- Manually close floating docks of the current main window when close is confirmed.
- Move logic to closeEvent() instead of misusing the destructor.