### PR TITLE
Fix test suite configuration on macOS without EXPERIMENTAL

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1486,10 +1486,11 @@ list(APPEND NEF3_BROKEN_TESTS
 
 # Platform specific test disable
 if(APPLE)
-  set_tests_properties(
+  # This test is EXPERIMENTAL-gated, so it is only registered when
+  # -DEXPERIMENTAL=ON. Use the safe variant, which tolerates its absence.
+  disable_tests_safe(
     # Fails to create a 3MF file to stdout, see #6895
     export-3mf-stdio_3mf-export
-    PROPERTIES DISABLED TRUE
   )
 elseif(UNIX)
 elseif(WIN32 OR MXECROSS)


### PR DESCRIPTION
### Problem

Configuring the test suite on macOS fails outright unless `-DEXPERIMENTAL=ON`
is passed:

```
CMake Error at CMakeLists.txt:1489 (set_tests_properties):
  set_tests_properties Can not find test to add properties to:
  export-3mf-stdio_3mf-export
-- Configuring incomplete, errors occurred!
```

Reproduce on any Mac, against current master:

```sh
OPENSCAD_BINARY=./build/OpenSCAD.app/Contents/MacOS/OpenSCAD cmake -S tests -B build-tests
```

`EXPERIMENTAL` defaults to `OFF` (`CMakeLists.txt:41`), so a plain configure
hits this.

### Cause

`set_tests_properties()` is a hard error when handed a name that is not a
registered test. `export-3mf-stdio` comes from an `add_cmdline_test()` tagged
`EXPERIMENTAL` (`tests/CMakeLists.txt:981`), and
`tests/cmake/TestFunctions.cmake:479` only reaches `add_test()` for those when
`EXPERIMENTAL` is set — so with the default the test does not exist and the
macOS disable block cannot name it.

`.github/workflows/macos-tests.yml:64` passes `-DEXPERIMENTAL=ON`, which is why
CI has never seen this.

Introduced in a9d04c6fc (#6900).

### Fix

Use `disable_tests_safe()`, already defined at `tests/CMakeLists.txt:25` for
precisely this situation and used by the surrounding blocks. It filters on
`if(TEST ...)` first, so the macOS disable still applies when the test exists
and becomes a no-op when it does not.

The Windows branch just below keeps the raw call deliberately:
`export-csg-nonascii` and `export-pdf` are registered unconditionally, so it is
safe there.

### Verification

The command above fails on master and reports `-- Configuring done` with this
change. Tested on macOS 27, arm64.

🤖 Generated with [Claude Code](https://claude.com/claude-code)