### PR TITLE
[WIP] Always use shaders when rendering CSG

### DIFF
--- a/shaders/MouseSelector.vert
+++ b/shaders/MouseSelector.vert
@@ -1,5 +1,7 @@
 #version 120
 
+invariant gl_Position;
+
 void main() {
   gl_Position = gl_ModelViewProjectionMatrix * gl_Vertex;
 }

--- a/shaders/OpenCSG.vert
+++ b/shaders/OpenCSG.vert
@@ -1,5 +1,7 @@
 #version 120
 
+invariant gl_Position;
+
 void main() {
   gl_Position = gl_ModelViewProjectionMatrix * gl_Vertex;
 }

--- a/shaders/Preview.frag
+++ b/shaders/Preview.frag
@@ -1,0 +1,7 @@
+#version 120
+
+varying vec4 fragColor;
+
+void main(void) {
+  gl_FragColor = fragColor;
+}

--- a/shaders/Preview.vert
+++ b/shaders/Preview.vert
@@ -1,0 +1,19 @@
+#version 120
+
+invariant gl_Position;
+
+varying vec4 fragColor;
+
+void main(void) {
+  gl_Position = gl_ModelViewProjectionMatrix * gl_Vertex;
+
+  // Assumes both lights are white diffuse and material specular is zero,
+  // matching GLView's fixed-function light/material setup. If that setup
+  // ever changes this needs to be updated to match.
+  vec3 normal = normalize(gl_NormalMatrix * gl_Normal);
+  vec3 lightDir0 = normalize(vec3(gl_LightSource[0].position));
+  vec3 lightDir1 = normalize(vec3(gl_LightSource[1].position));
+  float diffuse = max(dot(normal, lightDir0), 0.0) + max(dot(normal, lightDir1), 0.0);
+
+  fragColor = vec4(gl_Color.rgb * (gl_LightModel.ambient.rgb + diffuse), gl_Color.a);
+}

--- a/shaders/ViewEdges.vert
+++ b/shaders/ViewEdges.vert
@@ -1,5 +1,7 @@
 #version 120
 
+invariant gl_Position;
+
 attribute vec3 barycentric; // barycentric form of vertex coord
                             // either [1,0,0], [0,1,0] or [0,0,1] under normal circumstances (no edges disabled)
 

--- a/src/glview/GLView.cc
+++ b/src/glview/GLView.cc
@@ -59,20 +59,21 @@ void GLView::setupShader()
         {"barycentric", glGetAttribLocation(resource.shader_program, "barycentric")},
       },
   });
+
+  preview_shader = std::make_unique<ShaderUtils::ShaderInfo>(ShaderUtils::ShaderInfo{
+    .resource = ShaderUtils::compileShaderProgram(ShaderUtils::loadShaderSource("Preview.vert"),
+                                                  ShaderUtils::loadShaderSource("Preview.frag")),
+    .type = ShaderUtils::ShaderType::NONE,
+    .uniforms = {},
+    .attributes = {},
+  });
 }
 
 void GLView::teardownShader()
 {
-  if (edge_shader == nullptr) return;  // if OpenGL context was not initialized
-  if (edge_shader->resource.shader_program) {
-    glDeleteProgram(edge_shader->resource.shader_program);
-  }
-  if (edge_shader->resource.vertex_shader) {
-    glDeleteShader(edge_shader->resource.vertex_shader);
-  }
-  if (edge_shader->resource.fragment_shader) {
-    glDeleteShader(edge_shader->resource.fragment_shader);
-  }
+  // edge_shader/preview_shader may be null if the OpenGL context was never initialized
+  if (edge_shader) ShaderUtils::deleteShaderProgram(edge_shader->resource);
+  if (preview_shader) ShaderUtils::deleteShaderProgram(preview_shader->resource);
 }
 
 void GLView::setRenderer(std::shared_ptr<Renderer> r)
@@ -210,7 +211,7 @@ void GLView::paintGL()
     OpenCSG::setContext(this->opencsg_id);
 #endif
     this->renderer->prepare(edge_shader.get());
-    this->renderer->draw(showedges, edge_shader.get());
+    this->renderer->draw(showedges, showedges ? edge_shader.get() : preview_shader.get());
   }
   Vector3d eyedir(this->modelview[2], this->modelview[6], this->modelview[10]);
   glColor3f(1, 0, 0);

