### PR TITLE
perf(manifold): N-ary BatchBoolean for union/intersection/difference

### DIFF
--- a/src/geometry/manifold/ManifoldGeometry.cc
+++ b/src/geometry/manifold/ManifoldGeometry.cc
@@ -288,6 +288,54 @@ ManifoldGeometry ManifoldGeometry::binOp(const ManifoldGeometry& lhs, const Mani
   return {mani, originalIDs, originalIDToColor, subtractedIDs};
 }
 
+ManifoldGeometry ManifoldGeometry::boolOp(
+  manifold::OpType opType,
+  const std::vector<std::shared_ptr<const ManifoldGeometry>>& operands)
+{
+  std::vector<manifold::Manifold> manifolds;
+  manifolds.reserve(operands.size());
+  for (const auto& g : operands) manifolds.push_back(g->manifold_);
+
+  // Manifold's BatchBoolean performs a balanced (and internally parallel) reduction. For Subtract
+  // it computes operands[0] - union(operands[1..]). Both are geometrically identical to folding the
+  // pairwise operators, but avoid re-processing the growing accumulator on every step.
+  auto mani = manifold::Manifold::BatchBoolean(manifolds, opType);
+
+  // Merge the id / color / subtracted-id metadata exactly as the equivalent binOp() fold would.
+  std::set<uint32_t> originalIDs;
+  std::map<uint32_t, Color4f> originalIDToColor;
+  std::set<uint32_t> subtractedIDs;
+
+  if (opType == manifold::OpType::Subtract) {
+    const auto& first = *operands.front();
+    originalIDs = first.originalIDs_;
+    originalIDToColor = first.originalIDToColor_;
+    subtractedIDs = first.subtractedIDs_;
+    for (size_t i = 1; i < operands.size(); ++i) {
+      const auto& rhs = *operands[i];
+      originalIDs.insert(rhs.originalIDs_.begin(), rhs.originalIDs_.end());
+      // Mark rhs ids as subtracted, unless they're mapped to a color (matching binOp()).
+      for (const auto id : rhs.originalIDs_) {
+        auto it = rhs.originalIDToColor_.find(id);
+        if (it != rhs.originalIDToColor_.end()) {
+          originalIDToColor[id] = it->second;
+        } else {
+          subtractedIDs.insert(id);
+        }
+      }
+    }
+  } else {
+    // Add / Intersect: union the ids, colors and subtracted ids. Earlier operands win color
+    // conflicts (std::map::insert keeps the existing entry), matching the left-to-right fold.
+    for (const auto& g : operands) {
+      originalIDs.insert(g->originalIDs_.begin(), g->originalIDs_.end());
+      originalIDToColor.insert(g->originalIDToColor_.begin(), g->originalIDToColor_.end());
+      subtractedIDs.insert(g->subtractedIDs_.begin(), g->subtractedIDs_.end());
+    }
+  }
+  return {mani, originalIDs, originalIDToColor, subtractedIDs};
+}
+
 std::shared_ptr<ManifoldGeometry> minkowskiOp(const ManifoldGeometry& lhs, const ManifoldGeometry& rhs)
 {
 // FIXME: How to deal with operation not supported?

--- a/src/geometry/manifold/ManifoldGeometry.h
+++ b/src/geometry/manifold/ManifoldGeometry.h
@@ -10,6 +10,7 @@
 #include <memory>
 #include <set>
 #include <string>
+#include <vector>
 
 #include "geometry/Geometry.h"
 #include "geometry/linalg.h"
@@ -58,6 +59,15 @@ public:
   ManifoldGeometry operator-(const ManifoldGeometry& other) const;
   /*! minkowksi operation. */
   ManifoldGeometry minkowski(const ManifoldGeometry& other) const;
+
+  /*! N-ary union/intersection/difference via Manifold's batched (balanced, parallel)
+   *  BatchBoolean. Result is geometrically identical to folding operator+ / operator* /
+   *  operator- over the operands, but avoids re-processing the growing accumulator on every
+   *  step. opType must be Add, Intersect or Subtract; for Subtract, operands[0] is the minuend
+   *  and the remaining operands are subtracted (as their union). operands must be non-empty and
+   *  contain no empty geometries; the caller is responsible for that filtering. */
+  static ManifoldGeometry boolOp(manifold::OpType opType,
+                                 const std::vector<std::shared_ptr<const ManifoldGeometry>>& operands);
 
   Polygon2d slice() const;
   Polygon2d project() const;

--- a/src/geometry/manifold/manifold-applyops.cc
+++ b/src/geometry/manifold/manifold-applyops.cc
@@ -4,6 +4,7 @@
 #ifdef ENABLE_MANIFOLD
 
 #include <memory>
+#include <vector>
 
 #include "core/AST.h"
 #include "core/enums.h"
@@ -63,43 +64,54 @@ std::shared_ptr<ManifoldGeometry> applyOperator3DManifold(const Geometry::Geomet
     return std::make_shared<ManifoldGeometry>(manifold::Manifold::Hull(pts));
   }
 
-  std::shared_ptr<ManifoldGeometry> geom;
+  // Minkowski is not a batched boolean; keep the pairwise fold.
+  if (op == OpenSCADOperator::MINKOWSKI) {
+    std::shared_ptr<ManifoldGeometry> geom;
+    bool foundFirst = false;
+    for (const auto& item : children) {
+      auto chN = item.second ? createManifoldFromGeometry(item.second) : nullptr;
+      if (!chN || chN->isEmpty()) continue;
+      if (!foundFirst) {
+        geom = std::make_shared<ManifoldGeometry>(*chN);
+        foundFirst = true;
+        continue;
+      }
+      *geom = geom->minkowski(*chN);
+      if (item.first) item.first->progress_report();
+    }
+    return geom;
+  }
 
-  bool foundFirst = false;
+  manifold::OpType opType;
+  switch (op) {
+  case OpenSCADOperator::UNION:        opType = manifold::OpType::Add; break;
+  case OpenSCADOperator::INTERSECTION: opType = manifold::OpType::Intersect; break;
+  case OpenSCADOperator::DIFFERENCE:   opType = manifold::OpType::Subtract; break;
+  default:
+    LOG(message_group::Error, "Unsupported manifold operator: %1$d", static_cast<int>(op));
+    return nullptr;
+  }
 
+  // Collect the non-empty operands (preserving order and the same empty-geometry short-circuits as
+  // the pairwise fold), then evaluate them all at once with Manifold's batched BatchBoolean, which
+  // does a balanced/parallel reduction instead of re-processing a growing accumulator each step.
+  std::vector<std::shared_ptr<const ManifoldGeometry>> operands;
+  operands.reserve(children.size());
   for (const auto& item : children) {
     auto chN = item.second ? createManifoldFromGeometry(item.second) : nullptr;
-
-    // Intersecting something with nothing results in nothing
     if (!chN || chN->isEmpty()) {
-      if (op == OpenSCADOperator::INTERSECTION) {
-        geom = nullptr;
-        break;
-      }
-      if (op == OpenSCADOperator::DIFFERENCE && !foundFirst) {
-        geom = nullptr;
-        break;
-      }
+      // Intersecting with nothing, or subtracting from nothing, results in nothing.
+      if (op == OpenSCADOperator::INTERSECTION) return nullptr;
+      if (op == OpenSCADOperator::DIFFERENCE && operands.empty()) return nullptr;
       continue;
     }
-
-    // Initialize geom with first expected geometric object
-    if (!foundFirst) {
-      geom = std::make_shared<ManifoldGeometry>(*chN);
-      foundFirst = true;
-      continue;
-    }
-
-    switch (op) {
-    case OpenSCADOperator::UNION:        *geom = *geom + *chN; break;
-    case OpenSCADOperator::INTERSECTION: *geom = *geom * *chN; break;
-    case OpenSCADOperator::DIFFERENCE:   *geom = *geom - *chN; break;
-    case OpenSCADOperator::MINKOWSKI:    *geom = geom->minkowski(*chN); break;
-    default:                             LOG(message_group::Error, "Unsupported CGAL operator: %1$d", static_cast<int>(op));
-    }
+    operands.push_back(chN);
     if (item.first) item.first->progress_report();
   }
-  return geom;
+
+  if (operands.empty()) return nullptr;
+  if (operands.size() == 1) return std::make_shared<ManifoldGeometry>(*operands.front());
+  return std::make_shared<ManifoldGeometry>(ManifoldGeometry::boolOp(opType, operands));
 }
 
 };  // namespace ManifoldUtils


