### PR TITLE
Keyboard shortcut to move lines up and down

### DIFF
--- a/src/gui/Editor.h
+++ b/src/gui/Editor.h
@@ -92,6 +92,8 @@ public slots:
   virtual void nextBookmark() = 0;
   virtual void prevBookmark() = 0;
   virtual void jumpToNextError() = 0;
+  virtual void moveLineUp() = 0;
+  virtual void moveLineDown() = 0;
 
 private:
   QSize initialSizeHint;

--- a/src/gui/MainWindow.cc
+++ b/src/gui/MainWindow.cc
@@ -3628,6 +3628,8 @@ void MainWindow::setupEditor(const QStringList& filenames)
   connect(this->editActionUnindent, &QAction::triggered, tabManager, &TabManager::unindentSelection);
   connect(this->editActionComment, &QAction::triggered, tabManager, &TabManager::commentSelection);
   connect(this->editActionUncomment, &QAction::triggered, tabManager, &TabManager::uncommentSelection);
+  connect(this->editActionMoveLineUp, &QAction::triggered, tabManager, &TabManager::moveLineUp);
+  connect(this->editActionMoveLineDown, &QAction::triggered, tabManager, &TabManager::moveLineDown);
 
   connect(this->editActionToggleBookmark, &QAction::triggered, tabManager, &TabManager::toggleBookmark);
   connect(this->editActionNextBookmark, &QAction::triggered, tabManager, &TabManager::nextBookmark);

--- a/src/gui/MainWindow.ui
+++ b/src/gui/MainWindow.ui
@@ -288,6 +288,8 @@
     <addaction name="editActionUnindent"/>
     <addaction name="editActionComment"/>
     <addaction name="editActionUncomment"/>
+    <addaction name="editActionMoveLineUp"/>
+    <addaction name="editActionMoveLineDown"/>
     <addaction name="editActionConvertTabsToSpaces"/>
     <addaction name="editActionToggleBookmark"/>
     <addaction name="editActionNextBookmark"/>
@@ -894,6 +896,22 @@
    </property>
    <property name="shortcut">
     <string>Ctrl+Shift+D</string>
+   </property>
+  </action>
+<action name="editActionMoveLineUp">
+   <property name="text">
+    <string>Mo&amp;ve Line Up</string>
+   </property>
+   <property name="shortcut">
+    <string>Alt+Up</string>
+   </property>
+  </action>
+  <action name="editActionMoveLineDown">
+   <property name="text">
+    <string>Mo&amp;ve Line Down</string>
+   </property>
+   <property name="shortcut">
+    <string>Alt+Down</string>
    </property>
   </action>
   <action name="editActionNextTab">

--- a/src/gui/ScintillaEditor.cc
+++ b/src/gui/ScintillaEditor.cc
@@ -1640,3 +1640,13 @@ void ScintillaEditor::correctUserVarNamesForCompletionFromInputText(
   api->correctUserVarNamesForCompletionFromInputText(
     flagAutoCompleteIncludeVariables, flagAutoCompleteIncludeModules, flagAutoCompleteIncludeFunctions);
 }
+
+void ScintillaEditor::moveLineUp()
+{
+  qsci->SendScintilla(QsciScintilla::SCI_MOVESELECTEDLINESUP);
+}
+
+void ScintillaEditor::moveLineDown()
+{
+  qsci->SendScintilla(QsciScintilla::SCI_MOVESELECTEDLINESDOWN);
+}

--- a/src/gui/ScintillaEditor.h
+++ b/src/gui/ScintillaEditor.h
@@ -132,6 +132,8 @@ public slots:
   void applySettings();
   void onAutocompleteChanged(bool state);
   void onCharacterThresholdChanged(int val);
+  void moveLineUp() override;
+  void moveLineDown() override;
 
 private slots:
   void onTextChanged();

--- a/src/gui/TabManager.cc
+++ b/src/gui/TabManager.cc
@@ -299,6 +299,16 @@ void TabManager::uncommentSelection()
   editor->uncommentSelection();
 }
 
+void TabManager::moveLineUp()
+{
+  editor->moveLineUp();
+}
+
+void TabManager::moveLineDown()
+{
+  editor->moveLineDown();
+}
+
 void TabManager::toggleBookmark()
 {
   editor->toggleBookmark();

--- a/src/gui/TabManager.h
+++ b/src/gui/TabManager.h
@@ -117,4 +117,6 @@ public slots:
   void nextBookmark();
   void prevBookmark();
   void jumpToNextError();
+  void moveLineUp();
+  void moveLineDown();
 };


### PR DESCRIPTION
Using alt + up and alt + down moves lines up
and down inside the editor, respectively

Fixes #6662