### PR TITLE
Fix 3MF export via stdout producing invalid ZIP (fixes #6895) 

### DIFF
--- a/src/io/export.cc
+++ b/src/io/export.cc
@@ -39,8 +39,13 @@
 #include <iostream>
 #include <map>
 #include <memory>
+#include <optional>
+#include <random>
+#include <sstream>
 #include <string>
+#include <system_error>
 #include <unordered_map>
+#include <utility>
 #include <vector>
 
 #ifdef _WIN32
@@ -228,11 +233,143 @@ static void exportFile(const std::shared_ptr<const Geometry>& root_geom, std::os
   }
 }
 
+namespace {
+
+struct TemporaryExportPath {
+  std::filesystem::path dir;
+  std::filesystem::path file;
+
+  TemporaryExportPath() = default;
+  TemporaryExportPath(std::filesystem::path dir, std::filesystem::path file)
+    : dir(std::move(dir)), file(std::move(file))
+  {
+  }
+
+  TemporaryExportPath(const TemporaryExportPath&) = delete;
+  TemporaryExportPath& operator=(const TemporaryExportPath&) = delete;
+
+  TemporaryExportPath(TemporaryExportPath&& other) noexcept
+    : dir(std::move(other.dir)), file(std::move(other.file))
+  {
+    other.dir.clear();
+    other.file.clear();
+  }
+
+  TemporaryExportPath& operator=(TemporaryExportPath&& other) noexcept
+  {
+    if (this != &other) {
+      cleanup();
+      dir = std::move(other.dir);
+      file = std::move(other.file);
+      other.dir.clear();
+      other.file.clear();
+    }
+    return *this;
+  }
+
+  ~TemporaryExportPath()
+  {
+    cleanup();
+  }
+
+private:
+  void cleanup()
+  {
+    // Best-effort cleanup; export/copy failures are reported before destruction.
+    std::error_code ec;
+    if (!file.empty()) std::filesystem::remove(file, ec);
+    if (!dir.empty()) std::filesystem::remove(dir, ec);
+  }
+};
+
+std::string randomHexSuffix()
+{
+  std::random_device random;
+  std::ostringstream stream;
+  stream << std::hex << std::setfill('0');
+  for (int i = 0; i < 4; ++i) {
+    stream << std::setw(8) << static_cast<uint32_t>(random());
+  }
+  return stream.str();
+}
+
+std::optional<TemporaryExportPath> createTemporaryExportPath()
+{
+  std::error_code ec;
+  const auto base = std::filesystem::temp_directory_path(ec);
+  if (ec) {
+    LOG(message_group::Error, _("Could not find temporary directory: %1$s"), ec.message());
+    return std::nullopt;
+  }
+
+  for (int i = 0; i < 100; ++i) {
+    const auto dir = base / ("openscad-export-" + randomHexSuffix());
+    ec.clear();
+    if (std::filesystem::create_directory(dir, ec)) {
+      return TemporaryExportPath(dir, dir / "stdout.3mf");
+    }
+
+    std::error_code existsEc;
+    const bool collision = std::filesystem::exists(dir, existsEc);
+    if (ec && !collision) {
+      LOG(message_group::Error, _("Could not create temporary export directory \"%1$s\": %2$s"),
+          dir.string(), ec.message());
+      return std::nullopt;
+    }
+  }
+
+  LOG(message_group::Error, _("Could not create unique temporary export directory."));
+  return std::nullopt;
+}
+
+bool exportRequiresSeekableOutput(FileFormat format)
+{
+  return format == FileFormat::_3MF;
+}
+
+bool exportFileStdOutViaTempFile(const std::shared_ptr<const Geometry>& root_geom,
+                                 const ExportInfo& exportInfo)
+{
+  auto temp = createTemporaryExportPath();
+  if (!temp) return false;
+
+  if (!exportFileByName(root_geom, temp->file.string(), exportInfo)) {
+    return false;
+  }
+
+  std::ifstream input(temp->file, std::ios::binary);
+  if (!input.is_open()) {
+    LOG(message_group::Error, _("Can't open temporary export file \"%1$s\""), temp->file.string());
+    return false;
+  }
+
+  std::cout << input.rdbuf();
+  std::cout.flush();
+
+  // The stdout state is the primary signal for copy failures; this catches local temp-file read errors.
+  if (!input.eof() && input.fail()) {
+    LOG(message_group::Error, _("Error reading temporary export file \"%1$s\""), temp->file.string());
+    return false;
+  }
+  if (!std::cout) {
+    LOG(message_group::Error, _("Error writing export to stdout."));
+    return false;
+  }
+
+  return true;
+}
+
+}  // namespace
+
 bool exportFileStdOut(const std::shared_ptr<const Geometry>& root_geom, const ExportInfo& exportInfo)
 {
 #ifdef _WIN32
+  // Preserve binary stdout for both direct binary exporters and temp-file copy fallback.
   _setmode(_fileno(stdout), _O_BINARY);
 #endif
+  if (exportRequiresSeekableOutput(exportInfo.format)) {
+    return exportFileStdOutViaTempFile(root_geom, exportInfo);
+  }
   exportFile(root_geom, std::cout, exportInfo);
   return true;
 }