### PR DESCRIPTION
## Summary

`applyOperator3DManifold` currently folds the pairwise operators over the child list
(`geom = geom OP child`), issuing N−1 separate `manifold::Manifold::Boolean` calls and
re-processing the growing accumulator at each step. Manifold provides an N-ary
`BatchBoolean` that does a balanced (and internally parallel) reduction, and for `Subtract`
computes `first − union(rest)`.

This PR collects the non-empty operands and evaluates union / intersection / difference in a
**single `BatchBoolean` call**. Minkowski keeps the pairwise fold.

## Relationship to the `kintel-manifold-ops` experiment

This was previously prototyped in the `kintel-manifold-ops` branch
("Experiment with BatchBoolean()", 5678e527b, 2024). That experiment operated on raw
`getManifold()` results, so it **dropped the `ManifoldGeometry` metadata**
(`originalIDs_` / `originalIDToColor_` / `subtractedIDs_`) and the empty-geometry
short-circuits — i.e. it would have broken per-object colors, part-IDs and empty-result
handling. This PR is the completed version: a new `ManifoldGeometry::boolOp` merges that
metadata **exactly** as the equivalent `binOp()` fold, and the empty / single-child edge
cases are preserved.

## Correctness (validated, 5 machines)

Batched output is geometrically identical to the pairwise fold — **volume / surface-area /
bbox match to FP precision** across union / intersection / difference / nested / real models;
a colored model renders **byte-identical** PNG; empty-result and single-child edge cases match
the previous behaviour. The result triangle *count* can differ by a couple (same solid, different
triangulation), so invariants — not tri counts — are the oracle. CircleCI is green.

