### PR TITLE
Update German translation

### DIFF
--- a/locale/de.po
+++ b/locale/de.po
@@ -9,16 +9,16 @@ msgstr ""
 "Project-Id-Version: OpenSCAD 2014.01.05\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2026-01-13 22:53+0100\n"
-"PO-Revision-Date: 2021-12-04 20:17+0100\n"
+"PO-Revision-Date: 2026-09-02 14:00+0200\n"
 "Last-Translator: Torsten Paul <Torsten.Paul@gmx.de>\n"
 "Language-Team: German\n"
 "Language: de\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
 "X-Generator: Poedit 3.0\n"
 "X-Poedit-SourceCharset: UTF-8\n"
-"Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_AboutDialog.h:102
 #: src/gui/AboutDialog.h:17
@@ -29,23 +29,15 @@ msgstr "Über OpenSCAD"
 #: build/OpenSCADLibInternal_autogen/include/ui_LaunchingScreen.h:304
 msgid ""
 "<html><head/><body>\n"
-"<p style=\"font-family: 'Open Sans', 'Droid Sans', 'sans-serif'; font-"
-"weight: bold; padding-bottom: 0; margin-bottom: 0; font-size: 22pt;\"><span "
-"style=\"color: green;\">Open</span>SCAD</p>\n"
-"<p style=\"font-family: 'Open Sans', 'Droid Sans', 'sans-serif'; font-"
-"weight: normal; font-size: 14pt; padding-top: 0; margin-top: 0; margin-left: "
-"2em;\">The Programmers Solid 3D CAD Modeller</p>\n"
+"<p style=\"font-family: 'Open Sans', 'Droid Sans', 'sans-serif'; font-weight: bold; padding-bottom: 0; margin-bottom: 0; font-size: 22pt;\"><span style=\"color: green;\">Open</span>SCAD</p>\n"
+"<p style=\"font-family: 'Open Sans', 'Droid Sans', 'sans-serif'; font-weight: normal; font-size: 14pt; padding-top: 0; margin-top: 0; margin-left: 2em;\">The Programmers Solid 3D CAD Modeller</p>\n"
 "</body></html>\n"
 "\n"
 "\n"
 msgstr ""
 "<html><head/><body>\n"
-"<p style=\"font-family: 'Open Sans', 'Droid Sans', 'sans-serif'; font-"
-"weight: bold; padding-bottom: 0; margin-bottom: 0; font-size: 22pt;\"><span "
-"style=\"color: green;\">Open</span>SCAD</p>\n"
-"<p style=\"font-family: 'Open Sans', 'Droid Sans', 'sans-serif'; font-"
-"weight: normal; font-size: 14pt; padding-top: 0; margin-top: 0; margin-left: "
-"2em;\">The Programmers Solid 3D CAD Modeller</p>\n"
+"<p style=\"font-family: 'Open Sans', 'Droid Sans', 'sans-serif'; font-weight: bold; padding-bottom: 0; margin-bottom: 0; font-size: 22pt;\"><span style=\"color: green;\">Open</span>SCAD</p>\n"
+"<p style=\"font-family: 'Open Sans', 'Droid Sans', 'sans-serif'; font-weight: normal; font-size: 14pt; padding-top: 0; margin-top: 0; margin-left: 2em;\">The Programmers Solid 3D CAD Modeller</p>\n"
 "</body></html>\n"
 "\n"
 "\n"
@@ -67,27 +59,27 @@ msgstr "Animation"
 #: build/OpenSCADLibInternal_autogen/include/ui_Animate.h:257
 #: build/OpenSCADLibInternal_autogen/include/ui_Animate.h:259
 msgid "Toggle animation pause/unpause"
-msgstr ""
+msgstr "Wiedergabe anhalten bzw. fortsetzen"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_Animate.h:261
 #: build/OpenSCADLibInternal_autogen/include/ui_Animate.h:263
 msgid "Move to beginning (first frame)"
-msgstr ""
+msgstr "An den Anfang springen (erstes Bild)"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_Animate.h:265
 #: build/OpenSCADLibInternal_autogen/include/ui_Animate.h:267
 msgid "Step one frame back"
-msgstr ""
+msgstr "Ein Bild zurück"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_Animate.h:269
 #: build/OpenSCADLibInternal_autogen/include/ui_Animate.h:271
 msgid "Step one frame forward"
-msgstr ""
+msgstr "Ein Bild vor"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_Animate.h:273
 #: build/OpenSCADLibInternal_autogen/include/ui_Animate.h:275
 msgid "Move to end (last frame)"
-msgstr ""
+msgstr "An das Ende springen (letztes Bild)"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_Animate.h:278
 msgid "Time:"
@@ -212,7 +204,7 @@ msgstr "Z"
 #: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:889
 #: build/OpenSCADLibInternal_autogen/include/ui_ViewportControl.h:280
 msgid "Translation"
-msgstr "Translation"
+msgstr "Verschiebung"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:890
 msgid "ViewPort rel.<br/>Translation"
@@ -272,9 +264,8 @@ msgid "Update"
 msgstr "Aktualisieren"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:363
-#, fuzzy
 msgid "Button 19"
-msgstr "Knopf 1"
+msgstr "Knopf 19"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:364
 msgid "Button 5"
@@ -289,28 +280,24 @@ msgid "Button 7"
 msgstr "Knopf 7"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:367
-#, fuzzy
 msgid "Button 16"
-msgstr "Knopf 1"
+msgstr "Knopf 16"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:368
-#, fuzzy
 msgid "Button 20"
-msgstr "Knopf 2"
+msgstr "Knopf 20"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:369
 msgid "Button 1"
 msgstr "Knopf 1"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:370
-#, fuzzy
 msgid "Button 21"
-msgstr "Knopf 2"
+msgstr "Knopf 21"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:371
-#, fuzzy
 msgid "Button 18"
-msgstr "Knopf 1"
+msgstr "Knopf 18"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:372
 msgid "Button 0"
@@ -345,9 +332,8 @@ msgid "Button 3"
 msgstr "Knopf 3"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:380
-#, fuzzy
 msgid "Button 23"
-msgstr "Knopf 2"
+msgstr "Knopf 23"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:381
 msgid "Button 9"
@@ -366,50 +352,43 @@ msgid "Button 12"
 msgstr "Knopf 12"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:385
-#, fuzzy
 msgid "Button 17"
-msgstr "Knopf 1"
+msgstr "Knopf 17"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:386
-#, fuzzy
 msgid "Button 22"
-msgstr "Knopf 2"
+msgstr "Knopf 22"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_ColorList.h:399
-#, fuzzy
 msgid "Color List"
-msgstr "Farbschema:"
+msgstr "Farbliste"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_ColorList.h:400
 #: build/OpenSCADLibInternal_autogen/include/ui_ColorList.h:402
 #: build/OpenSCADLibInternal_autogen/include/ui_ColorList.h:404
 #: build/OpenSCADLibInternal_autogen/include/ui_ColorList.h:406
-#, fuzzy
 msgid "Reset Sample Text"
-msgstr "Axen&einteilung anzeigen"
+msgstr "Beispieltext zurücksetzen"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_ColorList.h:408
 #: build/OpenSCADLibInternal_autogen/include/ui_ColorList.h:410
-#, fuzzy
 msgid "Copy Color Name"
-msgstr "Font"
+msgstr "Farbnamen kopieren"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_ColorList.h:412
 #: build/OpenSCADLibInternal_autogen/include/ui_ColorList.h:414
 msgid "Copy Color RGB"
-msgstr ""
+msgstr "RGB-Wert kopieren"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_ColorList.h:416
 #: build/OpenSCADLibInternal_autogen/include/ui_FontList.h:305
-#, fuzzy
 msgid "Filter"
-msgstr "Filter:"
+msgstr "Filter"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_ColorList.h:417
 #: build/OpenSCADLibInternal_autogen/include/ui_ColorList.h:446
-#, fuzzy
 msgid "Color name"
-msgstr "Farbschema:"
+msgstr "Farbname"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_ColorList.h:418
 #: build/OpenSCADLibInternal_autogen/include/ui_FontList.h:309
@@ -421,53 +400,52 @@ msgstr "Fest"
 #: build/OpenSCADLibInternal_autogen/include/ui_ColorList.h:419
 #: build/OpenSCADLibInternal_autogen/include/ui_FontList.h:310
 msgid "Wildcard"
-msgstr ""
+msgstr "Platzhalter"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_ColorList.h:420
 #: build/OpenSCADLibInternal_autogen/include/ui_FontList.h:311
 msgid "RegExp"
-msgstr ""
+msgstr "Regulärer Ausdruck"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_ColorList.h:422
-#, fuzzy
 msgid "Sort order"
-msgstr "Rand"
+msgstr "Sortierung"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_ColorList.h:423
 msgid "Ascending"
-msgstr ""
+msgstr "Aufsteigend"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_ColorList.h:424
 msgid "Descending"
-msgstr ""
+msgstr "Absteigend"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_ColorList.h:425
 msgid "Alphabetically"
-msgstr ""
+msgstr "Alphabetisch"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_ColorList.h:426
-#, fuzzy
 msgid "By color"
-msgstr "Farbschema:"
+msgstr "Nach Farbe"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_ColorList.h:427
 msgid "By color warmth"
-msgstr ""
+msgstr "Nach Farbtemperatur"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_ColorList.h:428
 msgid "By lightness"
-msgstr ""
+msgstr "Nach Helligkeit"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_ColorList.h:430
 #: build/OpenSCADLibInternal_autogen/include/ui_FontList.h:316
-#, fuzzy
 msgid "Selection"
-msgstr "Aktion"
+msgstr "Auswahl"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_ColorList.h:433
 msgid "Reset background color"
-msgstr ""
+msgstr "Hintergrundfarbe zurücksetzen"
 
+#. Interner Wert bzw. Tastenkuerzel - nicht uebersetzen. Ein leerer msgstr
+#. laesst gettext den Originaltext zurueckgeben.
 #: build/OpenSCADLibInternal_autogen/include/ui_ColorList.h:435
 #: build/OpenSCADLibInternal_autogen/include/ui_ColorList.h:439
 #: build/OpenSCADLibInternal_autogen/include/ui_ColorList.h:451
