### PR TITLE
Add an "experimental, may change or be removed without notice" warning to Preferences/Features.

### DIFF
--- a/src/gui/Preferences.ui
+++ b/src/gui/Preferences.ui
@@ -1330,7 +1330,17 @@
              </font>
             </property>
             <property name="text">
-             <string>Features</string>
+             <string>Experimental Features</string>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <widget class="QLabel" name="labelFeaturesDisclaimer">
+            <property name="wordWrap">
+             <bool>true</bool>
+            </property>
+            <property name="text">
+             <string>These features are experimental.  They may change or be removed entirely without notice. You may enable them and use them and comment on them, but you must assume that they may not be in their final form and may never appear in an OpenSCAD release in any form.</string>
             </property>
            </widget>
           </item>


### PR DESCRIPTION
Changes the title at the top of the page from "Features" to "Experimental Features", and adds a disclaimer:
>These features are experimental.  They may change or be removed entirely without notice. You may enable them and use them and comment on them, but you must assume that they may not be in their final form and may never appear in an OpenSCAD release in any form.

Fixes #7008.

Was:
<img width="263" height="199" alt="image" src="https://github.com/user-attachments/assets/7d55451b-662e-4164-a857-dc232734d756" />


New:
<img width="876" height="237" alt="image" src="https://github.com/user-attachments/assets/815caf9f-1cae-4e35-a21c-d769c02d6ea9" />