## Performance (interleaved A/B, min-of-7; speedup = sequential / batched)

Honestly **modest and mostly union-shaped** — Manifold's sequential path is already
well-optimized (spatial culling), so the batched form mainly helps N-ary union (and many-cutter
difference). No regression on any machine, x86 or ARM:

| CPU | arch | cores | union | difference | intersection |
|---|---|---|---:|---:|---:|
| Intel Core i9-9880H | x86-64 | 8c/16t | 1.0–1.08× | ~1.0× | ~1.0× |
| Intel Xeon W-2235 | x86-64 | 6c/12t | 1.08× | 1.06× | 1.00× |
| AMD Ryzen Threadripper 1900X | x86-64 | 8c/16t | 1.06× | 1.01× | 1.03× |
| Broadcom BCM2712 — Cortex-A76 (RPi5) | aarch64 | 4c | **1.13×** | 1.03× | 1.01× |
| Apple M4 Pro | aarch64 | 10P+4E | 1.06–1.12× | 1.04–1.05× | 1.01× |

Peak RSS is also **≤** the sequential fold (union of 120 high-poly spheres: ~900 MB batched vs
~1080 MB sequential — `BatchBoolean` builds a deferred CsgNode tree rather than materializing every
operand at once).

## Honest note

The win is modest. If this stalled at `kintel-manifold-ops` because the speedup didn't justify
touching this path, that's a fair call — the value here is mainly (a) completing it *correctly*
(metadata + edge cases) and (b) the cross-arch data showing it's a consistent, no-downside win.
Feedback welcome. (A single-binary A/B toggle + benchmark harness used for the numbers above lives
on the `bench-toggle` branch of the fork, if reviewers want to reproduce.)
