### PR TITLE
Add remove() module as syntactic sugar for creating differences.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1015,6 +1015,8 @@ set(CORE_SOURCES
   src/core/ContextMemoryManager.cc
   src/core/CsgOpNode.cc
   src/core/CurveDiscretizer.cc
+  src/core/RemoveNode.cc
+  src/core/RemoveNodeRewriter.cc
   src/core/DrawingCallback.cc
   src/core/EvaluationSession.cc
   src/core/Expression.cc

--- a/src/core/CSGTreeEvaluator.h
+++ b/src/core/CSGTreeEvaluator.h
@@ -49,6 +49,7 @@ public:
   }
 
 private:
+  using ChildList = std::list<std::shared_ptr<const AbstractNode>>;
   void addToParent(const State& state, const AbstractNode& node);
   void applyToChildren(State& state, const AbstractNode& node, OpenSCADOperator op);
   std::shared_ptr<CSGNode> evaluateCSGNodeFromGeometry(State& state,
@@ -57,10 +58,8 @@ private:
                                                        const AbstractNode& node);
   void applyBackgroundAndHighlight(State& state, const AbstractNode& node);
 
-  using ChildList = std::list<std::shared_ptr<const AbstractNode>>;
-  std::map<int, ChildList> visitedchildren;
-
 protected:
+  std::map<int, ChildList> visitedchildren;
   const Tree& tree;
   GeometryEvaluator *geomevaluator;
   std::shared_ptr<CSGNode> rootNode;

--- a/src/core/CsgOpNode.cc
+++ b/src/core/CsgOpNode.cc
@@ -25,6 +25,7 @@
  */
 
 #include "core/CsgOpNode.h"
+#include "core/RemoveNode.h"
 
 #include <cassert>
 #include <memory>
@@ -59,6 +60,13 @@ static std::shared_ptr<AbstractNode> builtin_intersection(const ModuleInstantiat
   return children.instantiate(std::make_shared<CsgOpNode>(inst, OpenSCADOperator::INTERSECTION));
 }
 
+static std::shared_ptr<AbstractNode> builtin_remove(const ModuleInstantiation *inst, Arguments arguments,
+                                                    const Children& children)
+{
+  Parameters parameters = Parameters::parse(std::move(arguments), inst->location(), {});
+  return children.instantiate(std::make_shared<RemoveNode>(inst));
+}
+
 std::string CsgOpNode::toString() const
 {
   return this->name() + "()";
@@ -90,5 +98,10 @@ void register_builtin_csgops()
   Builtins::init("intersection", new BuiltinModule(builtin_intersection),
                  {
                    "intersection()",
+                 });
+
+  Builtins::init("remove", new BuiltinModule(builtin_remove),
+                 {
+                   "remove()",
                  });
 }

--- a/src/core/LocalScope.cc
+++ b/src/core/LocalScope.cc
@@ -10,6 +10,7 @@
 
 #include "core/Assignment.h"
 #include "core/ModuleInstantiation.h"
+#include "core/RemoveNodeRewriter.h"
 #include "core/UserModule.h"
 #include "core/function.h"
 #include "core/node.h"
@@ -88,6 +89,7 @@ std::shared_ptr<AbstractNode> LocalScope::instantiateModules(
       target->children.push_back(node);
     }
   }
+  rewriteRemoveNodes(*target);
   return target;
 }
 

--- a/src/core/RemoveNode.cc
+++ b/src/core/RemoveNode.cc
@@ -1,0 +1,11 @@
+#include "core/RemoveNode.h"
+
+std::string RemoveNode::name() const
+{
+  return "remove";
+}
+
+std::string RemoveNode::toString() const
+{
+  return this->name() + "()";
+}

--- a/src/core/RemoveNode.h
+++ b/src/core/RemoveNode.h
@@ -1,0 +1,13 @@
+#pragma once
+
+#include "core/ModuleInstantiation.h"
+#include "core/node.h"
+
+class RemoveNode : public AbstractNode
+{
+public:
+  VISITABLE();
+  RemoveNode(const ModuleInstantiation *mi) : AbstractNode(mi) {}
+  std::string name() const override;
+  std::string toString() const override;
+};

