### PR TITLE
Stop marking internal values as translatable

### DIFF
--- a/src/core/Settings.cc
+++ b/src/core/Settings.cc
@@ -45,11 +45,11 @@ std::vector<SettingsEntryEnum<std::string>::Item> axisValues()
   output.push_back({"None", "none", _("None")});
   for (size_t i = 0; i < max_axis; ++i) {
     const auto userData = (boost::format("+%d") % (i + 1)).str();
-    const auto name = (boost::format(_("axis-%d")) % i).str();
+    const auto name = (boost::format("axis-%d") % i).str();
     const auto text = (boost::format(_("Axis %d")) % i).str();
     output.push_back({userData, name, text});
     const auto userDataInv = (boost::format("-%d") % (i + 1)).str();
-    const auto nameInv = (boost::format(_("axis-inverted-%d")) % i).str();
+    const auto nameInv = (boost::format("axis-inverted-%d") % i).str();
     const auto textInv = (boost::format(_("Axis %d (inverted)")) % i).str();
     output.push_back({userDataInv, nameInv, textInv});
   }

--- a/src/gui/Export3mfDialog.ui
+++ b/src/gui/Export3mfDialog.ui
@@ -82,7 +82,7 @@
                <bool>true</bool>
               </property>
               <property name="_settings_value" stdset="0">
-               <string>micron</string>
+               <string notr="true">micron</string>
               </property>
               <attribute name="buttonGroup">
                <string notr="true">buttonGroupUnit</string>
@@ -95,7 +95,7 @@
                <string>Millimeter (default)</string>
               </property>
               <property name="_settings_value" stdset="0">
-               <string>millimeter</string>
+               <string notr="true">millimeter</string>
               </property>
               <attribute name="buttonGroup">
                <string notr="true">buttonGroupUnit</string>
@@ -108,7 +108,7 @@
                <string>Centimeter</string>
               </property>
               <property name="_settings_value" stdset="0">
-               <string>centimeter</string>
+               <string notr="true">centimeter</string>
               </property>
               <attribute name="buttonGroup">
                <string notr="true">buttonGroupUnit</string>
@@ -121,7 +121,7 @@
                <string>Meter</string>
               </property>
               <property name="_settings_value" stdset="0">
-               <string>meter</string>
+               <string notr="true">meter</string>
               </property>
               <attribute name="buttonGroup">
                <string notr="true">buttonGroupUnit</string>
@@ -134,7 +134,7 @@
                <string>Inch</string>
               </property>
               <property name="_settings_value" stdset="0">
-               <string>inch</string>
+               <string notr="true">inch</string>
               </property>
               <attribute name="buttonGroup">
                <string notr="true">buttonGroupUnit</string>
@@ -147,7 +147,7 @@
                <string>Foot</string>
               </property>
               <property name="_settings_value" stdset="0">
-               <string>foot</string>
+               <string notr="true">foot</string>
               </property>
               <attribute name="buttonGroup">
                <string notr="true">buttonGroupUnit</string>
@@ -176,7 +176,7 @@
                <string>Use colors from model and color scheme</string>
               </property>
               <property name="_settings_value" stdset="0">
-               <string>model</string>
+               <string notr="true">model</string>
               </property>
               <attribute name="buttonGroup">
                <string notr="true">buttonGroupColors</string>
@@ -192,7 +192,7 @@
                <bool>true</bool>
               </property>
               <property name="_settings_value" stdset="0">
-               <string>none</string>
+               <string notr="true">none</string>
               </property>
               <attribute name="buttonGroup">
                <string notr="true">buttonGroupColors</string>
@@ -205,7 +205,7 @@
                <string>Use selected color for all objects</string>
               </property>
               <property name="_settings_value" stdset="0">
-               <string>selected-only</string>
+               <string notr="true">selected-only</string>
               </property>
               <attribute name="buttonGroup">
                <string notr="true">buttonGroupColors</string>

--- a/src/gui/ExportPdfDialog.ui
+++ b/src/gui/ExportPdfDialog.ui
@@ -50,7 +50,7 @@
              <string>A6 (105 x 148 mm)</string>
             </property>
             <property name="_settings_value" stdset="0">
-             <string>a6</string>
+             <string notr="true">a6</string>
             </property>
             <attribute name="buttonGroup">
              <string notr="true">buttonGroupPaperSize</string>
@@ -63,7 +63,7 @@
              <string>A5 (148 x 210 mm)</string>
             </property>
             <property name="_settings_value" stdset="0">
-             <string>a5</string>
+             <string notr="true">a5</string>
             </property>
             <attribute name="buttonGroup">
              <string notr="true">buttonGroupPaperSize</string>
@@ -79,7 +79,7 @@
              <bool>true</bool>
             </property>
             <property name="_settings_value" stdset="0">
-             <string>a4</string>
+             <string notr="true">a4</string>
             </property>
             <attribute name="buttonGroup">
              <string notr="true">buttonGroupPaperSize</string>
@@ -92,7 +92,7 @@
              <string>A3 (297x420 mm)</string>
             </property>
             <property name="_settings_value" stdset="0">
-             <string>a3</string>
+             <string notr="true">a3</string>
             </property>
             <attribute name="buttonGroup">
              <string notr="true">buttonGroupPaperSize</string>
@@ -105,7 +105,7 @@
              <string>Letter (8.5x11 in)</string>
             </property>
             <property name="_settings_value" stdset="0">
