### PR TITLE
Treat non-strings as not-equal in string search() calls.

### DIFF
--- a/src/core/Value.cc
+++ b/src/core/Value.cc
@@ -369,6 +369,7 @@ bool Value::getPositiveInt(unsigned int& v) const
 
 const str_utf8_wrapper& Value::toStrUtf8Wrapper() const
 {
+  // Caution:  throws if the value is not STRING.
   return std::get<str_utf8_wrapper>(this->value);
 }
 

--- a/src/core/builtin_functions.cc
+++ b/src/core/builtin_functions.cc
@@ -743,8 +743,13 @@ static VectorType search(const str_utf8_wrapper& find, const VectorType& table,
             j, (index_col_num + 1), table[j].toEchoStringNoThrow());
         return {session};
       }
-      if (!ft.empty() &&
-          ft.get_utf8_char() == entryVec[index_col_num].toStrUtf8Wrapper().get_utf8_char()) {
+      const auto& entry = entryVec[index_col_num];
+      if (entry.type() != Value::Type::STRING) {
+        // Just as "==" silently treats a type mismatch as not-equal, we treat a type mismatch
+        // as not matching.
+        continue;
+      }
+      if (!ft.empty() && ft.get_utf8_char() == entry.toStrUtf8Wrapper().get_utf8_char()) {
         matchCount++;
         if (num_returns_per_match == 1) {
           returnvec.emplace_back(double(j));

--- a/tests/data/scad/misc/search-tests.scad
+++ b/tests/data/scad/misc/search-tests.scad
@@ -89,5 +89,10 @@ echo(search("a", lTableW5, num_returns_per_match=0));
 lTableW6=[ ["a",1],-1/0];
 echo(search("a", lTableW6, num_returns_per_match=0)); 
 
+// Mismatches are silently not-equal
+mixedTable=[ ["a", 1], [2, 2], ["b", 3] ];
+echo(search("b", mixedTable));
+echo(search(2, mixedTable));
+
 // for completeness
 cube(1.0);

--- a/tests/regression/echo/search-tests-expected.echo
+++ b/tests/regression/echo/search-tests-expected.echo
@@ -27,3 +27,5 @@ WARNING: Invalid entry in search vector at index 1, required number of values in
 ECHO: []
 WARNING: Invalid entry in search vector at index 1, required number of values in the entry: 1. Invalid entry: -inf in file search-tests.scad, line 90
 ECHO: []
+ECHO: [2]
+ECHO: [1]


### PR DESCRIPTION
Previous version would silently ignore bad values.  This warns and ignores (and so will abort if stop-on-warn is set).  Discuss.

Fixes #5017.