### PR TITLE
Stop using the GitHub Mac Intel image until Homebrew incompatibility is sorted

### DIFF
--- a/.github/workflows/macos-tests.yml
+++ b/.github/workflows/macos-tests.yml
@@ -17,7 +17,7 @@ jobs:
   build_and_test:
     strategy:
       matrix:
-        os: [macos-15-intel, macos-latest]
+        os: [macos-15, macos-latest]
         qt: [qt5, qt6]
         exclude:
           # macos-latest runs on arm64, which has a broken SW renderer


### PR DESCRIPTION
This PR simply changes the build machine from macOS15-Intel to the default arm64. The resulting CI fails some tests, but it gets farther along than the Intel-based build machine does, which fails during the preliminary Homebrew install. Short-term workaround for #7016 