### PR TITLE
Catch evaluation exceptions on the command line

### DIFF
--- a/src/openscad.cc
+++ b/src/openscad.cc
@@ -1181,6 +1181,12 @@ int openscad_main(int argc, char **argv)
       }
     } catch (const HardWarningException&) {
       rc = 1;
+    } catch (const std::exception& ex) {
+      LOG(message_group::Error, "Compilation aborted by exception: %1$s", ex.what());
+      rc = 1;
+    } catch (...) {
+      LOG(message_group::Error, "Compilation aborted by unknown exception");
+      rc = 1;
     }
 
     if (deps_output_file) {


### PR DESCRIPTION
While fuzzing OpenSCAD I ran across crashes from the search function and I commented on bug #5017 since that bug is what I hit in my fuzzing. However that bug is a symptom of the missing exception handling for the command line vs the GUI execution. In it I mentioned I would open a separate pull request and this is it to fix the command line crash abort. The following lines are Claude's write up. The system crash reporter is will happily scream repeatedly about this.

-------

An exception escaping evaluation aborts the headless process instead of being reported. The GUI already handles this: MainWindow wraps its compile in catch(HardWarningException) / catch(std::exception) / catch(...), routing the latter two to UnknownExceptionCleanup, which logs "Compilation aborted by exception: ...". openscad_main's equivalent try block has only the first clause, so anything else reaches the default terminate handler.

Reproducing with issue #5017, which throws out of search():
```console
  $ printf 'echo(search("a", [[1, 2]]));\n' > crash.scad
  $ openscad -o out.stl crash.scad; echo "exit=$?"
  libc++abi: terminating due to uncaught exception of type std::bad_variant_access
  exit=134
```
The same file in the GUI prints "ERROR: Compilation aborted by exception: bad_variant_access" and carries on. On macOS the abort also raises the system crash reporter, so a scripted build looks like a hard failure of the tool.

This adds the two missing clauses, with the same messages the GUI uses so the two paths report identically. HardWarningException stays first, since it derives from std::exception via EvaluationException/std::runtime_error and must keep matching its own clause.

Independent of the search() fix in #5017: it makes any escaped evaluation exception a diagnosed error and rc=1 rather than SIGABRT.