### PR TITLE
Fix GUI test fixture paths outside the macOS bundle

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1621,7 +1621,7 @@ if(APPLE AND NOT APPLE_UNIX)
     file(COPY
          ${CMAKE_SOURCE_DIR}/tests/data/basic-ux
          ${CMAKE_SOURCE_DIR}/tests/data/modulecache-tests
-         DESTINATION ${BUNDLE_RESOURCES_DIR}/tests)
+         DESTINATION ${BUNDLE_RESOURCES_DIR}/tests/data)
   endif()
 
 elseif(MINGW)

--- a/src/guitests/TestMainWindow.cc
+++ b/src/guitests/TestMainWindow.cc
@@ -10,8 +10,7 @@ void TestMainWindow::checkOpenTabPropagateToWindow()
 {
   restoreWindowInitialState();
 
-  QString filename =
-    QString::fromStdString(PlatformUtils::resourceBasePath()) + "/tests/basic-ux/empty.scad";
+  QString filename = fixturePath("basic-ux/empty.scad");
 
   // When we open a new file,
   window->tabManager->open(filename);
@@ -19,7 +18,7 @@ void TestMainWindow::checkOpenTabPropagateToWindow()
   // The window title must also have the name of open file
   QCOMPARE(window->windowTitle(), QFileInfo(filename).fileName());
 
-  filename = QString::fromStdString(PlatformUtils::resourceBasePath()) + "/tests/basic-ux/empty2.scad";
+  filename = fixturePath("basic-ux/empty2.scad");
 
   // When we open a new file,
   window->tabManager->open(filename);
@@ -32,8 +31,7 @@ void TestMainWindow::checkSaveToShouldUpdateWindowTitle()
 {
   restoreWindowInitialState();
 
-  QString filename =
-    QString::fromStdString(PlatformUtils::resourceBasePath()) + "/tests/basic-ux/empty.scad";
+  QString filename = fixturePath("basic-ux/empty.scad");
 
   // When we open a new file,
   window->tabManager->open(filename);

--- a/src/guitests/TestModuleCache.cc
+++ b/src/guitests/TestModuleCache.cc
@@ -61,8 +61,7 @@ void TestModuleCache::testMCAD()
 {
   restoreWindowInitialState();
 
-  QString filename =
-    QString::fromStdString(PlatformUtils::resourceBasePath()) + "/tests/modulecache-tests/use-mcad.scad";
+  QString filename = fixturePath("modulecache-tests/use-mcad.scad");
   window->tabManager->open(filename);   // Open use-mcad.scad
   window->actionReloadRenderPreview();  // F5
 

--- a/src/guitests/TestTabManager.cc
+++ b/src/guitests/TestTabManager.cc
@@ -15,10 +15,8 @@ void TestTabManager::checkOpenClose()
   // The window has only one editor with file default.scad
   restoreWindowInitialState();
 
-  QString filename =
-    QString::fromStdString(PlatformUtils::resourceBasePath()) + "/tests/basic-ux/empty.scad";
-  QString filename2 =
-    QString::fromStdString(PlatformUtils::resourceBasePath()) + "/tests/basic-ux/empty2.scad";
+  QString filename = fixturePath("basic-ux/empty.scad");
+  QString filename2 = fixturePath("basic-ux/empty2.scad");
 
   window->tabManager->open(filename);
   // The active editor must have a filepath equal to the loaded file
@@ -42,8 +40,7 @@ void TestTabManager::checkReOpen()
 {
   restoreWindowInitialState();
 
-  QString filename =
-    QString::fromStdString(PlatformUtils::resourceBasePath()) + "/tests/basic-ux/empty.scad";
+  QString filename = fixturePath("basic-ux/empty.scad");
   auto numPanel = window->tabManager->count();
 
   // When we open a new file,

--- a/src/guitests/UXTest.cc
+++ b/src/guitests/UXTest.cc
@@ -4,6 +4,11 @@
 
 #include "platform/PlatformUtils.h"
 
+QString UXTest::fixturePath(const QString& relative)
+{
+  return QString::fromStdString(PlatformUtils::resourceBasePath()) + "/tests/data/" + relative;
+}
+
 void UXTest::setWindow(MainWindow *window_)
 {
   window = window_;
@@ -11,8 +16,7 @@ void UXTest::setWindow(MainWindow *window_)
 
 void UXTest::restoreWindowInitialState()
 {
-  QString filename =
-    QString::fromStdString(PlatformUtils::resourceBasePath()) + "/tests/basic-ux/default.scad";
+  QString filename = fixturePath("basic-ux/default.scad");
   window->tabManager->open(filename);
 
   while (window->tabCount > 1) {

--- a/src/guitests/UXTest.h
+++ b/src/guitests/UXTest.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <QObject>
+#include <QString>
 
 #include "gui/MainWindow.h"
 
@@ -12,6 +13,11 @@ public:
   void setWindow(MainWindow *window);
 
 protected:
+  // Test fixtures live under tests/data/ in the source tree, and are copied into
+  // Contents/Resources/tests/data/ of the macOS bundle. Both layouts are reached
+  // through resourceBasePath(), so every test must go through here.
+  static QString fixturePath(const QString& relative);
+
   void restoreWindowInitialState();
 
   MainWindow *window;


### PR DESCRIPTION
Fixes #6952.

## Problem

The GUI tests build their fixture paths as `resourceBasePath() + "/tests/<name>"`, but the fixtures
live at `tests/data/<name>` in the source tree.

On macOS this happens to work: `CMakeLists.txt` copies `tests/data/basic-ux` and
`tests/data/modulecache-tests` into `Contents/Resources/tests/`, **flattening the `data/` level**,
so the path the tests ask for exists by accident. On every other platform `resourceBasePath()`
resolves to the source root (`lookupResourcesPath()` locates the directory containing
`color-schemes`, which for a build tree is `..`), where `tests/<name>` does not exist — and the
`file(COPY ...)` that would create it sits inside the `if(APPLE)` branch, so no other platform gets
it at all.

`TestModuleCache::testMCAD` is the visible symptom, failing on Linux with
`'node->getChildren().size() != 0' returned FALSE`.

## The part that matters more than the failing test

The other GUI tests were **passing vacuously** on Linux. Opening a nonexistent file still names the
tab after the basename, so `TestMainWindow::checkOpenTabPropagateToWindow`,
`TestTabManager`'s cases, and `UXTest::restoreWindowInitialState` all completed successfully while
loading nothing at all. `testMCAD` was only ever the *loudest* case — the one that needed the file
to have content. A green GUI run on Linux before this change asserted considerably less than it
appeared to.

## Fix

- Mirror the source layout into the macOS bundle (`.../Resources/tests/data`) instead of flattening
  it, so one path convention holds on every platform.
- Route all nine call sites through a single new `UXTest::fixturePath()` helper. Nine hand-built
  duplicate paths are what let this rot unnoticed; a tenth can no longer be added wrong.

I chose this over the approach suggested in #6952 (deriving from `CMAKE_SOURCE_DIR` for build-tree
runs) because it keeps `resourceBasePath()` as the single entry point the harness already uses,
rather than introducing a platform conditional into the tests.

## Testing

`--run-all-gui-tests`, fresh builds of this branch on both platforms:

| Platform | Before | After |
| --- | --- | --- |
| Debian 12, Qt6, real X11 (`DISPLAY=:0`) | `testMCAD` FAILS | **12 passed, 0 failures** |
| macOS (arm64), Qt6, `.app` bundle | `testMCAD` passes | **12 passed, 0 failures** |

The macOS run confirms the changed bundle destination does not break the platform where these tests
already worked. `clang-format` 18.1.8 is clean over `src/guitests/`.

A full `ctest` on macOS shows 3 pre-existing failures, all SVG arc tessellation
(`export-svg*_spec-paths-arcs01`), identical on this branch and on clean master at `3da45dd56`.

---

## Wiki-ready documentation

*The following is written for the openscad.org wiki and can be pasted in unedited.*

### GUI test fixtures

Fixtures for the GUI test suite (`OpenSCAD --run-all-gui-tests`) live under `tests/data/` in the
source tree — currently `tests/data/basic-ux/` and `tests/data/modulecache-tests/`.

Tests must not build fixture paths by hand. Use the helper on the `UXTest` base class:

```cpp
QString filename = fixturePath("basic-ux/empty.scad");
```

`fixturePath()` resolves against `PlatformUtils::resourceBasePath()` and appends `tests/data/`,
which is correct in both layouts the suite runs in:

- **Build tree (Linux, Windows, and macOS non-bundle runs)** — `resourceBasePath()` is the source
  root, and the fixtures are read from `tests/data/` directly.
- **macOS `.app` bundle** — `resourceBasePath()` is `Contents/Resources`, into which CMake copies
  the fixture directories under `tests/data/`, mirroring the source layout.

When adding a new fixture directory, add it to the `file(COPY ...)` list guarded by
`if(ENABLE_GUI_TESTS)` in `CMakeLists.txt` so it reaches the macOS bundle as well.

**A caution when writing GUI tests:** opening a path that does not exist does not fail loudly.
`TabManager::open()` will still create a tab named after the basename, so assertions about window
or tab titles pass whether or not the file was found. If your test depends on the fixture's
*contents*, assert on the parsed result — not just on the title — or it may pass on a platform
where the fixture was never located.
