### PR TITLE
Rename CGALWorker to GeometryWorker

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1294,7 +1294,7 @@ set(GUI_SOURCES
   ${GUI_SOURCES}
   src/openscad_gui.cc
   src/gui/AutoUpdater.cc
-  src/gui/CGALWorker.cc
+  src/gui/GeometryWorker.cc
   src/gui/ViewportControl.cc
   src/gui/Console.cc
   src/gui/Dock.cc
@@ -1374,7 +1374,7 @@ set(GUI_HEADERS
     src/gui/Animate.h
     src/gui/AppleEvents.h
     src/gui/AutoUpdater.h
-    src/gui/CGALWorker.h
+    src/gui/GeometryWorker.h
     src/gui/Console.h
     src/gui/Dock.h
     src/gui/Editor.h

--- a/src/gui/GeometryWorker.cc
+++ b/src/gui/GeometryWorker.cc
@@ -1,4 +1,4 @@
-#include "gui/CGALWorker.h"
+#include "gui/GeometryWorker.h"
 
 #include <QThread>
 #include <exception>
@@ -18,23 +18,23 @@
 #include "python/python_public.h"
 #endif
 
-CGALWorker::CGALWorker()
+GeometryWorker::GeometryWorker()
 {
   this->tree = nullptr;
   this->thread = new QThread();
   if (this->thread->stackSize() < 1024 * 1024) this->thread->setStackSize(1024 * 1024);
-  connect(this->thread, &QThread::started, this, &CGALWorker::work);
+  connect(this->thread, &QThread::started, this, &GeometryWorker::work);
   moveToThread(this->thread);
 }
 
-CGALWorker::~CGALWorker()
+GeometryWorker::~GeometryWorker()
 {
   this->thread->quit();
   this->thread->wait();
   delete this->thread;
 }
 
-void CGALWorker::start(const Tree& tree)
+void GeometryWorker::start(const Tree& tree)
 {
 #ifdef ENABLE_PYTHON
   python_unlock();
@@ -43,7 +43,7 @@ void CGALWorker::start(const Tree& tree)
   this->thread->start();
 }
 
-void CGALWorker::work()
+void GeometryWorker::work()
 {
   // this is a worker thread: we don't want any exceptions escaping and crashing the app.
 #ifdef ENABLE_PYTHON

--- a/src/gui/GeometryWorker.h
+++ b/src/gui/GeometryWorker.h
@@ -5,13 +5,13 @@
 
 class Tree;
 
-class CGALWorker : public QObject
+class GeometryWorker : public QObject
 {
   Q_OBJECT;
 
 public:
-  CGALWorker();
-  ~CGALWorker() override;
+  GeometryWorker();
+  ~GeometryWorker() override;
 
 public slots:
   void start(const Tree& tree);
@@ -24,5 +24,5 @@ signals:
 
 protected:
   class QThread *thread;
-  const class Tree *tree;
+  const Tree *tree = nullptr;
 };

--- a/src/gui/MainWindow.cc
+++ b/src/gui/MainWindow.cc
@@ -118,7 +118,7 @@
 #include "glview/preview/CSGTreeNormalizer.h"
 #include "glview/preview/ThrownTogetherRenderer.h"
 #include "gui/AboutDialog.h"
-#include "gui/CGALWorker.h"
+#include "gui/GeometryWorker.h"
 #include "gui/ColorList.h"
 #include "gui/Dock.h"
 #include "gui/ai/AIDock.h"
@@ -612,7 +612,7 @@ void MainWindow::updateReorderMode(bool reorderMode)
 
 MainWindow::~MainWindow()
 {
-  delete this->cgalworker;
+  delete this->geometryWorker;
 }
 
 void MainWindow::closeEvent(QCloseEvent *event)
@@ -2006,7 +2006,7 @@ void MainWindow::cgalRender()
   if (!isClosing) progress_report_prep(this->rootNode, report_func, this);
   else return;
 
-  this->cgalworker->start(this->tree);
+  this->geometryWorker->start(this->tree);
 }
 
 void MainWindow::actionRenderDone(const std::shared_ptr<const Geometry>& root_geom)
@@ -3491,8 +3491,8 @@ void MainWindow::setupCoreSubsystems()
   renderCompleteSoundEffect = new QSoundEffect(this);
   renderCompleteSoundEffect->setSource(QUrl("qrc:/sounds/complete.wav"));
 
-  this->cgalworker = new CGALWorker();
-  connect(this->cgalworker, &CGALWorker::done, this, &MainWindow::actionRenderDone);
+  this->geometryWorker = new GeometryWorker();
+  connect(this->geometryWorker, &GeometryWorker::done, this, &MainWindow::actionRenderDone);
 
   autoReloadTimer = new QTimer(this);
   autoReloadTimer->setSingleShot(false);

--- a/src/gui/MainWindow.h
+++ b/src/gui/MainWindow.h
@@ -44,7 +44,7 @@ Q_IMPORT_PLUGIN(QSvgPlugin)
 #endif
 
 class BuiltinContext;
-class CGALWorker;
+class GeometryWorker;
 class CSGNode;
 class CSGProducts;
 class FontListDialog;
@@ -121,8 +121,8 @@ public:
 
   Measurement::Measurement meas;
 
-  int compileErrors;
-  int compileWarnings;
+  int compileErrors = 0;
+  int compileWarnings = 0;
 
   MainWindow(const QStringList& filenames);
   ~MainWindow() override;
@@ -458,7 +458,7 @@ private:
   bool procevents{false};
   QTemporaryFile *tempFile{nullptr};
   ProgressWidget *progresswidget{nullptr};
-  CGALWorker *cgalworker;
+  GeometryWorker *geometryWorker;
   QMutex consolemutex;
   EditorInterface *renderedEditor;  // stores pointer to editor which has been most recently rendered
   time_t includesMTime{0};          // latest include mod time


### PR DESCRIPTION
First of a short series of preparatory refactorings for process isolation, as suggested in #6977. These carry no feature flags and no behaviour change, so they can be reviewed and merged on their own merits.

`CGALWorker` has not been CGAL-specific for some time — it evaluates the tree through whichever backend is selected, and Manifold is the default — so the name now points at the wrong one. Renaming it to `GeometryWorker` also gives the boundary a backend-neutral name before anything else hooks into it.

Also initialises three members that were left indeterminate: `GeometryWorker`'s `tree` pointer, and `MainWindow`'s `compileErrors` and `compileWarnings`. Each is assigned before use today, so this changes nothing; it just stops that being something a reader has to verify.

### Scope

```
R  src/gui/CGALWorker.cc -> src/gui/GeometryWorker.cc
R  src/gui/CGALWorker.h  -> src/gui/GeometryWorker.h
M  CMakeLists.txt        (two source-list entries)
M  src/gui/MainWindow.cc (references)
M  src/gui/MainWindow.h  (references, two member initialisers)
```

`grep -rn CGALWorker src/ CMakeLists.txt` is clean.

### Testing

- `ctest -j8` on macOS: 2687/2690, the 3 failures being the known SVG arc tessellation cases (`export-svg_spec-paths-arcs01` and its fill-stroke/fill-only variants), which fail on master too.
- `./scripts/beautify.sh --check` clean with clang-format 18.1.8.
- **No test file was modified.** That was the acceptance criterion I held this to: a refactoring that needs a test's expectations changed is not behaviour-free, and would belong in the feature PR instead.

### User documentation

No user-visible surface — this is an internal rename, so there is nothing to add to the wiki.
