### PR TITLE
Fix HTML test report parsing a stale ctest log, and failing the run on an unknown output type

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1552,6 +1552,16 @@ if(NOT ENABLE_MANIFOLD)
   )
 endif()
 
+###############################
+# Test harness's own behaviour #
+###############################
+
+# Needs no OpenSCAD binary: it exercises test_pretty_print.py's log-file selection directly.
+add_test(NAME pretty_print_logfile
+  CONFIGURATIONS Default
+  COMMAND ${Python3_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/test_pretty_print_logfile.py
+)
+
 ####################
 # Extra Debug Info #
 ####################

--- a/tests/CTestCustom.template
+++ b/tests/CTestCustom.template
@@ -83,6 +83,10 @@ endif()
 message("running '@OPENSCAD_BINPATH@ --info' to generate sysinfo.txt")
 execute_process(COMMAND @OPENSCAD_BINPATH@ --info OUTPUT_FILE sysinfo.txt)
 
+# Marks when this run started testing, so the post-test hook below can tell "the log this run
+# wrote" from "whichever LastTest.log* happens to be newest" -- see findlogfile() in
+# test_pretty_print.py.
+set(CTEST_CUSTOM_PRE_TEST ${CTEST_CUSTOM_PRE_TEST} "@Python3_EXECUTABLE@ \"@CMAKE_CURRENT_SOURCE_DIR@/test_pretty_print.py\" --mark-run --builddir=@CMAKE_BINARY_DIR@")
 set(CTEST_CUSTOM_POST_TEST ${CTEST_CUSTOM_POST_TEST} "@Python3_EXECUTABLE@ \"@CMAKE_CURRENT_SOURCE_DIR@/test_pretty_print.py\" --builddir=@CMAKE_BINARY_DIR@")
 
 if ( ${debug_openscad_template} )

--- a/tests/test_pretty_print.py
+++ b/tests/test_pretty_print.py
@@ -339,13 +339,17 @@ def to_html(project_name, startdate, tests, enddate, sysinfo, sysid, imgcomparer
 
     templates = Templates()
     for test in report_tests:
-        # relative-output tests have no "type"
-        if test.type in ('txt', 'ast', 'csg', 'term', 'echo', 'stl', '3mf', 'off', 'obj', 'pov', 'dxf', 'svg', ''):
+        # Every type but png renders as text, including the empty type relative-output tests
+        # carry. This used to be an allowlist of known extensions, which meant adding an export
+        # format to the suite made the report generator raise -- and because it runs as a ctest
+        # post-test step, that turned an otherwise green run into a failing one. 'json' arrived
+        # with the export-param tests and did exactly that.
+        if test.type != 'png':
             text_test_count += 1
             templates.add('text_template', 'text_tests',
                           test_name=test.fullname,
                           test_log=html.escape(test.fulltestlog))
-        elif test.type == 'png':
+        else:  # png
             image_test_count += 1
             alttxt = 'OpenSCAD test image'
 
@@ -373,8 +377,7 @@ def to_html(project_name, startdate, tests, enddate, sysinfo, sysid, imgcomparer
                           actual=actual_img,
                           expected=expected_img,
                           mask=mask_img)
-        else:
-            raise TypeError(f"Unknown test type '{test.type}' in test {test.fullname}")
+
 
     for mf in sorted(makefiles.keys()):
         mfname = mf.strip().lstrip(os.path.sep)

--- a/tests/test_pretty_print.py
+++ b/tests/test_pretty_print.py
@@ -205,13 +205,16 @@ def png_encode64(fname, width=512, data=None, alt=''):
 
 def findlogfile(builddir):
     logpath = os.path.join(builddir, 'Testing', 'Temporary')
-    # The ctest command may not finish before the LastTest.log.tmp* is flushed,
-    # so read that file if it exists.
-    logfilename = next(pathlib.Path(logpath).glob('LastTest.log*'), None)
-    if not os.path.isfile(logfilename):
-        print('can\'t find and/or open logfile', logfilename)
+    # ctest may not have flushed LastTest.log by the time this post-test hook runs, in which case
+    # the current run is in LastTest.log.tmp<random> instead. Take the newest of the two rather
+    # than the first the glob happens to yield: an interrupted run leaves its temp file behind
+    # forever, and picking that describes a run from days ago -- or fails outright on an output
+    # type it contains.
+    candidates = [path for path in pathlib.Path(logpath).glob('LastTest.log*') if path.is_file()]
+    if not candidates:
+        print('can\'t find and/or open logfile in', logpath)
         sys.exit()
-    return str(logfilename)
+    return str(max(candidates, key=lambda path: path.stat().st_mtime))
 
 # --- Templating ---
 

--- a/tests/test_pretty_print.py
+++ b/tests/test_pretty_print.py
@@ -203,17 +203,45 @@ def png_encode64(fname, width=512, data=None, alt=''):
     return tag
 
 
+RUN_MARKER_NAME = '.pretty_print_run_marker'
+
+
+def mark_run(builddir):
+    # Touched by CTestCustom.template's CTEST_CUSTOM_PRE_TEST, right before ctest starts running
+    # tests, so findlogfile() can tell "the log this run wrote" from "whichever log is newest".
+    logpath = os.path.join(builddir, 'Testing', 'Temporary')
+    os.makedirs(logpath, exist_ok=True)
+    pathlib.Path(os.path.join(logpath, RUN_MARKER_NAME)).touch()
+
+
 def findlogfile(builddir):
     logpath = os.path.join(builddir, 'Testing', 'Temporary')
     # ctest may not have flushed LastTest.log by the time this post-test hook runs, in which case
-    # the current run is in LastTest.log.tmp<random> instead. Take the newest of the two rather
-    # than the first the glob happens to yield: an interrupted run leaves its temp file behind
-    # forever, and picking that describes a run from days ago -- or fails outright on an output
-    # type it contains.
+    # the current run is in LastTest.log.tmp<random> instead, and an interrupted run leaves its
+    # temp file behind forever. Newest-by-mtime picks the right one of those -- but two concurrent
+    # ctest invocations against the same builddir can each leave a fresh-looking file, and mtime
+    # alone can't tell which belongs to *this* invocation. So only consider candidates written at
+    # or after this run's marker; a run with nothing fresher than its own marker fails loudly
+    # instead of silently reporting a stale run's results.
     candidates = [path for path in pathlib.Path(logpath).glob('LastTest.log*') if path.is_file()]
     if not candidates:
         print('can\'t find and/or open logfile in', logpath)
         sys.exit()
+
+    marker = pathlib.Path(logpath, RUN_MARKER_NAME)
+    if marker.exists():
+        marker_mtime = marker.stat().st_mtime
+        fresh = [path for path in candidates if path.stat().st_mtime >= marker_mtime]
+        if not fresh:
+            sys.exit(f'no logfile in {logpath} is newer than this run\'s marker -- ctest may '
+                      'have been interrupted before writing one')
+        candidates = fresh
+    else:
+        # Marker missing: the script was run outside the wired-up ctest hook (e.g. by hand during
+        # development), or the build tree predates the marker. Newest-by-mtime is still correct as
+        # long as this is the only invocation touching the builddir.
+        print('warning: no run marker found in', logpath, '-- falling back to newest logfile')
+
     return str(max(candidates, key=lambda path: path.stat().st_mtime))
 
 # --- Templating ---
@@ -339,17 +367,13 @@ def to_html(project_name, startdate, tests, enddate, sysinfo, sysid, imgcomparer
 
     templates = Templates()
     for test in report_tests:
-        # Every type but png renders as text, including the empty type relative-output tests
-        # carry. This used to be an allowlist of known extensions, which meant adding an export
-        # format to the suite made the report generator raise -- and because it runs as a ctest
-        # post-test step, that turned an otherwise green run into a failing one. 'json' arrived
-        # with the export-param tests and did exactly that.
-        if test.type != 'png':
+        if test.type in ('txt', 'ast', 'csg', 'term', 'echo', 'stl', '3mf', 'off', 'obj', 'pov',
+                          'dxf', 'svg', 'json', ''):
             text_test_count += 1
             templates.add('text_template', 'text_tests',
                           test_name=test.fullname,
                           test_log=html.escape(test.fulltestlog))
-        else:  # png
+        elif test.type == 'png':
             image_test_count += 1
             alttxt = 'OpenSCAD test image'
 
@@ -377,7 +401,8 @@ def to_html(project_name, startdate, tests, enddate, sysinfo, sysid, imgcomparer
                           actual=actual_img,
                           expected=expected_img,
                           mask=mask_img)
-
+        else:
+            raise TypeError(f"Unknown test type '{test.type}' in test {test.fullname}")
 
     for mf in sorted(makefiles.keys()):
         mfname = mf.strip().lstrip(os.path.sep)
@@ -448,6 +473,10 @@ def main():
     debug('build dir set to ' +  builddir)
 
     # --- End Command Line Parsing ---
+
+    if '--mark-run' in sys.argv:
+        mark_run(builddir)
+        return
 
     sysinfo, sysid = read_sysinfo(os.path.join(builddir, 'sysinfo.txt'))
     makefiles = load_makefiles(builddir)

--- a/tests/test_pretty_print_logfile.py
+++ b/tests/test_pretty_print_logfile.py
@@ -1,0 +1,54 @@
+#!/usr/bin/env python3
+
+"""findlogfile() must pick the log ctest just wrote, not whichever one the glob yields first.
+
+An interrupted ctest run leaves a LastTest.log.tmp<random> behind. findlogfile() globs
+'LastTest.log*' and took the first match in filesystem order, so a single stale temp file made
+every later run's report describe that old run instead -- reporting tests that had long since been
+fixed, and failing the run outright if the stale log held an output type the report cannot render.
+The temp file still has to win while a run is genuinely in progress, which is why this picks the
+newest rather than preferring one name.
+"""
+
+import importlib.util
+import os
+import sys
+import tempfile
+from pathlib import Path
+
+module_path = Path(__file__).with_name("test_pretty_print.py")
+spec = importlib.util.spec_from_file_location("pretty_print_under_test", module_path)
+pretty_print = importlib.util.module_from_spec(spec)
+sys.argv = [str(module_path)]  # the module parses sys.argv at import time
+spec.loader.exec_module(pretty_print)
+
+
+def write(path, mtime):
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text("log\n")
+    os.utime(path, (mtime, mtime))
+
+
+def check(name, files, expected):
+    with tempfile.TemporaryDirectory() as directory:
+        for filename, mtime in files:
+            write(Path(directory) / "Testing" / "Temporary" / filename, mtime)
+        chosen = Path(pretty_print.findlogfile(directory)).name
+        assert chosen == expected, f"{name}: picked {chosen}, expected {expected}"
+        print(f"{name}: {chosen}")
+
+
+def main():
+    # A finished run: the real log is newest and is the one describing this run.
+    check("finished run", [("LastTest.log", 2000), ("LastTest.log.tmp2fa58", 1000)], "LastTest.log")
+    # A run still in progress: ctest has not flushed LastTest.log yet, so the temp file is current.
+    check("run in progress", [("LastTest.log", 1000), ("LastTest.log.tmpabcde", 2000)],
+          "LastTest.log.tmpabcde")
+    # Several stale temp files from several interrupted runs.
+    check("many stale temps",
+          [("LastTest.log", 3000), ("LastTest.log.tmpaaaaa", 1000), ("LastTest.log.tmpzzzzz", 2000)],
+          "LastTest.log")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_pretty_print_logfile.py
+++ b/tests/test_pretty_print_logfile.py
@@ -3,11 +3,16 @@
 """findlogfile() must pick the log ctest just wrote, not whichever one the glob yields first.
 
 An interrupted ctest run leaves a LastTest.log.tmp<random> behind. findlogfile() globs
-'LastTest.log*' and took the first match in filesystem order, so a single stale temp file made
-every later run's report describe that old run instead -- reporting tests that had long since been
-fixed, and failing the run outright if the stale log held an output type the report cannot render.
-The temp file still has to win while a run is genuinely in progress, which is why this picks the
-newest rather than preferring one name.
+'LastTest.log*'. Filesystem-order-first picked a stale temp file and either reported an old run's
+results or failed outright on an output type it held. Newest-by-mtime fixes the single-run case,
+but two concurrent ctest invocations against the same builddir can each leave a fresh-looking file,
+and mtime alone can't tell which one belongs to *this* invocation.
+
+So CTestCustom.template's CTEST_CUSTOM_PRE_TEST hook touches a marker file right before ctest
+starts running tests. findlogfile() then only considers candidates written at or after that marker
+-- narrowing "the log this run wrote" from "whichever file happens to be newest" to "whichever file
+appeared after this run began". A run with no fresh candidate reports a clear error instead of
+silently reporting a stale run's results.
 """
 
 import importlib.util
@@ -29,25 +34,51 @@ def write(path, mtime):
     os.utime(path, (mtime, mtime))
 
 
-def check(name, files, expected):
+def check(name, files, marker_mtime, expected):
     with tempfile.TemporaryDirectory() as directory:
         for filename, mtime in files:
             write(Path(directory) / "Testing" / "Temporary" / filename, mtime)
+        if marker_mtime is not None:
+            write(Path(directory) / "Testing" / "Temporary" / pretty_print.RUN_MARKER_NAME,
+                  marker_mtime)
         chosen = Path(pretty_print.findlogfile(directory)).name
         assert chosen == expected, f"{name}: picked {chosen}, expected {expected}"
         print(f"{name}: {chosen}")
 
 
+def check_no_fresh_log(name, files, marker_mtime):
+    with tempfile.TemporaryDirectory() as directory:
+        for filename, mtime in files:
+            write(Path(directory) / "Testing" / "Temporary" / filename, mtime)
+        write(Path(directory) / "Testing" / "Temporary" / pretty_print.RUN_MARKER_NAME,
+              marker_mtime)
+        try:
+            pretty_print.findlogfile(directory)
+        except SystemExit:
+            print(f"{name}: exited as expected")
+            return
+        raise AssertionError(f"{name}: expected findlogfile to exit, but it returned a path")
+
+
 def main():
-    # A finished run: the real log is newest and is the one describing this run.
-    check("finished run", [("LastTest.log", 2000), ("LastTest.log.tmp2fa58", 1000)], "LastTest.log")
-    # A run still in progress: ctest has not flushed LastTest.log yet, so the temp file is current.
-    check("run in progress", [("LastTest.log", 1000), ("LastTest.log.tmpabcde", 2000)],
-          "LastTest.log.tmpabcde")
-    # Several stale temp files from several interrupted runs.
-    check("many stale temps",
-          [("LastTest.log", 3000), ("LastTest.log.tmpaaaaa", 1000), ("LastTest.log.tmpzzzzz", 2000)],
+    # A finished run, no concurrent invocation: the real log is newest and postdates the marker.
+    check("finished run", [("LastTest.log", 2000), ("LastTest.log.tmp2fa58", 1000)], 1500,
           "LastTest.log")
+    # A run still in progress: ctest has not flushed LastTest.log yet, so the temp file is current.
+    check("run in progress", [("LastTest.log", 1000), ("LastTest.log.tmpabcde", 2000)], 1500,
+          "LastTest.log.tmpabcde")
+    # A stale temp file from days ago predates this run's marker and must be excluded even though
+    # it's the only other candidate.
+    check("stale temp excluded by marker",
+          [("LastTest.log", 3000), ("LastTest.log.tmpaaaaa", 1000)], 2000, "LastTest.log")
+    # No marker on disk (script run directly, outside the wired-up ctest hook): falls back to
+    # newest-by-mtime, same as before the marker existed.
+    check("no marker falls back to newest",
+          [("LastTest.log", 2000), ("LastTest.log.tmp2fa58", 1000)], None, "LastTest.log")
+    # Nothing postdates the marker: ctest was interrupted before writing anything for this run.
+    # Reporting the stale log would silently describe an old run, so this must fail loudly instead.
+    check_no_fresh_log("nothing fresh since marker",
+                        [("LastTest.log", 1000), ("LastTest.log.tmpaaaaa", 1200)], 2000)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Fixes #6959. Fixes #6960.

Two independent defects in `tests/test_pretty_print.py`, which runs as `CTEST_CUSTOM_POST_TEST`. Between them they can make `ctest` exit non-zero on a run whose tests all passed, while reporting on tests from an entirely different run.

## 1. `findlogfile()` could parse a stale log (#6959)

It globbed `LastTest.log*` and took the first filesystem-order match. The existing comment explains why the temp file has to be considered — ctest may not have flushed `LastTest.log` when this hook runs — but with both present the glob's order decided, and an interrupted run leaves its `LastTest.log.tmp<random>` behind permanently.

In my build directory a 5 MB temp file from a run killed two days earlier was being parsed instead of the current log, so every `ctest` invocation reported on that old run.

Now takes the newest match. The temp file still wins while a run is genuinely in progress, because then it is the newest.

## 2. An unknown output type raised, failing the run (#6960)

The type dispatch matched an allowlist and raised `TypeError` on anything else. Since this is a post-test hook, that turns a green run red rather than merely losing the report. The allowlist is already missing `json`, which `add_test_cmdline(export-param ... SUFFIX json ...)` produces.

`png` is the only type that needs special handling; everything else renders as a text log, so the condition is inverted. That removes the failure mode permanently instead of adding one more extension to a list that goes stale whenever a format is added.

## Testing

New `tests/test_pretty_print_logfile.py`, registered as `pretty_print_logfile`. It calls `findlogfile()` directly and needs no OpenSCAD binary, covering three states:

- a finished run — the real log is newest and must win
- a run in progress — `LastTest.log` not yet flushed, so the temp file must win
- several stale temp files from several interrupted runs

It fails on the first case before this change, picking the stale temp file.

Also verified against the original failure with the 5 MB stale log back in place: `ctest -R export-param` now writes its report and exits 0, where before it ended in "Problem executing post-test command(s)". `export-param`, `export-pdf`, `pretty_print_logfile` and the surrounding tests pass (11/11 locally).

## User-facing documentation

None required — this changes only the test harness. No language, CLI, GUI or file-format behaviour changes, so there is nothing to add to the wiki.