### PR TITLE
Fix XML escaping in 3MF metadata export (lib3mf v1)

### DIFF
--- a/src/io/export_3mf_v1.cc
+++ b/src/io/export_3mf_v1.cc
@@ -116,6 +116,25 @@ int count_mesh_objects(PLib3MFModel *& model)
   return count;
 }
 
+std::string quote_xml(const std::string& value)
+{
+  std::string quoted;
+  quoted.reserve(value.size());
+
+  for (const char c : value) {
+    switch (c) {
+    case '&':  quoted += "&amp;"; break;
+    case '<':  quoted += "&lt;"; break;
+    case '>':  quoted += "&gt;"; break;
+    case '"':  quoted += "&quot;"; break;
+    case '\'': quoted += "&apos;"; break;
+    default:   quoted += c; break;
+    }
+  }
+
+  return quoted;
+}
+
 bool handle_triangle_color(PLib3MFPropertyHandler *propertyhandler, const std::unique_ptr<PolySet>& ps,
                            int triangle_index, int color_index, std::vector<DWORD>& materialMap,
                            ExportContext& ctx)
@@ -343,7 +362,8 @@ void add_meta_data(PLib3MFModelMeshObject *& model, const std::string& name, con
     return;
   }
 
-  lib3mf_model_addmetadatautf8(model, name.c_str(), v.c_str());
+  const std::string quoted = quote_xml(v);
+  lib3mf_model_addmetadatautf8(model, name.c_str(), quoted.c_str());
 }
 
 }  // namespace

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -972,6 +972,7 @@ add_cmdline_test(export-obj              EXPERIMENTAL OPENSCAD SUFFIX obj FILES 
 if (ENABLE_LIB3MF_TESTS)
 add_cmdline_test(export-3mf              EXPERIMENTAL OPENSCAD SUFFIX 3mf FILES ${EXPORT_3MF_TEST_FILES} ARGS --enable=predictible-output)
 add_cmdline_test(export-3mf              EXPERIMENTAL OPENSCAD SUFFIX 3mf FILES ${EXPORT_3MF_LAZY_UNION_TEST_FILES} ARGS --enable=predictible-output --enable=lazy-union)
+add_cmdline_test(export-3mf-stdio        EXPERIMENTAL OPENSCAD SUFFIX 3mf FILES ${EXPORT_3MF_TEST_FILES} STDIO ARGS --enable=predictible-output --export-format 3mf)
 endif()
 add_cmdline_test(export-pov-as-is        EXPERIMENTAL OPENSCAD SUFFIX pov FILES ${EXPORT_POV_TEST_FILES} ARGS --enable=predictible-output --backend=manifold)
 add_cmdline_test(export-pov-translate-1  EXPERIMENTAL OPENSCAD SUFFIX pov FILES ${EXPORT_POV_TEST_FILES} ARGS --enable=predictible-output --backend=manifold --camera=0,0,0,0,0,0,140)

--- a/tests/regression/export-3mf-stdio/3mf-export-expected.3mf
+++ b/tests/regression/export-3mf-stdio/3mf-export-expected.3mf
@@ -1,0 +1,66 @@
+<?xml version="1.0" encoding="utf-8"?>
+<model xmlns="http://schemas.microsoft.com/3dmanufacturing/core/2015/02" unit="millimeter" xml:lang="en-US">
+	<metadata name="Title">&lt;stdin&gt;</metadata>
+	<metadata name="Application">OpenSCAD (https://www.openscad.org/)</metadata>
+	<metadata name="CreationDate">XXXX-XX-XXTXXXXXXXXZ</metadata>
+	<resources>
+		<basematerials id="1">
+			<base name="Default" displaycolor="#F9D72CFF" />
+		</basematerials>
+		<object id="2" name="OpenSCAD Model" type="model" p:UUID="XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXX" pid="1" pindex="0">
+			<mesh>
+				<vertices>
+					<vertex x="0" y="0" z="0" />
+					<vertex x="0" y="0" z="10.000000" />
+					<vertex x="0" y="10.000000" z="0" />
+					<vertex x="0" y="10.000000" z="10.000000" />
+					<vertex x="1.000000" y="1.000000" z="10.000000" />
+					<vertex x="1.000000" y="1.000000" z="17.000000" />
+					<vertex x="1.000000" y="9.000000" z="10.000000" />
+					<vertex x="1.000000" y="9.000000" z="17.000000" />
+					<vertex x="9.000000" y="1.000000" z="10.000000" />
+					<vertex x="9.000000" y="1.000000" z="17.000000" />
+					<vertex x="9.000000" y="9.000000" z="10.000000" />
+					<vertex x="9.000000" y="9.000000" z="17.000000" />
+					<vertex x="10.000000" y="0" z="0" />
+					<vertex x="10.000000" y="0" z="10.000000" />
+					<vertex x="10.000000" y="10.000000" z="0" />
+					<vertex x="10.000000" y="10.000000" z="10.000000" />
+				</vertices>
+				<triangles>
+					<triangle v1="0" v2="1" v3="3" />
+					<triangle v1="0" v2="2" v3="14" />
+					<triangle v1="0" v2="3" v3="2" />
+					<triangle v1="0" v2="12" v3="13" />
+					<triangle v1="0" v2="13" v3="1" />
+					<triangle v1="0" v2="14" v3="12" />
+					<triangle v1="1" v2="4" v3="6" />
+					<triangle v1="1" v2="6" v3="3" />
+					<triangle v1="1" v2="8" v3="4" />
+					<triangle v1="1" v2="13" v3="8" />
+					<triangle v1="2" v2="3" v3="14" />
+					<triangle v1="3" v2="6" v3="15" />
+					<triangle v1="3" v2="15" v3="14" />
+					<triangle v1="4" v2="5" v3="7" />
+					<triangle v1="4" v2="7" v3="6" />
+					<triangle v1="4" v2="8" v3="5" />
+					<triangle v1="5" v2="8" v3="9" />
+					<triangle v1="5" v2="9" v3="7" />
+					<triangle v1="6" v2="7" v3="11" />
+					<triangle v1="6" v2="10" v3="15" />
+					<triangle v1="6" v2="11" v3="10" />
+					<triangle v1="7" v2="9" v3="11" />
+					<triangle v1="8" v2="10" v3="9" />
+					<triangle v1="8" v2="13" v3="15" />
+					<triangle v1="8" v2="15" v3="10" />
+					<triangle v1="9" v2="10" v3="11" />
+					<triangle v1="12" v2="14" v3="13" />
+					<triangle v1="13" v2="14" v3="15" />
+				</triangles>
+			</mesh>
+		</object>
+	</resources>
+	<build p:UUID="XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXX">
+		<item objectid="2" p:UUID="XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXX" />
+	</build>
+</model>


### PR DESCRIPTION
Fixes #6360

## Problem

When exporting to 3MF using lib3mf v1.x, metadata values (title, designer, description, copyright, license terms, rating) were written directly into the XML without escaping special characters. This produces invalid XML when a value contains `&`, `<`, `>`, `"`, or `'` — most visibly with the default `<stdin>` title when piping SCAD input via stdin:

```
echo "cube(1);" | openscad - -o test.3mf
```

produced:

```
<metadata name="Title"><stdin></metadata>
```

instead of:

```
<metadata name="Title">&lt;stdin&gt;</metadata>
```

## Fix

Adds a `quote_xml()` helper in `src/io/export_3mf_v1.cc` that escapes all five reserved XML characters. It's applied in `add_meta_data()` before values are passed to `lib3mf_model_addmetadatautf8()`, so it covers every metadata field routed through that function (title, designer, description, copyright, license terms, rating) rather than just the title case from the original report.

The lib3mf v2 exporter is untouched, since v2 already escapes correctly.

## Testing

Since MSYS2 (my usual build environment) only ships lib3mf 2.4.1, and this bug is specific to the v1.x code path, I couldn't test the fix directly in my normal setup - the v1 exporter file wasn't even being compiled. To get an environment with actual lib3mf 1.x, I built and tested in a Debian bookworm Docker container (matching `openscad/openscad:bookworm`, the environment the original bug report used), where `apt` provides lib3mf 1.8.1.

Verified:

* The original repro case (`echo "cube(1);" | openscad - -o test.3mf`) now produces correctly escaped `&lt;stdin&gt;`
* All five XML special characters (`&`, `<`, `>`, `"`, `'`) escape correctly when set via `-O export-3mf/meta-data-designer=...`
* Normal (non-stdin) 3MF export still works with no regressions

Also added a regression test (`export-3mf-stdio` in `tests/CMakeLists.txt`) that pipes a SCAD file through stdin and exports 3MF via stdout, along with the expected escaped XML fixture, so this is covered by CI going forward (CI presumably builds against whichever lib3mf version is current in its environment - happy to adjust if needed).
