### PR TITLE
Revert the cache-string changes from #2792, because they cause false matches.

### DIFF
--- a/src/core/NodeDumper.cc
+++ b/src/core/NodeDumper.cc
@@ -12,46 +12,6 @@
 #include "core/State.h"
 #include "core/node.h"
 
-void GroupNodeChecker::incChildCount(int groupNodeIndex)
-{
-  auto search = this->groupChildCounts.find(groupNodeIndex);
-  // if no entry then given node wasn't a group node
-  if (search != this->groupChildCounts.end()) {
-    ++(search->second);
-  }
-}
-
-int GroupNodeChecker::getChildCount(int groupNodeIndex) const
-{
-  auto search = this->groupChildCounts.find(groupNodeIndex);
-  if (search != this->groupChildCounts.end()) {
-    return search->second;
-  } else {
-    return -1;
-  }
-}
-
-Response GroupNodeChecker::visit(State& state, const GroupNode& node)
-{
-  if (state.isPrefix()) {
-    // create entry for group node, which children may increment
-    this->groupChildCounts.emplace(node.index(), 0);
-  } else if (state.isPostfix()) {
-    if ((this->getChildCount(node.index()) > 0) && state.parent()) {
-      this->incChildCount(state.parent()->index());
-    }
-  }
-  return Response::ContinueTraversal;
-}
-
-Response GroupNodeChecker::visit(State& state, const AbstractNode&)
-{
-  if (state.isPostfix() && state.parent()) {
-    this->incChildCount(state.parent()->index());
-  }
-  return Response::ContinueTraversal;
-}
-
 /*!
    \class NodeDumper
 
@@ -75,54 +35,6 @@ void NodeDumper::finalizeCache()
 bool NodeDumper::isCached(const AbstractNode& node) const
 {
   return this->cache.contains(node);
-}
-
-Response NodeDumper::visit(State& state, const GroupNode& node)
-{
-  if (!this->idString) {
-    return NodeDumper::visit(state, (const AbstractNode&)node);
-  }
-  if (state.isPrefix()) {
-    // For handling root modifier '!'
-    // Check if we are processing the root of the current Tree and init cache
-    if (this->root.get() == &node) {
-      this->initCache();
-    }
-
-    // ListNodes can pass down modifiers to children via state, so check both modinst and state
-    if (node.modinst->isBackground() || state.isBackground()) this->dumpstream << "%";
-    if (node.modinst->isHighlight() || state.isHighlight()) this->dumpstream << "#";
-
-// If IDPREFIX is set, we will output "/*id*/" in front of each node
-// which is useful for debugging.
-#ifdef IDPREFIX
-    if (this->idString) this->dumpstream << "\n";
-    this->dumpstream << "/*" << node.index() << "*/";
-#endif
-
-    // insert start index
-    this->cache.insertStart(node.index(), this->dumpstream.tellp());
-
-    if (this->groupChecker.getChildCount(node.index()) > 1) {
-      this->dumpstream << node << "{";
-    }
-    this->currindent++;
-  } else if (state.isPostfix()) {
-    this->currindent--;
-    if (this->groupChecker.getChildCount(node.index()) > 1) {
-      this->dumpstream << "}";
-    }
-    // insert end index
-    this->cache.insertEnd(node.index(), this->dumpstream.tellp());
-
-    // For handling root modifier '!'
-    // Check if we are processing the root of the current Tree and finalize cache
-    if (this->root.get() == &node) {
-      this->finalizeCache();
-    }
-  }
-
-  return Response::ContinueTraversal;
 }
 
 /*!

--- a/src/core/NodeDumper.h
+++ b/src/core/NodeDumper.h
@@ -11,27 +11,6 @@
 #include "core/NodeVisitor.h"
 #include "core/node.h"
 
-// GroupNodeChecker does a quick first pass to count children of group nodes
-// If a GroupNode has 0 children, don't include in node id strings
-// If a GroupNode has 1 child, we replace it with its child
-// This makes id strings much more compact for deeply nested trees, recursive scad scripts,
-// and increases likelihood of node cache hits.
-class GroupNodeChecker : public NodeVisitor
-{
-public:
-  GroupNodeChecker() = default;
-
-  Response visit(State& state, const AbstractNode& node) override;
-  Response visit(State& state, const GroupNode& node) override;
-  void incChildCount(int groupNodeIndex);
-  int getChildCount(int groupNodeIndex) const;
-  void reset() { groupChildCounts.clear(); }
-
-private:
-  // stores <node_idx,nonEmptyChildCount> for each group node
-  std::unordered_map<int, int> groupChildCounts;
-};
-
 class NodeDumper : public NodeVisitor
 {
 public:
@@ -39,13 +18,9 @@ public:
              bool idString)
     : cache(cache), indent(std::move(indent)), idString(idString), root(std::move(root_node))
   {
-    if (idString) {
-      groupChecker.traverse(*root);
-    }
   }
 
   Response visit(State& state, const AbstractNode& node) override;
-  Response visit(State& state, const GroupNode& node) override;
   Response visit(State& state, const ListNode& node) override;
   Response visit(State& state, const RootNode& node) override;
 
@@ -61,6 +36,5 @@ private:
 
   int currindent{0};
   std::shared_ptr<const AbstractNode> root;
-  GroupNodeChecker groupChecker;
   std::ostringstream dumpstream;
 };


### PR DESCRIPTION
Revert the cache-string changes from #2792, because they cause false matches.
Fixes #6456.