### PR TITLE
Fix use-after-free when a MainWindow is destroyed

### DIFF
--- a/src/gui/MainWindow.cc
+++ b/src/gui/MainWindow.cc
@@ -612,6 +612,17 @@ void MainWindow::updateReorderMode(bool reorderMode)
 
 MainWindow::~MainWindow()
 {
+  // The QWidget destructor deletes our child docks, and deleting a QDockWidget
+  // reparents and hides it, which emits Dock::visibilityChanged and sends hide
+  // events through our event filter. Qt only severs connections in ~QObject,
+  // which runs last, so those slots would re-enter this MainWindow after its
+  // own members (exportMap, activeEditor, rubberBandManager, ...) have already
+  // been destroyed. Sever the links here, while the object is still whole.
+  for (auto& [dock, title] : docks) {
+    dock->disconnect(this);
+    dock->removeEventFilter(this);
+  }
+
   delete this->geometryWorker;
 }
 


### PR DESCRIPTION
### Problem

Closing a window can segfault during teardown. Two crash reports with this
stack (macOS 26/27, arm64, Qt 6):

```
MainWindow::~MainWindow
  QWidget::~QWidget -> QObjectPrivate::deleteChildren
    Dock::~Dock -> QDockWidget::~QDockWidget
      QWidget::setParent -> QWidgetPrivate::hide_helper
        visibilityChanged -> MainWindow::onEditorDockVisibilityChanged
          MainWindow::updateExportActions
            MainWindow::formatIdentifierToAction
              exportMap.find()          <-- EXC_BAD_ACCESS, already destroyed
```

The docks are children of the `MainWindow`, so `~QWidget` deletes them, and
deleting a `QDockWidget` reparents and hides it — which emits
`visibilityChanged` and pushes hide events through the window's event filter.
Both re-enter `MainWindow` after its members are gone: C++ destroys members
immediately after the `~MainWindow` body, whereas Qt only severs connections
in `~QObject`, which runs last.

Three dead objects get touched on that path:

- `exportMap` — `onEditorDockVisibilityChanged` → `updateExportActions` →
  `formatIdentifierToAction` (the actual fault)
- `activeEditor` — `onEditorDockVisibilityChanged` dereferences it directly
- `rubberBandManager` — read by `MainWindow::eventFilter`

### Fix

Disconnect the docks and remove the event filter in the destructor body,
while the object is still whole.

### Verification

Reduced to a standalone ~90-line Qt program (no OpenSCAD code) that mirrors
the topology: a `QDockWidget` child, a value member read from the
`visibilityChanged` slot, an event filter on the dock, and `WA_DeleteOnClose`.
Built with AddressSanitizer, it faults with a frame-for-frame match of the
report above; compiling in the two lines from this PR makes it pass.

```
ERROR: AddressSanitizer: SEGV on unknown address 0x000000000018
  #0  std::__hash_table<...>::find<int>(int const&)
  #2  Window::onEditorDockVisibilityChanged(bool)
  #9  QDockWidget::event(QEvent*)
  #13 QWidgetPrivate::hide_helper()
  #17 QDockWidget::~QDockWidget()
  #18 QObjectPrivate::deleteChildren()
  #19 QWidget::~QWidget()
  #20 Window::~Window()
  #23 QObject::event(QEvent*)      [DeferredDelete]
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)