### PR TITLE
Set colors for line-folding markers.  Tweak bookmark marker.

### DIFF
--- a/src/gui/ScintillaEditor.cc
+++ b/src/gui/ScintillaEditor.cc
@@ -502,6 +502,8 @@ void ScintillaEditor::setColormap(const EditorColorScheme *colorScheme)
     newLexer->setPaper(paperColor);
 
     const auto& colors = pt.get_child("colors");
+    const QColor marginBackgroundColor(readColor(colors, "margin-background", paperColor));
+    const QColor marginForegroundColor(readColor(colors, "margin-foreground", textColor));
 
     newLexer->setColor(readColor(colors, "operator", textColor), ScadLexer2::Operator);
     newLexer->setColor(readColor(colors, "comment", textColor), ScadLexer2::Comment);
@@ -583,8 +585,13 @@ void ScintillaEditor::setColormap(const EditorColorScheme *colorScheme)
 
     qsci->setMarkerBackgroundColor(readColor(colors, "error-marker", QColor(255, 0, 0, 100)),
                                    errMarkerNumber);
-    qsci->setMarkerBackgroundColor(readColor(colors, "bookmark-marker", QColor(150, 200, 255, 100)),
-                                   bmMarkerNumber);  // light blue
+
+    // Set both the foreground (outline) and background (fill) colors for bookmarks to the
+    // bookmark color.  Otherwise the colored part is really small.
+    const QColor bmColor(
+      readColor(colors, "bookmark-marker", QColor(150, 200, 255, 100)));  // light blue
+    qsci->setMarkerBackgroundColor(bmColor, bmMarkerNumber);
+    qsci->setMarkerForegroundColor(bmColor, bmMarkerNumber);
     qsci->setMarkerBackgroundColor(readColor(colors, "reference-marker1", QColor(11, 156, 49, 100)),
                                    selectionMarkerLevelNumber);
     qsci->setMarkerBackgroundColor(readColor(colors, "reference-marker2", QColor(11, 156, 49, 50)),
@@ -597,8 +604,7 @@ void ScintillaEditor::setColormap(const EditorColorScheme *colorScheme)
                                    selectionMarkerLevelNumber + 4);
     qsci->setMarkerBackgroundColor(readColor(colors, "reference-marker6", QColor(11, 156, 49, 50)),
                                    selectionMarkerLevelNumber + 5);
-    qsci->setMarkerBackgroundColor(readColor(colors, "bookmark-marker", QColor(150, 200, 255, 50)),
-                                   bmMarkerNumber);  // light blue
+
     qsci->setIndicatorForegroundColor(
       readColor(colors, "selected-highlight-indicator", QColor(11, 156, 49, 100)),
       selectionIndicatorIsActiveNumber);  // light green
@@ -647,10 +653,9 @@ void ScintillaEditor::setColormap(const EditorColorScheme *colorScheme)
       readColor(colors, "hyperlink-indicator-hover", QColor(139, 24, 168, 100)),
       hyperlinkIndicatorNumber);  // violet
     qsci->setWhitespaceForegroundColor(readColor(colors, "whitespace-foreground", textColor));
-    qsci->setMarginsBackgroundColor(readColor(colors, "margin-background", paperColor));
-    qsci->setMarginsForegroundColor(readColor(colors, "margin-foreground", textColor));
-    qsci->setFoldMarginColors(readColor(colors, "margin-background", paperColor),
-                              readColor(colors, "margin-background", paperColor));
+    qsci->setMarginsBackgroundColor(marginBackgroundColor);
+    qsci->setMarginsForegroundColor(marginForegroundColor);
+    qsci->setFoldMarginColors(marginBackgroundColor, marginBackgroundColor);
     qsci->setMatchedBraceBackgroundColor(readColor(colors, "matched-brace-background", paperColor));
     qsci->setMatchedBraceForegroundColor(readColor(colors, "matched-brace-foreground", textColor));
     qsci->setUnmatchedBraceBackgroundColor(readColor(colors, "unmatched-brace-background", paperColor));
@@ -658,6 +663,38 @@ void ScintillaEditor::setColormap(const EditorColorScheme *colorScheme)
     qsci->setSelectionForegroundColor(readColor(colors, "selection-foreground", paperColor));
     qsci->setSelectionBackgroundColor(readColor(colors, "selection-background", textColor));
     qsci->setEdgeColor(readColor(colors, "edge", textColor));
