### PR TITLE
Extract MainWindow::resetCompileMessageCounts()

### DIFF
--- a/src/gui/MainWindow.cc
+++ b/src/gui/MainWindow.cc
@@ -739,8 +739,7 @@ void MainWindow::compile(bool reload, bool forcedone)
     bool shouldcompiletoplevel = false;
     bool didcompile = false;
 
-    compileErrors = 0;
-    compileWarnings = 0;
+    resetCompileMessageCounts();
 
     this->renderStatistic.start();
 
@@ -929,6 +928,12 @@ void MainWindow::compileDone(bool didchange)
       }
     }
   }
+}
+
+void MainWindow::resetCompileMessageCounts()
+{
+  this->compileErrors = 0;
+  this->compileWarnings = 0;
 }
 
 void MainWindow::compileEnded()

--- a/src/gui/MainWindow.h
+++ b/src/gui/MainWindow.h
@@ -279,6 +279,7 @@ private slots:
   void instantiateRoot();
   void compileDone(bool didchange);
   void compileEnded();
+  void resetCompileMessageCounts();
 
 private slots:
   void on_editActionCopyVPT_triggered();


### PR DESCRIPTION
Second of the preparatory refactorings for process isolation suggested in #6977. No feature flag, no behaviour change.

`MainWindow` resets `compileErrors` and `compileWarnings` together at the top of `compile()`. This moves that pair into a `resetCompileMessageCounts()` method.

**Being straight about the motivation:** there is only one caller today, so this is not a saving on its own — it is preparation. When geometry evaluation moves to a separate process, the path that receives a worker's result has to reset the same counters, and extracting the pair now keeps that later change to the one line that actually needs it rather than duplicating the reset.

That is the kind of change you asked for in #6977 — *"shuffling code around to prepare the boundaries where the separate process would hook into in the next step"* — but I would rather state the single-caller point than have you find it.

### Testing

- `ctest -j8` on macOS: 2687/2690, the 3 failures being the known SVG arc tessellation cases (`export-svg_spec-paths-arcs01` and its fill-stroke/fill-only variants), which fail on master too.
- `./scripts/beautify.sh --check` clean with clang-format 18.1.8.
- No test file was modified.

### User documentation

No user-visible surface — internal refactoring, nothing to add to the wiki.