--- a/src/core/RemoveNodeRewriter.cc
+++ b/src/core/RemoveNodeRewriter.cc
@@ -1,0 +1,127 @@
+#include "core/RemoveNodeRewriter.h"
+
+#include <algorithm>
+#include <cassert>
+#include <cstddef>
+#include <memory>
+#include <utility>
+#include <vector>
+#include <iterator>
+
+#include "core/CsgOpNode.h"
+#include "core/ModuleInstantiation.h"
+#include "core/RemoveNode.h"
+#include "core/enums.h"
+
+namespace {
+
+using NodeList = std::vector<std::shared_ptr<AbstractNode>>;
+using Range = std::pair<NodeList::const_iterator, NodeList::const_iterator>;
+using SegmentList = std::vector<Range>;
+
+auto isRemoveNode = [](const std::shared_ptr<AbstractNode>& node) -> bool {
+  return nullptr != std::dynamic_pointer_cast<RemoveNode>(node);
+};
+
+void applyRemoveModifiers(AbstractNode& remNode)
+{
+  auto *mi = const_cast<ModuleInstantiation *>(remNode.modinst);
+  if (!(mi->tag_root || mi->tag_highlight || mi->tag_background)) return;
+
+  for (auto& child : remNode.children) {
+    auto *childMi = const_cast<ModuleInstantiation *>(child->modinst);
+    childMi->tag_root |= mi->tag_root;
+    childMi->tag_highlight |= mi->tag_highlight;
+    childMi->tag_background |= mi->tag_background;
+  }
+  mi->tag_root = mi->tag_highlight = mi->tag_background = false;
+}
+
+std::shared_ptr<AbstractNode> createUnion(const ModuleInstantiation *mi, Range nodeList)
+{
+  const auto cnt = std::distance(nodeList.first, nodeList.second);
+  if (cnt == 0) return std::make_shared<GroupNode>(mi);
+  if (cnt == 1) return *nodeList.first;
+  auto node = std::make_shared<CsgOpNode>(mi, OpenSCADOperator::UNION);
+  std::vector<std::shared_ptr<AbstractNode>> children;
+  children.insert(children.begin(), nodeList.first, nodeList.second);
+  node->children = std::move(children);
+  return node;
+}
+
+SegmentList groupNodes(const NodeList& nodeList)
+{
+  if (nodeList.empty()) return {};
+
+  auto start_it = nodeList.begin();
+
+  SegmentList segments;
+  bool current_state = isRemoveNode(*start_it);
+  if (current_state) segments.emplace_back(start_it, start_it);
+
+  for (auto next_it = nodeList.begin() + 1; next_it != nodeList.end(); ++next_it) {
+    bool next_state = isRemoveNode(*next_it);
+    if (next_state != current_state) {
+      segments.emplace_back(start_it, next_it);
+      start_it = next_it;
+      current_state = next_state;
+    }
+  }
+
+  segments.emplace_back(start_it, nodeList.end());
+  if (segments.size() % 2) {
+    segments.emplace_back(nodeList.end(), nodeList.end());
+  }
+
+  return segments;
+}
+
+NodeList rewriteSpans(const ModuleInstantiation *mi, const SegmentList& segmentList)
+{
+  NodeList out;
+
+  for (size_t i = 0; i < segmentList.size(); i += 2) {
+    const auto& [posStart, posEnd] = segmentList[i];
+    const auto& [negStart, negEnd] = segmentList[i + 1];
+
+    std::vector<std::shared_ptr<AbstractNode>> negChildren;
+    for (auto it = negStart; it != negEnd; it++) {
+      const auto& negNode = *it;
+      applyRemoveModifiers(*negNode);
+      negChildren.insert(negChildren.end(), negNode->children.begin(), negNode->children.end());
+    }
+
+    if (std::distance(negStart, negEnd) == 0) {
+      out.insert(out.end(), posStart, posEnd);
+    } else {
+      auto diff = std::make_shared<CsgOpNode>(mi, OpenSCADOperator::DIFFERENCE);
+      diff->children.push_back(createUnion(mi, segmentList[i]));
+      diff->children.insert(diff->children.end(), negChildren.begin(), negChildren.end());
+      out.push_back(std::move(diff));
+    }
+  }
+
+  return out;
+}
+
+bool rewriteNode(AbstractNode& node)
+{
+  bool hasRemove = false;
+  for (auto& child : node.children) {
+    if (rewriteNode(*child)) hasRemove = true;
+  }
+
+  if (!hasRemove && std::none_of(node.children.begin(), node.children.end(), isRemoveNode)) {
+    return false;
+  }
+
+  node.children = rewriteSpans(node.modinst, groupNodes(node.children));
+  return true;
+}
+
+}  // namespace
+
+void rewriteRemoveNodes(AbstractNode& node)
+{
+  rewriteNode(node);
+}

