### PR TITLE
Fix macOS launch crash when opening scad file via double-click

### DIFF
--- a/src/gui/Preferences.cc
+++ b/src/gui/Preferences.cc
@@ -163,7 +163,6 @@ Preferences::Preferences(QWidget *parent) : QMainWindow(parent)
   init();
   AxisConfig->init();
   setupFeaturesPage();
-  setup3DPrintPage();
   updateGUI();
 }
 
@@ -1102,6 +1101,7 @@ void Preferences::on_checkBoxEnableRemotePrintServices_toggled(bool checked)
 {
   S::enableRemotePrintServices.setValue(checked);
   writeSettings();
+  setup3DPrintPage();
 }
 
 void Preferences::on_comboBoxDefaultPrintService_activated(int)
@@ -1808,6 +1808,10 @@ void Preferences::keyPressEvent(QKeyEvent *e)
 
 void Preferences::showEvent(QShowEvent *e)
 {
+  if (!this->printPageSetupDone) {
+    setup3DPrintPage();
+    this->printPageSetupDone = true;
+  }
   QMainWindow::showEvent(e);
   hidePasswords();
 }

--- a/src/gui/Preferences.cc
+++ b/src/gui/Preferences.cc
@@ -623,6 +623,7 @@ void Preferences::setup3DPrintPage()
   if (it != services.end()) {
     comboBoxDefaultPrintService->setCurrentText(it->second);
   }
+  this->printPageSetupDone = true;
 }
 
 void Preferences::on_colorSchemeChooser_itemSelectionChanged()
@@ -1810,7 +1811,6 @@ void Preferences::showEvent(QShowEvent *e)
 {
   if (!this->printPageSetupDone) {
     setup3DPrintPage();
-    this->printPageSetupDone = true;
   }
   QMainWindow::showEvent(e);
   hidePasswords();

--- a/src/gui/Preferences.h
+++ b/src/gui/Preferences.h
@@ -231,6 +231,7 @@ private:
   nlohmann::json inMemoryAISettings;
   QTimer *aiSaveTimer = nullptr;
   QString currentLoadedProfileName;
+  bool printPageSetupDone{false};
 };
 
 class GlobalPreferences


### PR DESCRIPTION
### Problem Description
On macOS, double-clicking a `.scad` file to launch OpenSCAD (or using `open -a OpenSCAD file.scad` from terminal) causes it to crash on launch if the welcome screen is enabled or settings initialization happens early.

During startup, `GlobalPreferences::inst()` is queried to read default configurations. This constructs the `Preferences` singleton instance. Inside its constructor, `setup3DPrintPage()` is called, which calls `PrintService::getPrintServices()`. If remote print services are enabled, this triggers a synchronous network request using a nested `QEventLoop::exec()`. 

Spinning a nested event loop during early static local initialization allows the pending `QFileOpenEvent` (from LaunchServices/Finder) to be processed immediately on the main thread. The event filter catches it and attempts to construct a `MainWindow`, which again queries `GlobalPreferences::inst()`. Since `GlobalPreferences::inst()` has not completed its static initialization, the C++ runtime detects recursive static variable initialization re-entrancy on the same thread and aborts the application immediately via `__cxa_guard_acquire` -> `abort()`.

### Solution
- Defer `setup3DPrintPage()` (and therefore the synchronous network fetch of print services) from the `Preferences` constructor to `Preferences::showEvent(...)` so it is initialized lazily only when the settings window is actually displayed to the user.
- Add a private boolean `printPageSetupDone{false}` to track when it has been set up.
- Call `setup3DPrintPage()` inside `Preferences::on_checkBoxEnableRemotePrintServices_toggled(...)` so that toggling the setting updates the default print service combobox dynamically.

Closes #5891
Also possibly related to #2682
