### PR TITLE
Refactor tool execution to use callback pattern

### DIFF
--- a/src/core/AIService.cc
+++ b/src/core/AIService.cc
@@ -8,11 +8,6 @@
 #include "json/json.hpp"
 #include <fstream>
 #include <cstdlib>
-#include <future>
-#include <QApplication>
-#include "gui/MainWindow.h"
-#include "gui/OpenSCADApp.h"
-#include "gui/ai/ChatWidget.h"
 
 static std::string getAISettingsPath()
 {
@@ -77,128 +72,12 @@ static bool loadActiveProfile(AIProfileConfig& config, std::string& error_msg)
   return true;
 }
 
-static std::string executeToolOnMainThread(const std::string& name, const std::string& arguments_json)
-{
-  auto promise = std::make_shared<std::promise<std::string>>();
-  auto future = promise->get_future();
-
-  QMetaObject::invokeMethod(
-    qApp,
-    [promise, name, arguments_json]() {
-      try {
-        MainWindow *mw = nullptr;
-        for (auto *win : scadApp->windowManager.getWindows()) {
-          mw = win;
-          break;
-        }
-
-        std::string result_val;
-
-        if (name == "get_editor_code") {
-          if (mw && mw->activeEditor) {
-            result_val = mw->activeEditor->toPlainText().toStdString();
-          } else {
-            result_val = "Error: No active editor found.";
-          }
-        } else if (name == "set_editor_code") {
-          auto args = nlohmann::json::parse(arguments_json);
-          if (!args.contains("code")) {
-            result_val = "Error: Missing required argument 'code'.";
-            promise->set_value(result_val);
-            return;
-          }
-          std::string code = args["code"].get<std::string>();
-          ChatWidget *chatWidget = nullptr;
-          if (mw) {
-            chatWidget = mw->findChild<ChatWidget *>();
-          }
-          if (chatWidget) {
-            chatWidget->proposeCodeChange(code);
-            result_val =
-              "Success: Code change proposed to the user for review. The user will review and choose "
-              "whether to apply it.";
-          } else {
-            if (mw && mw->activeEditor) {
-              mw->activeEditor->setText(QString::fromStdString(code));
-              result_val = "Success: Code set in the editor.";
-            } else {
-              result_val = "Error: No active editor found.";
-            }
-          }
-        } else if (name == "trigger_preview") {
-          ChatWidget *chatWidget = nullptr;
-          if (mw) {
-            chatWidget = mw->findChild<ChatWidget *>();
-          }
-          if (chatWidget && chatWidget->hasPendingCodeChanges()) {
-            result_val = "Info: Preview postponed because code changes are pending user review.";
-          } else {
-            if (mw) {
-              mw->actionRenderPreview();
-              result_val = "Success: Preview triggered.";
-            } else {
-              result_val = "Error: No active MainWindow found.";
-            }
-          }
-        } else {
-          result_val = "Error: Unknown tool name '" + name + "'.";
-        }
-
-        promise->set_value(result_val);
-
-        // Log the tool execution in the ChatWidget
-        ChatWidget *chatWidget = nullptr;
-        if (mw) {
-          chatWidget = mw->findChild<ChatWidget *>();
-        }
-        if (chatWidget) {
-          chatWidget->logToolExecution(name, result_val);
-        }
-
-      } catch (const std::exception& e) {
-        std::string err = std::string("Error parsing/executing tool: ") + e.what();
-        promise->set_value(err);
-
-        MainWindow *mw = nullptr;
-        for (auto *win : scadApp->windowManager.getWindows()) {
-          mw = win;
-          break;
-        }
-        ChatWidget *chatWidget = nullptr;
-        if (mw) {
-          chatWidget = mw->findChild<ChatWidget *>();
-        }
-        if (chatWidget) {
-          chatWidget->logToolExecution(name, err);
-        }
-      } catch (...) {
-        std::string err = "Error: Unknown exception occurred during tool execution.";
-        promise->set_value(err);
-
-        MainWindow *mw = nullptr;
-        for (auto *win : scadApp->windowManager.getWindows()) {
-          mw = win;
-          break;
-        }
-        ChatWidget *chatWidget = nullptr;
-        if (mw) {
-          chatWidget = mw->findChild<ChatWidget *>();
-        }
-        if (chatWidget) {
-          chatWidget->logToolExecution(name, err);
-        }
-      }
-    },
-    Qt::QueuedConnection);
-
-  return future.get();
-}
-
 class AIService::Impl
 {
 public:
   std::unique_ptr<HTTPClient> http_client;
   std::unique_ptr<AIClient> ai_client;
+  ToolExecutor tool_executor = nullptr;
 
   Impl()
   {
@@ -221,6 +100,11 @@ AIService::~AIService() = default;
 
 AIService::AIService(AIService&&) noexcept = default;
 AIService& AIService::operator=(AIService&&) noexcept = default;
+
+void AIService::registerToolExecutor(ToolExecutor executor)
+{
+  impl->tool_executor = std::move(executor);
+}
 
 void AIService::chatCompletionStream(std::vector<ChatMessage>& history, ChunkCallback on_chunk,
                                      ErrorCallback on_error, CompleteCallback on_complete)
@@ -334,7 +218,12 @@ void AIService::chatCompletionStream(std::vector<ChatMessage>& history, ChunkCal
     history.push_back(assistant_msg);
 
     for (const auto& tc : tool_calls) {
-      std::string result = executeToolOnMainThread(tc.name, tc.arguments);
+      std::string result;
+      if (impl->tool_executor) {
+        result = impl->tool_executor(tc.name, tc.arguments);
+      } else {
+        result = "Error: No tool executor registered.";
+      }
       ChatMessage tool_msg;
       tool_msg.role = "tool";
       tool_msg.content = result;

--- a/src/core/AIService.h
+++ b/src/core/AIService.h
@@ -44,6 +44,10 @@ public:
   // Cancel any active AI completion requests
   void cancelPendingRequests();
 
+  using ToolExecutor =
+    std::function<std::string(const std::string& name, const std::string& arguments_json)>;
+  void registerToolExecutor(ToolExecutor executor);
+
 private:
   class Impl;
   std::unique_ptr<Impl> impl;

--- a/src/gui/ai/ChatWidget.cc
+++ b/src/gui/ai/ChatWidget.cc
@@ -1,6 +1,7 @@
 #include "gui/ai/ChatWidget.h"
 #include "gui/qtgettext.h"
-
+#include "json/json.hpp"
+#include <future>
 #include <QScrollBar>
 #include <QFrame>
 #include <QLabel>
@@ -113,6 +114,28 @@ ChatWidget::ChatWidget(QWidget *parent) : QWidget(parent)
   // Initialize backend and state
   aiService = std::make_shared<AIService>();
   aliveState = std::make_shared<bool>(true);
+
+  // Register tool executor callback
+  aiService->registerToolExecutor([this](const std::string& name, const std::string& arguments_json) {
+    auto promise = std::make_shared<std::promise<std::string>>();
+    auto future = promise->get_future();
+
+    QMetaObject::invokeMethod(
+      qApp,
+      [this, promise, name, arguments_json]() {
+        try {
+          std::string result_val = this->executeTool(name, arguments_json);
+          promise->set_value(result_val);
+        } catch (const std::exception& e) {
+          promise->set_value(std::string("Error parsing/executing tool: ") + e.what());
+        } catch (...) {
+          promise->set_value("Error: Unknown exception occurred during tool execution.");
+        }
+      },
+      Qt::QueuedConnection);
+
+    return future.get();
+  });
 
   // Initial welcome greeting
   addMessage(_("Hello! I am your OpenSCAD AI assistant. Ask me to write some code, e.g. "
@@ -413,4 +436,49 @@ void ChatWidget::logToolExecution(const std::string& name, const std::string& re
 
   // Scroll to bottom
   scrollArea->verticalScrollBar()->setValue(scrollArea->verticalScrollBar()->maximum());
+}
+
+std::string ChatWidget::executeTool(const std::string& name, const std::string& arguments_json)
+{
+  MainWindow *mw = nullptr;
+  for (auto *win : scadApp->windowManager.getWindows()) {
+    mw = win;
+    break;
+  }
+
+  std::string result_val;
+
+  if (name == "get_editor_code") {
+    if (mw && mw->activeEditor) {
+      result_val = mw->activeEditor->toPlainText().toStdString();
+    } else {
+      result_val = "Error: No active editor found.";
+    }
+  } else if (name == "set_editor_code") {
+    auto args = nlohmann::json::parse(arguments_json);
+    if (!args.contains("code")) {
+      return "Error: Missing required argument 'code'.";
+    }
+    std::string code = args["code"].get<std::string>();
+    this->proposeCodeChange(code);
+    result_val =
+      "Success: Code change proposed to the user for review. The user will review and choose whether to "
+      "apply it.";
+  } else if (name == "trigger_preview") {
+    if (this->hasPendingCodeChanges()) {
+      result_val = "Info: Preview postponed because code changes are pending user review.";
+    } else {
+      if (mw) {
+        mw->actionRenderPreview();
+        result_val = "Success: Preview triggered.";
+      } else {
+        result_val = "Error: No active MainWindow found.";
+      }
+    }
+  } else {
+    result_val = "Error: Unknown tool name '" + name + "'.";
+  }
+
+  this->logToolExecution(name, result_val);
+  return result_val;
 }

--- a/src/gui/ai/ChatWidget.h
+++ b/src/gui/ai/ChatWidget.h
@@ -47,6 +47,7 @@ private:
   MessageBubble *addMessage(const QString& text, bool isUser);
   bool isDarkTheme() const;
   void enableInput(bool enabled);
+  std::string executeTool(const std::string& name, const std::string& arguments_json);
 
   std::shared_ptr<AIService> aiService;
   std::vector<ChatMessage> history;


### PR DESCRIPTION
Move tool execution logic from AIService to ChatWidget using dependency injection. AIService now accepts a registered ToolExecutor callback instead of directly implementing tool operations. This decouples the core AI service from GUI components, improving modularity and testability.