@@ -492,41 +470,45 @@ msgstr ""
 
 #: build/OpenSCADLibInternal_autogen/include/ui_ColorList.h:437
 msgid "Select background color"
-msgstr ""
+msgstr "Hintergrundfarbe wählen"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_ColorList.h:440
-#, fuzzy
 msgid "Color RGB"
-msgstr "Farbschema:"
+msgstr "RGB-Wert"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_ColorList.h:441
 msgid "As Foreground"
-msgstr ""
+msgstr "Als Vordergrund"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_ColorList.h:442
-#, fuzzy
 msgid "As Background"
-msgstr "Für dunklen Hintergrund"
+msgstr "Als Hintergrund"
 
+#. Interner Wert bzw. Tastenkuerzel - nicht uebersetzen. Ein leerer msgstr
+#. laesst gettext den Originaltext zurueckgeben.
 #: build/OpenSCADLibInternal_autogen/include/ui_ColorList.h:443
 msgid "R:"
 msgstr ""
 
+#. Interner Wert bzw. Tastenkuerzel - nicht uebersetzen. Ein leerer msgstr
+#. laesst gettext den Originaltext zurueckgeben.
 #: build/OpenSCADLibInternal_autogen/include/ui_ColorList.h:444
 msgid "G:"
 msgstr ""
 
+#. Interner Wert bzw. Tastenkuerzel - nicht uebersetzen. Ein leerer msgstr
+#. laesst gettext den Originaltext zurueckgeben.
 #: build/OpenSCADLibInternal_autogen/include/ui_ColorList.h:445
 msgid "B:"
 msgstr ""
 
 #: build/OpenSCADLibInternal_autogen/include/ui_ColorList.h:449
 msgid "Reset foreground color"
-msgstr ""
+msgstr "Vordergrundfarbe zurücksetzen"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_ColorList.h:453
 msgid "Select foreground color"
-msgstr ""
+msgstr "Vordergrundfarbe wählen"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_Console.h:42
 msgid "Clear"
@@ -560,7 +542,7 @@ msgstr "Return"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_ErrorLog.h:98
 msgid "double click to jump to file and line"
-msgstr ""
+msgstr "Doppelklick springt zu Datei und Zeile"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_ErrorLog.h:100
 msgid "&Show"
@@ -601,9 +583,8 @@ msgid "DEPRECATED"
 msgstr "DEPRECATED"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_Export3mfDialog.h:448
-#, fuzzy
 msgid "Export 3MF Options"
-msgstr "Export Features"
+msgstr "3MF-Exporteinstellungen"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_Export3mfDialog.h:450
 #: build/OpenSCADLibInternal_autogen/include/ui_ExportPdfDialog.h:543
@@ -613,21 +594,25 @@ msgstr ""
 
 #: build/OpenSCADLibInternal_autogen/include/ui_Export3mfDialog.h:452
 msgid "Unit"
-msgstr ""
+msgstr "Einheit"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_Export3mfDialog.h:453
 #: src/core/Settings.cc:431
 msgid "Micron"
-msgstr ""
+msgstr "Mikrometer"
 
+#. Interner Wert bzw. Tastenkuerzel - nicht uebersetzen. Ein leerer msgstr
+#. laesst gettext den Originaltext zurueckgeben.
 #: build/OpenSCADLibInternal_autogen/include/ui_Export3mfDialog.h:454
 msgid "micron"
 msgstr ""
 
 #: build/OpenSCADLibInternal_autogen/include/ui_Export3mfDialog.h:455
 msgid "Millimeter (default)"
-msgstr ""
+msgstr "Millimeter (Vorgabe)"
 
+#. Interner Wert bzw. Tastenkuerzel - nicht uebersetzen. Ein leerer msgstr
+#. laesst gettext den Originaltext zurueckgeben.
 #: build/OpenSCADLibInternal_autogen/include/ui_Export3mfDialog.h:456
 msgid "millimeter"
 msgstr ""
@@ -635,8 +620,10 @@ msgstr ""
 #: build/OpenSCADLibInternal_autogen/include/ui_Export3mfDialog.h:457
 #: src/core/Settings.cc:433
 msgid "Centimeter"
-msgstr ""
+msgstr "Zentimeter"
 
+#. Interner Wert bzw. Tastenkuerzel - nicht uebersetzen. Ein leerer msgstr
+#. laesst gettext den Originaltext zurueckgeben.
 #: build/OpenSCADLibInternal_autogen/include/ui_Export3mfDialog.h:458
 msgid "centimeter"
 msgstr ""
@@ -644,39 +631,45 @@ msgstr ""
 #: build/OpenSCADLibInternal_autogen/include/ui_Export3mfDialog.h:459
 #: src/core/Settings.cc:434
 msgid "Meter"
-msgstr ""
+msgstr "Meter"
 
+#. Interner Wert bzw. Tastenkuerzel - nicht uebersetzen. Ein leerer msgstr
+#. laesst gettext den Originaltext zurueckgeben.
 #: build/OpenSCADLibInternal_autogen/include/ui_Export3mfDialog.h:460
-#, fuzzy
 msgid "meter"
-msgstr "Parameter"
+msgstr ""
 
 #: build/OpenSCADLibInternal_autogen/include/ui_Export3mfDialog.h:461
 #: src/core/Settings.cc:435
 msgid "Inch"
-msgstr ""
+msgstr "Zoll"
 
+#. Interner Wert bzw. Tastenkuerzel - nicht uebersetzen. Ein leerer msgstr
+#. laesst gettext den Originaltext zurueckgeben.
 #: build/OpenSCADLibInternal_autogen/include/ui_Export3mfDialog.h:462
 msgid "inch"
 msgstr ""
 
 #: build/OpenSCADLibInternal_autogen/include/ui_Export3mfDialog.h:463
 msgid "Foot"
-msgstr ""
+msgstr "Fuß"
 
+#. Interner Wert bzw. Tastenkuerzel - nicht uebersetzen. Ein leerer msgstr
+#. laesst gettext den Originaltext zurueckgeben.
 #: build/OpenSCADLibInternal_autogen/include/ui_Export3mfDialog.h:464
 msgid "foot"
 msgstr ""
 
 #: build/OpenSCADLibInternal_autogen/include/ui_Export3mfDialog.h:468
-#, fuzzy
 msgid "Colors"
-msgstr "Farbschema:"
+msgstr "Farben"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_Export3mfDialog.h:469
 msgid "Use colors from model and color scheme"
-msgstr ""
+msgstr "Farben aus Modell und Farbschema verwenden"
 
+#. Interner Wert bzw. Tastenkuerzel - nicht uebersetzen. Ein leerer msgstr
+#. laesst gettext den Originaltext zurueckgeben.
 #: build/OpenSCADLibInternal_autogen/include/ui_Export3mfDialog.h:470
 msgid "model"
 msgstr ""
@@ -684,16 +677,20 @@ msgstr ""
 #: build/OpenSCADLibInternal_autogen/include/ui_Export3mfDialog.h:471
 #: src/core/Settings.cc:424
 msgid "No colors"
-msgstr ""
+msgstr "Keine Farben"
 
+#. Interner Wert bzw. Tastenkuerzel - nicht uebersetzen. Ein leerer msgstr
+#. laesst gettext den Originaltext zurueckgeben.
 #: build/OpenSCADLibInternal_autogen/include/ui_Export3mfDialog.h:472
 msgid "none"
 msgstr ""
 
 #: build/OpenSCADLibInternal_autogen/include/ui_Export3mfDialog.h:473
 msgid "Use selected color for all objects"
-msgstr ""
+msgstr "Gewählte Farbe für alle Objekte verwenden"
 
+#. Interner Wert bzw. Tastenkuerzel - nicht uebersetzen. Ein leerer msgstr
+#. laesst gettext den Originaltext zurueckgeben.
 #: build/OpenSCADLibInternal_autogen/include/ui_Export3mfDialog.h:474
 msgid "selected-only"
 msgstr ""
@@ -701,27 +698,29 @@ msgstr ""
 #: build/OpenSCADLibInternal_autogen/include/ui_Export3mfDialog.h:478
 #: build/OpenSCADLibInternal_autogen/include/ui_ExportPdfDialog.h:561
 msgid "Meta data"
-msgstr ""
+msgstr "Metadaten"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_Export3mfDialog.h:479
 msgid ""
 "The fields Title, Application and CreationDate are always filled in the "
 "exported file when meta data is enabled."
 msgstr ""
+"Die Felder Title, Application und CreationDate werden in der Exportdatei "
+"immer ausgefüllt, wenn Metadaten aktiviert sind."
 
 #: build/OpenSCADLibInternal_autogen/include/ui_Export3mfDialog.h:481
 #: build/OpenSCADLibInternal_autogen/include/ui_ExportPdfDialog.h:570
 msgid "A copyright associated with this document"
-msgstr ""
+msgstr "Ein mit diesem Dokument verbundener Urheberrechtsvermerk"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_Export3mfDialog.h:483
 msgid "Copyright"
-msgstr ""
+msgstr "Urheberrecht"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_Export3mfDialog.h:484
 #: build/OpenSCADLibInternal_autogen/include/ui_ExportPdfDialog.h:567
 msgid "Title, leave empty to use the file name"
-msgstr ""
+msgstr "Titel; leer lassen, um den Dateinamen zu verwenden"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_Export3mfDialog.h:485
 #: build/OpenSCADLibInternal_autogen/include/ui_ParameterDescriptionWidget.h:101
@@ -730,58 +729,56 @@ msgid "Description"
 msgstr "Beschreibung"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_Export3mfDialog.h:486
-#, fuzzy
 msgid "Designer"
-msgstr "D&esign"
+msgstr "Gestalter"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_Export3mfDialog.h:487
 msgid "License terms"
-msgstr ""
+msgstr "Lizenzbedingungen"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_Export3mfDialog.h:489
 msgid "An industry rating associated with this document"
-msgstr ""
+msgstr "Eine mit diesem Dokument verbundene Branchenbewertung"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_Export3mfDialog.h:494
 #: build/OpenSCADLibInternal_autogen/include/ui_ExportPdfDialog.h:574
 msgid "A name for a designer of this document"