--- a/src/io/export.cc
+++ b/src/io/export.cc
@@ -267,10 +267,7 @@ struct TemporaryExportPath {
     return *this;
   }
 
-  ~TemporaryExportPath()
-  {
-    cleanup();
-  }
+  ~TemporaryExportPath() { cleanup(); }
 
 private:
   void cleanup()

--- a/src/openscad.cc
+++ b/src/openscad.cc
@@ -210,12 +210,8 @@ bool checkAndExport(const std::shared_ptr<const Geometry>& root_geom, unsigned d
     return false;
   }
 
-  if (is_stdout) {
-    exportFileStdOut(root_geom, exportInfo);
-  } else {
-    exportFileByName(root_geom, filename, exportInfo);
-  }
-  return true;
+  return is_stdout ? exportFileStdOut(root_geom, exportInfo)
+                   : exportFileByName(root_geom, filename, exportInfo);
 }
 
 void help(const char *arg0, const po::options_description& desc, bool failure = false)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1493,14 +1493,7 @@ list(APPEND NEF3_BROKEN_TESTS
 )
 
 # Platform specific test disable
-if(APPLE)
-  set_tests_properties(
-    # Fails to create a 3MF file to stdout, see #6895
-    export-3mf-stdio_3mf-export
-    PROPERTIES DISABLED TRUE
-  )
-elseif(UNIX)
-elseif(WIN32 OR MXECROSS)
+if(WIN32 OR MXECROSS)
   set_tests_properties(
     # Known UTF-8 issue on Windows
     export-csg-nonascii_sfære


### PR DESCRIPTION
Fixes #6895.

## Fix

3MF stdout export (`-o - --export-format 3mf`) now writes to a uniquely named temporary `.3mf` file first, then streams the completed file to stdout. This avoids the underlying issue: the lib3mf writer needs a seekable stream, and stdout is not seekable when connected to a pipe.

This deliberately always routes 3MF stdout exports through a temp file, rather than probing whether stdout happens to be seekable via `lseek` / `_lseeki64`. This keeps the behavior simple and portable across platforms, at the cost of a small extra copy even when stdout is redirected to a regular file.

## Implementation Details

- Creates the temp directory atomically with `std::filesystem::create_directory` and a `std::random_device`-based retry loop.
- Retries random-name collisions, but logs and aborts on real filesystem errors.
- Uses a move-only RAII guard for cleanup. This avoids moved-from temporaries deleting the active temp directory.
- Checks `std::cout` as the primary signal for copy failures, with the temp-file input stream checked defensively.

## Also Included

`checkAndExport()` now propagates the actual export success/failure instead of unconditionally returning `true`. Failed exports, including temp-file/stdout failures, now surface as a nonzero CLI exit code.

## Tests

- Re-enables `export-3mf-stdio_3mf-export`, which was disabled on macOS in #6900 pending this fix.
- Verified `cmake --build build --target OpenSCADExe`.
- Manually verified stdin-to-stdout 3MF export produces a valid ZIP with `unzip -t`.
- Manually verified repeated stdout exports use fresh temp paths and produce valid archives.
- Also verified direct-file export (`-o test.3mf`) still produces a valid archive.
- Verified via `ctest -R export-3mf-stdio_3mf-export`.