### PR TITLE
import() function:  Derive type from extension.  Allow explicitly specifying.  Reject unknown types.

### DIFF
--- a/src/core/builtin_functions.cc
+++ b/src/core/builtin_functions.cc
@@ -55,6 +55,7 @@
 #include "version.h"
 // hash double
 #include "geometry/linalg.h"
+#include "handle_dep.h"
 
 #if defined __WIN32__ || defined _MSC_VER
 #include <process.h>
@@ -1103,10 +1104,37 @@ Value builtin_is_object(Arguments arguments, const Location& loc)
 Value builtin_import(Arguments arguments, const Location& loc)
 {
   auto session = arguments.session();
-  const Parameters parameters = Parameters::parse(std::move(arguments), loc, {}, {"file"});
+  const Parameters parameters = Parameters::parse(std::move(arguments), loc, {}, {"file", "type"});
+  std::string type = parameters.get("type", "");
   std::string raw_filename = parameters.get("file", "");
+
   std::string file = lookup_file(raw_filename, loc.filePath().parent_path().string());
-  return import_json(file, session, loc);
+  if (!file.empty()) handle_dep(file);
+
+  if (type.empty()) {
+    // Not explicitly specified; derive the file type from its extension.
+    std::string extraw = fs::path(file).extension().generic_string();
+    std::string ext = boost::algorithm::to_lower_copy(extraw);
+    if (ext == ".json") {
+      type = "json";
+    } else if (ext.empty()) {
+      LOG(message_group::Warning, loc, arguments.documentRoot(),
+          "No file extension or type while trying to import '%1$s'", raw_filename);
+      return Value::undefined.clone();
+    } else {
+      LOG(message_group::Warning, loc, arguments.documentRoot(),
+          "Unsupported file extension '%1$s' while trying to import '%2$s'", ext, raw_filename);
+      return Value::undefined.clone();
+    }
+  }
+
+  if (type == "json") {
+    return import_json(file, session, loc);
+  } else {
+    LOG(message_group::Warning, loc, arguments.documentRoot(),
+        "Unsupported file type '%1$s' while trying to import '%2$s'", type, raw_filename);
+    return Value::undefined.clone();
+  }
 }
 
 void register_builtin_functions()

--- a/tests/data/json/data
+++ b/tests/data/json/data
@@ -1,0 +1,14 @@
+{
+	"number": 2,
+	"float": 3.5e-10,
+	"bool": true,
+	"string": "hallo world!",
+        "array_number": [ 0, 1, 2, 3, 5 ],
+	"array-string": [ "one", "two", "three" ],
+	"array-mixed": [ "one", 1, false ],
+	"object": {
+		"name": "The object name",
+		"nested": { "value": 42 },
+		"number": 4
+	}
+}

--- a/tests/data/json/data.rose
+++ b/tests/data/json/data.rose
@@ -1,0 +1,14 @@
+{
+	"number": 2,
+	"float": 3.5e-10,
+	"bool": true,
+	"string": "hallo world!",
+        "array_number": [ 0, 1, 2, 3, 5 ],
+	"array-string": [ "one", "two", "three" ],
+	"array-mixed": [ "one", 1, false ],
+	"object": {
+		"name": "The object name",
+		"nested": { "value": 42 },
+		"number": 4
+	}
+}

--- a/tests/data/scad/json/import-json.scad
+++ b/tests/data/scad/json/import-json.scad
@@ -9,3 +9,18 @@ echo(data.object.nested.value); // ECHO: 42
 
 // Test an import of a file with a non-ASCII name.
 echo(import("../../json/☠-data.json"));
+
+// Test file-type checking
+// A JSON by any other name would smell as sweet.
+// Test that an unknown extension fails.
+echo(import("../../json/data.rose"));
+// Test that an unknown extension succeeds when you explicitly specify a known type.
+echo(import("../../json/data.rose", type="json"));
+// Test that a known extension fails when you explicitly specify an unknown type.
+echo(import("../../json/data.json", type="rose"));
+
+
+// Test that a file with no extension fails.
+echo(import("../../json/data"));
+// Test that a file with no extension succeeds when you explicitly specify a known type.
+echo(import("../../json/data", type="json"));

--- a/tests/regression/echo/import-json-expected.echo
+++ b/tests/regression/echo/import-json-expected.echo
@@ -5,3 +5,11 @@ ECHO: ["one", "two", "three"]
 ECHO: "The object name"
 ECHO: 42
 ECHO: 0
+WARNING: Unsupported file extension '.rose' while trying to import '../../json/data.rose' in file import-json.scad, line 16
+ECHO: undef
+ECHO: { array-mixed = ["one", 1, false]; array-string = ["one", "two", "three"]; array_number = [0, 1, 2, 3, 5]; bool = true; float = 3.5e-10; number = 2; object = { name = "The object name"; nested = { value = 42; }; number = 4; }; string = "hallo world!"; }
+WARNING: Unsupported file type 'rose' while trying to import '../../json/data.json' in file import-json.scad, line 20
+ECHO: undef
+WARNING: No file extension or type while trying to import '../../json/data' in file import-json.scad, line 24
+ECHO: undef
+ECHO: { array-mixed = ["one", 1, false]; array-string = ["one", "two", "three"]; array_number = [0, 1, 2, 3, 5]; bool = true; float = 3.5e-10; number = 2; object = { name = "The object name"; nested = { value = 42; }; number = 4; }; string = "hallo world!"; }


### PR DESCRIPTION
Allows for future expansion into importing additional file types.

Adds a `type` parameter to the import() function.

The type of the file is the `type` specified, if any.  If none is specified, it's the file extension, if any.

If there is no type specified - neither explicitly nor as part of the file name - or if the type is unknown, it's a warning and the function returns `undef`.

JSON (type="json", extension ".json") remains the only type supported.

Fixes #6030.