-msgstr ""
+msgstr "Name einer Gestalterin oder eines Gestalters dieses Dokuments"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_Export3mfDialog.h:498
 msgid "Rating"
-msgstr ""
+msgstr "Bewertung"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_Export3mfDialog.h:500
 msgid "License information associated with this document"
-msgstr ""
+msgstr "Mit diesem Dokument verbundene Lizenzangaben"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_Export3mfDialog.h:504
 #: build/OpenSCADLibInternal_autogen/include/ui_ExportPdfDialog.h:564
 msgid "A description of the document"
-msgstr ""
+msgstr "Eine Beschreibung des Dokuments"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_Export3mfDialog.h:507
-#, fuzzy
 msgid "Format"
-msgstr "Form"
+msgstr "Format"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_Export3mfDialog.h:508
 msgid "Decimal precision"
-msgstr ""
+msgstr "Nachkommastellen"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_Export3mfDialog.h:509
 msgid "Export colors as"
-msgstr ""
+msgstr "Farben exportieren als"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_Export3mfDialog.h:511
 msgid "Reset value to the default decimal precision value."
-msgstr ""
+msgstr "Wert auf die vorgegebene Anzahl Nachkommastellen zurücksetzen."
 
 #: build/OpenSCADLibInternal_autogen/include/ui_Export3mfDialog.h:514
 #: build/OpenSCADLibInternal_autogen/include/ui_ExportPdfDialog.h:632
 #: build/OpenSCADLibInternal_autogen/include/ui_PrintInitDialog.h:184
 msgid "Always show dialog"
-msgstr ""
+msgstr "Dialog immer anzeigen"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_Export3mfDialog.h:515
 #: build/OpenSCADLibInternal_autogen/include/ui_ExportPdfDialog.h:633
@@ -792,20 +789,20 @@ msgid "Cancel"
 msgstr "Abbrechen"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_ExportPdfDialog.h:541
-#, fuzzy
 msgid "Export PDF Options"
-msgstr "Export Features"
+msgstr "PDF-Exporteinstellungen"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_ExportPdfDialog.h:545
-#, fuzzy
 msgid "Page Size"
-msgstr "Schrittgröße"
+msgstr "Seitengröße"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_ExportPdfDialog.h:546
 #: src/core/Settings.cc:376
 msgid "A6 (105 x 148 mm)"
-msgstr ""
+msgstr "A6 (105 × 148 mm)"
 
+#. Interner Wert bzw. Tastenkuerzel - nicht uebersetzen. Ein leerer msgstr
+#. laesst gettext den Originaltext zurueckgeben.
 #: build/OpenSCADLibInternal_autogen/include/ui_ExportPdfDialog.h:547
 msgid "a6"
 msgstr ""
@@ -813,8 +810,10 @@ msgstr ""
 #: build/OpenSCADLibInternal_autogen/include/ui_ExportPdfDialog.h:548
 #: src/core/Settings.cc:377
 msgid "A5 (148 x 210 mm)"
-msgstr ""
+msgstr "A5 (148 × 210 mm)"
 
+#. Interner Wert bzw. Tastenkuerzel - nicht uebersetzen. Ein leerer msgstr
+#. laesst gettext den Originaltext zurueckgeben.
 #: build/OpenSCADLibInternal_autogen/include/ui_ExportPdfDialog.h:549
 msgid "a5"
 msgstr ""
@@ -822,8 +821,10 @@ msgstr ""
 #: build/OpenSCADLibInternal_autogen/include/ui_ExportPdfDialog.h:550
 #: src/core/Settings.cc:378
 msgid "A4 (210x297 mm)"
-msgstr ""
+msgstr "A4 (210 × 297 mm)"
 
+#. Interner Wert bzw. Tastenkuerzel - nicht uebersetzen. Ein leerer msgstr
+#. laesst gettext den Originaltext zurueckgeben.
 #: build/OpenSCADLibInternal_autogen/include/ui_ExportPdfDialog.h:551
 msgid "a4"
 msgstr ""
@@ -831,8 +832,10 @@ msgstr ""
 #: build/OpenSCADLibInternal_autogen/include/ui_ExportPdfDialog.h:552
 #: src/core/Settings.cc:379
 msgid "A3 (297x420 mm)"
-msgstr ""
+msgstr "A3 (297 × 420 mm)"
 
+#. Interner Wert bzw. Tastenkuerzel - nicht uebersetzen. Ein leerer msgstr
+#. laesst gettext den Originaltext zurueckgeben.
 #: build/OpenSCADLibInternal_autogen/include/ui_ExportPdfDialog.h:553
 msgid "a3"
 msgstr ""
@@ -840,8 +843,10 @@ msgstr ""
 #: build/OpenSCADLibInternal_autogen/include/ui_ExportPdfDialog.h:554
 #: src/core/Settings.cc:380
 msgid "Letter (8.5x11 in)"
-msgstr ""
+msgstr "Letter (8,5 × 11 Zoll)"
 
+#. Interner Wert bzw. Tastenkuerzel - nicht uebersetzen. Ein leerer msgstr
+#. laesst gettext den Originaltext zurueckgeben.
 #: build/OpenSCADLibInternal_autogen/include/ui_ExportPdfDialog.h:555
 msgid "letter"
 msgstr ""
@@ -849,8 +854,10 @@ msgstr ""
 #: build/OpenSCADLibInternal_autogen/include/ui_ExportPdfDialog.h:556
 #: src/core/Settings.cc:381
 msgid "Legal (8.5x14 in)"
-msgstr ""
+msgstr "Legal (8,5 × 14 Zoll)"
 
+#. Interner Wert bzw. Tastenkuerzel - nicht uebersetzen. Ein leerer msgstr
+#. laesst gettext den Originaltext zurueckgeben.
 #: build/OpenSCADLibInternal_autogen/include/ui_ExportPdfDialog.h:557
 msgid "legal"
 msgstr ""
@@ -858,8 +865,10 @@ msgstr ""
 #: build/OpenSCADLibInternal_autogen/include/ui_ExportPdfDialog.h:558
 #: src/core/Settings.cc:382
 msgid "Tabloid (11x17 in)"
-msgstr ""
+msgstr "Tabloid (11 × 17 Zoll)"
 
+#. Interner Wert bzw. Tastenkuerzel - nicht uebersetzen. Ein leerer msgstr
+#. laesst gettext den Originaltext zurueckgeben.
 #: build/OpenSCADLibInternal_autogen/include/ui_ExportPdfDialog.h:560
 msgid "tabloid"
 msgstr ""
@@ -869,40 +878,43 @@ msgid ""
 "The fields Title, Creator and CreateDate are always filled in the exported "
 "file when meta data is enabled."
 msgstr ""
+"Die Felder Title, Creator und CreateDate werden in der Exportdatei immer "
+"ausgefüllt, wenn Metadaten aktiviert sind."
 
 #: build/OpenSCADLibInternal_autogen/include/ui_ExportPdfDialog.h:568
 msgid "Subject"
-msgstr ""
+msgstr "Thema"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_ExportPdfDialog.h:572
 msgid "Keywords"
-msgstr ""
+msgstr "Schlagwörter"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_ExportPdfDialog.h:577
 msgid "Author"
-msgstr ""
+msgstr "Verfasser"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_ExportPdfDialog.h:580
 msgid ""
-"<html><head/><body><p>Set the direction of the largest page dimension.</p></"
-"body></html>"
+"<html><head/><body><p>Set the direction of the largest page "
+"dimension.</p></body></html>"
 msgstr ""
 
 #: build/OpenSCADLibInternal_autogen/include/ui_ExportPdfDialog.h:582
-#, fuzzy
 msgid "Page Orientation"
-msgstr "Einrückung"
+msgstr "Seitenausrichtung"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_ExportPdfDialog.h:583
 #: src/core/Settings.cc:386
 msgid "Portrait (Vertical)"
-msgstr ""
+msgstr "Hochformat (senkrecht)"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_ExportPdfDialog.h:585
 #: src/core/Settings.cc:387
 msgid "Landscape (Horizontal)"
-msgstr ""
+msgstr "Querformat (waagerecht)"
 
+#. Interner Wert bzw. Tastenkuerzel - nicht uebersetzen. Ein leerer msgstr
+#. laesst gettext den Originaltext zurueckgeben.
 #: build/OpenSCADLibInternal_autogen/include/ui_ExportPdfDialog.h:586
 msgid "landscape"
 msgstr ""
@@ -916,16 +928,17 @@ msgstr ""
 #: build/OpenSCADLibInternal_autogen/include/ui_ExportPdfDialog.h:590
 #: src/core/Settings.cc:388
 msgid "Auto"
-msgstr ""
+msgstr "Automatisch"
 
+#. Interner Wert bzw. Tastenkuerzel - nicht uebersetzen. Ein leerer msgstr
+#. laesst gettext den Originaltext zurueckgeben.
 #: build/OpenSCADLibInternal_autogen/include/ui_ExportPdfDialog.h:591
 msgid "auto"
 msgstr ""
 
 #: build/OpenSCADLibInternal_autogen/include/ui_ExportPdfDialog.h:592
-#, fuzzy
 msgid "Annotations"
-msgstr "Rotation"
+msgstr "Beschriftungen"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_ExportPdfDialog.h:594
 msgid ""
@@ -934,110 +947,118 @@ msgstr ""
 
 #: build/OpenSCADLibInternal_autogen/include/ui_ExportPdfDialog.h:596
 msgid "Show Design Filename"
-msgstr ""
+msgstr "Dateinamen des Entwurfs anzeigen"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_ExportPdfDialog.h:598
 msgid ""
-"<html><head/><body><p>Include rulers on page to confirm 1:1 printing scale.</"
-"p></body></html>"
+"<html><head/><body><p>Include rulers on page to confirm 1:1 printing "
+"scale.</p></body></html>"
 msgstr ""
 
 #: build/OpenSCADLibInternal_autogen/include/ui_ExportPdfDialog.h:600
-#, fuzzy
 msgid "Show Scale"
-msgstr "Axen&einteilung anzeigen"
+msgstr "Maßstab anzeigen"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_ExportPdfDialog.h:602
 msgid ""