--- a/src/glview/GLView.h
+++ b/src/glview/GLView.h
@@ -67,6 +67,7 @@ public:
   virtual float getDPI() { return 1.0f; }
 
   std::unique_ptr<ShaderUtils::ShaderInfo> edge_shader;
+  std::unique_ptr<ShaderUtils::ShaderInfo> preview_shader;
   std::shared_ptr<Renderer> renderer;
   const ColorScheme *colorscheme;
   Camera cam;

--- a/src/glview/ShaderUtils.cc
+++ b/src/glview/ShaderUtils.cc
@@ -90,4 +90,17 @@ ShaderResource compileShaderProgram(const std::string& vs_str, const std::string
   };
 }
 
+void deleteShaderProgram(const ShaderResource& resource)
+{
+  if (resource.shader_program) {
+    glDeleteProgram(resource.shader_program);
+  }
+  if (resource.vertex_shader) {
+    glDeleteShader(resource.vertex_shader);
+  }
+  if (resource.fragment_shader) {
+    glDeleteShader(resource.fragment_shader);
+  }
+}
+
 }  // namespace ShaderUtils

--- a/src/glview/ShaderUtils.h
+++ b/src/glview/ShaderUtils.h
@@ -28,5 +28,6 @@ struct ShaderInfo {
 
 std::string loadShaderSource(const std::string& name);
 ShaderResource compileShaderProgram(const std::string& vs_str, const std::string& fs_str);
+void deleteShaderProgram(const ShaderResource& resource);
 
 }  // namespace ShaderUtils

--- a/src/glview/preview/OpenCSGRenderer.cc
+++ b/src/glview/preview/OpenCSGRenderer.cc
@@ -117,23 +117,17 @@ void OpenCSGRenderer::prepare(const ShaderUtils::ShaderInfo *shaderinfo)
 void OpenCSGRenderer::draw(bool showedges, const ShaderUtils::ShaderInfo *shaderinfo) const
 {
 #ifdef ENABLE_OPENCSG
-  // Only use shader if select rendering or showedges
-  bool enable_shader =
-    shaderinfo && ((shaderinfo->type == ShaderUtils::ShaderType::EDGE_RENDERING && showedges) ||
-                   shaderinfo->type == ShaderUtils::ShaderType::SELECT_RENDERING);
-
   for (const auto& product : vertex_state_containers_) {
     if (product->primitives().size() > 1) {
 #if OPENCSG_VERSION >= 0x0180
-      if (enable_shader) OpenCSG::setVertexShader(opencsg_vertex_shader_code_);
-      else OpenCSG::setVertexShader({});
+      OpenCSG::setVertexShader(opencsg_vertex_shader_code_);
 #endif
       GL_CHECKD(OpenCSG::render(product->primitives()));
       GL_TRACE0("glDepthFunc(GL_EQUAL)");
       GL_CHECKD(glDepthFunc(GL_EQUAL));
     }
 
-    if (enable_shader) {
+    if (shaderinfo) {
       GL_TRACE("glUseProgram(%d)", shaderinfo->resource.shader_program);
       GL_CHECKD(glUseProgram(shaderinfo->resource.shader_program));
       VBOUtils::shader_attribs_enable(*shaderinfo);
@@ -160,7 +154,7 @@ void OpenCSGRenderer::draw(bool showedges, const ShaderUtils::ShaderInfo *shader
       }
     }
 
-    if (enable_shader) {
+    if (shaderinfo) {
       GL_TRACE0("glUseProgram(0)");
       GL_CHECKD(glUseProgram(0));
       VBOUtils::shader_attribs_disable(*shaderinfo);


### PR DESCRIPTION
This eliminates rendering bugs on certain platforms which were caused by unexpected variance due to by mixing fixed-function and shader based rendering.

Also added "invariant" declarations to shaders to the same effect.

This fix works _almost_ perfectly on my machine - if I rotate a complicated model I can sometimes see a stray pixel or two, but at least the result is much closer to what it is supposed to be.

This needs to be tested on more platforms because it seems to be driver/hardware dependent. In the long run it would be best to get rid of fixed-function pipeline usage everywhere (I didn't update the other renderers as they weren't affected). There should be no reason to not use shaders anymore.

Fixes #6957 on my machine at least.