### PR TITLE
Move "Show Welcome Screen" to Preferences/Dialogs.

### DIFF
--- a/src/gui/Preferences.ui
+++ b/src/gui/Preferences.ui
@@ -2264,13 +2264,6 @@
                 </widget>
                </item>
                <item>
-                <widget class="QCheckBox" name="launcherBox">
-                 <property name="text">
-                  <string>Show Welcome Screen</string>
-                 </property>
-                </widget>
-               </item>
-               <item>
                 <widget class="QCheckBox" name="localizationCheckBox">
                  <property name="text">
                   <string>Enable user interface localization (requires restart of OpenSCAD)</string>
@@ -2886,6 +2879,13 @@
            <string>Dialog visibility</string>
           </property>
           <layout class="QVBoxLayout" name="verticalLayout_19">
+           <item>
+            <widget class="QCheckBox" name="launcherBox">
+             <property name="text">
+              <string>Always show Welcome screen</string>
+             </property>
+            </widget>
+           </item>
            <item>
             <widget class="QCheckBox" name="checkBoxAlwaysShowExportPdfDialog">
              <property name="text">


### PR DESCRIPTION
Fixes #6945.

This is a simplistic move.  In particular, it does not:
* Rename the UI element from `launcherBox` to `checkBoxAlwaysShowLauncherDialog`.
* Reword the launcher dialog to say "Always show dialog", or reword the other dialogs to say "Don't show again".
