### PR TITLE
Fix #3732: only create backups after document changes

### DIFF
--- a/src/gui/MainWindow.cc
+++ b/src/gui/MainWindow.cc
@@ -737,7 +737,9 @@ void MainWindow::compile(bool reload, bool forcedone)
       if (GlobalPreferences::inst()->getValue("advanced/consoleAutoClear").toBool()) {
         this->console->clear();
       }
-      if (activeEditor->isContentModified()) saveBackup();
+      if (activeEditor->isContentModified() && backupPending) {
+        saveBackup();
+      }
       parseTopLevelDocument();
       didcompile = true;
     }
@@ -1243,7 +1245,8 @@ void MainWindow::saveBackup()
     LOG(message_group::UI_Warning, "Failed to create backup file");
     return;
   }
-  return writeBackup(this->tempFile);
+  writeBackup(this->tempFile);
+  backupPending = false;
 }
 
 void MainWindow::on_fileActionSave_triggered()
@@ -2749,7 +2752,8 @@ void MainWindow::editorContentChanged()
 {
   // this slot is called when the content of the active editor changed.
   // it rely on the activeEditor member to pick the new data.
-
+  backupPending = true;
+  
   auto current_doc = activeEditor->toPlainText();
   if (current_doc != lastCompiledDoc) {
     animateWidget->editorContentChanged();

--- a/src/gui/MainWindow.h
+++ b/src/gui/MainWindow.h
@@ -458,6 +458,7 @@ private:
 
   char const *afterCompileSlot;
   bool procevents{false};
+  bool backupPending{true};
   QTemporaryFile *tempFile{nullptr};
   ProgressWidget *progresswidget{nullptr};
   CGALWorker *cgalworker;


### PR DESCRIPTION
## Summary

Fixes #3732.

Backups were triggered whenever `isContentModified()` returned true.
For unsaved files this state remains true until a save occurs, which can
cause repeated backup creation during repeated compilations.

This change tracks whether the document has changed since the last backup
and only creates a backup when new edits have occurred.

## Testing

Tested manually:

1. Created a new untitled document.
2. Modified the contents.
3. Triggered preview/compile.
4. Verified that a backup file was created.
5. Triggered repeated previews without modifying the document.
6. Verified that no additional backup files were created.
7. Modified the document again.
8. Verified that the next preview created a new backup.

## Notes

The original dirty-state (`isContentModified()`) behavior remains unchanged.
The change only affects backup creation logic.

Before:
<img width="1414" height="942" alt="Screenshot 2026-08-02 at 10 37 10 PM" src="https://github.com/user-attachments/assets/accab30e-c786-4f99-b6d3-6ce22f004ee5" />

After:
<img width="1416" height="940" alt="Screenshot 2026-08-02 at 10 38 11 PM" src="https://github.com/user-attachments/assets/768e809f-7ecc-420d-b8ac-280813649331" />