-"<html><head/><body><p>Include a grid of the selected size on the page.</p></"
-"body></html>"
+"<html><head/><body><p>Include a grid of the selected size on the "
+"page.</p></body></html>"
 msgstr ""
 
 #: build/OpenSCADLibInternal_autogen/include/ui_ExportPdfDialog.h:604
-#, fuzzy
 msgid "Show Grid"
-msgstr "&Kanten anzeigen"
+msgstr "Raster anzeigen"
 
+#. Interner Wert bzw. Tastenkuerzel - nicht uebersetzen. Ein leerer msgstr
+#. laesst gettext den Originaltext zurueckgeben.
 #: build/OpenSCADLibInternal_autogen/include/ui_ExportPdfDialog.h:605
 msgid "2mm"
 msgstr ""
 
+#. Interner Wert bzw. Tastenkuerzel - nicht uebersetzen. Ein leerer msgstr
+#. laesst gettext den Originaltext zurueckgeben.
 #: build/OpenSCADLibInternal_autogen/include/ui_ExportPdfDialog.h:606
 msgid "2.5mm"
 msgstr ""
 
+#. Interner Wert bzw. Tastenkuerzel - nicht uebersetzen. Ein leerer msgstr
+#. laesst gettext den Originaltext zurueckgeben.
 #: build/OpenSCADLibInternal_autogen/include/ui_ExportPdfDialog.h:607
 msgid "4mm"
 msgstr ""
 
+#. Interner Wert bzw. Tastenkuerzel - nicht uebersetzen. Ein leerer msgstr
+#. laesst gettext den Originaltext zurueckgeben.
 #: build/OpenSCADLibInternal_autogen/include/ui_ExportPdfDialog.h:608
 msgid "5mm"
 msgstr ""
 
+#. Interner Wert bzw. Tastenkuerzel - nicht uebersetzen. Ein leerer msgstr
+#. laesst gettext den Originaltext zurueckgeben.
 #: build/OpenSCADLibInternal_autogen/include/ui_ExportPdfDialog.h:609
 msgid "10mm"
 msgstr ""
 
 #: build/OpenSCADLibInternal_autogen/include/ui_ExportPdfDialog.h:611
 msgid ""
-"<html><head/><body><p>Include text describing usage of scale.</p></body></"
-"html>"
+"<html><head/><body><p>Include text describing usage of "
+"scale.</p></body></html>"
 msgstr ""
 
 #: build/OpenSCADLibInternal_autogen/include/ui_ExportPdfDialog.h:613
-#, fuzzy
 msgid "Show Scale Usage"
-msgstr "Axen&einteilung anzeigen"
+msgstr "Hinweis zum Maßstab anzeigen"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_ExportPdfDialog.h:614
 #: build/OpenSCADLibInternal_autogen/include/ui_ExportSvgDialog.h:203
 msgid "Fill and Stroke"
-msgstr ""
+msgstr "Füllung und Kontur"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_ExportPdfDialog.h:616
 msgid ""
-"<html><head/><body><p>Enable filling of exported geometry with a color.</p></"
-"body></html>"
+"<html><head/><body><p>Enable filling of exported geometry with a "
+"color.</p></body></html>"
 msgstr ""
 
 #: build/OpenSCADLibInternal_autogen/include/ui_ExportPdfDialog.h:618
 #: build/OpenSCADLibInternal_autogen/include/ui_ExportSvgDialog.h:207
 msgid "Fill Geometry"
-msgstr ""
+msgstr "Geometrie füllen"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_ExportPdfDialog.h:623
 msgid ""
-"<html><head/><body><p>Enable outline stroke for exported geometry.</p></"
-"body></html>"
+"<html><head/><body><p>Enable outline stroke for exported "
+"geometry.</p></body></html>"
 msgstr ""
 
 #: build/OpenSCADLibInternal_autogen/include/ui_ExportPdfDialog.h:625
 #: build/OpenSCADLibInternal_autogen/include/ui_ExportSvgDialog.h:214
 msgid "Stroke Outline"
-msgstr ""
+msgstr "Kontur zeichnen"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_ExportPdfDialog.h:629
 #: build/OpenSCADLibInternal_autogen/include/ui_ExportSvgDialog.h:218
 msgid "Stroke Width:"
-msgstr ""
+msgstr "Konturbreite:"
 
+#. Interner Wert bzw. Tastenkuerzel - nicht uebersetzen. Ein leerer msgstr
+#. laesst gettext den Originaltext zurueckgeben.
 #: build/OpenSCADLibInternal_autogen/include/ui_ExportPdfDialog.h:630
 #: build/OpenSCADLibInternal_autogen/include/ui_ExportSvgDialog.h:219
 msgid " mm"
 msgstr ""
 
 #: build/OpenSCADLibInternal_autogen/include/ui_ExportSvgDialog.h:202
-#, fuzzy
 msgid "Export SVG Options"
-msgstr "Export Features"
+msgstr "SVG-Exporteinstellungen"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_ExportSvgDialog.h:205
 msgid "Enable filling of exported geometry with a color."
-msgstr ""
+msgstr "Exportierte Geometrie mit einer Farbe füllen."
 
 #: build/OpenSCADLibInternal_autogen/include/ui_ExportSvgDialog.h:212
 msgid "Enable outline stroke for exported geometry."
-msgstr ""
+msgstr "Kontur der exportierten Geometrie zeichnen."
 
 #: build/OpenSCADLibInternal_autogen/include/ui_FontListDialog.h:106
 msgid "OpenSCAD Font List"
@@ -1062,116 +1083,105 @@ msgid ""
 "OpenSCAD.</p><p>Example:</p><pre style=\" margin-top:12px; margin-"
 "bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-"
 "indent:0px;\"><span style=\" font-family:'Courier New,courier';\">  "
-"text(&quot;OpenSCAD&quot;, font = &quot;DejaVu Sans&quot;);</span></pre><pre "
-"style=\" margin-top:0px; margin-bottom:12px; margin-left:0px; margin-"
+"text(&quot;OpenSCAD&quot;, font = &quot;DejaVu Sans&quot;);</span></pre><pre"
+" style=\" margin-top:0px; margin-bottom:12px; margin-left:0px; margin-"
 "right:0px; -qt-block-indent:0; text-indent:0px;\"><span style=\" font-"
 "family:'Courier New,courier';\">  text(&quot;OpenSCAD&quot;, font = "
 "&quot;Liberation Sans:style=Italic&quot;);</span></pre></body></html>"
 msgstr ""
-"<html><head/><body><p>Diese Liste zeigt die Fonts, die momentan mit OpenSCAD "
-"registriert sind.</p><p>Beispiele:</p><pre style=\" margin-top:12px; margin-"
-"bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-"
-"indent:0px;\"><span style=\" font-family:'Courier New,courier';\">  "
-"text(&quot;OpenSCAD&quot;, font = &quot;DejaVu Sans&quot;);</span></pre><pre "
-"style=\" margin-top:0px; margin-bottom:12px; margin-left:0px; margin-"
+"<html><head/><body><p>Diese Liste zeigt die Fonts, die momentan mit OpenSCAD"
+" registriert sind.</p><p>Beispiele:</p><pre style=\" margin-top:12px; "
+"margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; "
+"text-indent:0px;\"><span style=\" font-family:'Courier New,courier';\">  "
+"text(&quot;OpenSCAD&quot;, font = &quot;DejaVu Sans&quot;);</span></pre><pre"
+" style=\" margin-top:0px; margin-bottom:12px; margin-left:0px; margin-"
 "right:0px; -qt-block-indent:0; text-indent:0px;\"><span style=\" font-"
 "family:'Courier New,courier';\">  text(&quot;OpenSCAD&quot;, font = "
 "&quot;Liberation Sans:style=Italic&quot;);</span></pre></body></html>"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_FontList.h:291
 #: src/gui/MainWindow.cc:292
-#, fuzzy
 msgid "Font List"
-msgstr "&Fontliste"
+msgstr "Schriftenliste"
 
+#. Interner Wert bzw. Tastenkuerzel - nicht uebersetzen. Ein leerer msgstr
+#. laesst gettext den Originaltext zurueckgeben.
 #: build/OpenSCADLibInternal_autogen/include/ui_FontList.h:292
 msgid "ResetSampleText"
 msgstr ""
 
 #: build/OpenSCADLibInternal_autogen/include/ui_FontList.h:293
-#, fuzzy
 msgid "Open Font Folder"
-msgstr "&Datei öffen"
+msgstr "Schriftverzeichnis öffnen"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_FontList.h:294
 msgid "Copy Font Folder"
-msgstr ""
+msgstr "Schriftverzeichnis kopieren"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_FontList.h:295
-#, fuzzy
 msgid "Copy Full Path to Font"
-msgstr "Pfad kopieren"
+msgstr "Vollständigen Pfad zur Schrift kopieren"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_FontList.h:296
-#, fuzzy
 msgid "Copy Font Style"
-msgstr "&Fontliste"
+msgstr "Schriftschnitt kopieren"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_FontList.h:297
-#, fuzzy
 msgid "Copy Font Name"
-msgstr "Font"
+msgstr "Schriftnamen kopieren"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_FontList.h:298
-#, fuzzy
 msgid "Show Font Name"
-msgstr "Font"
+msgstr "Schriftnamen anzeigen"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_FontList.h:299
 msgid "Show Styled Font Name"
-msgstr ""
+msgstr "Schriftnamen mit Schnitt anzeigen"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_FontList.h:300
-#, fuzzy
 msgid "Show Font Style"
-msgstr "&Fontliste"
+msgstr "Schriftschnitt anzeigen"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_FontList.h:301
-#, fuzzy
 msgid "Show Sample Text"
-msgstr "Axen&einteilung anzeigen"
+msgstr "Beispieltext anzeigen"
 
+#. Interner Wert bzw. Tastenkuerzel - nicht uebersetzen. Ein leerer msgstr
+#. laesst gettext den Originaltext zurueckgeben.
 #: build/OpenSCADLibInternal_autogen/include/ui_FontList.h:302
-#, fuzzy
 msgid "ShowFileName"
