### PR TITLE
Fix OFF header (Fixes import in FreeCAD, tested with v1.1.1).

### DIFF
--- a/src/io/export_off.cc
+++ b/src/io/export_off.cc
@@ -37,6 +37,13 @@
 #include "io/export.h"
 #include "utils/printutils.h"
 
+// https://en.wikipedia.org/wiki/OFF_(file_format)
+//
+// https://segeval.cs.princeton.edu/public/off_format.html
+// Note: OFF header is supposed to be the only content on the
+// first line, the docs above show that wrong in the first
+// example.
+
 void export_off(const std::shared_ptr<const Geometry>& geom, std::ostream& output)
 {
   auto ps = PolySetUtils::getGeometryAsPolySet(geom);
@@ -46,7 +53,7 @@ void export_off(const std::shared_ptr<const Geometry>& geom, std::ostream& outpu
   const auto& v = ps->vertices;
   const size_t numverts = v.size();
 
-  output << "OFF " << numverts << " " << ps->indices.size() << " 0\n";
+  output << "OFF\n" << numverts << " " << ps->indices.size() << " 0\n";
   for (size_t i = 0; i < numverts; ++i) {
     output << v[i][0] << " " << v[i][1] << " " << v[i][2] << " " << "\n";
   }


### PR DESCRIPTION
Issue and fix was reported via IRC.

> Hi! I use openscad spapshot to export .off with colors. It is a small format issue. It turns out messy when importing in FreeCad. But files can be manually edited to have OFF on the first line and the 3 numbers (numVertices numFaces numEdges) on line two. The normal description of .OFF format is two important lines first, but opescad seems to do it in one line as a typing error in the description from: http://segeval.cs.princeton.edu/public/off_format.html.
> The fix seems just to edit line 49 in the file https://github.com/openscad/openscad/blob/master/src/io/export_off.cc