### PR TITLE
Add viewport tools and AI agent modes

### DIFF
--- a/src/core/AIClient.cc
+++ b/src/core/AIClient.cc
@@ -252,6 +252,62 @@ nlohmann::json getOpenSCADTools()
   trigger_preview["function"] = tp_fn;
   tools.push_back(trigger_preview);
 
+  nlohmann::json get_viewport = nlohmann::json::object();
+  get_viewport["type"] = "function";
+  nlohmann::json gv_fn = nlohmann::json::object();
+  gv_fn["name"] = "get_viewport";
+  gv_fn["description"] =
+    "Retrieve the current 3D viewport camera parameters (vpt, vpr, vpd, vpf, projection).";
+  nlohmann::json gv_params = nlohmann::json::object();
+  gv_params["type"] = "object";
+  gv_params["properties"] = nlohmann::json::object();
+  gv_fn["parameters"] = gv_params;
+  get_viewport["function"] = gv_fn;
+  tools.push_back(get_viewport);
+
+  nlohmann::json set_camera = nlohmann::json::object();
+  set_camera["type"] = "function";
+  nlohmann::json sc_fn = nlohmann::json::object();
+  sc_fn["name"] = "set_camera";
+  sc_fn["description"] =
+    "Set the 3D viewport camera translation (vpt), rotation (vpr), distance (vpd), field of view (vpf), "
+    "or projection mode.";
+  nlohmann::json sc_params = nlohmann::json::object();
+  sc_params["type"] = "object";
+  nlohmann::json sc_props = nlohmann::json::object();
+
+  nlohmann::json vpt_arr = nlohmann::json::object();
+  vpt_arr["type"] = "array";
+  vpt_arr["description"] = "Translation vector [x, y, z] (vpt).";
+  vpt_arr["items"] = nlohmann::json::object({{"type", "number"}});
+  sc_props["vpt"] = vpt_arr;
+
+  nlohmann::json vpr_arr = nlohmann::json::object();
+  vpr_arr["type"] = "array";
+  vpr_arr["description"] = "Rotation angles in degrees [x, y, z] (vpr).";
+  vpr_arr["items"] = nlohmann::json::object({{"type", "number"}});
+  sc_props["vpr"] = vpr_arr;
+
+  nlohmann::json vpd_num = nlohmann::json::object();
+  vpd_num["type"] = "number";
+  vpd_num["description"] = "Camera distance (vpd).";
+  sc_props["vpd"] = vpd_num;
+
+  nlohmann::json vpf_num = nlohmann::json::object();
+  vpf_num["type"] = "number";
+  vpf_num["description"] = "Field of view angle (vpf).";
+  sc_props["vpf"] = vpf_num;
+
+  nlohmann::json proj_str = nlohmann::json::object();
+  proj_str["type"] = "string";
+  proj_str["description"] = "Projection mode: 'ortho' / 'orthogonal' or 'perspective'.";
+  sc_props["projection"] = proj_str;
+
+  sc_params["properties"] = sc_props;
+  sc_fn["parameters"] = sc_params;
+  set_camera["function"] = sc_fn;
+  tools.push_back(set_camera);
+
   return tools;
 }
 
@@ -318,7 +374,7 @@ void AIClient::sendChatCompletion(const AIProfileConfig& config,
       const std::string& key = el.key();
       if (key == "model" || key == "stream" || key == "messages" || key == "tools" ||
           key == "system_prompt" || key == "default_prompt" || key == "context_limit" ||
-          key == "payload_limit" || key == "auto_attach_viewport") {
+          key == "payload_limit" || key == "auto_attach_viewport" || key == "max_auto_turns") {
         continue;
       }
       payload[key] = el.value();
@@ -474,7 +530,7 @@ void AIClient::sendChatCompletionStream(const AIProfileConfig& config,
       const std::string& key = el.key();
       if (key == "model" || key == "stream" || key == "messages" || key == "tools" ||
           key == "system_prompt" || key == "default_prompt" || key == "context_limit" ||
-          key == "payload_limit" || key == "auto_attach_viewport") {
+          key == "payload_limit" || key == "auto_attach_viewport" || key == "max_auto_turns") {
         continue;
       }
       payload[key] = el.value();

--- a/src/core/AIService.cc
+++ b/src/core/AIService.cc
@@ -116,7 +116,8 @@ void AIService::registerToolExecutor(ToolExecutor executor)
 }
 
 void AIService::chatCompletionStream(std::vector<ChatMessage>& history, ChunkCallback on_chunk,
-                                     ErrorCallback on_error, CompleteCallback on_complete)
+                                     ErrorCallback on_error, CompleteCallback on_complete,
+                                     bool interactiveMode, int current_auto_turn)
 {
   AIProfileConfig config;
   std::string error_msg;
@@ -125,6 +126,13 @@ void AIService::chatCompletionStream(std::vector<ChatMessage>& history, ChunkCal
       on_error(error_msg);
     }
     return;
+  }
+
+  int max_auto_turns = 5;
+  if (config.parameters.contains("max_auto_turns") &&
+      config.parameters["max_auto_turns"].is_number_integer()) {
+    max_auto_turns = config.parameters["max_auto_turns"].get<int>();
+    if (max_auto_turns < 1) max_auto_turns = 1;
   }
 
   std::vector<AIChatMessage> ai_history;
