### PR TITLE
Fix VBO deletion landing in the wrong GL context

### DIFF
--- a/src/gui/MainWindow.cc
+++ b/src/gui/MainWindow.cc
@@ -959,12 +959,16 @@ void MainWindow::instantiateRoot()
 {
   // Go on and instantiate root_node, then call the continuation slot
 
-  // Invalidate renderers before we kill the CSG tree
-  this->qglview->setRenderer(nullptr);
+  // Invalidate renderers before we kill the CSG tree. Renderers own vertex
+  // buffers and delete them from their destructors, so drop them with our own
+  // GL context current.
+  this->qglview->withCurrentContext([this]() {
+    this->qglview->setRenderer(nullptr);
 #ifdef ENABLE_OPENCSG
-  this->previewRenderer = nullptr;
+    this->previewRenderer = nullptr;
 #endif
-  this->thrownTogetherRenderer = nullptr;
+    this->thrownTogetherRenderer = nullptr;
+  });
 
   // Remove previous CSG tree
   this->absoluteRootNode.reset();
@@ -1993,8 +1997,10 @@ void MainWindow::cgalRender()
     return;
   }
 
-  this->qglview->setRenderer(nullptr);
-  this->geomRenderer = nullptr;
+  this->qglview->withCurrentContext([this]() {
+    this->qglview->setRenderer(nullptr);
+    this->geomRenderer = nullptr;
+  });
   rootGeom.reset();
 
   LOG("Rendering Polygon Mesh using %1$s...",
@@ -3150,12 +3156,15 @@ void MainWindow::onTabManagerAboutToCloseEditor(EditorInterface *closingEditor)
   if (closingEditor == renderedEditor) {
     renderedEditor = nullptr;
 
-    // Invalidate renderers before we kill the CSG tree
-    this->qglview->setRenderer(nullptr);
+    // Invalidate renderers before we kill the CSG tree, with our own GL
+    // context current so their buffers are deleted where they were created.
+    this->qglview->withCurrentContext([this]() {
+      this->qglview->setRenderer(nullptr);
 #ifdef ENABLE_OPENCSG
-    this->previewRenderer = nullptr;
+      this->previewRenderer = nullptr;
 #endif
-    this->thrownTogetherRenderer = nullptr;
+      this->thrownTogetherRenderer = nullptr;
+    });
 
     // Remove previous CSG tree
     this->absoluteRootNode.reset();

--- a/src/gui/QGLView.cc
+++ b/src/gui/QGLView.cc
@@ -114,6 +114,20 @@ void QGLView::resetView()
   cam.resetView();
 }
 
+void QGLView::withCurrentContext(const std::function<void()>& fn)
+{
+  // See the discussion at QGLView::mouseDoubleClickEvent() for why the
+  // previous context is saved and restored rather than simply dropped.
+  QOpenGLContext *oldContext = getGLContext();
+  this->makeCurrent();
+  auto guard = sg::make_scope_guard([this, oldContext] {
+    this->doneCurrent();
+    setGLContext(oldContext);
+  });
+
+  fn();
+}
+
 void QGLView::viewAll()
 {
   if (auto renderer = this->getRenderer()) {

--- a/src/gui/QGLView.h
+++ b/src/gui/QGLView.h
@@ -4,6 +4,7 @@
 #include "core/Selection.h"
 #include "gui/MouseSelector.h"
 
+#include <functional>
 #include <memory>
 #include <array>
 #include <QImage>
@@ -34,6 +35,12 @@ class QGLView : public QOpenGLWidget, public GLView
 public:
   QGLView(QWidget *parent = nullptr);
   ~QGLView() override;
+
+  // Runs fn with this view's GL context current, restoring whichever context
+  // was current before. Anything owning GL objects - renderers own vertex
+  // buffers - has to be released this way: buffer names are only meaningful in
+  // the context that generated them.
+  void withCurrentContext(const std::function<void()>& fn);
 #ifdef ENABLE_OPENCSG
   bool hasOpenCSGSupport() { return this->is_opencsg_capable; }
 #endif

--- a/src/openscad_gui.cc
+++ b/src/openscad_gui.cc
@@ -113,6 +113,16 @@ bool isDarkMode()
 
 void configureOpenGLContext()
 {
+  // Each QOpenGLWidget otherwise gets an unshared context with its own object
+  // name space, so two windows both hand out buffer name 1. Renderers are
+  // released outside of paintGL() (MainWindow::instantiateRoot()), where the
+  // current context belongs to whichever window painted last, and the
+  // glDeleteBuffers() in ~VertexStateContainer then destroys that window's
+  // identically-numbered buffers. It crashes on its next repaint, drawing from
+  // a buffer that no longer exists. Sharing gives all the widgets one name
+  // space, so a delete always reaches the buffer it was meant for.
+  QCoreApplication::setAttribute(Qt::AA_ShareOpenGLContexts);
+
 #if defined(Q_OS_UNIX) && !defined(Q_OS_MACOS)
   // OpenSCAD still relies on legacy OpenGL compatibility features and GLSL 1.20
   // shaders, so a GLES context is not currently usable. On Wayland/EGL setups Qt


### PR DESCRIPTION
Fixes #7010.

### Problem

With the same file open in two windows, OpenSCAD segfaults in the driver's
client-array vertex path:

```
Exception: EXC_BAD_ACCESS (SIGSEGV), KERN_INVALID_ADDRESS at 0x0000000c

0  GLEngine   gleRunVertexSubmitImmediate
3  GLEngine   glDrawArrays_IMM_Exec
4  OpenSCAD   VertexState::draw()
5  OpenSCAD   OpenCSGRenderer::draw(bool, ShaderUtils::ShaderInfo const*)
6  OpenSCAD   GLView::paintGL()
```

Reproduced reliably on macOS 27, arm64, Qt 6.8.4:

1. Open a `.scad` file, then open the same file again so it shows in two
   separate windows.
2. Save in the first window, to trigger a render.
3. Switch to the second window and save there too.
4. Switch back to the first. It crashes on the repaint.

### Cause

Each `QGLView` gets its own unshared `QOpenGLContext`, so every window has a
separate object name space and both start handing out buffer name 1.

`MainWindow::instantiateRoot()`, `MainWindow::cgalRender()` and
`MainWindow::onTabManagerAboutToCloseEditor()` drop the last reference to the
renderers during compilation. That happens outside `paintGL()` and without
making any context current, so the `glDeleteBuffers()` in
`~VertexStateContainer` runs in whichever context painted last: the *other*
window's. Its identically-numbered buffers are destroyed behind its back.

On that window's next repaint `glBindBuffer()` names a buffer that no longer
exists, so nothing is bound, and the buffer offsets handed to
`glVertexPointer()` are dereferenced as client-side pointers, faulting near
address zero. The faulting address is the byte offset of whichever attribute
the driver reads first — 0x0 and 0xc in the two reports I have.

With a single window the same call deletes into no current context at all,
where `glDeleteBuffers()` is a silent no-op and the buffers leak until the
context goes away.

### Fix

- Set `Qt::AA_ShareOpenGLContexts`, so all views share one object name space
  and a delete always reaches the buffer it was meant for. This alone stops
  the crash.
- Add `QGLView::withCurrentContext()` and release the renderers through it, so
  their buffers are deleted in the context that created them rather than being
  leaked when no context is current. It saves and restores the previously
  current context, following the existing idiom in
  `QGLView::mouseDoubleClickEvent()`.

The second change addresses the leak by construction; I have not measured it.
The crash fix is the part demonstrated below.

### Verification

Reproduced reliably before the change, and does not reproduce after it —
tested with five windows on the same file, saving and switching between them
repeatedly, rotating the preview in between to confirm the buffers stay valid
across repaints.

All three sites where renderers are released were exercised without
regression: preview (F5) and save, render (F6), and closing an editor tab with
a preview showing.

### Related

- #6947 / #6948 touch the same VBO lifecycle from the performance side. No
  file overlap with this change, but caching buffers across renderer
  recreation interacts with it — such a cache would need to be per-context.
- #5647 may be the same defect on Windows, reported against the editor-tab
  close path, which is one of the three sites above. Unconfirmed, as that
  issue has no stack trace.

🤖 Generated with [Claude Code](https://claude.com/claude-code)