### PR TITLE
Fix minimum version lookup in check-dependencies.sh

### DIFF
--- a/scripts/check-dependencies.sh
+++ b/scripts/check-dependencies.sh
@@ -400,12 +400,12 @@ get_minversion_from_readme()
   debug get_minversion_from_readme $*
 
   # Extract dependency name
-  if [ ! $1 ]; then return; fi
+  if [ ! "$1" ]; then return; fi
   depname=$1
 
   debug $depname
   local grv_tmp=
-  for READFILE in README.md ../README.md "`dirname "$0"`/../README.md"
+  for READFILE in README.md ../README.md "$(dirname "$0")/../README.md"
   do
     if [ ! -e "$READFILE" ]
     then
@@ -413,16 +413,25 @@ get_minversion_from_readme()
       continue
     fi
     debug "get_minversion_from_readme $READFILE found"
-    grep -qi ".$depname.*([0-9]" $READFILE || continue
-    grv_tmp="`grep -i ".$depname.*([0-9]" $READFILE | sed s/"*"//`"
-    debug $grv_tmp
-    grv_tmp="`echo $grv_tmp | awk -F"(" '{print $2}'`"
-    debug $grv_tmp
-    grv_tmp="`echo $grv_tmp | awk -F"-" '{print $1}'`"
-    debug $grv_tmp
-    grv_tmp="`echo $grv_tmp | sed s/"x"/"0"/g`"
-    debug $grv_tmp
-    grv_tmp="`echo $grv_tmp | sed s/"[^0-9.]"//g`"
+    grv_tmp="$(awk -v depname="$depname" '
+      /^[[:space:]]*\*/ {
+        line = $0
+        dep = line
+        sub(/^[[:space:]]*\*+[[:space:]]*/, "", dep)
+        sub(/^\[/, "", dep)
+        sub(/\].*/, "", dep)
+        sub(/[[:space:]]*\(.*/, "", dep)
+
+        if (tolower(dep) == tolower(depname) && match(line, /\([[:space:]]*[0-9][^)]*\)/)) {
+          version = substr(line, RSTART + 1, RLENGTH - 2)
+          sub(/[[:space:]]*-.*/, "", version)
+          gsub(/[xX]/, "0", version)
+          gsub(/[^0-9.]/, "", version)
+          print version
+          exit
+        }
+      }
+    ' "$READFILE")"
     debug $grv_tmp
     if [ "z$grv_tmp" = "z" ]
     then
@@ -440,19 +449,62 @@ get_minversion_from_readme()
   fi
 }
 
+get_minversion_from_cmake()
+{
+  debug get_minversion_from_cmake
+
+  local gmvc_tmp=
+  for CMAKEFILE in CMakeLists.txt ../CMakeLists.txt "$(dirname "$0")/../CMakeLists.txt"
+  do
+    if [ ! -e "$CMAKEFILE" ]
+    then
+      debug "get_minversion_from_cmake $CMAKEFILE not found"
+      continue
+    fi
+    debug "get_minversion_from_cmake $CMAKEFILE found"
+    gmvc_tmp="$(awk '
+      /^[[:space:]]*cmake_minimum_required[[:space:]]*\(/ {
+        line = tolower($0)
+        if (match(line, /version[[:space:]]+[0-9][0-9.]*/)) {
+          version = substr(line, RSTART, RLENGTH)
+          sub(/^version[[:space:]]+/, "", version)
+          print version
+          exit
+        }
+      }
+    ' "$CMAKEFILE")"
+    debug "$gmvc_tmp"
+    if [ "z$gmvc_tmp" = "z" ]
+    then
+      debug "get_minversion_from_cmake no result from $CMAKEFILE"
+      continue
+    fi
+    get_minversion_from_cmake_result=$gmvc_tmp
+    return 0
+  done
+
+  debug "get_minversion_from_cmake no result found anywhere"
+  get_minversion_from_cmake_result=""
+  return 0
+}
+
 find_min_version()
 {
   find_min_version_result=
   fmvtmp=
-  if [ ! $1 ] ; then return; fi
+  if [ ! "$1" ] ; then return; fi
   fmvdep=$1
   get_minversion_from_readme $fmvdep
   fmvtmp=$get_minversion_from_readme_result
 
+  if [ "$fmvdep" = "cmake" ]; then
+    get_minversion_from_cmake
+    fmvtmp=$get_minversion_from_cmake_result
+  fi
+
   # items not included in README.md
   if [ $fmvdep = "git" ]; then fmvtmp=1.5 ; fi
   if [ $fmvdep = "curl" ]; then fmvtmp=6 ; fi
-  if [ $fmvdep = "make" ]; then fmvtmp=3 ; fi
   if [ $fmvdep = "python" ]; then fmvtmp=2 ; fi
 
   find_min_version_result=$fmvtmp

--- a/scripts/check-dependencies.sh
+++ b/scripts/check-dependencies.sh
@@ -505,6 +505,7 @@ find_min_version()
   # items not included in README.md
   if [ $fmvdep = "git" ]; then fmvtmp=1.5 ; fi
   if [ $fmvdep = "curl" ]; then fmvtmp=6 ; fi
+  if [ "$fmvdep" = "make" ]; then fmvtmp=3 ; fi
   if [ $fmvdep = "python" ]; then fmvtmp=2 ; fi
 
   find_min_version_result=$fmvtmp


### PR DESCRIPTION
## Summary

Fix `scripts/check-dependencies.sh` dependency minimum version lookup, which had two related issues:

1. The README parser matched dependency names loosely, so `make` could incorrectly match the `cmake` entry.
2. `cmake`'s minimum version was sourced from the README, which can drift from the actual build requirement.

This PR fixes README matching to use exact dependency labels and changes `cmake`'s minimum version to be read directly from `cmake_minimum_required()` in `CMakeLists.txt`, the build-system source of truth.

For dependencies without a defined minimum version, such as `make`, the script now reports `unknown` instead of inferring a value.

## Changes

- Match README dependency entries by exact dependency label instead of substring.
- Read the `cmake` minimum version from `cmake_minimum_required()` in `CMakeLists.txt`.
- Report `unknown / NotOK` when no minimum version is defined for `make`, instead of using an incorrect match or fallback.

## Verification

Ran:

- `bash -n scripts/check-dependencies.sh`
- `scripts/check-dependencies.sh debug`
- `shellcheck scripts/check-dependencies.sh`

Confirmed:

- `cmake` minimum: `3.13`
- `make` minimum: `unknown / NotOK`

ShellCheck warnings in the touched area were reviewed; remaining warnings are pre-existing script-wide cleanup items outside the scope of this issue.

Fixes #6302