### PR TITLE
Indicate that some buttons open a new window

### DIFF
--- a/src/gui/MainWindow.ui
+++ b/src/gui/MainWindow.ui
@@ -738,7 +738,7 @@
     <iconset theme="chokusen-open"/>
    </property>
    <property name="text">
-    <string>&amp;Open File</string>
+    <string>&amp;Open File...</string>
    </property>
    <property name="shortcut">
     <string>Ctrl+O</string>
@@ -770,7 +770,7 @@
   </action>
   <action name="fileActionSaveACopy">
    <property name="text">
-    <string>Save a Copy</string>
+    <string>Save a Copy...</string>
    </property>
   </action>
   <action name="fileActionSaveAll">
@@ -1041,17 +1041,17 @@
   </action>
   <action name="designActionDisplayAST">
    <property name="text">
-    <string>Display A&amp;ST...</string>
+    <string>Display A&amp;ST</string>
    </property>
   </action>
   <action name="designActionDisplayCSGTree">
    <property name="text">
-    <string>Display CSG &amp;Tree...</string>
+    <string>Display CSG &amp;Tree</string>
    </property>
   </action>
   <action name="designActionDisplayCSGProducts">
    <property name="text">
-    <string>Display CSG Pr&amp;oducts...</string>
+    <string>Display CSG Pr&amp;oducts</string>
    </property>
   </action>
   <action name="fileActionExportBinarySTL">
@@ -1439,7 +1439,7 @@
   </action>
   <action name="fileShowLibraryFolder">
    <property name="text">
-    <string>Show &amp;Library Folder...</string>
+    <string>Show &amp;Library Folder</string>
    </property>
   </action>
   <action name="viewActionResetView">
@@ -1601,7 +1601,7 @@
   </action>
   <action name="windowActionJumpTo">
    <property name="text">
-    <string>Jump To ...</string>
+    <string>Jump To</string>
    </property>
    <property name="shortcut">
     <string>Ctrl+J</string>


### PR DESCRIPTION
Added ellipses to the following:
File/Open File
File/Save a Copy

Removed ellipses from the following:
File/Show Library Folder...
Design/Display AST...
Design/Display CSG Tree...
Design/Display CSG Products...
Window/Jump To...

Fixes #6839