-             <string>letter</string>
+             <string notr="true">letter</string>
             </property>
             <attribute name="buttonGroup">
              <string notr="true">buttonGroupPaperSize</string>
@@ -118,7 +118,7 @@
              <string>Legal (8.5x14 in)</string>
             </property>
             <property name="_settings_value" stdset="0">
-             <string>legal</string>
+             <string notr="true">legal</string>
             </property>
             <attribute name="buttonGroup">
              <string notr="true">buttonGroupPaperSize</string>
@@ -134,7 +134,7 @@
              <string/>
             </property>
             <property name="_settings_value" stdset="0">
-             <string>tabloid</string>
+             <string notr="true">tabloid</string>
             </property>
             <attribute name="buttonGroup">
              <string notr="true">buttonGroupPaperSize</string>
@@ -314,7 +314,7 @@
              <string>Landscape (Horizontal)</string>
             </property>
             <property name="_settings_value" stdset="0">
-             <string>landscape</string>
+             <string notr="true">landscape</string>
             </property>
             <attribute name="buttonGroup">
              <string notr="true">buttonGroupOrientation</string>
@@ -330,7 +330,7 @@
              <string>Auto</string>
             </property>
             <property name="_settings_value" stdset="0">
-             <string>auto</string>
+             <string notr="true">auto</string>
             </property>
             <attribute name="buttonGroup">
              <string notr="true">buttonGroupOrientation</string>

--- a/src/gui/FontList.ui
+++ b/src/gui/FontList.ui
@@ -290,7 +290,7 @@
     <iconset theme="chokusen-undo"/>
    </property>
    <property name="text">
-    <string>ResetSampleText</string>
+    <string>Reset Sample Text</string>
    </property>
   </action>
   <action name="actionOpenFolder">

--- a/src/gui/ViewportControl.ui
+++ b/src/gui/ViewportControl.ui
@@ -11,7 +11,7 @@
    </rect>
   </property>
   <property name="windowTitle">
-   <string>ViewportControlWidget</string>
+   <string notr="true">ViewportControlWidget</string>
   </property>
   <layout class="QVBoxLayout" name="verticalLayout">
    <item>


### PR DESCRIPTION
Follow-up to #7007, taking up the offer to handle the translation markers so
#7018 can go in as is.

Four kinds of string that end up in the catalogue without being user
interface text:

**`_settings_value` in the export dialogs (18 strings).** The value written
to the settings, sitting next to the label that is shown:

    <property name="text"><string>Landscape (Horizontal)</string></property>
    <property name="_settings_value" stdset="0"><string>landscape</string></property>

The label stays translatable, the value gets `notr="true"`. Verified with
`uic -tr _`: the translatable calls drop from 45 to 36 in Export3mfDialog and
from 63 to 54 in ExportPdfDialog, while `setProperty("_settings_value", ...)`
keeps its literal.

**The item names in `Settings.cc` (2 strings).** `axisValues()` wraps both the
display string and the internal name in `_()`:

    const auto name = (boost::format(_("axis-%d")) % i).str();
    const auto text = (boost::format(_("Axis %d")) % i).str();

`SettingsEntryEnum::decode()` compares `item.name` against the stored value, so
an axis mapping saved in German would not be found again in English. The `_()`
is dropped from the two names. The line directly above already does it that
way — `output.push_back({"None", "none", _("None")})` — so this only makes the
loop consistent with it.

**A Designer placeholder (1 string).** `ViewportControl.ui` carries
`ViewportControlWidget` as its `windowTitle`. The widget is placed in a dock
that supplies its own title, so it is never shown; marked `notr="true"`.

**One that is a plain bug rather than a marker problem (1 string).**
`FontList.ui` has the object name as the action's text:

    <action name="actionResetSampleText">
      <property name="text"><string>ResetSampleText</string></property>

`FontList.cc` adds it with `lineEditSampleText->addAction(..., QLineEdit::TrailingPosition)`,
so it is an inline button with an icon and no label. Qt falls back to the action
text for the tooltip when none is set, so hovering it read `ResetSampleText`;
it now reads what `ColorList.ui` has always had. This changes a translatable
string rather than removing one.

That is 20 entries fewer in the template.

## What I left alone

**`shortcut` properties (60 strings).** I flagged these in #7007 and was wrong
to. Qt deliberately makes key sequences translatable so a translator can adapt
a binding to a different keyboard layout; they only break if translated badly,
not by being translatable. Removing that would be a policy change rather than a
cleanup, so I have not touched them. Happy to if you would rather they went.

**`qrc:/html/AboutDialog.html` and `qrc:/html/PrintInitDialog.html`.** Also
flagged in #7007, also wrong: `uic` does not wrap a `<string>` inside `<url>`
in a translation call at all, and neither is in the template. Nothing to do.

**`%v / %m` on the progress bar and the ` mm` suffix.** Both are in the
template. The suffix is legitimately translatable; the progress format is
harmless either way. Left as they are.

## Follow-up

The 20 entries stay in the catalogues until the next template run, which I
assume you would fold into #7018 or do afterwards. Say the word if you would
like me to prepare that instead.

Verified with `uic -tr _` from Qt 6.10 against every touched file, and by hand
in the running application: the page size and orientation of the PDF export
dialog still survive closing and reopening it, and the font list tooltip now
reads properly.