@@ -143,12 +151,12 @@ void AIService::chatCompletionStream(std::vector<ChatMessage>& history, ChunkCal
     "`cube(10);`) MUST end with a semicolon. Semicolons are NOT used after module definitions `module "
     "name() { ... }` or after blocks `{ ... }`.\n"
     "3. **Tool Workflow**:\n"
-    "   - YOU MUST USE `set_editor_code` to propose any code changes so they are set for user review.\n"
+    "   - YOU MUST USE `set_editor_code` to apply code changes. Behaviour differs by mode (see below).\n"
     "   - You can output code blocks in markdown format in the chat for explanation, but you MUST also "
-    "call the `set_editor_code` tool so the changes are set for review and can be applied "
-    "automatically.\n"
+    "call `set_editor_code` to update the script.\n"
     "   - Use `get_editor_code()` if you need to see the latest script state.\n"
-    "   - Use `trigger_preview()` once after setting the code to validate the result.\n"
+    "   - Use `trigger_preview()` after setting code to validate compilation and check for errors.\n"
+    "   - Use `get_viewport()` and `set_camera(...)` to inspect or adjust 3D view camera angles.\n"
     "4. **Response and Engagement**: Explain the reasoning behind your proposed code changes. Output "
     "standard text to explain your thoughts and keep the user engaged while proposing code changes via "
     "tools.\n"
@@ -157,6 +165,26 @@ void AIService::chatCompletionStream(std::vector<ChatMessage>& history, ChunkCal
 
   if (config.parameters.contains("system_prompt") && config.parameters["system_prompt"].is_string()) {
     sys_prompt = config.parameters["system_prompt"].get<std::string>();
+  }
+
+  // Append mode-specific instructions so the model understands its operating context
+  if (interactiveMode) {
+    sys_prompt +=
+      "\n\n### Current Operating Mode: INTERACTIVE REVIEW\n"
+      "You are in interactive review mode. Follow these rules strictly:\n"
+      "- Read the script with `get_editor_code()` if needed, then call `set_editor_code` ONCE with "
+      "your proposed changes.\n"
+      "- After calling `set_editor_code`, STOP. Do NOT call `trigger_preview` yourself. "
+      "The user will review your diff and the preview will fire automatically upon acceptance.\n"
+      "- Do NOT loop or call further tools after proposing code.";
+  } else {
+    sys_prompt +=
+      "\n\n### Current Operating Mode: AUTONOMOUS AGENTIC\n"
+      "You are in autonomous mode. Follow these rules:\n"
+      "- Apply code changes directly with `set_editor_code`, then immediately call `trigger_preview` "
+      "to validate the result.\n"
+      "- If `trigger_preview` reports errors, read the error messages and call `set_editor_code` again "
+      "with a fix. Repeat until the code compiles cleanly or you exhaust your turn limit.";
   }
 
   int context_limit = 10;
@@ -196,11 +224,10 @@ void AIService::chatCompletionStream(std::vector<ChatMessage>& history, ChunkCal
       "import(\"file.stl\")\n\n"
       "### Available Tools\n"
       "- **get_editor_code()**: Returns the current contents of the active editor tab.\n"
-      "- **set_editor_code({\"code\": \"...\"})**:  Proposes code changes for user review in a "
-      "side-by-side diff dialog. "
-      "Always use this instead of pasting code in chat.\n"
-      "- **trigger_preview()**: Renders the current editor code in the 3D viewport. "
-      "Automatically postponed if code changes are pending review.";
+      "- **set_editor_code({\"code\": \"...\"})**: Applies code changes directly to active editor.\n"
+      "- **trigger_preview()**: Renders current editor code and returns compile errors/warnings.\n"
+      "- **get_viewport()**: Returns 3D viewport camera parameters (vpt, vpr, vpd, vpf, projection).\n"
+      "- **set_camera({\"vpt\": [x,y,z], \"vpr\": [x,y,z], ...})**: Sets 3D view camera vectors.";
     ai_history.push_back({"system", sys_prompt + ref_doc});
   }
 
@@ -255,8 +282,14 @@ void AIService::chatCompletionStream(std::vector<ChatMessage>& history, ChunkCal
     ai_history.push_back(am);
   }
 
-  auto on_complete_wrapper = [this, config, &history, on_chunk, on_error, on_complete,
-                              sys_prompt](const std::vector<AIToolCall>& tool_calls) {
+  // In interactive mode the model gets at most 2 LLM calls: one to call tools
+  // (e.g. get_editor_code then set_editor_code) and one final response after
+  // seeing those results. We enforce this by capping the effective turn limit.
+  const int effective_max_turns = interactiveMode ? std::min(max_auto_turns, 2) : max_auto_turns;
+
+  auto on_complete_wrapper = [this, config, &history, on_chunk, on_error, on_complete, current_auto_turn,
+                              effective_max_turns,
+                              interactiveMode](const std::vector<AIToolCall>& tool_calls) {
     if (tool_calls.empty()) {
       if (on_complete) {
         on_complete();
@@ -295,7 +328,15 @@ void AIService::chatCompletionStream(std::vector<ChatMessage>& history, ChunkCal
       history.push_back(tool_msg);
     }
 
-    chatCompletionStream(history, on_chunk, on_error, on_complete);
+    if (current_auto_turn + 1 >= effective_max_turns) {
+      if (on_complete) {
+        on_complete();
+      }
+      return;
+    }
+
+    chatCompletionStream(history, on_chunk, on_error, on_complete, interactiveMode,
+                         current_auto_turn + 1);
   };
 
   impl->ai_client->sendChatCompletionStream(config, ai_history, on_chunk, on_error, on_complete_wrapper);
@@ -475,6 +516,20 @@ bool AIService::getAutoAttachViewport() const
   return false;
 }
 
+int AIService::getMaxAutoTurns() const
+{
+  AIProfileConfig config;
+  std::string error_msg;
+  if (loadActiveProfile(config, error_msg)) {
+    if (config.parameters.contains("max_auto_turns") &&
+        config.parameters["max_auto_turns"].is_number_integer()) {
+      int val = config.parameters["max_auto_turns"].get<int>();
+      if (val >= 1) return val;
+    }
+  }
+  return 5;
+}
+
 #else  // __EMSCRIPTEN__
 
 class AIService::Impl
@@ -490,7 +545,7 @@ AIService::AIService(AIService&&) noexcept = default;
 AIService& AIService::operator=(AIService&&) noexcept = default;
 
 void AIService::chatCompletionStream(std::vector<ChatMessage>&, ChunkCallback, ErrorCallback on_error,
-                                     CompleteCallback)
+                                     CompleteCallback, bool, int)
 {
   if (on_error) {
     on_error("AI service is not supported on WebAssembly.");
@@ -521,6 +576,11 @@ int AIService::getPayloadLimit() const
 bool AIService::getAutoAttachViewport() const
 {
   return false;
+}
+
+int AIService::getMaxAutoTurns() const
+{
+  return 5;
 }
 
 #endif  // __EMSCRIPTEN__

--- a/src/core/AIService.cc
+++ b/src/core/AIService.cc
@@ -87,6 +87,7 @@ public:
   std::unique_ptr<HTTPClient> http_client;
   std::unique_ptr<AIClient> ai_client;
   ToolExecutor tool_executor = nullptr;
+  HistoryDrainCallback history_drain_callback = nullptr;
 
   Impl()
   {
@@ -113,6 +114,11 @@ AIService& AIService::operator=(AIService&&) noexcept = default;
 void AIService::registerToolExecutor(ToolExecutor executor)
 {
   impl->tool_executor = std::move(executor);
+}
+
+void AIService::registerHistoryDrainCallback(HistoryDrainCallback callback)
+{
+  impl->history_drain_callback = std::move(callback);
 }
 
 void AIService::chatCompletionStream(std::vector<ChatMessage>& history, ChunkCallback on_chunk,
@@ -326,6 +332,13 @@ void AIService::chatCompletionStream(std::vector<ChatMessage>& history, ChunkCal
       tool_msg.content = result;
       tool_msg.tool_call_id = tc.id;
       history.push_back(tool_msg);
+    }
+
+    // Allow the UI layer to inject additional context messages (e.g. a
+    // viewport snapshot captured after trigger_preview) into history before
+    // the next recursive LLM call.
+    if (impl->history_drain_callback) {
+      impl->history_drain_callback(history);
     }
 
     if (current_auto_turn + 1 >= effective_max_turns) {

--- a/src/core/AIService.h
+++ b/src/core/AIService.h
@@ -64,6 +64,12 @@ public:
     std::function<std::string(const std::string& name, const std::string& arguments_json)>;
   void registerToolExecutor(ToolExecutor executor);
 
+  // Optional callback invoked after each tool-execution round, before the next
+  // recursive LLM call. The callback receives the history vector by reference
+  // and may append additional messages (e.g. a viewport snapshot image message).
+  using HistoryDrainCallback = std::function<void(std::vector<ChatMessage>& history)>;
+  void registerHistoryDrainCallback(HistoryDrainCallback callback);
+
 private:
   class Impl;
   std::unique_ptr<Impl> impl;

--- a/src/core/AIService.h
+++ b/src/core/AIService.h
@@ -38,7 +38,8 @@ public:
 
   // Async chat completion with streaming output
   void chatCompletionStream(std::vector<ChatMessage>& history, ChunkCallback on_chunk,
-                            ErrorCallback on_error, CompleteCallback on_complete);
+                            ErrorCallback on_error, CompleteCallback on_complete,
+                            bool interactiveMode = false, int current_auto_turn = 0);
 
   // Async chat completion with full non-streaming response
   void chatCompletion(const std::vector<ChatMessage>& history, ResponseCallback on_response,
@@ -55,6 +56,9 @@ public:
 
   // Get auto attach viewport setting
   bool getAutoAttachViewport() const;
+
+  // Get max auto turns setting
+  int getMaxAutoTurns() const;
 
   using ToolExecutor =
     std::function<std::string(const std::string& name, const std::string& arguments_json)>;

--- a/src/gui/Preferences.cc
+++ b/src/gui/Preferences.cc
@@ -329,6 +329,7 @@ void Preferences::init()
         params["context_limit"] = 10;
         params["payload_limit"] = 50000;
         params["auto_attach_viewport"] = false;
+        params["max_auto_turns"] = 5;
       }
       prof["params"] = params;
       prof["apiKey"] = "";
@@ -1506,6 +1507,7 @@ void Preferences::on_pushButtonAINewProfile_clicked()
   params["context_limit"] = 10;
   params["payload_limit"] = 50000;
   params["auto_attach_viewport"] = false;
+  params["max_auto_turns"] = 5;
   newProfile["params"] = params;
 
   profilesObj[trimmed.toStdString()] = newProfile;
@@ -1631,6 +1633,9 @@ void Preferences::loadAIParams(const QString& profileName)
   }
   if (!paramsObj.contains("auto_attach_viewport")) {
     paramsObj["auto_attach_viewport"] = false;
+  }
+  if (!paramsObj.contains("max_auto_turns")) {
+    paramsObj["max_auto_turns"] = 5;
   }
 
   std::string sysPrompt = paramsObj.value("system_prompt", "");

--- a/src/gui/ai/ChatWidget.cc
+++ b/src/gui/ai/ChatWidget.cc
@@ -2,6 +2,7 @@
 #include "gui/qtgettext.h"
 #include "json/json.hpp"
 #include <future>
+#include <algorithm>
 #include <QScrollBar>
 #include <QFrame>
 #include <QLabel>
@@ -24,6 +25,8 @@
 #include "gui/ai/CollapsibleBubble.h"
 #include "gui/ai/ViewportGrabber.h"
 #include "gui/QGLView.h"
+#include "glview/Camera.h"
+#include "gui/Console.h"
 
 // MessageBubble implementation
 MessageBubble::MessageBubble(const QString& text, bool isUser,
@@ -143,6 +146,7 @@ ChatWidget::ChatWidget(QWidget *parent) : QWidget(parent)
   connect(clearButton, &QPushButton::clicked, this, &ChatWidget::onClearPressed);
   connect(analyzeScreenButton, &QPushButton::clicked, this, &ChatWidget::onAnalyzeScreenPressed);
   connect(attachImageButton, &QPushButton::clicked, this, &ChatWidget::onAttachImagePressed);
+  connect(agentModeCheckBox, &QCheckBox::toggled, this, [this](bool checked) { agenticMode = checked; });
 
   // Setup chat options menu
   QMenu *chatMenu = new QMenu(this);
@@ -242,14 +246,19 @@ ChatWidget::ChatWidget(QWidget *parent) : QWidget(parent)
     if (result == QDialog::Accepted) {
       if (mw && mw->activeEditor) {
         mw->activeEditor->setText(QString::fromStdString(proposedCode));
-        if (dlg.shouldTriggerPreview()) {
+        // In interactive mode, fire preview automatically after acceptance
+        // (regardless of the dialog's own checkbox since the model already
+        // called trigger_preview and it was deferred).
+        if (pendingAutoPreview || dlg.shouldTriggerPreview()) {
           mw->actionRenderPreview();
         }
+        pendingAutoPreview = false;
       }
       proposedCode = "";
       originalCode = "";
       diffBannerWidget->hide();
     } else if (result == 2) {  // Discarded Changes
+      pendingAutoPreview = false;
       proposedCode = "";
       originalCode = "";
       diffBannerWidget->hide();
@@ -332,6 +341,7 @@ void ChatWidget::onSendPressed()
 
   auto alive = this->aliveState;
 
+  agentModeCheckBox->setEnabled(false);
   aiService->chatCompletionStream(
     history,
     [this, alive](const std::string& chunk) {
@@ -380,6 +390,7 @@ void ChatWidget::onSendPressed()
         activeAIBubble = nullptr;
         activeResponseText = nullptr;
         this->enableInput(true);
+        this->agentModeCheckBox->setEnabled(true);
       });
     },
     [this, alive]() {
@@ -416,8 +427,10 @@ void ChatWidget::onSendPressed()
         activeAIBubble = nullptr;
         activeResponseText = nullptr;
         this->enableInput(true);
+        this->agentModeCheckBox->setEnabled(true);
       });
-    });
+    },
+    !agenticMode);
 }
 
 void ChatWidget::startNewResponseTurn()
@@ -646,11 +659,17 @@ void ChatWidget::logToolExecution(const std::string& name, const std::string& re
     detail = tr("Tool: get_editor_code\nResult: Read %1 lines.")
                .arg(QString::fromStdString(result).count('\n'));
   } else if (name == "set_editor_code") {
-    summary = tr("Proposed code changes");
-    detail = tr("Tool: set_editor_code\nResult: Proposed changes to the active editor.");
+    summary = tr("Applied code changes");
+    detail = tr("Tool: set_editor_code\nResult: Applied code changes to the active editor.");
   } else if (name == "trigger_preview") {
     summary = tr("Triggered render preview");
     detail = QString::fromStdString("Tool: trigger_preview\nResult: " + result);
+  } else if (name == "get_viewport") {
+    summary = tr("Inspected 3D Viewport");
+    detail = QString::fromStdString("Tool: get_viewport\nResult: " + result);
+  } else if (name == "set_camera") {
+    summary = tr("Adjusted Camera View");
+    detail = QString::fromStdString("Tool: set_camera\nResult: " + result);
   } else {
     summary = tr("Executed tool: %1").arg(QString::fromStdString(name));
     detail = QString::fromStdString("Tool: " + name + "\nResult: " + result);
@@ -707,22 +726,116 @@ std::string ChatWidget::executeTool(const std::string& name, const std::string& 
       result_val = "Error: Proposed code change is too large (" + std::to_string(code.size()) +
                    " bytes). The maximum allowed size is " + std::to_string(limit) + " bytes.";
     } else {
-      this->proposeCodeChange(code);
-      result_val =
-        "Success: Code change proposed to the user for review. The user will review and choose whether "
-        "to "
-        "apply it.";
+      if (mw && mw->activeEditor) {
+        if (agenticMode) {
+          // Agentic mode: apply directly so the loop can validate immediately
+          mw->activeEditor->setPlainText(QString::fromStdString(code));
+          result_val = "Success: Code applied directly to the active editor.";
+        } else {
+          // Interactive mode: stage a diff for user review
+          this->proposeCodeChange(code);
+          result_val =
+            "Success: Code change proposed for user review. "
+            "The diff banner is now visible. "
+            "Do NOT call trigger_preview — it will fire automatically after the user accepts.";
+        }
+      } else {
+        result_val = "Error: No active editor found.";
+      }
     }
   } else if (name == "trigger_preview") {
-    if (this->hasPendingCodeChanges()) {
-      result_val = "Info: Preview postponed because code changes are pending user review.";
-    } else {
-      if (mw) {
-        mw->actionRenderPreview();
-        result_val = "Success: Preview triggered.";
-      } else {
-        result_val = "Error: No active MainWindow found.";
+    if (hasPendingCodeChanges()) {
+      // In interactive mode, the model called trigger_preview but code is
+      // pending user review. Defer the preview and auto-fire it on acceptance.
+      pendingAutoPreview = true;
+      result_val =
+        "Postponed: Code changes are pending user review. "
+        "The preview will fire automatically once the user accepts the diff.";
+    } else if (mw) {
+      mw->actionRenderPreview();
+      int new_errors = mw->compileErrors;
+      int new_warnings = mw->compileWarnings;
+      QString console_text = mw->console ? mw->console->toPlainText() : "";
+      QStringList lines = console_text.split('\n', Qt::SkipEmptyParts);
+      QString recent_console;
+      int start_idx = std::max(0, static_cast<int>(lines.size()) - 15);
+      for (int i = start_idx; i < lines.size(); ++i) {
+        recent_console += lines[i] + "\n";
       }
+
+      std::stringstream ss;
+      if (new_errors > 0) {
+        ss << "Error: Compilation failed with " << new_errors << " error(s) and " << new_warnings
+           << " warning(s).\n";
+        if (!recent_console.isEmpty()) {
+          ss << "Recent console output:\n" << recent_console.toStdString();
+        }
+      } else if (new_warnings > 0) {
+        ss << "Success with Warnings: Render completed with 0 errors and " << new_warnings
+           << " warning(s).\n";
+        if (!recent_console.isEmpty()) {
+          ss << "Recent console output:\n" << recent_console.toStdString();
+        }
+      } else {
+        ss << "Success: Render completed with 0 errors and 0 warnings.\n";
+        if (!recent_console.isEmpty()) {
+          ss << "Recent console output:\n" << recent_console.toStdString();
+        }
+      }
+      result_val = ss.str();
+    } else {
+      result_val = "Error: No active MainWindow found.";
+    }
+  } else if (name == "get_viewport") {
+    if (mw && mw->qglview) {
+      const Camera& cam = mw->qglview->cam;
+      std::string meta = ViewportGrabber::serializeCameraMetadata(cam);
+      std::string img_b64 = ViewportGrabber::captureViewportBase64(mw->qglview, 1024);
+      if (!img_b64.empty()) {
+        this->pendingAttachments.push_back({"image/png", img_b64});
+        this->updateAttachmentPreviewBar();
+        meta += "\n(Captured viewport snapshot and attached to pending message context)";
+      }
+      result_val = meta;
+    } else {
+      result_val = "Error: 3D viewport non-existent or inactive.";
+    }
+  } else if (name == "set_camera") {
+    if (mw && mw->qglview) {
+      try {
+        auto args = nlohmann::json::parse(arguments_json);
+        Camera cam = mw->qglview->cam;
+        if (args.contains("vpt") && args["vpt"].is_array() && args["vpt"].size() == 3) {
+          cam.setVpt(args["vpt"][0].get<double>(), args["vpt"][1].get<double>(),
+                     args["vpt"][2].get<double>());
+        }
+        if (args.contains("vpr") && args["vpr"].is_array() && args["vpr"].size() == 3) {
+          cam.setVpr(args["vpr"][0].get<double>(), args["vpr"][1].get<double>(),
+                     args["vpr"][2].get<double>());
+        }
+        if (args.contains("vpd") && args["vpd"].is_number()) {
+          cam.setVpd(args["vpd"].get<double>());
+        }
+        if (args.contains("vpf") && args["vpf"].is_number()) {
+          cam.setVpf(args["vpf"].get<double>());
+        }
+        if (args.contains("projection") && args["projection"].is_string()) {
+          std::string proj = args["projection"].get<std::string>();
+          if (proj == "ortho" || proj == "orthogonal" || proj == "ORTHOGONAL") {
+            cam.projection = Camera::ProjectionType::ORTHOGONAL;
+          } else if (proj == "perspective" || proj == "PERSPECTIVE") {
+            cam.projection = Camera::ProjectionType::PERSPECTIVE;
+          }
+        }
+        mw->qglview->setCamera(cam);
+        mw->qglview->update();
+        result_val = "Success: Updated 3D viewport camera settings.\n" +
+                     ViewportGrabber::serializeCameraMetadata(cam);
+      } catch (const std::exception& e) {
+        result_val = std::string("Error parsing set_camera arguments: ") + e.what();
+      }
+    } else {
+      result_val = "Error: 3D viewport non-existent or inactive.";
     }
   } else {
     result_val = "Error: Unknown tool name '" + name + "'.";
@@ -941,11 +1054,17 @@ void ChatWidget::rebuildChatUI()
                 detail = tr("Tool: get_editor_code\nResult: Read %1 lines.")
                            .arg(QString::fromStdString(result).count('\n'));
               } else if (name == "set_editor_code") {
-                summary = tr("Proposed code changes");
-                detail = tr("Tool: set_editor_code\nResult: Proposed changes to the active editor.");
+                summary = tr("Applied code changes");
+                detail = tr("Tool: set_editor_code\nResult: Applied code changes to the active editor.");
               } else if (name == "trigger_preview") {
                 summary = tr("Triggered render preview");
                 detail = QString::fromStdString("Tool: trigger_preview\nResult: " + result);
+              } else if (name == "get_viewport") {
+                summary = tr("Inspected 3D Viewport");
+                detail = QString::fromStdString("Tool: get_viewport\nResult: " + result);
+              } else if (name == "set_camera") {
+                summary = tr("Adjusted Camera View");
+                detail = QString::fromStdString("Tool: set_camera\nResult: " + result);
               } else {
                 summary = tr("Executed tool: %1").arg(QString::fromStdString(name));
                 detail = QString::fromStdString("Tool: " + name + "\nResult: " + result);

--- a/src/gui/ai/ChatWidget.cc
+++ b/src/gui/ai/ChatWidget.cc
@@ -182,6 +182,20 @@ ChatWidget::ChatWidget(QWidget *parent) : QWidget(parent)
     return future.get();
   });
 
+  // Register history drain callback: after each tool round, inject any pending
+  // viewport snapshot into history so the model sees it on the next turn.
+  aiService->registerHistoryDrainCallback([this](std::vector<ChatMessage>& hist) {
+    QMetaObject::invokeMethod(
+      qApp,
+      [this, &hist]() {
+        if (pendingViewportSnapshot.has_value()) {
+          hist.push_back(std::move(*pendingViewportSnapshot));
+          pendingViewportSnapshot.reset();
+        }
+      },
+      Qt::DirectConnection);
+  });
+
   // Initial welcome greeting
   addMessage(_("Hello! I am your OpenSCAD AI assistant. Ask me to write some code, e.g. "
                "\"draw a sphere\" or \"create a box with a hole\"."),
@@ -404,9 +418,10 @@ void ChatWidget::onSendPressed()
           }
         } else if (activeResponseText) {
           this->history.push_back({"assistant", *activeResponseText});
-          // Fallback: If no tool was executed during this turn, extract code blocks from assistant text
-          // and propose change
-          if (!this->hasPendingCodeChanges()) {
+          // Fallback: only in interactive mode — if the model wrote a code block in
+          // chat text without calling set_editor_code, extract and propose it.
+          // In agentic mode this never runs, preventing spurious diff dialogs.
+          if (!agenticMode && !this->hasPendingCodeChanges()) {
             std::string text = *activeResponseText;
             size_t start = text.find("```");
             if (start != std::string::npos) {
@@ -783,6 +798,28 @@ std::string ChatWidget::executeTool(const std::string& name, const std::string& 
         }
       }
       result_val = ss.str();
+      // After a successful render, capture the viewport and attach it to history
+      // as a user-role message so the model can see the rendered result in the
+      // next agentic turn. This avoids the pendingAttachments path which only
+      // fires on explicit user sends.
+      if (mw->qglview) {
+        std::string img_b64 = ViewportGrabber::captureViewportBase64(mw->qglview, 512);
+        if (!img_b64.empty()) {
+          ChatMessage snap_msg;
+          snap_msg.role = "user";
+          snap_msg.content = "[Viewport snapshot after trigger_preview]";
+          snap_msg.images.push_back({"image/png", img_b64});
+          // This message is appended to history inside executeTool, which is
+          // called synchronously from AIService's on_complete_wrapper before the
+          // recursive chatCompletionStream call, so it will be included.
+          // We return the image caption in result_val for tool message content.
+          result_val += "\n(Viewport snapshot captured and attached for visual inspection.)";
+          // Store for AIService to inject; we can't push to this->history directly
+          // here because AIService owns the history vector passed by reference.
+          // Instead, store it and append in the next on_complete_wrapper iteration.
+          this->pendingViewportSnapshot = snap_msg;
+        }
+      }
     } else {
       result_val = "Error: No active MainWindow found.";
     }
@@ -792,9 +829,23 @@ std::string ChatWidget::executeTool(const std::string& name, const std::string& 
       std::string meta = ViewportGrabber::serializeCameraMetadata(cam);
       std::string img_b64 = ViewportGrabber::captureViewportBase64(mw->qglview, 1024);
       if (!img_b64.empty()) {
-        this->pendingAttachments.push_back({"image/png", img_b64});
-        this->updateAttachmentPreviewBar();
-        meta += "\n(Captured viewport snapshot and attached to pending message context)";
+        if (agenticMode) {
+          // In agentic mode: return image inline via pendingViewportSnapshot so
+          // it reaches the model in the next turn rather than polluting the
+          // user-send attachment queue.
+          ChatMessage snap_msg;
+          snap_msg.role = "user";
+          snap_msg.content = "[Viewport snapshot from get_viewport]";
+          snap_msg.images.push_back({"image/png", img_b64});
+          this->pendingViewportSnapshot = snap_msg;
+          meta += "\n(Viewport snapshot captured and will be included in the next model context.)";
+        } else {
+          // Interactive mode: attach to the pending attachments bar so the user
+          // can see the image was captured and it goes with the next user send.
+          this->pendingAttachments.push_back({"image/png", img_b64});
+          this->updateAttachmentPreviewBar();
+          meta += "\n(Captured viewport snapshot and attached to pending message context)";
+        }
       }
       result_val = meta;
     } else {

--- a/src/gui/ai/ChatWidget.h
+++ b/src/gui/ai/ChatWidget.h
@@ -76,5 +76,6 @@ private:
   std::vector<ImageAttachment> pendingAttachments;
   bool agenticMode = true;          // true = agentic (auto-loop), false = interactive review
   bool pendingAutoPreview = false;  // fire preview automatically after user accepts diff
-  std::optional<ChatMessage> pendingViewportSnapshot;  // viewport image to inject before next agentic turn
+  std::optional<ChatMessage>
+    pendingViewportSnapshot;  // viewport image to inject before next agentic turn
 };

--- a/src/gui/ai/ChatWidget.h
+++ b/src/gui/ai/ChatWidget.h
@@ -73,4 +73,6 @@ private:
   QWidget *diffBannerWidget = nullptr;
   CollapsibleBubble *activeToolBubble = nullptr;
   std::vector<ImageAttachment> pendingAttachments;
+  bool agenticMode = true;          // true = agentic (auto-loop), false = interactive review
+  bool pendingAutoPreview = false;  // fire preview automatically after user accepts diff
 };

--- a/src/gui/ai/ChatWidget.h
+++ b/src/gui/ai/ChatWidget.h
@@ -2,6 +2,7 @@
 
 #include <QWidget>
 #include <memory>
+#include <optional>
 #include <vector>
 #include "core/AIService.h"
 #include "gui/qtgettext.h"  // IWYU pragma: keep
@@ -75,4 +76,5 @@ private:
   std::vector<ImageAttachment> pendingAttachments;
   bool agenticMode = true;          // true = agentic (auto-loop), false = interactive review
   bool pendingAutoPreview = false;  // fire preview automatically after user accepts diff
+  std::optional<ChatMessage> pendingViewportSnapshot;  // viewport image to inject before next agentic turn
 };

--- a/src/gui/ai/ChatWidget.ui
+++ b/src/gui/ai/ChatWidget.ui
@@ -276,6 +276,19 @@
            </property>
           </spacer>
          </item>
+         <item>
+          <widget class="QCheckBox" name="agentModeCheckBox">
+           <property name="toolTip">
+            <string>Agentic mode: allow the AI to call tools in multiple automatic turns per request</string>
+           </property>
+           <property name="text">
+            <string>Agentic</string>
+           </property>
+           <property name="checked">
+            <bool>true</bool>
+           </property>
+          </widget>
+         </item>
         </layout>
        </item>
       </layout>


### PR DESCRIPTION
Adds get_viewport and set_camera AI tools and implements two AI operating modes: agentic (autonomous multi-turn: apply changes and trigger preview) and interactive review (propose changes for user acceptance; defer preview and auto-fire on accept). Introduces max_auto_turns profile parameter and getter, enforces turn caps, and updates system prompts. Chat UI: adds Agentic checkbox, handles applying vs proposing code, defers/auto-triggers previews, and logs viewport/camera actions. Preferences default for max_auto_turns is added.