-msgstr "Dateiname kopieren"
+msgstr ""
 
 #: build/OpenSCADLibInternal_autogen/include/ui_FontList.h:303
-#, fuzzy
 msgid "Show File Path"
-msgstr "Axen&einteilung anzeigen"
+msgstr "Dateipfad anzeigen"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_FontList.h:304
-#, fuzzy
 msgid "Reset Columns"
-msgstr ""
-"Trim\n"
-"zurücksetzen"
+msgstr "Spalten zurücksetzen"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_FontList.h:307
 msgid "Any"
-msgstr ""
+msgstr "Alle"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_FontList.h:313
 #: build/OpenSCADLibInternal_autogen/include/ui_FontList.h:317
 #: src/gui/FontList.cc:367
-#, fuzzy
 msgid "Font name"
-msgstr "Font"
+msgstr "Schriftname"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_FontList.h:314
 #: src/gui/FontList.cc:371
 msgid "Sample text"
-msgstr ""
+msgstr "Beispieltext"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_FontList.h:315
 msgid "Chars"
-msgstr ""
+msgstr "Zeichen"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_FontList.h:318
-#, fuzzy
 msgid "Font path"
-msgstr "Font"
+msgstr "Schriftpfad"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_FontList.h:319
 #: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2278
@@ -1269,7 +1279,7 @@ msgstr "Ctrl+Shift+S"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_MainWindow.h:1267
 msgid "Save a Copy"
-msgstr ""
+msgstr "Kopie speichern"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_MainWindow.h:1268
 msgid "Save All"
@@ -1453,17 +1463,20 @@ msgstr "F8"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_MainWindow.h:1355
 msgid "Measure &Distance"
-msgstr ""
+msgstr "Abstand &messen"
 
+#. Interner Wert bzw. Tastenkuerzel - nicht uebersetzen. Ein leerer msgstr
+#. laesst gettext den Originaltext zurueckgeben.
 #: build/OpenSCADLibInternal_autogen/include/ui_MainWindow.h:1357
 msgid "D"
 msgstr ""
 
 #: build/OpenSCADLibInternal_autogen/include/ui_MainWindow.h:1359
-#, fuzzy
 msgid "Measure &Angle"
-msgstr "Messungen: Fläche"
+msgstr "&Winkel messen"
 
+#. Interner Wert bzw. Tastenkuerzel - nicht uebersetzen. Ein leerer msgstr
+#. laesst gettext den Originaltext zurueckgeben.
 #: build/OpenSCADLibInternal_autogen/include/ui_MainWindow.h:1361
 msgid "A"
 msgstr ""
@@ -1485,24 +1498,20 @@ msgid "Display CSG Pr&oducts..."
 msgstr "CSG &Gleichungen anzeigen..."
 
 #: build/OpenSCADLibInternal_autogen/include/ui_MainWindow.h:1367
-#, fuzzy
 msgid "Export as &STL (binary)..."
-msgstr "&STL exportieren..."
+msgstr "&STL exportieren (binär)..."
 
 #: build/OpenSCADLibInternal_autogen/include/ui_MainWindow.h:1368
-#, fuzzy
 msgid "Export as &STL (ascii)..."
-msgstr "&STL exportieren..."
+msgstr "STL exportieren (&ASCII)..."
 
 #: build/OpenSCADLibInternal_autogen/include/ui_MainWindow.h:1369
-#, fuzzy
 msgid "Export as &OBJ..."
-msgstr "&OFF exportieren..."
+msgstr "OB&J exportieren..."
 
 #: build/OpenSCADLibInternal_autogen/include/ui_MainWindow.h:1370
-#, fuzzy
 msgid "Export as &POV..."
-msgstr "&OFF exportieren..."
+msgstr "POV e&xportieren..."
 
 #: build/OpenSCADLibInternal_autogen/include/ui_MainWindow.h:1371
 msgid "Export as &OFF..."
@@ -1554,7 +1563,7 @@ msgstr "Ctrl+3"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_MainWindow.h:1393
 msgid "Show Scale Markers"
-msgstr "Axen&einteilung anzeigen"
+msgstr "Achsen&einteilung anzeigen"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_MainWindow.h:1394
 msgid "&Top"
@@ -1655,7 +1664,7 @@ msgstr "&DXF exportieren..."
 #: build/OpenSCADLibInternal_autogen/include/ui_MainWindow.h:1434
 #: build/OpenSCADLibInternal_autogen/include/ui_MainWindow.h:1436
 msgid "Revoke Trusted Python Files"
-msgstr ""
+msgstr "Vertrauen für Python-Dateien widerrufen"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_MainWindow.h:1438
 msgid "&Close"
@@ -1753,7 +1762,6 @@ msgstr "Ans&icht zurücksetzen"
 msgid "Export as S&VG..."
 msgstr "S&VG exportieren..."
 
-
 #: build/OpenSCADLibInternal_autogen/include/ui_MainWindow.h:1477
 msgid "Export as &3MF..."
 msgstr "&3MF exportieren..."
@@ -1835,14 +1843,12 @@ msgid "Hide 3D View toolbar"
 msgstr "3D Symbolleiste ausblenden"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_MainWindow.h:1511
-#, fuzzy
 msgid "&Next Window\tCtrl+K"
-msgstr "&Nächstes Fenster"
+msgstr "&Nächstes Fenster\tCtrl+K"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_MainWindow.h:1512
-#, fuzzy
 msgid "&Previous Window\tCtrl+H"
-msgstr "&Vorheriges Fenster"
+msgstr "&Vorheriges Fenster\tCtrl+H"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_MainWindow.h:1513
 msgid "Insert Template"
@@ -1854,27 +1860,28 @@ msgstr "Alt+Ins"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_MainWindow.h:1517
 msgid "Fold/Unfoll All"
-msgstr ""
+msgstr "Alle ein-/ausklappen"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_MainWindow.h:1518
 msgid "Jump To ..."
-msgstr ""
+msgstr "Springe zu …"
 
+#. Interner Wert bzw. Tastenkuerzel - nicht uebersetzen. Ein leerer msgstr
+#. laesst gettext den Originaltext zurueckgeben.
 #: build/OpenSCADLibInternal_autogen/include/ui_MainWindow.h:1520
-#, fuzzy
 msgid "Ctrl+J"
-msgstr "Ctrl+N"
+msgstr ""
 
 #: build/OpenSCADLibInternal_autogen/include/ui_MainWindow.h:1522
 #: src/gui/MainWindow.cc:1725 src/gui/MainWindow.cc:1732
 #: src/gui/MainWindow.cc:1745 src/gui/MainWindow.cc:1750
 msgid "Create Virtual Environment"
-msgstr ""
+msgstr "Virtuelle Umgebung anlegen"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_MainWindow.h:1523
 #: src/gui/MainWindow.cc:1767
 msgid "Select Virtual Environment"
-msgstr ""
+msgstr "Virtuelle Umgebung auswählen"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_MainWindow.h:1524
 #: build/OpenSCADLibInternal_autogen/include/ui_OctoPrintApiKeyDialog.h:107
@@ -1897,6 +1904,8 @@ msgstr "&Beispiele"
 msgid "E&xport"
 msgstr "&Exportieren"
 
+#. Interner Wert bzw. Tastenkuerzel - nicht uebersetzen. Ein leerer msgstr
+#. laesst gettext den Originaltext zurueckgeben.
 #: build/OpenSCADLibInternal_autogen/include/ui_MainWindow.h:1531
 msgid "Python"
 msgstr ""
@@ -1956,64 +1965,63 @@ msgstr "Customizer"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_MouseConfigWidget.h:215
 msgid "Ctrl + Shift + Middle-click"
-msgstr ""
+msgstr "Strg + Umschalt + Mittelklick"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_MouseConfigWidget.h:216
 msgid "Left-click"
-msgstr ""
+msgstr "Linksklick"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_MouseConfigWidget.h:217
 msgid "Ctrl + Left-click"
-msgstr ""
+msgstr "Strg + Linksklick"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_MouseConfigWidget.h:218
 msgid "Shift + Left-click"
-msgstr ""
+msgstr "Umschalt + Linksklick"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_MouseConfigWidget.h:219
 msgid "Ctrl + Shift + Right-click"
-msgstr ""
+msgstr "Strg + Umschalt + Rechtsklick"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_MouseConfigWidget.h:220
-#, fuzzy
 msgid "Preset"
-msgstr "Zurücksetzen"
+msgstr "Voreinstellung"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_MouseConfigWidget.h:221
 msgid "Right-click"
-msgstr ""
+msgstr "Rechtsklick"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_MouseConfigWidget.h:222
 msgid "Ctrl + Middle-click"
-msgstr ""
+msgstr "Strg + Mittelklick"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_MouseConfigWidget.h:223
 msgid "Shift + Middle-click"
-msgstr ""
+msgstr "Umschalt + Mittelklick"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_MouseConfigWidget.h:224
 msgid "Ctrl + Right-click"
-msgstr ""
+msgstr "Strg + Rechtsklick"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_MouseConfigWidget.h:225
 msgid "Ctrl + Shift + Left-click"
-msgstr ""
+msgstr "Strg + Umschalt + Linksklick"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_MouseConfigWidget.h:226
 msgid "Shift + Right-click"
-msgstr ""
+msgstr "Umschalt + Rechtsklick"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_MouseConfigWidget.h:227
 msgid "Middle-click"
-msgstr ""
+msgstr "Mittelklick"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_OctoPrintApiKeyDialog.h:106
 msgid "OctoPrint API Key Request"
-msgstr ""
+msgstr "OctoPrint-Schlüsselanforderung"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_OctoPrintApiKeyDialog.h:108
 msgid "Retry"
-msgstr ""
+msgstr "Erneut versuchen"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_OpenCSGWarningDialog.h:76
 msgid "OpenGL Warning"
@@ -2021,27 +2029,17 @@ msgstr "OpenGL Warnung"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_OpenCSGWarningDialog.h:77
 msgid ""
