### PR TITLE
Avoid aborting when parser path canonicalization fails

### DIFF
--- a/src/core/parsersettings.cc
+++ b/src/core/parsersettings.cc
@@ -89,7 +89,12 @@ inline fs::path find_valid_path_(const fs::path& sourcepath, const fs::path& loc
   if (localpath.is_absolute()) {
     if (check_valid(localpath, openfilenames)) {
 #ifndef __EMSCRIPTEN__
-      return fs::canonical(localpath);
+      try {
+        return fs::canonical(localpath);
+      } catch (const fs::filesystem_error&) {
+        // Canonicalization is best effort; the original path was already validated.
+        return localpath;
+      }
 #else
       return localpath;
 #endif
@@ -97,7 +102,13 @@ inline fs::path find_valid_path_(const fs::path& sourcepath, const fs::path& loc
   } else {
     fs::path fpath = sourcepath / localpath;
 #ifndef __EMSCRIPTEN__
-    if (fs::exists(fpath)) fpath = fs::canonical(fpath);
+    if (fs::exists(fpath)) {
+      try {
+        fpath = fs::canonical(fpath);
+      } catch (const fs::filesystem_error&) {
+        // Keep the existing path if the platform cannot canonicalize it.
+      }
+    }
 #endif
     if (check_valid(fpath, openfilenames)) return fpath;
     fpath = search_libs(localpath);


### PR DESCRIPTION
## Summary

- catch filesystem errors at the parser path canonicalization sites
- retain the already validated path when canonicalization is unavailable
- keep the workaround local to include/use resolution

## Rationale

Some Windows `std::filesystem` implementations can reject paths that have already passed existence checks. The throwing `canonical()` overload then terminates OpenSCAD instead of allowing the readable path to be used.

This defensively addresses the canonicalization crash reported in #5425. It does not claim complete MinGW UNC support; other operations such as UNC current-directory handling and library discovery remain outside this patch.

## Testing

Not built locally; this worktree has no configured build directory. The change is intentionally limited to `src/core/parsersettings.cc` and will be exercised by CI.