### PR TITLE
Make SVG arc tessellation reproducible across CPU architectures (fixes #6161)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -141,6 +141,14 @@ set_target_properties(OpenSCADLibInternal PROPERTIES
 )
 
 add_library(svg STATIC)
+# Disable floating-point contraction (fusing a*b+c into a single fma) for the SVG code.
+# arm64 has FMA in its baseline ISA and Clang fuses by default; the x86-64 baseline has no
+# FMA instruction, so the same expressions round at every step. path::arc_to() feeds its
+# results into a ceil() that picks the arc's segment count, so a sub-ulp difference there
+# changes the number of segments and hence every emitted coordinate. See #6161.
+if(NOT MSVC)
+  target_compile_options(svg PRIVATE -ffp-contract=off)
+endif()
 target_link_libraries(OpenSCADExe PUBLIC svg)
 # TODO: https://github.com/openscad/openscad/issues/6369 - Update includes so we don't need this, which also prevents trivially including other parts of OpenSCAD.
 target_include_directories(svg PUBLIC


### PR DESCRIPTION
Fixes #6161.

## Root cause

The divergence is **FMA contraction**, and the variable is CPU architecture — not OS, not CI-vs-local.

arm64 has FMA in its baseline ISA, so Clang contracts `a*b + c` into a single `fma` instruction:
one rounding step instead of two, and a different result. The x86-64 baseline has no FMA
instruction available, so the same expressions round after every multiply.

`path::arc_to()` in `src/libsvg/path.cc` is built from exactly that shape:

```cpp
double x1_ = cos_rad * dx + sin_rad * dy;
double cx  = cos_rad * cx_ - sin_rad * cy_ + (x1 + x2) / 2.0;
```

Those results propagate into `delta`, which feeds `getCircularSegmentCount(rmax, delta)` — ending
in a `ceil()` in `src/core/CurveDiscretizer.cc` — and then:

```cpp
unsigned int steps = std::max(fn, static_cast<unsigned int>((std::fabs(delta) * 10.0 / 180) + 4));
```

A sub-ulp difference on either side of an integer boundary flips `steps` by one. Every sample point
is `phi = theta + delta * a / steps`, so **one flipped integer re-samples the entire arc.** That is
why @AaronVerDow saw "two new lines have been added" rather than last-digit noise — his reading in
the issue thread was exactly right, and this is the mechanism behind it.

## Evidence

| Where | Arch | Result |
| --- | --- | --- |
| macOS CI (`macos-15-intel`) | x86_64 | passes |
| Debian 12, local | x86_64 | passes |
| macOS M1 Max, local | arm64 | fails |

Linux-vs-macOS and CI-vs-local both cut across the pass/fail line; x86-vs-ARM does not. This matches
@kintel's observation in the thread that "Intel vs. Apple Silicon is the only thing that seems to
trigger this issue."

Rebuilding **only** the `svg` target with `-ffp-contract=off`, changing nothing else, makes all four
`spec-paths-arcs01` tests pass on arm64.

## What the divergence actually is

Measured on `export-svg_spec-paths-arcs01`, expected vs arm64 actual:

```
vertex count  expected=170  actual=172  (+2)
max distance from an expected vertex to the nearest actual vertex: 0.437210 units
bounding box  identical on both axes to 4 dp
```

Worth stating precisely, because it cuts both ways:

- It is **not** a last-significant-digit rounding difference. Vertices move by up to 0.44 units on a
  model spanning ~93 × ~33 units, and there are two extra of them.
- It is **not** wrong geometry either. Both polylines are valid discretizations of the *same* ideal
  arc, sampled at different parameter values; the bounding box is unchanged and a part produced from
  either would be indistinguishable.

So the defect is **reproducibility**, not correctness: identical input produces different output
bytes depending on the CPU the binary runs on. That matters for anything hashing or diffing exported
files — build caches, "did my change alter the output?" checks, reproducible-build claims — and it
is invisible until something compares against a golden.

## Why CI never sees it

`.github/workflows/macos-tests.yml` lists `os: [macos-15-intel, macos-latest]` and then excludes
`macos-latest`:

```yaml
        exclude:
          # macos-latest runs on arm64, which has a broken SW renderer
          - os: macos-latest
```

The exclusion is for an unrelated reason, but its effect is that no arm64 macOS job ever runs. The
one configuration where this reproduces is structurally absent from CI while being present on
essentially every current Mac.

## The change

```cmake
if(NOT MSVC)
  target_compile_options(svg PRIVATE -ffp-contract=off)
endif()
```

Scoped to the `svg` target deliberately:

- It is provably sufficient — all four arc tests pass with only this.
- The affected code (`path::arc_to()`) lives in that target.
- Widening it project-wide would change FP semantics for CGAL/Manifold-adjacent code and risks new
  golden-file failures on x86, which would be an unrelated reason to reject a small fix.

The `if(NOT MSVC)` guard is because `-ffp-contract=off` is GCC/Clang spelling; MSVC does not contract
by default under `/fp:precise`.

## Testing

Full `ctest` on macOS arm64 (M1 Max), Qt6:

- **Before:** 3 failed / 2725 — the three `spec-paths-arcs01` tests, everything else passing.
- **After:** **100% tests passed out of 2758**, zero failures.

Full `ctest -j16` on Debian 12 / x86_64, Qt6, same commit: **100% passed, 0 failed out of 2759** —
confirming the flag does not shift results on the architecture that was already producing the
goldens.

## On the alternatives in #6161

The thread proposes switching these tests to export-import-to-PNG comparison, using simpler
primitives, or generating goldens from a known-good binary. Those are reasonable and — PNG
comparison especially — independently worthwhile, but they all make the *test* stop failing while
leaving the output architecture-dependent, which is the underlying defect.

If you'd rather keep the test-strategy direction @AaronVerDow started, I'm happy for this PR to be
closed and only the root-cause analysis kept in #6161. The two aren't in conflict.

## Is anything else architecture-dependent?

I checked, because it determines whether this fix should be scoped wider. I exported a corpus of
curved-geometry models to ASCII STL on both machines from the same commit with unpatched binaries,
and compared vertices order-independently (export order is not stable for minkowski/hull):

```
model                             A        B deviation    verdict
01-sphere-default              2688     2688 0            noise
02-sphere-near-boundary       17334    17334 7.11e-15     noise
03-cylinder-cone                696      696 0            noise
04-circle-2d                    696      696 0            noise
05-rotate-extrude              1308     1308 0            noise
06-linear-extrude-twist        1524     1524 8.88e-16     noise
07-offset-round                 204      204 0            noise
08-minkowski-sphere            1188     1188 1.78e-15     noise
09-hull-spheres                 552      552 0            noise
10-svg-arcs                    2028     2004 -            STRUCTURAL
```

The corpus covers `$fa`/`$fs` circle discretisation, cone tessellation, `rotate_extrude`,
`getHelixSlices` twist slices, Clipper2 rounded offset joins, and minkowski/hull over curved
inputs. **SVG arc import is the only path that diverges**, which is why this PR is scoped to the
`svg` target rather than the whole project.

Caveat: this is a detector, not a proof. Divergence only manifests when a value lands near a
rounding boundary, so a clean result is evidence rather than a guarantee.
`02-sphere-near-boundary` sweeps radii in irregular steps specifically to raise the odds of
straddling one, and still came back clean. Happy to share the harness if it would be useful.