-"<!DOCTYPE HTML PUBLIC \"-//W3C//DTD HTML 4.0//EN\" \"http://www.w3.org/TR/"
-"REC-html40/strict.dtd\">\n"
-"<html><head><meta name=\"qrichtext\" content=\"1\" /><style type=\"text/"
-"css\">\n"
+"<!DOCTYPE HTML PUBLIC \"-//W3C//DTD HTML 4.0//EN\" \"http://www.w3.org/TR/REC-html40/strict.dtd\">\n"
+"<html><head><meta name=\"qrichtext\" content=\"1\" /><style type=\"text/css\">\n"
 "p, li { white-space: pre-wrap; }\n"
-"</style></head><body style=\" font-family:'Lucida Grande'; font-size:13pt; "
-"font-weight:400; font-style:normal;\">\n"
-"<p style=\"-qt-paragraph-type:empty; margin-top:0px; margin-bottom:0px; "
-"margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;\"></"
-"p></body></html>"
+"</style></head><body style=\" font-family:'Lucida Grande'; font-size:13pt; font-weight:400; font-style:normal;\">\n"
+"<p style=\"-qt-paragraph-type:empty; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;\"></p></body></html>"
 msgstr ""
-"<!DOCTYPE HTML PUBLIC \"-//W3C//DTD HTML 4.0//EN\" \"http://www.w3.org/TR/"
-"REC-html40/strict.dtd\">\n"
-"<html><head><meta name=\"qrichtext\" content=\"1\" /><style type=\"text/"
-"css\">\n"
+"<!DOCTYPE HTML PUBLIC \"-//W3C//DTD HTML 4.0//EN\" \"http://www.w3.org/TR/REC-html40/strict.dtd\">\n"
+"<html><head><meta name=\"qrichtext\" content=\"1\" /><style type=\"text/css\">\n"
 "p, li { white-space: pre-wrap; }\n"
-"</style></head><body style=\" font-family:'Lucida Grande'; font-size:13pt; "
-"font-weight:400; font-style:normal;\">\n"
-"<p style=\"-qt-paragraph-type:empty; margin-top:0px; margin-bottom:0px; "
-"margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;\"></"
-"p></body></html>"
+"</style></head><body style=\" font-family:'Lucida Grande'; font-size:13pt; font-weight:400; font-style:normal;\">\n"
+"<p style=\"-qt-paragraph-type:empty; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;\"></p></body></html>"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_OpenCSGWarningDialog.h:82
 msgid "Show this message again"
@@ -2148,7 +2146,7 @@ msgstr "Knöpfe"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2246
 msgid "Mouse"
-msgstr ""
+msgstr "Maus"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2247
 #: build/OpenSCADLibInternal_autogen/include/ui_PrintInitDialog.h:178
@@ -2161,27 +2159,27 @@ msgstr "3D-Druckdienstleister"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2251
 msgid "Dialogs"
-msgstr ""
+msgstr "Dialoge"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2252
 msgid "Directory of the output file"
-msgstr ""
+msgstr "Verzeichnis der Ausgabedatei"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2253
 msgid "Extension of the output file without leading dot"
-msgstr ""
+msgstr "Endung der Ausgabedatei ohne führenden Punkt"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2254
 msgid "Full path to the main source file"
-msgstr ""
+msgstr "Vollständiger Pfad zur Hauptquelldatei"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2255
 msgid "Directory of the main source file"
-msgstr ""
+msgstr "Verzeichnis der Hauptquelldatei"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2256
 msgid "Full path to the output file"
-msgstr ""
+msgstr "Vollständiger Pfad zur Ausgabedatei"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2257
 msgid "Color scheme:"
@@ -2425,16 +2423,15 @@ msgstr "Zuletzt gesucht: "
 
 #: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2328
 msgid "General"
-msgstr ""
+msgstr "Allgemein"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2329
-#, fuzzy
 msgid "Default Print Service"
-msgstr "3D-Druckdienstleister"
+msgstr "Vorgegebener Druckdienst"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2330
 msgid "Enable remote print services"
-msgstr ""
+msgstr "Entfernte Druckdienste aktivieren"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2331
 #: build/OpenSCADLibInternal_autogen/include/ui_PrintInitDialog.h:181
@@ -2478,7 +2475,7 @@ msgstr "Aktion"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2342
 msgid "Request"
-msgstr ""
+msgstr "Anfordern"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2343
 msgid "Show"
@@ -2491,32 +2488,32 @@ msgstr ""
 
 #: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2345
 #: src/gui/Preferences.cc:437
-#, fuzzy
 msgid "Local Application"
-msgstr "Application"
+msgstr "Lokales Programm"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2347
-#, fuzzy
 msgid "File"
-msgstr "&Datei"
+msgstr "Datei"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2352
 msgid "Executable"
-msgstr ""
+msgstr "Programmdatei"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2356
 msgid ""
 "Directory for storing the exported file, leave empty to use the default "
 "system location."
 msgstr ""
+"Verzeichnis für die Exportdatei; leer lassen, um den Vorgabeort des Systems "
+"zu verwenden."
 
 #: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2359
 msgid "Temp Dir"
-msgstr ""
+msgstr "Temporäres Verzeichnis"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2361
 msgid "3D Preview (OpenCSG)"
-msgstr ""
+msgstr "3D-Vorschau (OpenCSG)"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2362
 msgid "Show capability warning"
@@ -2535,14 +2532,12 @@ msgid "Force Goldfeather"
 msgstr "Goldfeather Algorithmus erzwingen"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2366
-#, fuzzy
 msgid "3D Rendering"
-msgstr "&Rendern"
+msgstr "3D-Rendern"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2367
-#, fuzzy
 msgid "Backend"
-msgstr "Hinten"
+msgstr "Unterbau"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2368
 msgid "CGAL Cache size"
@@ -2600,7 +2595,7 @@ msgstr "Konsole"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2383
 msgid "Clear console before Preview/Render"
-msgstr ""
+msgstr "Konsole vor Vorschau bzw. Rendern leeren"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2384
 msgid "Maximum lines for Console to keep:"
@@ -2620,9 +2615,8 @@ msgid "OpenSCAD Language Features"
 msgstr "OpenSCAD Spracheigenschaften"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2390
-#, fuzzy
 msgid "Warnings"
-msgstr "OpenGL Warnung"
+msgstr "Warnungen"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2391
 msgid "Stop on the first warning"
@@ -2638,19 +2632,19 @@ msgstr "Warnen bei nicht übereinstimmenden Parametern"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2394
 msgid "Trace"
-msgstr ""
+msgstr "Ablaufverfolgung"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2395
 msgid "Trace depth:"
-msgstr ""
+msgstr "Tiefe der Ablaufverfolgung:"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2396
 msgid "(max. number or trace messages)"
-msgstr ""
+msgstr "(höchste Anzahl an Meldungen)"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2397
 msgid "Show parameters of usermodule calls in trace"
-msgstr ""
+msgstr "Parameter von Modulaufrufen in der Ablaufverfolgung anzeigen"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2398
 msgid "Render Summary"
@@ -2674,11 +2668,11 @@ msgstr "Export Features"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2403
 msgid "Toolbar Export 3D"
-msgstr ""
+msgstr "Werkzeugleiste 3D-Export"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2404
 msgid "Toolbar Export 2D"
-msgstr ""
+msgstr "Werkzeugleiste 2D-Export"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2405
 msgid "Debugging"
@@ -2690,75 +2684,74 @@ msgstr "Protokoll für HIDAPI einschalten (benötigt Neustart von OpenSCAD)"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2407
 msgid "Dialog visibility"
-msgstr ""
+msgstr "Sichtbarkeit der Dialoge"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2408
 msgid "Always show PDF export dialog"
-msgstr ""
+msgstr "PDF-Exportdialog immer anzeigen"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2409
 msgid "Always show 3MF export dialog"
-msgstr ""
+msgstr "3MF-Exportdialog immer anzeigen"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2410
 msgid "Always show Print Service dialog"
-msgstr ""
+msgstr "Druckdienst-Dialog immer anzeigen"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_PrintInitDialog.h:180
-#, fuzzy
 msgid "Run local Application"
-msgstr "Application"
+msgstr "Lokales Programm ausführen"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_PrintInitDialog.h:182
-#, fuzzy
 msgid "File format"
-msgstr "Datei Format"
+msgstr "Dateiformat"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_PrintInitDialog.h:183
 msgid "Enable remote services that need network access"
-msgstr ""
+msgstr "Entfernte Dienste mit Netzzugriff aktivieren"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_ProgressWidget.h:70
 msgid "%v / %m"
 msgstr "%v / %m"
 
+#. Interner Wert bzw. Tastenkuerzel - nicht uebersetzen. Ein leerer msgstr
+#. laesst gettext den Originaltext zurueckgeben.
 #: build/OpenSCADLibInternal_autogen/include/ui_ViewportControl.h:266
-#, fuzzy
 msgid "ViewportControlWidget"
-msgstr "3D Symbolleiste ausblenden"
+msgstr ""
 
 #: build/OpenSCADLibInternal_autogen/include/ui_ViewportControl.h:271
-#, fuzzy
 msgid "Aspect Ratio"
-msgstr "Application"
+msgstr "Seitenverhältnis"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_ViewportControl.h:272
 msgid "Width"
-msgstr ""
+msgstr "Breite"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_ViewportControl.h:273
-#, fuzzy
 msgid "Height"
-msgstr "&Rechts"
+msgstr "Höhe"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_ViewportControl.h:275
 msgid "Lock"
-msgstr ""
+msgstr "Sperren"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_ViewportControl.h:276
-#, fuzzy
 msgid "Details"
-msgstr "Details anzeigen"
+msgstr "Einzelheiten"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_ViewportControl.h:277
-#, fuzzy
 msgid "Distance"
-msgstr "Weiterführende Beispiele"
+msgstr "Abstand"
 
+#. Interner Wert bzw. Tastenkuerzel - nicht uebersetzen. Ein leerer msgstr
+#. laesst gettext den Originaltext zurueckgeben.
 #: build/OpenSCADLibInternal_autogen/include/ui_ViewportControl.h:278
 msgid "FOV"
 msgstr ""
 
+#. Interner Wert bzw. Tastenkuerzel - nicht uebersetzen. Ein leerer msgstr
+#. laesst gettext den Originaltext zurueckgeben.
 #: src/core/Settings.cc:48
 #, c-format
 msgid "axis-%d"