+
+    const auto folderMarkers = {
+      QsciScintilla::SC_MARKNUM_FOLDEROPEN,     // Outermost [-]
+      QsciScintilla::SC_MARKNUM_FOLDER,         // Outermost [+]
+      QsciScintilla::SC_MARKNUM_FOLDERSUB,      // Vertical line alongside block
+      QsciScintilla::SC_MARKNUM_FOLDERTAIL,     // Tail at the end of outermost block
+      QsciScintilla::SC_MARKNUM_FOLDEREND,      // Inner [+]
+      QsciScintilla::SC_MARKNUM_FOLDEROPENMID,  // Inner [-]
+      QsciScintilla::SC_MARKNUM_FOLDERMIDTAIL,  // Tail at the end of inner block
+    };
+
+    // Note:  You should be able to use setMarkerBackgroundColor, but QScintilla never marks
+    // SC_MARKNUM_FOLDER<whatever> as allocated, and so the request is silently rejected. Ref
+    // QsciScintilla::setMarkerBackgroundColor(), which rejects unallocated marker numbers, and
+    // QsciScintilla::setFoldMarker(), which directly calls SCI_MARKERDEFINE instead of calling
+    // QsciScintilla::markerDefine().
+
+    // Note:  For some reason, Scintilla considers the lines, boxes, and symbols associated with
+    // line folding to be "background", and the interior of the boxes (not the symbols) to be
+    // "foreground".
+
+    // Note:  There are hints in the Scintilla source that the selected-background color is sometimes
+    // used, but I haven't been able to find any cases.  Make it red so that it's more obvious
+    // if it's ever used.
+
+    for (auto m : folderMarkers) {
+      // Only the [+] and [-] markers need FORE, but it doesn't hurt to set on the others too.
+      qsci->SendScintilla(QsciScintilla::SCI_MARKERSETBACK, m, marginForegroundColor);
+      qsci->SendScintilla(QsciScintilla::SCI_MARKERSETFORE, m, marginBackgroundColor);
+      qsci->SendScintilla(QsciScintilla::SCI_MARKERSETBACKSELECTED, m, QColor(Qt::red));
+    }
+
   } catch (const std::exception& e) {
     noColor();
   }
@@ -677,7 +714,6 @@ void ScintillaEditor::noColor()
   qsci->setMarkerBackgroundColor(QColor(11, 156, 49, 50), selectionMarkerLevelNumber + 3);
   qsci->setMarkerBackgroundColor(QColor(11, 156, 49, 50), selectionMarkerLevelNumber + 4);
   qsci->setMarkerBackgroundColor(QColor(11, 156, 49, 50), selectionMarkerLevelNumber + 5);
-  qsci->setMarkerBackgroundColor(QColor(150, 200, 255, 100), bmMarkerNumber);  // light blue
   qsci->setIndicatorForegroundColor(QColor(11, 156, 49, 100), selectionIndicatorIsActiveNumber);
   qsci->setIndicatorOutlineColor(QColor(0, 0, 0, 255), selectionIndicatorIsActiveNumber);
   qsci->setIndicatorForegroundColor(QColor(11, 156, 49, 50), selectionIndicatorIsActiveNumber + 1);

--- a/src/gui/ScintillaEditor.h
+++ b/src/gui/ScintillaEditor.h
@@ -148,9 +148,12 @@ private:
   static const int findIndicatorNumber = 9;
   static const int hyperlinkIndicatorNumber = 10;
   static const int hyperlinkIndicatorOffset = 100;
+
+  // Note:  Marker numbers 25-31 are reserved for line-folding markers.
   static const int errMarkerNumber = 2;
   static const int bmMarkerNumber = 3;
-  static const int selectionMarkerLevelNumber = 20;  // 20 - 25, there is at max 5 level of depth
+  static const int selectionMarkerLevelNumber = 4;  // 4-9, there is at max 5 level of depth
+
   static const int selectionIndicatorIsActiveNumber =
     11;  // Represents the active selected area text 11 - 12
   static const int selectionIndicatorIsImpactedNumber =


### PR DESCRIPTION
Fixes #6927.

Sets the line-fold markers to the margin foreground color, the same as the color used for line numbers.

Changes bookmark markers so that they are entirely set to the bookmark-marker color, rather than  having a black border.  Not is a black border invisible in dark mode, but even with the border visible the fill color, the bookmark-marker color, is very small.

Fixes a bug where collapsed inner blocks would show a naked "+" instead of a boxed "+", and also caused the "+" to erroneously and redundantly appear in the error/bookmark column.  This was caused by a conflict between the marker numbers allocated by Scintilla for folding markers and the marker numbers allocated by OpenSCAD for selection markers.

Risk:  there might be unobvious reasons why selection markers needed to start at 20, instead of at 4, immediately after the bookmark and error markers.

Removes two duplicate sets of the bookmark-marker background color.

Before:
<img width="79" height="182" alt="image" src="https://github.com/user-attachments/assets/55cfa431-4117-495e-a00d-664cc71d799f" /><img width="90" height="182" alt="image" src="https://github.com/user-attachments/assets/760ef6aa-c182-45fc-834f-71eb4f96d886" />

After:
<img width="77" height="179" alt="image" src="https://github.com/user-attachments/assets/abbce3fa-97e4-4731-a4af-062b0df29365" /><img width="85" height="179" alt="image" src="https://github.com/user-attachments/assets/3141b931-a556-424f-92ee-b66419f7dc43" />
