### PR TITLE
Rename Preferences "Features" tab to "Experimental".

### DIFF
--- a/src/gui/Preferences.ui
+++ b/src/gui/Preferences.ui
@@ -3298,7 +3298,7 @@
      <normaloff>:/icons/prefsFeatures.png</normaloff>:/icons/prefsFeatures.png</iconset>
    </property>
    <property name="text">
-    <string>Features</string>
+    <string>Experimental</string>
    </property>
    <property name="toolTip">
     <string>Enable/Disable experimental features</string>


### PR DESCRIPTION
Like the title says, as @kintel suggested.

Note:  the word "Experimental" is, in the font I end up with, a little larger than the icon.  That causes the icons to spread out a little.

Before:
<img width="486" height="62" alt="image" src="https://github.com/user-attachments/assets/5cf08c92-2c97-4405-85d1-d33844b16146" />

After:
<img width="539" height="66" alt="image" src="https://github.com/user-attachments/assets/508f1f1e-adad-43a3-9c6d-0213f6ea8670" />

I think this is better, but if others don't like the slight layout change that's OK.