@@ -2769,10 +2762,12 @@ msgstr ""
 msgid "Axis %d"
 msgstr "Achse %d"
 
+#. Interner Wert bzw. Tastenkuerzel - nicht uebersetzen. Ein leerer msgstr
+#. laesst gettext den Originaltext zurueckgeben.
 #: src/core/Settings.cc:52
-#, fuzzy, c-format
+#, c-format
 msgid "axis-inverted-%d"
-msgstr "Achse %d (invertiert)"
+msgstr ""
 
 #: src/core/Settings.cc:53
 #, c-format
@@ -2801,30 +2796,27 @@ msgstr "Hochladen, Slicen und Druck starten"
 
 #: src/core/Settings.cc:423
 msgid "Use colors from model"
-msgstr ""
+msgstr "Farben aus dem Modell verwenden"
 
 #: src/core/Settings.cc:425
-#, fuzzy
 msgid "Use selected color only"
-msgstr "&Auswahl suchen"
+msgstr "Nur die gewählte Farbe verwenden"
 
 #: src/core/Settings.cc:432
-#, fuzzy
 msgid "Millimeter"
-msgstr "Parameter"
+msgstr "Millimeter"
 
 #: src/core/Settings.cc:436
 msgid "Feet"
-msgstr ""
+msgstr "Fuß"
 
 #: src/core/Settings.cc:444
-#, fuzzy
 msgid "Color"
-msgstr "Farbschema:"
+msgstr "Farbe"
 
 #: src/core/Settings.cc:445
 msgid "Base Material"
-msgstr ""
+msgstr "Grundmaterial"
 
 #: src/glview/Camera.cc:183
 #, c-format
@@ -2836,17 +2828,16 @@ msgstr ""
 "Abstand = %.2f, Sichtfeld = %.2f"
 
 #: src/gui/Animate.cc:201
-#, fuzzy
 msgid "press to pause animation"
-msgstr "Voreinstellungsauswahl"
+msgstr "zum Anhalten der Animation drücken"
 
 #: src/gui/Animate.cc:205
 msgid "press to start animation"
-msgstr ""
+msgstr "zum Starten der Animation drücken"
 
 #: src/gui/Animate.cc:208
 msgid "incorrect values"
-msgstr ""
+msgstr "ungültige Werte"
 
 #: src/gui/Console.cc:165
 msgid "Save console content"
@@ -2854,37 +2845,35 @@ msgstr "Log speichern"
 
 #: src/gui/Export3mfDialog.cc:77
 msgid ""
-"This OpenSCAD build uses lib3mf version 1. Setting the decimal precision for "
-"export needs version 2 or later."
+"This OpenSCAD build uses lib3mf version 1. Setting the decimal precision for"
+" export needs version 2 or later."
 msgstr ""
+"Diese OpenSCAD-Fassung verwendet lib3mf Version 1. Das Einstellen der "
+"Nachkommastellen für den Export erfordert Version 2 oder neuer."
 
 #: src/gui/ExternalToolInterface.cc:185
 msgid "Exported design exceeds the service upload limit of (%1 MB)."
 msgstr "Design Export überschreitet das Limit des Services von %1 MB."
 
 #: src/gui/FontList.cc:368
-#, fuzzy
 msgid "Styled font name"
-msgstr "Font"
+msgstr "Schriftname mit Schnitt"
 
 #: src/gui/FontList.cc:369
-#, fuzzy
 msgid "Font style"
-msgstr "&Fontliste"
+msgstr "Schriftschnitt"
 
 #: src/gui/FontList.cc:372
-#, fuzzy
 msgid "File name"
-msgstr "Dateiname kopieren"
+msgstr "Dateiname"
 
 #: src/gui/FontList.cc:373
-#, fuzzy
 msgid "File path"
-msgstr "Datei Format"
+msgstr "Dateipfad"
 
 #: src/gui/FontList.cc:374
 msgid "Hash"
-msgstr ""
+msgstr "Prüfsumme"
 
 #: src/gui/input/AxisConfigWidget.h:87
 msgid ""
@@ -2895,7 +2884,8 @@ msgstr ""
 
 #: src/gui/input/AxisConfigWidget.h:90
 msgid ""
-"The DBUS driver is not for actual devices but for remote control, Linux only."
+"The DBUS driver is not for actual devices but for remote control, Linux "
+"only."
 msgstr "Der DBUS Treiber dient der Fernsteuerung, nur für Linux."
 
 #: src/gui/input/AxisConfigWidget.h:92
@@ -2914,11 +2904,11 @@ msgstr ""
 
 #: src/gui/input/AxisConfigWidget.h:96
 msgid ""
-"The Joystick driver uses the Linux joystick device (fixed to /dev/input/"
-"js0), Linux only."
+"The Joystick driver uses the Linux joystick device (fixed to "
+"/dev/input/js0), Linux only."
 msgstr ""
-"Der Joystick Treiber bedient die Linux Joystick Schnittstelle (/dev/input/"
-"js0), nur Linux."
+"Der Joystick Treiber bedient die Linux Joystick Schnittstelle "
+"(/dev/input/js0), nur Linux."
 
 #: src/gui/input/AxisConfigWidget.h:98
 msgid "The QGAMEPAD driver is for multiplattform Gamepad Support."
@@ -2934,7 +2924,7 @@ msgstr "Fehlerliste"
 
 #: src/gui/MainWindow.cc:293
 msgid "Viewport-Control"
-msgstr ""
+msgstr "Ansichtssteuerung"
 
 #: src/gui/MainWindow.cc:1303
 msgid "Compile error."
@@ -2960,13 +2950,15 @@ msgstr ""
 
 #: src/gui/MainWindow.cc:1710
 msgid "Trusted Files"
-msgstr ""
+msgstr "Vertrauenswürdige Dateien"
 
 #: src/gui/MainWindow.cc:2069
 msgid ""
 "Python files can potentially contain harmful stuff.\n"
 "Do you trust this file ?\n"
 msgstr ""
+"Python-Dateien können schädlichen Inhalt enthalten.\n"
+"Vertrauen Sie dieser Datei?\n"
 
 #: src/gui/MainWindow.cc:2177
 msgid "Application"
@@ -3015,15 +3007,15 @@ msgstr "Zeitüberschreitung"
 
 #: src/gui/OctoPrintApiKeyDialog.cc:57
 msgid "API key created, waiting for approval in OctoPrint..."
-msgstr ""
+msgstr "Schlüssel erzeugt, warte auf Bestätigung in OctoPrint …"
 
 #: src/gui/OctoPrintApiKeyDialog.cc:88
 msgid "API key approved."
-msgstr ""
+msgstr "Schlüssel bestätigt."
 
 #: src/gui/OctoPrintApiKeyDialog.cc:98
 msgid "API key approval failed."
-msgstr ""
+msgstr "Bestätigung des Schlüssels fehlgeschlagen."
 
 #: src/gui/OpenSCADApp.cc:46
 msgid "Unknown error"
@@ -3038,8 +3030,7 @@ msgid ""
 "A critical error was caught. The application may have become unstable:\n"
 "%1"
 msgstr ""
-"Ein kritischer Fehler wurde abgefangen. Die Anwendung könnte jetzt instabil "
-"laufen:\n"
+"Ein kritischer Fehler wurde abgefangen. Die Anwendung könnte jetzt instabil laufen:\n"
 "%1"
 
 #: src/gui/OpenSCADApp.cc:77
@@ -3079,7 +3070,7 @@ msgstr "<Standard>"
 
 #: src/gui/Preferences.cc:435
 msgid "NONE"
-msgstr ""
+msgstr "KEINE"
 
 #: src/gui/Preferences.cc:1134
 msgid "Success: Server Version = %2, API Version = %1"
@@ -3092,22 +3083,18 @@ msgstr "Fehler"
 
 #: src/gui/QGLView.cc:161
 msgid ""
-"Warning: Missing OpenGL capabilities for OpenCSG - OpenCSG has been "
-"disabled.\n"
+"Warning: Missing OpenGL capabilities for OpenCSG - OpenCSG has been disabled.\n"
 "\n"
 msgstr ""
-"Achtung: Der Funktionsumfang des OpenGL Treibers reicht für die Vorschau "
-"nicht aus - OpenCSG wurde deaktiviert.\n"
+"Achtung: Der Funktionsumfang des OpenGL Treibers reicht für die Vorschau nicht aus - OpenCSG wurde deaktiviert.\n"
 "\n"
 
 #: src/gui/QGLView.cc:163
 msgid ""
-"It is highly recommended to use OpenSCAD on a system with OpenGL 2.0 or "
-"later.\n"
+"It is highly recommended to use OpenSCAD on a system with OpenGL 2.0 or later.\n"
 "Your renderer information is as follows:\n"
 msgstr ""
-"Für die korrekte Anzeige der Vorschau benötigt OpenSCAD mindestens OpenGL "
-"2.0.\n"
+"Für die korrekte Anzeige der Vorschau benötigt OpenSCAD mindestens OpenGL 2.0.\n"
 "Informationen zum OpenGL Treiber:\n"
 
 #: src/gui/QGLView.cc:167
@@ -3121,15 +3108,14 @@ msgstr ""
 "OpenGL version %4\n"
 
 #: src/gui/QGLView.cc:173
-#, fuzzy
 msgid ""
 "GLAD version %1\n"
 "%2 (%3)\n"
 "OpenGL version %4\n"
 msgstr ""
-"GLEW version %1\n"
+"GLAD-Version %1\n"
 "%2 (%3)\n"
-"OpenGL version %4\n"
+"OpenGL-Version %4\n"
 
 #: src/gui/TabManager.cc:359
 msgid "Copy file name"
@@ -3140,9 +3126,8 @@ msgid "Copy full path"
 msgstr "Pfad kopieren"
 
 #: src/gui/TabManager.cc:371
-#, fuzzy
 msgid "Open Folder"
-msgstr "&Datei öffen"
+msgstr "Verzeichnis öffnen"
 
 #: src/gui/TabManager.cc:376
 msgid "Close Tab"