--- a/src/core/RemoveNodeRewriter.h
+++ b/src/core/RemoveNodeRewriter.h
@@ -1,0 +1,3 @@
+#pragma once
+
+void rewriteRemoveNodes(class AbstractNode& node);


### PR DESCRIPTION
Proposal for a `remove()` node which provides a way of writing differences as flat list. This is done by rewriting the CSG tree so in the final tree, the `remove()` node is not present anymore. Consecutive positive nodes are collected into a `union()` which is then placed as first element of a `difference()` that includes all following negative nodes.

This came out of a discussion with a teacher working with a blind student finding that a `difference()` clause is difficult to navigate when not having the option to see the whole structure on a screen.

Thoughts? Questions?

<details><summary>Source code from the screenshot</summary>

```openscad
$fa = 2; $fs = 0.2;

module test() {

cube(1);
color("green") cube(10, center = true);
#remove() cylinder(h = 20, d = 6, center = true);
%remove() rotate([0, 90, 0]) cylinder(h = 20, d = 6, center = true);
#remove() rotate([90, 0, 0]) cylinder(h = 20, d = 6, center = true);

color("cyan") sphere(5);
color("blue") cylinder(h = 15, d = 2, center = true);
remove() cube([20, 20, 1], center = true);

color("red") translate([0, 20, 0]) cylinder(h = 3, r = 2);

}

test();
```
</details>

The generated CSG tree looks like this:

```openscad
group() {
  difference() {
    union() {
      cube(size = [1, 1, 1], center = false);
      color([0, 0.501961, 0, 1]) {
        cube(size = [10, 10, 10], center = true);
      }
    }
#    cylinder($fn = 0, $fa = 2, $fs = 0.2, h = 20, r1 = 3, r2 = 3, center = true);
%    multmatrix([[0, 0, 1, 0], [0, 1, 0, 0], [-1, 0, 0, 0], [0, 0, 0, 1]]) {
      cylinder($fn = 0, $fa = 2, $fs = 0.2, h = 20, r1 = 3, r2 = 3, center = true);
    }
#    multmatrix([[1, 0, 0, 0], [0, 0, -1, 0], [0, 1, 0, 0], [0, 0, 0, 1]]) {
      cylinder($fn = 0, $fa = 2, $fs = 0.2, h = 20, r1 = 3, r2 = 3, center = true);
    }
  }
  difference() {
    union() {
      color([0, 1, 1, 1]) {
        sphere($fn = 0, $fa = 2, $fs = 0.2, r = 5);
      }
      color([0, 0, 1, 1]) {
        cylinder($fn = 0, $fa = 2, $fs = 0.2, h = 15, r1 = 1, r2 = 1, center = true);
      }
    }
    cube(size = [20, 20, 1], center = true);
  }
  color([1, 0, 0, 1]) {
    multmatrix([[1, 0, 0, 0], [0, 1, 0, 20], [0, 0, 1, 0], [0, 0, 0, 1]]) {
      cylinder($fn = 0, $fa = 2, $fs = 0.2, h = 3, r1 = 2, r2 = 2, center = false);
    }
  }
}

```

<img width="800" src="https://github.com/user-attachments/assets/2aa6ff20-a815-46a4-a687-d16111b72133" />
