### PR TITLE
Add chat export/import and context window management

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -104,3 +104,4 @@ tests/regression/export-pdf/simple-pdf.pdf
 scripts/run-clang-tidy-cached
 .clangd
 /builddir
+/tests

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1359,6 +1359,7 @@ set(GUI_SOURCES
   src/gui/ai/AIDock.cc
   src/gui/ai/ChatWidget.cc
   src/gui/ai/ChatInputEdit.cc
+  src/gui/ai/ViewportGrabber.cc
   ${INPUT_DRIVER_SOURCES}
   )
 

--- a/src/core/AIClient.cc
+++ b/src/core/AIClient.cc
@@ -298,7 +298,8 @@ void AIClient::sendChatCompletion(const AIProfileConfig& config,
     for (auto& el : config.parameters.items()) {
       const std::string& key = el.key();
       if (key == "model" || key == "stream" || key == "messages" || key == "tools" ||
-          key == "system_prompt" || key == "default_prompt" || key == "context_limit") {
+          key == "system_prompt" || key == "default_prompt" || key == "context_limit" ||
+          key == "payload_limit") {
         continue;
       }
       payload[key] = el.value();
@@ -434,7 +435,8 @@ void AIClient::sendChatCompletionStream(const AIProfileConfig& config,
     for (auto& el : config.parameters.items()) {
       const std::string& key = el.key();
       if (key == "model" || key == "stream" || key == "messages" || key == "tools" ||
-          key == "system_prompt" || key == "default_prompt" || key == "context_limit") {
+          key == "system_prompt" || key == "default_prompt" || key == "context_limit" ||
+          key == "payload_limit") {
         continue;
       }
       payload[key] = el.value();

--- a/src/core/AIClient.cc
+++ b/src/core/AIClient.cc
@@ -297,7 +297,8 @@ void AIClient::sendChatCompletion(const AIProfileConfig& config,
   if (config.parameters.is_object()) {
     for (auto& el : config.parameters.items()) {
       const std::string& key = el.key();
-      if (key == "model" || key == "stream" || key == "messages" || key == "tools") {
+      if (key == "model" || key == "stream" || key == "messages" || key == "tools" ||
+          key == "system_prompt" || key == "default_prompt" || key == "context_limit") {
         continue;
       }
       payload[key] = el.value();
@@ -432,7 +433,8 @@ void AIClient::sendChatCompletionStream(const AIProfileConfig& config,
   if (config.parameters.is_object()) {
     for (auto& el : config.parameters.items()) {
       const std::string& key = el.key();
-      if (key == "model" || key == "stream" || key == "messages" || key == "tools") {
+      if (key == "model" || key == "stream" || key == "messages" || key == "tools" ||
+          key == "system_prompt" || key == "default_prompt" || key == "context_limit") {
         continue;
       }
       payload[key] = el.value();

--- a/src/core/AIClient.cc
+++ b/src/core/AIClient.cc
@@ -267,7 +267,25 @@ void AIClient::sendChatCompletion(const AIProfileConfig& config,
   for (const auto& msg : history) {
     nlohmann::json m = nlohmann::json::object();
     m["role"] = msg.role;
-    if (!msg.content.empty() || msg.tool_calls.empty()) {
+    if (!msg.images.empty()) {
+      nlohmann::json content_arr = nlohmann::json::array();
+      if (!msg.content.empty()) {
+        nlohmann::json text_obj = nlohmann::json::object();
+        text_obj["type"] = "text";
+        text_obj["text"] = msg.content;
+        content_arr.push_back(text_obj);
+      }
+      for (const auto& img : msg.images) {
+        nlohmann::json img_obj = nlohmann::json::object();
+        img_obj["type"] = "image_url";
+        nlohmann::json url_obj = nlohmann::json::object();
+        url_obj["url"] =
+          "data:" + (img.mime_type.empty() ? "image/png" : img.mime_type) + ";base64," + img.base64_data;
+        img_obj["image_url"] = url_obj;
+        content_arr.push_back(img_obj);
+      }
+      m["content"] = content_arr;
+    } else if (!msg.content.empty() || msg.tool_calls.empty()) {
       m["content"] = msg.content;
     } else {
       m["content"] = nullptr;
@@ -293,13 +311,14 @@ void AIClient::sendChatCompletion(const AIProfileConfig& config,
   }
   payload["messages"] = messages;
   payload["tools"] = getOpenSCADTools();
+  payload["tool_choice"] = "auto";
 
   if (config.parameters.is_object()) {
     for (auto& el : config.parameters.items()) {
       const std::string& key = el.key();
       if (key == "model" || key == "stream" || key == "messages" || key == "tools" ||
           key == "system_prompt" || key == "default_prompt" || key == "context_limit" ||
-          key == "payload_limit") {
+          key == "payload_limit" || key == "auto_attach_viewport") {
         continue;
       }
       payload[key] = el.value();
@@ -404,7 +423,25 @@ void AIClient::sendChatCompletionStream(const AIProfileConfig& config,
   for (const auto& msg : history) {
     nlohmann::json m = nlohmann::json::object();
     m["role"] = msg.role;
-    if (!msg.content.empty() || msg.tool_calls.empty()) {
+    if (!msg.images.empty()) {
+      nlohmann::json content_arr = nlohmann::json::array();
+      if (!msg.content.empty()) {
+        nlohmann::json text_obj = nlohmann::json::object();
+        text_obj["type"] = "text";
+        text_obj["text"] = msg.content;
+        content_arr.push_back(text_obj);
+      }
+      for (const auto& img : msg.images) {
+        nlohmann::json img_obj = nlohmann::json::object();
+        img_obj["type"] = "image_url";
+        nlohmann::json url_obj = nlohmann::json::object();
+        url_obj["url"] =
+          "data:" + (img.mime_type.empty() ? "image/png" : img.mime_type) + ";base64," + img.base64_data;
+        img_obj["image_url"] = url_obj;
+        content_arr.push_back(img_obj);
+      }
+      m["content"] = content_arr;
+    } else if (!msg.content.empty() || msg.tool_calls.empty()) {
       m["content"] = msg.content;
     } else {
       m["content"] = nullptr;
@@ -430,13 +467,14 @@ void AIClient::sendChatCompletionStream(const AIProfileConfig& config,
   }
   payload["messages"] = messages;
   payload["tools"] = getOpenSCADTools();
+  payload["tool_choice"] = "auto";
 
   if (config.parameters.is_object()) {
     for (auto& el : config.parameters.items()) {
       const std::string& key = el.key();
       if (key == "model" || key == "stream" || key == "messages" || key == "tools" ||
           key == "system_prompt" || key == "default_prompt" || key == "context_limit" ||
-          key == "payload_limit") {
+          key == "payload_limit" || key == "auto_attach_viewport") {
         continue;
       }
       payload[key] = el.value();

--- a/src/core/AIClient.h
+++ b/src/core/AIClient.h
@@ -15,11 +15,17 @@ struct AIToolCall {
   std::string arguments;
 };
 
+struct AIImageAttachment {
+  std::string mime_type;    // e.g. "image/png"
+  std::string base64_data;  // raw base64 string
+};
+
 struct AIChatMessage {
   std::string role;
   std::string content;
   std::string tool_call_id;
   std::vector<AIToolCall> tool_calls;
+  std::vector<AIImageAttachment> images;
 };
 
 struct AIProfileConfig {

--- a/src/core/AIService.cc
+++ b/src/core/AIService.cc
@@ -150,6 +150,13 @@ void AIService::chatCompletionStream(std::vector<ChatMessage>& history, ChunkCal
     sys_prompt = config.parameters["system_prompt"].get<std::string>();
   }
 
+  int context_limit = 10;
+  if (config.parameters.contains("context_limit") &&
+      config.parameters["context_limit"].is_number_integer()) {
+    context_limit = config.parameters["context_limit"].get<int>();
+    if (context_limit < 1) context_limit = 1;
+  }
+
   bool already_has_system = false;
   if (!history.empty() && history[0].role == "system") {
     already_has_system = true;
@@ -158,7 +165,54 @@ void AIService::chatCompletionStream(std::vector<ChatMessage>& history, ChunkCal
     ai_history.push_back({"system", sys_prompt});
   }
 
-  for (const auto& msg : history) {
+  // Attach hidden OpenSCAD reference documentation
+  std::string ref_doc =
+    "### OpenSCAD Quick Reference\n"
+    "**3D Primitives**: cube([x,y,z], center), sphere(r, $fn), cylinder(h, r1, r2, center, $fn)\n"
+    "**2D Primitives**: circle(r, $fn), square([x,y], center), polygon(points, paths), text(t, size, "
+    "font, halign, valign)\n"
+    "**Transforms**: translate([x,y,z]), rotate([x,y,z]), scale([x,y,z]), mirror([x,y,z]), "
+    "multmatrix(m), color(c, alpha), offset(r|delta, chamfer), hull(), minkowski()\n"
+    "**Boolean Ops**: union(), difference(), intersection()\n"
+    "**Extrusion**: linear_extrude(height, center, twist, slices, scale, $fn), "
+    "rotate_extrude(angle, $fn)\n"
+    "**Modules**: module name(params) { body } -- NO semicolon after definition. "
+    "Call with: name(args);\n"
+    "**Functions**: function name(params) = expression;\n"
+    "**Control**: for(i=[start:step:end]), if(cond), let(assignments), each, "
+    "assert(cond, msg), echo(values)\n"
+    "**Math**: sin, cos, tan, asin, acos, atan, atan2, abs, ceil, floor, round, "
+    "sqrt, pow, exp, ln, log, min, max, norm, cross\n"
+    "**List Ops**: concat, len, lookup, str, chr, ord, search, flatten\n"
+    "**Special Vars**: $fn (fragments), $fa (fragment angle), $fs (fragment size), "
+    "$t (animation), $vpr/$vpt/$vpd/$vpf (viewport)\n"
+    "**Import/Use**: use <file.scad> (functions/modules only), include <file.scad> (full), "
+    "import(\"file.stl\")\n\n"
+    "### Available Tools\n"
+    "- **get_editor_code()**: Returns the current contents of the active editor tab.\n"
+    "- **set_editor_code({\"code\": \"...\"})**: Proposes code changes for user review in a "
+    "side-by-side diff dialog. "
+    "Always use this instead of pasting code in chat.\n"
+    "- **trigger_preview()**: Renders the current editor code in the 3D viewport. "
+    "Automatically postponed if code changes are pending review.";
+  ai_history.push_back({"system", ref_doc});
+
+  // Apply sliding window: keep last context_limit turn pairs (a turn starts with a "user" message)
+  size_t window_start = 0;
+  {
+    std::vector<size_t> turn_starts;
+    for (size_t i = 0; i < history.size(); ++i) {
+      if (history[i].role == "user") {
+        turn_starts.push_back(i);
+      }
+    }
+    if (static_cast<int>(turn_starts.size()) > context_limit) {
+      window_start = turn_starts[turn_starts.size() - context_limit];
+    }
+  }
+
+  for (size_t i = window_start; i < history.size(); ++i) {
+    const auto& msg = history[i];
     AIChatMessage am;
     am.role = msg.role;
     am.content = msg.content;

--- a/src/core/AIService.cc
+++ b/src/core/AIService.cc
@@ -58,6 +58,15 @@ static bool loadActiveProfile(AIProfileConfig& config, std::string& error_msg)
   auto& profile = profiles[active_profile_name];
 
   config.endpoint = profile.value("endpoint", "");
+  if (config.endpoint.empty()) {
+    error_msg = "API endpoint is empty. Please configure a valid API URL in Preferences -> AI tab.";
+    return false;
+  }
+  if (config.endpoint.rfind("http://", 0) != 0 && config.endpoint.rfind("https://", 0) != 0) {
+    error_msg =
+      "Invalid API endpoint: '" + config.endpoint + "'. Must start with 'http://' or 'https://'";
+    return false;
+  }
   config.apiKey = profile.value("apiKey", "");
 
   if (profile.contains("params") && profile["params"].is_object()) {
@@ -406,6 +415,19 @@ void AIService::cancelPendingRequests()
   impl->ai_client->cancelPendingRequests();
 }
 
+int AIService::getPayloadLimit() const
+{
+  AIProfileConfig config;
+  std::string error_msg;
+  if (loadActiveProfile(config, error_msg)) {
+    if (config.parameters.contains("payload_limit") &&
+        config.parameters["payload_limit"].is_number_integer()) {
+      return config.parameters["payload_limit"].get<int>();
+    }
+  }
+  return 50000;
+}
+
 #else  // __EMSCRIPTEN__
 
 class AIService::Impl
@@ -442,6 +464,11 @@ std::string AIService::getDefaultPrompt() const
 
 void AIService::cancelPendingRequests()
 {
+}
+
+int AIService::getPayloadLimit() const
+{
+  return 50000;
 }
 
 #endif  // __EMSCRIPTEN__

--- a/src/core/AIService.cc
+++ b/src/core/AIService.cc
@@ -226,6 +226,9 @@ void AIService::chatCompletionStream(std::vector<ChatMessage>& history, ChunkCal
     am.role = msg.role;
     am.content = msg.content;
     am.tool_call_id = msg.tool_call_id;
+    for (const auto& img : msg.images) {
+      am.images.push_back({img.mime_type, img.base64_data});
+    }
     if (!msg.tool_calls.empty()) {
       try {
         auto tcs_json = nlohmann::json::parse(msg.tool_calls);
@@ -356,6 +359,9 @@ void AIService::chatCompletion(const std::vector<ChatMessage>& history, Response
     am.role = msg.role;
     am.content = msg.content;
     am.tool_call_id = msg.tool_call_id;
+    for (const auto& img : msg.images) {
+      am.images.push_back({img.mime_type, img.base64_data});
+    }
     if (!msg.tool_calls.empty()) {
       try {
         auto tcs_json = nlohmann::json::parse(msg.tool_calls);
@@ -428,6 +434,19 @@ int AIService::getPayloadLimit() const
   return 50000;
 }
 
+bool AIService::getAutoAttachViewport() const
+{
+  AIProfileConfig config;
+  std::string error_msg;
+  if (loadActiveProfile(config, error_msg)) {
+    if (config.parameters.contains("auto_attach_viewport") &&
+        config.parameters["auto_attach_viewport"].is_boolean()) {
+      return config.parameters["auto_attach_viewport"].get<bool>();
+    }
+  }
+  return false;
+}
+
 #else  // __EMSCRIPTEN__
 
 class AIService::Impl
@@ -469,6 +488,11 @@ void AIService::cancelPendingRequests()
 int AIService::getPayloadLimit() const
 {
   return 50000;
+}
+
+bool AIService::getAutoAttachViewport() const
+{
+  return false;
 }
 
 #endif  // __EMSCRIPTEN__

--- a/src/core/AIService.cc
+++ b/src/core/AIService.cc
@@ -171,40 +171,38 @@ void AIService::chatCompletionStream(std::vector<ChatMessage>& history, ChunkCal
     already_has_system = true;
   }
   if (!already_has_system) {
-    ai_history.push_back({"system", sys_prompt});
+    // Append hidden OpenSCAD reference documentation to the system prompt
+    std::string ref_doc =
+      "\n\n### OpenSCAD Quick Reference\n"
+      "**3D Primitives**: cube([x,y,z], center), sphere(r, $fn), cylinder(h, r1, r2, center, $fn)\n"
+      "**2D Primitives**: circle(r, $fn), square([x,y], center), polygon(points, paths), text(t, size, "
+      "font, halign, valign)\n"
+      "**Transforms**: translate([x,y,z]), rotate([x,y,z]), scale([x,y,z]), mirror([x,y,z]), "
+      "multmatrix(m), color(c, alpha), offset(r|delta, chamfer), hull(), minkowski()\n"
+      "**Boolean Ops**: union(), difference(), intersection()\n"
+      "**Extrusion**: linear_extrude(height, center, twist, slices, scale, $fn), "
+      "rotate_extrude(angle, $fn)\n"
+      "**Modules**: module name(params) { body } -- NO semicolon after definition. "
+      "Call with: name(args);\n"
+      "**Functions**: function name(params) = expression;\n"
+      "**Control**: for(i=[start:step:end]), if(cond), let(assignments), each, "
+      "assert(cond, msg), echo(values)\n"
+      "**Math**: sin, cos, tan, asin, acos, atan, atan2, abs, ceil, floor, round, "
+      "sqrt, pow, exp, ln, log, min, max, norm, cross\n"
+      "**List Ops**: concat, len, lookup, str, chr, ord, search, flatten\n"
+      "**Special Vars**: $fn (fragments), $fa (fragment angle), $fs (fragment size), "
+      "$t (animation), $vpr/$vpt/$vpd/$vpf (viewport)\n"
+      "**Import/Use**: use <file.scad> (functions/modules only), include <file.scad> (full), "
+      "import(\"file.stl\")\n\n"
+      "### Available Tools\n"
+      "- **get_editor_code()**: Returns the current contents of the active editor tab.\n"
+      "- **set_editor_code({\"code\": \"...\"})**:  Proposes code changes for user review in a "
+      "side-by-side diff dialog. "
+      "Always use this instead of pasting code in chat.\n"
+      "- **trigger_preview()**: Renders the current editor code in the 3D viewport. "
+      "Automatically postponed if code changes are pending review.";
+    ai_history.push_back({"system", sys_prompt + ref_doc});
   }
-
-  // Attach hidden OpenSCAD reference documentation
-  std::string ref_doc =
-    "### OpenSCAD Quick Reference\n"
-    "**3D Primitives**: cube([x,y,z], center), sphere(r, $fn), cylinder(h, r1, r2, center, $fn)\n"
-    "**2D Primitives**: circle(r, $fn), square([x,y], center), polygon(points, paths), text(t, size, "
-    "font, halign, valign)\n"
-    "**Transforms**: translate([x,y,z]), rotate([x,y,z]), scale([x,y,z]), mirror([x,y,z]), "
-    "multmatrix(m), color(c, alpha), offset(r|delta, chamfer), hull(), minkowski()\n"
-    "**Boolean Ops**: union(), difference(), intersection()\n"
-    "**Extrusion**: linear_extrude(height, center, twist, slices, scale, $fn), "
-    "rotate_extrude(angle, $fn)\n"
-    "**Modules**: module name(params) { body } -- NO semicolon after definition. "
-    "Call with: name(args);\n"
-    "**Functions**: function name(params) = expression;\n"
-    "**Control**: for(i=[start:step:end]), if(cond), let(assignments), each, "
-    "assert(cond, msg), echo(values)\n"
-    "**Math**: sin, cos, tan, asin, acos, atan, atan2, abs, ceil, floor, round, "
-    "sqrt, pow, exp, ln, log, min, max, norm, cross\n"
-    "**List Ops**: concat, len, lookup, str, chr, ord, search, flatten\n"
-    "**Special Vars**: $fn (fragments), $fa (fragment angle), $fs (fragment size), "
-    "$t (animation), $vpr/$vpt/$vpd/$vpf (viewport)\n"
-    "**Import/Use**: use <file.scad> (functions/modules only), include <file.scad> (full), "
-    "import(\"file.stl\")\n\n"
-    "### Available Tools\n"
-    "- **get_editor_code()**: Returns the current contents of the active editor tab.\n"
-    "- **set_editor_code({\"code\": \"...\"})**: Proposes code changes for user review in a "
-    "side-by-side diff dialog. "
-    "Always use this instead of pasting code in chat.\n"
-    "- **trigger_preview()**: Renders the current editor code in the 3D viewport. "
-    "Automatically postponed if code changes are pending review.";
-  ai_history.push_back({"system", ref_doc});
 
   // Apply sliding window: keep last context_limit turn pairs (a turn starts with a "user" message)
   size_t window_start = 0;
@@ -351,7 +349,37 @@ void AIService::chatCompletion(const std::vector<ChatMessage>& history, Response
     already_has_system = true;
   }
   if (!already_has_system) {
-    ai_history.push_back({"system", sys_prompt});
+    // Append hidden OpenSCAD reference documentation to the system prompt
+    std::string ref_doc =
+      "\n\n### OpenSCAD Quick Reference\n"
+      "**3D Primitives**: cube([x,y,z], center), sphere(r, $fn), cylinder(h, r1, r2, center, $fn)\n"
+      "**2D Primitives**: circle(r, $fn), square([x,y], center), polygon(points, paths), text(t, size, "
+      "font, halign, valign)\n"
+      "**Transforms**: translate([x,y,z]), rotate([x,y,z]), scale([x,y,z]), mirror([x,y,z]), "
+      "multmatrix(m), color(c, alpha), offset(r|delta, chamfer), hull(), minkowski()\n"
+      "**Boolean Ops**: union(), difference(), intersection()\n"
+      "**Extrusion**: linear_extrude(height, center, twist, slices, scale, $fn), "
+      "rotate_extrude(angle, $fn)\n"
+      "**Modules**: module name(params) { body } -- NO semicolon after definition. "
+      "Call with: name(args);\n"
+      "**Functions**: function name(params) = expression;\n"
+      "**Control**: for(i=[start:step:end]), if(cond), let(assignments), each, "
+      "assert(cond, msg), echo(values)\n"
+      "**Math**: sin, cos, tan, asin, acos, atan, atan2, abs, ceil, floor, round, "
+      "sqrt, pow, exp, ln, log, min, max, norm, cross\n"
+      "**List Ops**: concat, len, lookup, str, chr, ord, search, flatten\n"
+      "**Special Vars**: $fn (fragments), $fa (fragment angle), $fs (fragment size), "
+      "$t (animation), $vpr/$vpt/$vpd/$vpf (viewport)\n"
+      "**Import/Use**: use <file.scad> (functions/modules only), include <file.scad> (full), "
+      "import(\"file.stl\")\n\n"
+      "### Available Tools\n"
+      "- **get_editor_code()**: Returns the current contents of the active editor tab.\n"
+      "- **set_editor_code({\"code\": \"...\"})**:  Proposes code changes for user review in a "
+      "side-by-side diff dialog. "
+      "Always use this instead of pasting code in chat.\n"
+      "- **trigger_preview()**: Renders the current editor code in the 3D viewport. "
+      "Automatically postponed if code changes are pending review.";
+    ai_history.push_back({"system", sys_prompt + ref_doc});
   }
 
   for (const auto& msg : history) {

--- a/src/core/AIService.h
+++ b/src/core/AIService.h
@@ -44,6 +44,9 @@ public:
   // Cancel any active AI completion requests
   void cancelPendingRequests();
 
+  // Get the configured character/payload size limit
+  int getPayloadLimit() const;
+
   using ToolExecutor =
     std::function<std::string(const std::string& name, const std::string& arguments_json)>;
   void registerToolExecutor(ToolExecutor executor);

--- a/src/core/AIService.h
+++ b/src/core/AIService.h
@@ -6,11 +6,17 @@
 #include <functional>
 #include <memory>
 
+struct ImageAttachment {
+  std::string mime_type;    // e.g. "image/png"
+  std::string base64_data;  // raw base64 string
+};
+
 struct ChatMessage {
   std::string role;
   std::string content;
   std::string tool_call_id;
   std::string tool_calls;  // Serialized JSON representation
+  std::vector<ImageAttachment> images;
 };
 
 class AIService
@@ -46,6 +52,9 @@ public:
 
   // Get the configured character/payload size limit
   int getPayloadLimit() const;
+
+  // Get auto attach viewport setting
+  bool getAutoAttachViewport() const;
 
   using ToolExecutor =
     std::function<std::string(const std::string& name, const std::string& arguments_json)>;

--- a/src/gui/MainWindow.h
+++ b/src/gui/MainWindow.h
@@ -374,7 +374,6 @@ public:
     setCurrentOutput();
     return sg::make_scope_guard([this] { clearCurrentOutput(); });
   }
-
   bool isEmpty();
 
   void onAxisChanged(InputEventAxisChanged *event) override;

--- a/src/gui/Preferences.cc
+++ b/src/gui/Preferences.cc
@@ -327,6 +327,7 @@ void Preferences::init()
           "6. **Tone**: Technical, concise, and helpful. Avoid long conversational filler.";
         params["default_prompt"] = "Create a sphere with radius 10 and detail level $fn=50.";
         params["context_limit"] = 10;
+        params["payload_limit"] = 50000;
       }
       prof["params"] = params;
       prof["apiKey"] = "";
@@ -1502,6 +1503,7 @@ void Preferences::on_pushButtonAINewProfile_clicked()
     "6. **Tone**: Technical, concise, and helpful. Avoid long conversational filler.";
   params["default_prompt"] = "Create a sphere with radius 10 and detail level $fn=50.";
   params["context_limit"] = 10;
+  params["payload_limit"] = 50000;
   newProfile["params"] = params;
 
   profilesObj[trimmed.toStdString()] = newProfile;
@@ -1621,6 +1623,9 @@ void Preferences::loadAIParams(const QString& profileName)
   }
   if (!paramsObj.contains("context_limit")) {
     paramsObj["context_limit"] = 10;
+  }
+  if (!paramsObj.contains("payload_limit")) {
+    paramsObj["payload_limit"] = 50000;
   }
 
   std::string sysPrompt = paramsObj.value("system_prompt", "");

--- a/src/gui/Preferences.cc
+++ b/src/gui/Preferences.cc
@@ -328,6 +328,7 @@ void Preferences::init()
         params["default_prompt"] = "Create a sphere with radius 10 and detail level $fn=50.";
         params["context_limit"] = 10;
         params["payload_limit"] = 50000;
+        params["auto_attach_viewport"] = false;
       }
       prof["params"] = params;
       prof["apiKey"] = "";
@@ -1504,6 +1505,7 @@ void Preferences::on_pushButtonAINewProfile_clicked()
   params["default_prompt"] = "Create a sphere with radius 10 and detail level $fn=50.";
   params["context_limit"] = 10;
   params["payload_limit"] = 50000;
+  params["auto_attach_viewport"] = false;
   newProfile["params"] = params;
 
   profilesObj[trimmed.toStdString()] = newProfile;
@@ -1626,6 +1628,9 @@ void Preferences::loadAIParams(const QString& profileName)
   }
   if (!paramsObj.contains("payload_limit")) {
     paramsObj["payload_limit"] = 50000;
+  }
+  if (!paramsObj.contains("auto_attach_viewport")) {
+    paramsObj["auto_attach_viewport"] = false;
   }
 
   std::string sysPrompt = paramsObj.value("system_prompt", "");

--- a/src/gui/TabManager.cc
+++ b/src/gui/TabManager.cc
@@ -584,7 +584,7 @@ bool TabManager::refreshDocument()
     }
   }
   if (file_opened) {
-    parent->fileChangedOnDisk();
+    this->parent->fileChangedOnDisk();
   }
   return file_opened;
 }

--- a/src/gui/ai/ChatWidget.cc
+++ b/src/gui/ai/ChatWidget.cc
@@ -267,6 +267,14 @@ void ChatWidget::onSendPressed()
     return;
   }
 
+  if (prompt.length() > 100000) {
+    addMessage(prompt, true);
+    addMessage(
+      tr("Error: Prompt size exceeds the limit of 100,000 characters. Please shorten your prompt."),
+      false);
+    return;
+  }
+
   inputField->clear();
   addMessage(prompt, true);
 
@@ -298,6 +306,29 @@ void ChatWidget::onSendPressed()
       QMetaObject::invokeMethod(qApp, [this, alive, error_msg]() {
         if (!*alive || !isRequestRunning) return;
         std::string display_err = "Error: " + error_msg;
+        if (error_msg.find("Connection refused") != std::string::npos) {
+          display_err +=
+            "\n\n*Troubleshooting Tip: Connection refused. Please check if your local model server "
+            "(such as Ollama or LM Studio) is running and listening on the configured port.*";
+        } else if (error_msg.find("Host not found") != std::string::npos ||
+                   error_msg.find("unreachable") != std::string::npos) {
+          display_err +=
+            "\n\n*Troubleshooting Tip: Host unreachable. Please check your internet connection and "
+            "verify that the API endpoint URL in Preferences is correct.*";
+        } else if (error_msg.find("timed out") != std::string::npos ||
+                   error_msg.find("Timeout") != std::string::npos) {
+          display_err +=
+            "\n\n*Troubleshooting Tip: The request timed out. The server might be busy or offline. "
+            "Please try again.*";
+        } else if (error_msg.find("HTTP status 401") != std::string::npos) {
+          display_err +=
+            "\n\n*Troubleshooting Tip: Unauthorized. Please check if your API Key is entered correctly "
+            "in Preferences -> AI tab.*";
+        } else if (error_msg.find("HTTP status 404") != std::string::npos) {
+          display_err +=
+            "\n\n*Troubleshooting Tip: Not Found. Please check if the endpoint URL and model name are "
+            "configured correctly in Preferences.*";
+        }
         if (activeResponseText && activeResponseText->empty()) {
           activeAIBubble->updateText(QString::fromStdString(display_err));
         } else {
@@ -463,10 +494,18 @@ std::string ChatWidget::executeTool(const std::string& name, const std::string& 
   }
 
   std::string result_val;
+  int limit = aiService ? aiService->getPayloadLimit() : 50000;
 
   if (name == "get_editor_code") {
     if (mw && mw->activeEditor) {
-      result_val = mw->activeEditor->toPlainText().toStdString();
+      std::string code = mw->activeEditor->toPlainText().toStdString();
+      if (static_cast<int>(code.size()) > limit) {
+        result_val = "Error: The active editor script is too large (" + std::to_string(code.size()) +
+                     " bytes). The maximum allowed size for AI analysis is " + std::to_string(limit) +
+                     " bytes. Please reduce the script size.";
+      } else {
+        result_val = code;
+      }
     } else {
       result_val = "Error: No active editor found.";
     }
@@ -476,10 +515,16 @@ std::string ChatWidget::executeTool(const std::string& name, const std::string& 
       return "Error: Missing required argument 'code'.";
     }
     std::string code = args["code"].get<std::string>();
-    this->proposeCodeChange(code);
-    result_val =
-      "Success: Code change proposed to the user for review. The user will review and choose whether to "
-      "apply it.";
+    if (static_cast<int>(code.size()) > limit) {
+      result_val = "Error: Proposed code change is too large (" + std::to_string(code.size()) +
+                   " bytes). The maximum allowed size is " + std::to_string(limit) + " bytes.";
+    } else {
+      this->proposeCodeChange(code);
+      result_val =
+        "Success: Code change proposed to the user for review. The user will review and choose whether "
+        "to "
+        "apply it.";
+    }
   } else if (name == "trigger_preview") {
     if (this->hasPendingCodeChanges()) {
       result_val = "Info: Preview postponed because code changes are pending user review.";

--- a/src/gui/ai/ChatWidget.cc
+++ b/src/gui/ai/ChatWidget.cc
@@ -10,6 +10,14 @@
 #include <QKeyEvent>
 #include <QApplication>
 #include <QPalette>
+#include <QMenu>
+#include <QToolButton>
+#include <QFileDialog>
+#include <QClipboard>
+#include <QDateTime>
+#include <QMessageBox>
+#include <fstream>
+#include "json/json.hpp"
 #include "gui/MainWindow.h"
 #include "gui/ai/DiffDialog.h"
 #include "gui/OpenSCADApp.h"
@@ -110,6 +118,14 @@ ChatWidget::ChatWidget(QWidget *parent) : QWidget(parent)
   connect(sendButton, &QPushButton::clicked, this, &ChatWidget::onSendPressed);
   connect(inputField, &ChatInputEdit::sendPressed, this, &ChatWidget::onSendPressed);
   connect(clearButton, &QPushButton::clicked, this, &ChatWidget::onClearPressed);
+
+  // Setup chat options menu
+  QMenu *chatMenu = new QMenu(this);
+  chatMenu->addAction(_("Export Chat..."), this, &ChatWidget::exportChat);
+  chatMenu->addAction(_("Import Chat..."), this, &ChatWidget::importChat);
+  chatMenu->addSeparator();
+  chatMenu->addAction(_("Copy as Markdown"), this, &ChatWidget::copyAsMarkdown);
+  menuButton->setMenu(chatMenu);
 
   // Initialize backend and state
   aiService = std::make_shared<AIService>();
@@ -481,4 +497,197 @@ std::string ChatWidget::executeTool(const std::string& name, const std::string& 
 
   this->logToolExecution(name, result_val);
   return result_val;
+}
+
+void ChatWidget::exportChat()
+{
+  QString fileName =
+    QFileDialog::getSaveFileName(this, _("Export Chat History"), "", _("OpenSCAD Chat (*.oschat.json)"));
+
+  if (fileName.isEmpty()) {
+    return;
+  }
+
+  nlohmann::json j;
+  j["version"] = 1;
+  j["application"] = "OpenSCAD";
+  j["exported_at"] = QDateTime::currentDateTime().toString(Qt::ISODate).toStdString();
+
+  nlohmann::json hist_arr = nlohmann::json::array();
+  for (const auto& msg : this->history) {
+    nlohmann::json m;
+    m["role"] = msg.role;
+    m["content"] = msg.content;
+    m["tool_call_id"] = msg.tool_call_id;
+    m["tool_calls"] = msg.tool_calls;
+    hist_arr.push_back(m);
+  }
+  j["history"] = hist_arr;
+
+  std::ofstream file(fileName.toStdString());
+  if (!file.is_open()) {
+    QMessageBox::critical(this, _("Export Error"), _("Could not write to the chosen file."));
+    return;
+  }
+
+  file << j.dump(2);
+  QMessageBox::information(this, _("Export Successful"), _("Chat history exported successfully."));
+}
+
+void ChatWidget::importChat()
+{
+  QString fileName =
+    QFileDialog::getOpenFileName(this, _("Import Chat History"), "", _("OpenSCAD Chat (*.oschat.json)"));
+
+  if (fileName.isEmpty()) {
+    return;
+  }
+
+  std::ifstream file(fileName.toStdString());
+  if (!file.is_open()) {
+    QMessageBox::critical(this, _("Import Error"), _("Could not open the chosen file."));
+    return;
+  }
+
+  nlohmann::json j;
+  try {
+    file >> j;
+  } catch (const std::exception& e) {
+    QMessageBox::critical(this, _("Import Error"), tr("Failed to parse JSON file: %1").arg(e.what()));
+    return;
+  }
+
+  if (!j.is_object() || !j.contains("history") || !j["history"].is_array()) {
+    QMessageBox::critical(this, _("Import Error"), _("Invalid chat file: missing history array."));
+    return;
+  }
+
+  std::vector<ChatMessage> new_history;
+  for (const auto& m : j["history"]) {
+    if (!m.is_object()) continue;
+    ChatMessage msg;
+    msg.role = m.value("role", "");
+    msg.content = m.value("content", "");
+    msg.tool_call_id = m.value("tool_call_id", "");
+    msg.tool_calls = m.value("tool_calls", "");
+    new_history.push_back(msg);
+  }
+
+  this->history = std::move(new_history);
+  rebuildChatUI();
+
+  QMessageBox::information(this, _("Import Successful"), _("Chat history imported successfully."));
+}
+
+void ChatWidget::copyAsMarkdown()
+{
+  std::string markdown = "";
+  for (const auto& msg : this->history) {
+    if (msg.role == "system") {
+      continue;
+    } else if (msg.role == "user") {
+      markdown += "**User**:\n" + msg.content + "\n\n";
+    } else if (msg.role == "assistant") {
+      if (!msg.content.empty()) {
+        markdown += "**AI**:\n" + msg.content + "\n\n";
+      }
+      if (!msg.tool_calls.empty()) {
+        try {
+          auto tcs_json = nlohmann::json::parse(msg.tool_calls);
+          if (tcs_json.is_array()) {
+            for (auto& tc_json : tcs_json) {
+              std::string name = "";
+              if (tc_json.contains("function") && tc_json["function"].is_object()) {
+                name = tc_json["function"].value("name", "");
+              }
+              markdown += "*[Executed Tool: " + name + "]*\n\n";
+            }
+          }
+        } catch (...) {
+        }
+      }
+    }
+  }
+
+  QApplication::clipboard()->setText(QString::fromStdString(markdown));
+  QMessageBox::information(this, _("Chat Copied"),
+                           _("Chat conversation copied to clipboard as Markdown."));
+}
+
+void ChatWidget::rebuildChatUI()
+{
+  // First, clear everything in scrollLayout except the last item (scrollSpacer)
+  QLayoutItem *child;
+  while (scrollLayout->count() > 1) {
+    child = scrollLayout->takeAt(0);
+    if (child->widget()) {
+      delete child->widget();
+    }
+    delete child;
+  }
+  activeToolBubble = nullptr;
+
+  // Replay history to build bubbles
+  for (size_t i = 0; i < this->history.size(); ++i) {
+    const auto& msg = this->history[i];
+    if (msg.role == "system") {
+      continue;
+    } else if (msg.role == "user") {
+      addMessage(QString::fromStdString(msg.content), true);
+      activeToolBubble = nullptr;
+    } else if (msg.role == "assistant") {
+      if (!msg.content.empty()) {
+        addMessage(QString::fromStdString(msg.content), false);
+        activeToolBubble = nullptr;
+      }
+      if (!msg.tool_calls.empty()) {
+        try {
+          auto tcs_json = nlohmann::json::parse(msg.tool_calls);
+          if (tcs_json.is_array()) {
+            for (auto& tc_json : tcs_json) {
+              std::string id = tc_json.value("id", "");
+              std::string name = "";
+              if (tc_json.contains("function") && tc_json["function"].is_object()) {
+                name = tc_json["function"].value("name", "");
+              }
+
+              // Find corresponding tool result
+              std::string result = "No response";
+              for (size_t j = i + 1; j < this->history.size(); ++j) {
+                if (this->history[j].role == "tool" && this->history[j].tool_call_id == id) {
+                  result = this->history[j].content;
+                  break;
+                }
+              }
+
+              QString summary;
+              QString detail;
+              if (name == "get_editor_code") {
+                summary = tr("Inspected current code");
+                detail = tr("Tool: get_editor_code\nResult: Read %1 lines.")
+                           .arg(QString::fromStdString(result).count('\n'));
+              } else if (name == "set_editor_code") {
+                summary = tr("Proposed code changes");
+                detail = tr("Tool: set_editor_code\nResult: Proposed changes to the active editor.");
+              } else if (name == "trigger_preview") {
+                summary = tr("Triggered render preview");
+                detail = QString::fromStdString("Tool: trigger_preview\nResult: " + result);
+              } else {
+                summary = tr("Executed tool: %1").arg(QString::fromStdString(name));
+                detail = QString::fromStdString("Tool: " + name + "\nResult: " + result);
+              }
+
+              if (!activeToolBubble) {
+                activeToolBubble = new CollapsibleBubble(summary, detail, this);
+                scrollLayout->insertWidget(scrollLayout->count() - 1, activeToolBubble);
+              } else {
+                activeToolBubble->addToolCall(summary, detail);
+              }
+            }
+          }
+        } catch (...) {
+        }
+      }
+    }
+  }
 }

--- a/src/gui/ai/ChatWidget.cc
+++ b/src/gui/ai/ChatWidget.cc
@@ -22,9 +22,13 @@
 #include "gui/ai/DiffDialog.h"
 #include "gui/OpenSCADApp.h"
 #include "gui/ai/CollapsibleBubble.h"
+#include "gui/ai/ViewportGrabber.h"
+#include "gui/QGLView.h"
 
 // MessageBubble implementation
-MessageBubble::MessageBubble(const QString& text, bool isUser, QWidget *parent) : QWidget(parent)
+MessageBubble::MessageBubble(const QString& text, bool isUser,
+                             const std::vector<ImageAttachment>& images, QWidget *parent)
+  : QWidget(parent)
 {
   QHBoxLayout *layout = new QHBoxLayout(this);
   layout->setContentsMargins(0, 4, 0, 4);
@@ -72,6 +76,25 @@ MessageBubble::MessageBubble(const QString& text, bool isUser, QWidget *parent) 
 
   frameLayout->addWidget(this->label);
 
+  if (!images.empty()) {
+    QHBoxLayout *imgLayout = new QHBoxLayout();
+    imgLayout->setSpacing(6);
+    for (const auto& img : images) {
+      QByteArray data = QByteArray::fromBase64(QByteArray::fromStdString(img.base64_data));
+      QImage qimg;
+      if (qimg.loadFromData(data)) {
+        QLabel *imgLabel = new QLabel(bubbleFrame);
+        QPixmap pixmap =
+          QPixmap::fromImage(qimg).scaled(120, 120, Qt::KeepAspectRatio, Qt::SmoothTransformation);
+        imgLabel->setPixmap(pixmap);
+        imgLabel->setStyleSheet("border-radius: 6px;");
+        imgLayout->addWidget(imgLabel);
+      }
+    }
+    imgLayout->addStretch(1);
+    frameLayout->addLayout(imgLayout);
+  }
+
   if (!isUser && text == _("Thinking...")) {
     thinkingStep = 0;
     thinkingTimer = new QTimer(this);
@@ -118,6 +141,8 @@ ChatWidget::ChatWidget(QWidget *parent) : QWidget(parent)
   connect(sendButton, &QPushButton::clicked, this, &ChatWidget::onSendPressed);
   connect(inputField, &ChatInputEdit::sendPressed, this, &ChatWidget::onSendPressed);
   connect(clearButton, &QPushButton::clicked, this, &ChatWidget::onClearPressed);
+  connect(analyzeScreenButton, &QPushButton::clicked, this, &ChatWidget::onAnalyzeScreenPressed);
+  connect(attachImageButton, &QPushButton::clicked, this, &ChatWidget::onAttachImagePressed);
 
   // Setup chat options menu
   QMenu *chatMenu = new QMenu(this);
@@ -275,11 +300,28 @@ void ChatWidget::onSendPressed()
     return;
   }
 
+  if (pendingAttachments.empty() && aiService && aiService->getAutoAttachViewport()) {
+    MainWindow *mw = nullptr;
+    for (auto *win : scadApp->windowManager.getWindows()) {
+      mw = win;
+      break;
+    }
+    if (mw && mw->qglview) {
+      std::string base64_img = ViewportGrabber::captureViewportBase64(mw->qglview, 1024);
+      if (!base64_img.empty()) {
+        pendingAttachments.push_back({"image/png", base64_img});
+      }
+    }
+  }
+
   inputField->clear();
-  addMessage(prompt, true);
+  addMessage(prompt, true, pendingAttachments);
 
   // Save to history
-  history.push_back({"user", prompt.toStdString()});
+  history.push_back({"user", prompt.toStdString(), "", "", pendingAttachments});
+
+  pendingAttachments.clear();
+  updateAttachmentPreviewBar();
 
   // Set active request states
   isRequestRunning = true;
@@ -351,6 +393,24 @@ void ChatWidget::onSendPressed()
           }
         } else if (activeResponseText) {
           this->history.push_back({"assistant", *activeResponseText});
+          // Fallback: If no tool was executed during this turn, extract code blocks from assistant text
+          // and propose change
+          if (!this->hasPendingCodeChanges()) {
+            std::string text = *activeResponseText;
+            size_t start = text.find("```");
+            if (start != std::string::npos) {
+              size_t code_start = text.find('\n', start);
+              if (code_start != std::string::npos) {
+                size_t end = text.find("```", code_start);
+                if (end != std::string::npos) {
+                  std::string code = text.substr(code_start + 1, end - (code_start + 1));
+                  if (!code.empty()) {
+                    this->proposeCodeChange(code);
+                  }
+                }
+              }
+            }
+          }
         }
         isRequestRunning = false;
         activeAIBubble = nullptr;
@@ -367,9 +427,10 @@ void ChatWidget::startNewResponseTurn()
   activeToolBubble = nullptr;
 }
 
-MessageBubble *ChatWidget::addMessage(const QString& text, bool isUser)
+MessageBubble *ChatWidget::addMessage(const QString& text, bool isUser,
+                                      const std::vector<ImageAttachment>& images)
 {
-  MessageBubble *bubble = new MessageBubble(text, isUser, scrollAreaWidgetContents);
+  MessageBubble *bubble = new MessageBubble(text, isUser, images, scrollAreaWidgetContents);
   scrollLayout->insertWidget(scrollLayout->count() - 1, bubble);
 
   // Auto-scroll to bottom after layout calculation
@@ -378,6 +439,133 @@ MessageBubble *ChatWidget::addMessage(const QString& text, bool isUser)
   });
 
   return bubble;
+}
+
+void ChatWidget::onAnalyzeScreenPressed()
+{
+  MainWindow *mw = nullptr;
+  for (auto *win : scadApp->windowManager.getWindows()) {
+    mw = win;
+    break;
+  }
+
+  if (!mw || !mw->qglview) {
+    QMessageBox::warning(this, _("Viewport Error"),
+                         _("Could not find active 3D Viewport to grab screen."));
+    return;
+  }
+
+  std::string base64_img = ViewportGrabber::captureViewportBase64(mw->qglview, 1024);
+  if (base64_img.empty()) {
+    QMessageBox::warning(this, _("Viewport Error"), _("Failed to capture 3D viewport frame."));
+    return;
+  }
+
+  std::string meta = ViewportGrabber::serializeCameraMetadata(mw->qglview->cam);
+
+  pendingAttachments.push_back({"image/png", base64_img});
+  updateAttachmentPreviewBar();
+
+  QString currentText = inputField->toPlainText();
+  if (currentText.isEmpty()) {
+    inputField->setPlainText(
+      QString::fromStdString(meta + "\n\nDescribe what you see in this 3D view: "));
+  } else if (!currentText.contains("[Viewport Camera Metadata]")) {
+    inputField->setPlainText(QString::fromStdString(meta + "\n\n") + currentText);
+  }
+}
+
+void ChatWidget::onAttachImagePressed()
+{
+  QString filePath = QFileDialog::getOpenFileName(this, _("Attach Image"), "",
+                                                  _("Image Files (*.png *.jpg *.jpeg *.webp)"));
+
+  if (filePath.isEmpty()) {
+    return;
+  }
+
+  QFile file(filePath);
+  if (!file.open(QIODevice::ReadOnly)) {
+    QMessageBox::warning(this, _("File Error"), _("Could not open the selected image file."));
+    return;
+  }
+
+  QByteArray data = file.readAll();
+  std::string base64_str = data.toBase64().toStdString();
+
+  std::string mime = "image/png";
+  QString suffix = QFileInfo(filePath).suffix().toLower();
+  if (suffix == "jpg" || suffix == "jpeg") {
+    mime = "image/jpeg";
+  } else if (suffix == "webp") {
+    mime = "image/webp";
+  }
+
+  pendingAttachments.push_back({mime, base64_str});
+  updateAttachmentPreviewBar();
+}
+
+void ChatWidget::removeAttachment(size_t index)
+{
+  if (index < pendingAttachments.size()) {
+    pendingAttachments.erase(pendingAttachments.begin() + index);
+    updateAttachmentPreviewBar();
+  }
+}
+
+void ChatWidget::updateAttachmentPreviewBar()
+{
+  QLayoutItem *child;
+  while ((child = attachmentPreviewLayout->takeAt(0)) != nullptr) {
+    if (child->widget()) {
+      delete child->widget();
+    }
+    delete child;
+  }
+
+  if (pendingAttachments.empty()) {
+    attachmentPreviewWidget->setVisible(false);
+    return;
+  }
+
+  attachmentPreviewWidget->setVisible(true);
+
+  for (size_t i = 0; i < pendingAttachments.size(); ++i) {
+    const auto& att = pendingAttachments[i];
+
+    QWidget *itemWidget = new QWidget(attachmentPreviewWidget);
+    QHBoxLayout *itemLayout = new QHBoxLayout(itemWidget);
+    itemLayout->setContentsMargins(4, 2, 4, 2);
+    itemLayout->setSpacing(4);
+
+    QLabel *thumbLabel = new QLabel(itemWidget);
+    QByteArray data = QByteArray::fromBase64(QByteArray::fromStdString(att.base64_data));
+    QImage qimg;
+    if (qimg.loadFromData(data)) {
+      QPixmap pix =
+        QPixmap::fromImage(qimg).scaled(48, 48, Qt::KeepAspectRatio, Qt::SmoothTransformation);
+      thumbLabel->setPixmap(pix);
+    } else {
+      thumbLabel->setText(_("[Img]"));
+    }
+
+    QPushButton *removeBtn = new QPushButton("X", itemWidget);
+    removeBtn->setFixedSize(20, 20);
+    removeBtn->setToolTip(_("Remove attachment"));
+    connect(removeBtn, &QPushButton::clicked, this, [this, i]() { removeAttachment(i); });
+
+    itemLayout->addWidget(thumbLabel);
+    itemLayout->addWidget(removeBtn);
+
+    itemWidget->setStyleSheet(
+      "QWidget { background-color: #374151; border-radius: 6px; } QLabel { color: white; } QPushButton "
+      "{ background-color: #ef4444; color: white; border: none; border-radius: 4px; font-weight: bold; "
+      "}");
+
+    attachmentPreviewLayout->addWidget(itemWidget);
+  }
+
+  attachmentPreviewLayout->addStretch(1);
 }
 
 void ChatWidget::onClearPressed()
@@ -547,7 +735,7 @@ std::string ChatWidget::executeTool(const std::string& name, const std::string& 
 void ChatWidget::exportChat()
 {
   QString fileName =
-    QFileDialog::getSaveFileName(this, _("Export Chat History"), "", _("OpenSCAD Chat (*.oschat.json)"));
+    QFileDialog::getSaveFileName(this, _("Export Chat History"), "", _("JSON Files (*.json)"));
 
   if (fileName.isEmpty()) {
     return;
@@ -565,13 +753,25 @@ void ChatWidget::exportChat()
     m["content"] = msg.content;
     m["tool_call_id"] = msg.tool_call_id;
     m["tool_calls"] = msg.tool_calls;
+
+    if (!msg.images.empty()) {
+      nlohmann::json img_arr = nlohmann::json::array();
+      for (const auto& img : msg.images) {
+        nlohmann::json im;
+        im["mime_type"] = img.mime_type;
+        im["base64_data"] = img.base64_data;
+        img_arr.push_back(im);
+      }
+      m["images"] = img_arr;
+    }
+
     hist_arr.push_back(m);
   }
   j["history"] = hist_arr;
 
   std::ofstream file(fileName.toStdString());
   if (!file.is_open()) {
-    QMessageBox::critical(this, _("Export Error"), _("Could not write to the chosen file."));
+    QMessageBox::warning(this, _("Export Warning"), _("Could not write to the chosen file."));
     return;
   }
 
@@ -582,7 +782,7 @@ void ChatWidget::exportChat()
 void ChatWidget::importChat()
 {
   QString fileName =
-    QFileDialog::getOpenFileName(this, _("Import Chat History"), "", _("OpenSCAD Chat (*.oschat.json)"));
+    QFileDialog::getOpenFileName(this, _("Import Chat History"), "", _("JSON Files (*.json)"));
 
   if (fileName.isEmpty()) {
     return;
@@ -590,7 +790,7 @@ void ChatWidget::importChat()
 
   std::ifstream file(fileName.toStdString());
   if (!file.is_open()) {
-    QMessageBox::critical(this, _("Import Error"), _("Could not open the chosen file."));
+    QMessageBox::warning(this, _("Import Warning"), _("Could not open the selected file."));
     return;
   }
 
@@ -598,30 +798,59 @@ void ChatWidget::importChat()
   try {
     file >> j;
   } catch (const std::exception& e) {
-    QMessageBox::critical(this, _("Import Error"), tr("Failed to parse JSON file: %1").arg(e.what()));
+    QMessageBox::warning(this, _("Import Warning"), tr("Failed to parse JSON file: %1").arg(e.what()));
     return;
   }
 
   if (!j.is_object() || !j.contains("history") || !j["history"].is_array()) {
-    QMessageBox::critical(this, _("Import Error"), _("Invalid chat file: missing history array."));
+    QMessageBox::warning(this, _("Import Warning"),
+                         _("Selected file does not contain a valid chat history array."));
     return;
   }
 
   std::vector<ChatMessage> new_history;
+  int skipped_count = 0;
   for (const auto& m : j["history"]) {
-    if (!m.is_object()) continue;
+    if (!m.is_object()) {
+      skipped_count++;
+      continue;
+    }
     ChatMessage msg;
     msg.role = m.value("role", "");
     msg.content = m.value("content", "");
     msg.tool_call_id = m.value("tool_call_id", "");
     msg.tool_calls = m.value("tool_calls", "");
-    new_history.push_back(msg);
+
+    if (m.contains("images") && m["images"].is_array()) {
+      for (const auto& im : m["images"]) {
+        if (im.is_object()) {
+          ImageAttachment img;
+          img.mime_type = im.value("mime_type", "image/png");
+          img.base64_data = im.value("base64_data", "");
+          if (!img.base64_data.empty()) {
+            msg.images.push_back(img);
+          }
+        }
+      }
+    }
+
+    if (!msg.role.empty()) {
+      new_history.push_back(msg);
+    } else {
+      skipped_count++;
+    }
   }
 
   this->history = std::move(new_history);
   rebuildChatUI();
 
-  QMessageBox::information(this, _("Import Successful"), _("Chat history imported successfully."));
+  if (skipped_count > 0) {
+    QMessageBox::warning(
+      this, _("Import Warning"),
+      tr("Imported chat history with warnings: %1 invalid entries were skipped.").arg(skipped_count));
+  } else {
+    QMessageBox::information(this, _("Import Successful"), _("Chat history imported successfully."));
+  }
 }
 
 void ChatWidget::copyAsMarkdown()
@@ -678,11 +907,11 @@ void ChatWidget::rebuildChatUI()
     if (msg.role == "system") {
       continue;
     } else if (msg.role == "user") {
-      addMessage(QString::fromStdString(msg.content), true);
+      addMessage(QString::fromStdString(msg.content), true, msg.images);
       activeToolBubble = nullptr;
     } else if (msg.role == "assistant") {
-      if (!msg.content.empty()) {
-        addMessage(QString::fromStdString(msg.content), false);
+      if (!msg.content.empty() || !msg.images.empty()) {
+        addMessage(QString::fromStdString(msg.content), false, msg.images);
         activeToolBubble = nullptr;
       }
       if (!msg.tool_calls.empty()) {

--- a/src/gui/ai/ChatWidget.h
+++ b/src/gui/ai/ChatWidget.h
@@ -8,6 +8,7 @@
 #include "ui_ChatWidget.h"
 
 class QLabel;
+class QMenu;
 class QTimer;
 
 class MessageBubble : public QWidget
@@ -42,9 +43,13 @@ public:
 private slots:
   void onSendPressed();
   void onClearPressed();
+  void exportChat();
+  void importChat();
+  void copyAsMarkdown();
 
 private:
   MessageBubble *addMessage(const QString& text, bool isUser);
+  void rebuildChatUI();
   bool isDarkTheme() const;
   void enableInput(bool enabled);
   std::string executeTool(const std::string& name, const std::string& arguments_json);

--- a/src/gui/ai/ChatWidget.h
+++ b/src/gui/ai/ChatWidget.h
@@ -15,7 +15,8 @@ class MessageBubble : public QWidget
 {
   Q_OBJECT
 public:
-  MessageBubble(const QString& text, bool isUser, QWidget *parent = nullptr);
+  MessageBubble(const QString& text, bool isUser, const std::vector<ImageAttachment>& images = {},
+                QWidget *parent = nullptr);
   void updateText(const QString& text);
 
 private:
@@ -46,10 +47,15 @@ private slots:
   void exportChat();
   void importChat();
   void copyAsMarkdown();
+  void onAnalyzeScreenPressed();
+  void onAttachImagePressed();
+  void removeAttachment(size_t index);
 
 private:
-  MessageBubble *addMessage(const QString& text, bool isUser);
+  MessageBubble *addMessage(const QString& text, bool isUser,
+                            const std::vector<ImageAttachment>& images = {});
   void rebuildChatUI();
+  void updateAttachmentPreviewBar();
   bool isDarkTheme() const;
   void enableInput(bool enabled);
   std::string executeTool(const std::string& name, const std::string& arguments_json);
@@ -66,4 +72,5 @@ private:
   std::string originalCode;
   QWidget *diffBannerWidget = nullptr;
   CollapsibleBubble *activeToolBubble = nullptr;
+  std::vector<ImageAttachment> pendingAttachments;
 };

--- a/src/gui/ai/ChatWidget.ui
+++ b/src/gui/ai/ChatWidget.ui
@@ -70,6 +70,25 @@
        </spacer>
       </item>
       <item>
+       <widget class="QToolButton" name="menuButton">
+        <property name="maximumSize">
+         <size>
+          <width>28</width>
+          <height>16777215</height>
+         </size>
+        </property>
+        <property name="toolTip">
+         <string>Chat options</string>
+        </property>
+        <property name="text">
+         <string>&#x2630;</string>
+        </property>
+        <property name="popupMode">
+         <enum>QToolButton::InstantPopup</enum>
+        </property>
+       </widget>
+      </item>
+      <item>
        <widget class="QPushButton" name="clearButton">
         <property name="maximumSize">
          <size>

--- a/src/gui/ai/ChatWidget.ui
+++ b/src/gui/ai/ChatWidget.ui
@@ -169,53 +169,118 @@
      </widget>
     </widget>
    </item>
-   <item>
-    <widget class="QWidget" name="inputWidget" native="true">
-     <layout class="QHBoxLayout" name="inputLayout">
-      <property name="leftMargin">
-       <number>4</number>
-      </property>
-      <property name="topMargin">
-       <number>4</number>
-      </property>
-      <property name="rightMargin">
-       <number>4</number>
-      </property>
-      <property name="bottomMargin">
-       <number>4</number>
-      </property>
-      <item>
-       <widget class="ChatInputEdit" name="inputField">
-        <property name="maximumSize">
-         <size>
-          <width>16777215</width>
-          <height>50</height>
-         </size>
-        </property>
-       </widget>
-      </item>
-      <item>
-       <widget class="QPushButton" name="sendButton">
-        <property name="minimumSize">
-         <size>
-          <width>60</width>
-          <height>50</height>
-         </size>
-        </property>
-        <property name="maximumSize">
-         <size>
-          <width>60</width>
-          <height>50</height>
-         </size>
-        </property>
-        <property name="text">
-         <string>Send</string>
-        </property>
-       </widget>
-      </item>
-     </layout>
-    </widget>
-   </item>
+    <item>
+     <widget class="QWidget" name="inputWidget" native="true">
+      <layout class="QVBoxLayout" name="inputContainerLayout">
+       <property name="spacing">
+        <number>4</number>
+       </property>
+       <property name="leftMargin">
+        <number>4</number>
+       </property>
+       <property name="topMargin">
+        <number>4</number>
+       </property>
+       <property name="rightMargin">
+        <number>4</number>
+       </property>
+       <property name="bottomMargin">
+        <number>4</number>
+       </property>
+       <item>
+        <widget class="QWidget" name="attachmentPreviewWidget" native="true">
+         <property name="visible">
+          <bool>false</bool>
+         </property>
+         <layout class="QHBoxLayout" name="attachmentPreviewLayout">
+          <property name="spacing">
+           <number>6</number>
+          </property>
+          <property name="leftMargin">
+           <number>0</number>
+          </property>
+          <property name="topMargin">
+           <number>0</number>
+          </property>
+          <property name="rightMargin">
+           <number>0</number>
+          </property>
+          <property name="bottomMargin">
+           <number>0</number>
+          </property>
+         </layout>
+        </widget>
+       </item>
+       <item>
+        <layout class="QHBoxLayout" name="inputLayout">
+         <item>
+          <widget class="ChatInputEdit" name="inputField">
+           <property name="maximumSize">
+            <size>
+             <width>16777215</width>
+             <height>50</height>
+            </size>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QPushButton" name="sendButton">
+           <property name="minimumSize">
+            <size>
+             <width>60</width>
+             <height>50</height>
+            </size>
+           </property>
+           <property name="maximumSize">
+            <size>
+             <width>60</width>
+             <height>50</height>
+            </size>
+           </property>
+           <property name="text">
+            <string>Send</string>
+           </property>
+          </widget>
+         </item>
+        </layout>
+       </item>
+       <item>
+        <layout class="QHBoxLayout" name="actionButtonsLayout">
+         <property name="spacing">
+          <number>4</number>
+         </property>
+         <item>
+          <widget class="QPushButton" name="analyzeScreenButton">
+           <property name="toolTip">
+            <string>Grab active 3D viewport frame and camera metadata</string>
+           </property>
+           <property name="text">
+            <string>Analyze Screen</string>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QPushButton" name="attachImageButton">
+           <property name="toolTip">
+            <string>Attach local image file</string>
+           </property>
+           <property name="text">
+            <string>Attach Image</string>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <spacer name="actionsSpacer">
+           <property name="orientation">
+            <enum>Qt::Horizontal</enum>
+           </property>
+          </spacer>
+         </item>
+        </layout>
+       </item>
+      </layout>
+     </widget>
+    </item>
   </layout>
  </widget>
  <customwidgets>

--- a/src/gui/ai/ViewportGrabber.cc
+++ b/src/gui/ai/ViewportGrabber.cc
@@ -1,0 +1,52 @@
+#include "gui/ai/ViewportGrabber.h"
+#include "gui/QGLView.h"
+#include "glview/Camera.h"
+
+#include <QBuffer>
+#include <QByteArray>
+#include <QImage>
+#include <iomanip>
+#include <sstream>
+
+std::string ViewportGrabber::captureViewportBase64(QGLView *glView, int maxDimension)
+{
+  if (!glView) {
+    return "";
+  }
+
+  const QImage& frame = glView->grabFrame();
+  if (frame.isNull()) {
+    return "";
+  }
+
+  QImage scaled = frame;
+  if (frame.width() > maxDimension || frame.height() > maxDimension) {
+    scaled = frame.scaled(maxDimension, maxDimension, Qt::KeepAspectRatio, Qt::SmoothTransformation);
+  }
+
+  QByteArray byteArray;
+  QBuffer buffer(&byteArray);
+  buffer.open(QIODevice::WriteOnly);
+  scaled.save(&buffer, "PNG");
+
+  return byteArray.toBase64().toStdString();
+}
+
+std::string ViewportGrabber::serializeCameraMetadata(const Camera& cam)
+{
+  const auto vpt = cam.getVpt();
+  const auto vpr = cam.getVpr();
+
+  std::stringstream ss;
+  ss << std::fixed << std::setprecision(2);
+  ss << "[Viewport Camera Metadata]\n"
+     << "- Translation (vpt): [" << vpt.x() << ", " << vpt.y() << ", " << vpt.z() << "]\n"
+     << "- Rotation (vpr): [" << vpr.x() << ", " << vpr.y() << ", " << vpr.z() << "]\n"
+     << "- Distance (vpd): " << cam.zoomValue() << "\n"
+     << "- Field of View (vpf): " << cam.fovValue() << "\n"
+     << "- Projection: "
+     << (cam.projection == Camera::ProjectionType::ORTHOGONAL ? "ORTHOGONAL" : "PERSPECTIVE") << "\n"
+     << "- Dimensions: " << cam.pixel_width << "x" << cam.pixel_height;
+
+  return ss.str();
+}

--- a/src/gui/ai/ViewportGrabber.h
+++ b/src/gui/ai/ViewportGrabber.h
@@ -1,0 +1,16 @@
+#pragma once
+
+#include <string>
+
+class QGLView;
+class Camera;
+
+class ViewportGrabber
+{
+public:
+  // Capture 3D viewport frame, scale to maxDimension preserving aspect ratio, encode as base64 PNG
+  static std::string captureViewportBase64(QGLView *glView, int maxDimension = 1024);
+
+  // Serialize camera vectors (vpt, vpr, distance, fov, projection mode) into structured text
+  static std::string serializeCameraMetadata(const Camera& cam);
+};


### PR DESCRIPTION
Implement sliding window context management to limit conversation history based on configurable context_limit parameter (default 10 turns). Add OpenSCAD reference documentation to system prompt including 3D/2D primitives, transforms, and available tools.

Add chat history export/import in JSON format and copy-as-markdown functionality via new menu button. Exclude context management parameters (system_prompt, default_prompt, context_limit) from API payloads.