@@ -3191,11 +3176,11 @@ msgstr ""
 #: src/gui/ViewportControl.cc:177 src/gui/ViewportControl.cc:180
 #: src/gui/ViewportControl.cc:193
 msgid "extreme values might may lead to strange behavior"
-msgstr ""
+msgstr "Extremwerte können zu seltsamem Verhalten führen"
 
 #: src/gui/ViewportControl.cc:190
 msgid "negative distances are not supported"
-msgstr ""
+msgstr "Negative Abstände werden nicht unterstützt"
 
 #: src/io/export.cc:245
 #, c-format
@@ -3238,50 +3223,50 @@ msgid ""
 "OpenSCAD is a software for creating solid 3D CAD models. Unlike most free "
 "software for creating 3D models (such as Blender) it does not focus on the "
 "artistic aspects of 3D modelling but instead on the CAD aspects. Thus it "
-"might be the application you are looking for when you are planning to create "
-"3D models of machine parts but pretty sure is not what you are looking for "
+"might be the application you are looking for when you are planning to create"
+" 3D models of machine parts but pretty sure is not what you are looking for "
 "when you are more interested in creating computer-animated movies."
 msgstr ""
 "OpenSCAD is a software for creating solid 3D CAD models. Unlike most free "
 "software for creating 3D models (such as Blender) it does not focus on the "
 "artistic aspects of 3D modelling but instead on the CAD aspects. Thus it "
-"might be the application you are looking for when you are planning to create "
-"3D models of machine parts but pretty sure is not what you are looking for "
+"might be the application you are looking for when you are planning to create"
+" 3D models of machine parts but pretty sure is not what you are looking for "
 "when you are more interested in creating computer-animated movies."
 
 #. (itstool) path: description/p
 #: openscad.appdata.xml.in2:21
 msgid ""
-"OpenSCAD is not an interactive modeller. Instead it is something like a 3D-"
-"compiler that reads in a script file that describes the object and renders "
-"the 3D model from this script file. This gives you (the designer) full "
-"control over the modelling process and enables you to easily change any step "
-"in the modelling process or make designs that are defined by configurable "
-"parameters."
+"OpenSCAD is not an interactive modeller. Instead it is something like a "
+"3D-compiler that reads in a script file that describes the object and "
+"renders the 3D model from this script file. This gives you (the designer) "
+"full control over the modelling process and enables you to easily change any"
+" step in the modelling process or make designs that are defined by "
+"configurable parameters."
 msgstr ""
-"OpenSCAD is not an interactive modeller. Instead it is something like a 3D-"
-"compiler that reads in a script file that describes the object and renders "
-"the 3D model from this script file. This gives you (the designer) full "
-"control over the modelling process and enables you to easily change any step "
-"in the modelling process or make designs that are defined by configurable "
-"parameters."
+"OpenSCAD is not an interactive modeller. Instead it is something like a "
+"3D-compiler that reads in a script file that describes the object and "
+"renders the 3D model from this script file. This gives you (the designer) "
+"full control over the modelling process and enables you to easily change any"
+" step in the modelling process or make designs that are defined by "
+"configurable parameters."
 
 #. (itstool) path: description/p
 #: openscad.appdata.xml.in2:22
 msgid ""
-"OpenSCAD provides two main modelling techniques: First there is constructive "
-"solid geometry (aka CSG) and second there is extrusion of 2D outlines. As "
+"OpenSCAD provides two main modelling techniques: First there is constructive"
+" solid geometry (aka CSG) and second there is extrusion of 2D outlines. As "
 "data exchange format for this 2D outlines Autocad DXF files are used. In "
 "addition to 2D paths for extrusion it is also possible to read design "
-"parameters from DXF files. Besides DXF files OpenSCAD can read and create 3D "
-"models in the STL and OFF file formats."
+"parameters from DXF files. Besides DXF files OpenSCAD can read and create 3D"
+" models in the STL and OFF file formats."
 msgstr ""
-"OpenSCAD provides two main modelling techniques: First there is constructive "
-"solid geometry (aka CSG) and second there is extrusion of 2D outlines. As "
+"OpenSCAD provides two main modelling techniques: First there is constructive"
+" solid geometry (aka CSG) and second there is extrusion of 2D outlines. As "
 "data exchange format for this 2D outlines Autocad DXF files are used. In "
 "addition to 2D paths for extrusion it is also possible to read design "
-"parameters from DXF files. Besides DXF files OpenSCAD can read and create 3D "
-"models in the STL and OFF file formats."
+"parameters from DXF files. Besides DXF files OpenSCAD can read and create 3D"
+" models in the STL and OFF file formats."
 
 #~ msgid "&Font List"
 #~ msgstr "&Fontliste"
@@ -3399,8 +3384,7 @@ msgstr ""
 #~ "Warning: You may experience OpenCSG rendering errors.\n"
 #~ "\n"
 #~ msgstr ""
-#~ "Achtung: Es können Darstellungsfehler beim Anzeigen der Vorschau "
-#~ "auftreten.\n"
+#~ "Achtung: Es können Darstellungsfehler beim Anzeigen der Vorschau auftreten.\n"
 #~ "\n"
 
 #~ msgid "save preset"
@@ -3425,8 +3409,8 @@ msgstr ""
 #~ msgstr "Änderungen an den aktuelle Voreinstellung nicht gespeichert"
 
 #~ msgid ""
-#~ "The changes on the current preset %1 are not saved yet. Do you really "
-#~ "want to reset this preset and lose your changes?"
+#~ "The changes on the current preset %1 are not saved yet. Do you really want "
+#~ "to reset this preset and lose your changes?"
 #~ msgstr ""
 #~ "Die Änderungen an der akutellen Voreinstellung %1 sind noch nicht "
 #~ "gespeichert.Möchten Sie die Änderungen wirklich zurücksetzen?"
@@ -3438,12 +3422,12 @@ msgstr ""
 #~ msgstr "JSON file ist nicht schreibbar"
 
 #~ msgid ""
-#~ "The current preset %1 contains changes, but is not saved yet. Do you "
-#~ "really want to change the preset and lose your changes?"
+#~ "The current preset %1 contains changes, but is not saved yet. Do you really "
+#~ "want to change the preset and lose your changes?"
 #~ msgstr ""
 #~ "Die Änderungen an der akutellen Voreinstellung %1 sind noch nicht "
-#~ "gespeichert.Möchten Sie wirklich die Voreinstellung wechseln und somit "
-#~ "Ihre Änderungen verlieren?"
+#~ "gespeichert.Möchten Sie wirklich die Voreinstellung wechseln und somit Ihre "
+#~ "Änderungen verlieren?"
 
 #~ msgid "Do you want to delete the current preset?"
 #~ msgstr "Möchten Sie die aktuelle Voreinstellung löschen?"


### PR DESCRIPTION
The German catalogue was last revised in December 2021 and had drifted to
63 % translated. Since `msgfmt` drops fuzzy entries, 254 of 702 strings were
reaching the user interface in English.

| | before | after |
|---|---|---|
| translated | 448 | 655 |
| fuzzy | 77 | 0 |
| untranslated | 177 | 47 |

`msgfmt -c` reports no problems. Only `locale/de.po` changes.

## The fuzzy entries were wrong, not approximate

All 77 were msgmerge guesses matched on string similarity, and none of them
was salvageable:

| msgid | previous msgstr |
|---|---|
| `Page Size` | `Schrittgröße` (step size) |
| `Backend` | `Hinten` (at the back) |
| `Distance` | `Weiterführende Beispiele` (advanced examples) |
| `Copy Color Name` | `Font` |
| `Button 19` | `Knopf 1` |

Harmless while the flag is set, since msgfmt skips them, but anyone running
`msgfmt --use-fuzzy` would get an unusable interface. They are now either
translated or empty.

## 38 strings left untranslated on purpose

These are not display text, and each now carries a translator comment saying
so:

- Values from the `_settings_value` property of combo box entries: `a3`…`a6`,
  `letter`, `legal`, `tabloid`, `micron`, `millimeter`, `centimeter`, `meter`,
  `inch`, `foot`, `model`, `none`, `selected-only`, `landscape`, `auto`. The
  visible label sits in the adjacent `text` property and is translated;
  translating the value would change what gets written to the settings.
- The internal names built in `Settings.cc`: `axis-%d` and `axis-inverted-%d`.
  The display strings `Axis %d` and `Axis %d (inverted)` are separate and are
  translated.
- Qt object names that ended up in the template: `ResetSampleText`,
  `ViewportControlWidget`.

An empty msgstr makes gettext return the original, which is what these need.
That these strings are marked translatable at all looks like a bug in the
`.ui` files and in `Settings.cc` rather than something translators should be
working around, but that is a separate matter.

## Other changes

`Show Scale Markers` was translated as `Axen&einteilung anzeigen`. Five other
entries spell `Achsen` correctly; fixed.

The new export entries for OBJ and POV would both have taken `O` as their
accelerator, which `OFF` already uses. They are now `OB&J` and `POV e&xportieren`,
and no letter repeats in that submenu.

`Ctrl+N` style entries are left untouched: those are QKeySequence strings, not
labels, and Qt renders them as `Strg+N` on a German system by itself. The mouse
configuration labels, which are display text, do use `Strg` and `Umschalt`.

## Scope

Only gaps and wrong entries were touched. Existing translations that read
oddly — `Font` for `Font`, `Trim` for `Trim`, and a number of compounds written
as two words — were left alone; that is a separate pass and would have buried
this diff.

The 47 remaining untranslated strings are the HTML tooltips of the PDF export
dialog plus the marked internal values above.

## A note for a follow-up

A handful of the strings translated here no longer match the source. The
template was generated on 2026-01-13, and accelerator markers have been added
to `MainWindow.ui` since, so for example the template has `Preview` while the
source now says `P&review`. Those translations sit unused until the template is
regenerated, at which point msgmerge will pick them up.

I counted 31 of 105 menu entries in `MainWindow.ui` that are currently absent
from `locale/openscad.pot` and therefore untranslatable in all fourteen
languages. I will open a separate issue about that rather than fold a
regeneration into this PR, since regenerating touches every `.po` file.

(I am a native German speaker, so I was able to check everything)