### PR TITLE
Various translation cleanups

### DIFF
--- a/locale/LINGUAS
+++ b/locale/LINGUAS
@@ -1,2 +1,2 @@
 # available languages
-cs de es fr hy it ka pl pt_BR ru tr uk zh_CN zh_TW
+cs de es fr hy it ka pl pt_BR ru sv tr uk zh_CN zh_TW

--- a/locale/cs.po
+++ b/locale/cs.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: OpenSCAD 2013.02.24\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-09-06 23:38+0200\n"
+"POT-Creation-Date: 2026-09-06 17:48-0700\n"
 "PO-Revision-Date: 2015-03-06 10:27+0100\n"
 "Last-Translator: Miro Hrončok <miro@hroncok.cz>\n"
 "Language-Team: Czech <miro@hroncok.cz>\n"
@@ -93,151 +93,115 @@ msgstr "Kroky:"
 msgid "Dump Pictures"
 msgstr "Ukládat obrázky"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:852
-#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:362
-#: build/OpenSCADLibInternal_autogen/include/ui_MouseConfigWidget.h:214
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2464
-msgid "Preferences"
-msgstr "Předvolby"
-
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:853
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:854
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:858
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:862
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:864
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:866
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:868
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:870
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:881
+#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:860
+#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:861
+#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:865
+#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:869
+#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:871
+#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:873
+#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:875
+#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:877
+#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:888
 msgid "Trim"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:855
+#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:862
 #, fuzzy
 msgid "Reset Trim"
 msgstr "Výchozí pohled"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:856
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:859
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:860
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:861
 #: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:863
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:865
+#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:866
 #: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:867
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:869
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:880
+#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:868
+#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:870
+#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:872
+#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:874
+#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:876
+#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:887
 msgid "DeadZone"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:857
+#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:864
 msgid "Auto Trim Axes"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:871
+#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:878
 msgid "Axis 2"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:872
+#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:879
 msgid "Axis 0"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:873
+#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:880
 msgid "Axis 3"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:874
+#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:881
 msgid "Axis 6"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:875
+#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:882
 msgid "Axis 8"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:876
+#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:883
 msgid "Axis 7"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:877
+#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:884
 msgid "Axis 5"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:878
+#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:885
 msgid "Axis 1"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:879
+#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:886
 msgid "Axis 4"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:882
+#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:889
 #: build/OpenSCADLibInternal_autogen/include/ui_ViewportControl.h:279
 #, fuzzy
 msgid "Rotation"
 msgstr "&Dokumentace"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:883
+#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:890
 #, fuzzy
 msgid "Zoom"
 msgstr "Přiblížit"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:884
-msgid "X"
-msgstr ""
-
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:885
+#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:891
 msgid "Gain"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:886
-msgid "Y"
-msgstr ""
-
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:887
-msgid "Z"
-msgstr ""
-
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:888
+#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:892
 #: build/OpenSCADLibInternal_autogen/include/ui_ViewportControl.h:280
 msgid "Translation"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:889
+#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:893
 #, fuzzy
 msgid "ViewPort rel.<br/>Translation"
 msgstr "Vložit posun pohl&edu"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:890
+#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:894
 #, fuzzy
-msgid "ViewPort rel.<br />Rotation"
+msgid "ViewPort rel.<br/>Rotation"
 msgstr "Vložit posun pohl&edu"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:891
+#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:895
 msgid "Axis Setup:"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:892
+#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:896
 msgid "<b>Driver selection:</b> <i>(changes requires restarting OpenSCAD)</i>"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:893
-#, fuzzy
-msgid "SpaceNav"
-msgstr "mezer"
-
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:894
-msgid "HIDAPI"
-msgstr ""
-
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:895
-msgid "QGamepad"
-msgstr ""
-
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:896
-msgid "Joystick"
-msgstr ""
-
 #: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:897
-msgid "DBus"
+msgid "Joystick"
 msgstr ""
 
 #: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:898
@@ -249,126 +213,117 @@ msgid "Status:"
 msgstr ""
 
 #: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:900
-#, fuzzy
-msgid "TextLabel"
-msgstr "za textem"
-
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:901
 #: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2468
 msgid "Update"
 msgstr "Aktualizace"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:363
+#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:362
 msgid "Button 19"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:364
+#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:363
 msgid "Button 5"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:365
+#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:364
 msgid "Button 14"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:366
+#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:365
 msgid "Button 7"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:367
+#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:366
 msgid "Button 16"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:368
+#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:367
 msgid "Button 20"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:369
+#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:368
 msgid "Button 1"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:370
+#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:369
 msgid "Button 21"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:371
+#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:370
 msgid "Button 18"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:372
+#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:371
 msgid "Button 0"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:373
+#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:372
 msgid "Button 4"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:374
+#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:373
 msgid "Button 10"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:375
+#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:374
 msgid "Button 6"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:376
+#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:375
 msgid "Button 8"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:377
+#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:376
 msgid "Button 15"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:378
+#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:377
 msgid "Button 11"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:379
+#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:378
 msgid "Button 3"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:380
+#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:379
 msgid "Button 23"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:381
+#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:380
 msgid "Button 9"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:382
+#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:381
 msgid "Button 2"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:383
+#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:382
 msgid "Button 13"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:384
+#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:383
 msgid "Button 12"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:385
+#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:384
 msgid "Button 17"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:386
+#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:385
 msgid "Button 22"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_ChatWidget.h:194
+#: build/OpenSCADLibInternal_autogen/include/ui_ChatWidget.h:195
 msgid "AI Chat"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_ChatWidget.h:195
+#: build/OpenSCADLibInternal_autogen/include/ui_ChatWidget.h:196
 #: src/gui/ai/ChatWidget.cc:138
 msgid "AI Assistant"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_ChatWidget.h:197
+#: build/OpenSCADLibInternal_autogen/include/ui_ChatWidget.h:198
 msgid "Chat options"
-msgstr ""
-
-#: build/OpenSCADLibInternal_autogen/include/ui_ChatWidget.h:199
-msgid "☰"
 msgstr ""
 
 #: build/OpenSCADLibInternal_autogen/include/ui_ChatWidget.h:201
@@ -596,7 +551,7 @@ msgstr "Skrýt nástrojové lišty"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_ErrorLog.h:93
 #: build/OpenSCADLibInternal_autogen/include/ui_ViewportControl.h:267
-msgid "RowSelected"
+msgid "Row Selected"
 msgstr ""
 
 #: build/OpenSCADLibInternal_autogen/include/ui_ErrorLog.h:95
@@ -653,9 +608,7 @@ msgid "Export 3MF Options"
 msgstr "Funkce"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_Export3mfDialog.h:459
-#: build/OpenSCADLibInternal_autogen/include/ui_ExportPdfDialog.h:552
-msgid ""
-"<html><head/><body><p>Set the PDF page (paper) size.  </p></body></html>"
+msgid "Set the unit used in the exported file"
 msgstr ""
 
 #: build/OpenSCADLibInternal_autogen/include/ui_Export3mfDialog.h:461
@@ -805,6 +758,10 @@ msgstr ""
 msgid "Export PDF Options"
 msgstr "Funkce"
 
+#: build/OpenSCADLibInternal_autogen/include/ui_ExportPdfDialog.h:552
+msgid "Set the PDF page (paper) size."
+msgstr ""
+
 #: build/OpenSCADLibInternal_autogen/include/ui_ExportPdfDialog.h:554
 #, fuzzy
 msgid "Page Size"
@@ -864,9 +821,7 @@ msgid "Author"
 msgstr ""
 
 #: build/OpenSCADLibInternal_autogen/include/ui_ExportPdfDialog.h:582
-msgid ""
-"<html><head/><body><p>Set the direction of the largest page dimension.</p></"
-"body></html>"
+msgid "Set the direction of the largest page dimension."
 msgstr ""
 
 #: build/OpenSCADLibInternal_autogen/include/ui_ExportPdfDialog.h:584
@@ -885,9 +840,7 @@ msgid "Landscape (Horizontal)"
 msgstr ""
 
 #: build/OpenSCADLibInternal_autogen/include/ui_ExportPdfDialog.h:589
-msgid ""
-"<html><head/><body><p>Determine best orientation based on maximum geometry "
-"dimension.</p></body></html>"
+msgid "Determine best orientation based on maximum geometry dimension."
 msgstr ""
 
 #: build/OpenSCADLibInternal_autogen/include/ui_ExportPdfDialog.h:591
@@ -901,8 +854,7 @@ msgid "Annotations"
 msgstr "&Dokumentace"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_ExportPdfDialog.h:594
-msgid ""
-"<html><head/><body><p>Include design filename on page.</p></body></html>"
+msgid "Include design filename on page."
 msgstr ""
 
 #: build/OpenSCADLibInternal_autogen/include/ui_ExportPdfDialog.h:596
@@ -910,9 +862,7 @@ msgid "Show Design Filename"
 msgstr ""
 
 #: build/OpenSCADLibInternal_autogen/include/ui_ExportPdfDialog.h:598
-msgid ""
-"<html><head/><body><p>Include rulers on page to confirm 1:1 printing scale.</"
-"p></body></html>"
+msgid "Include rulers on page to confirm 1:1 printing scale."
 msgstr ""
 
 #: build/OpenSCADLibInternal_autogen/include/ui_ExportPdfDialog.h:600
@@ -921,9 +871,7 @@ msgid "Show Scale"
 msgstr "Zobrazit pravítko"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_ExportPdfDialog.h:602
-msgid ""
-"<html><head/><body><p>Include a grid of the selected size on the page.</p></"
-"body></html>"
+msgid "Include a grid of the selected size on the page."
 msgstr ""
 
 #: build/OpenSCADLibInternal_autogen/include/ui_ExportPdfDialog.h:604
@@ -952,9 +900,7 @@ msgid "10mm"
 msgstr ""
 
 #: build/OpenSCADLibInternal_autogen/include/ui_ExportPdfDialog.h:611
-msgid ""
-"<html><head/><body><p>Include text describing usage of scale.</p></body></"
-"html>"
+msgid "Include text describing usage of scale."
 msgstr ""
 
 #: build/OpenSCADLibInternal_autogen/include/ui_ExportPdfDialog.h:613
@@ -968,9 +914,8 @@ msgid "Fill and Stroke"
 msgstr ""
 
 #: build/OpenSCADLibInternal_autogen/include/ui_ExportPdfDialog.h:616
-msgid ""
-"<html><head/><body><p>Enable filling of exported geometry with a color.</p></"
-"body></html>"
+#: build/OpenSCADLibInternal_autogen/include/ui_ExportSvgDialog.h:205
+msgid "Enable filling of exported geometry with a color."
 msgstr ""
 
 #: build/OpenSCADLibInternal_autogen/include/ui_ExportPdfDialog.h:618
@@ -979,9 +924,8 @@ msgid "Fill Geometry"
 msgstr ""
 
 #: build/OpenSCADLibInternal_autogen/include/ui_ExportPdfDialog.h:623
-msgid ""
-"<html><head/><body><p>Enable outline stroke for exported geometry.</p></"
-"body></html>"
+#: build/OpenSCADLibInternal_autogen/include/ui_ExportSvgDialog.h:212
+msgid "Enable outline stroke for exported geometry."
 msgstr ""
 
 #: build/OpenSCADLibInternal_autogen/include/ui_ExportPdfDialog.h:625
@@ -1003,14 +947,6 @@ msgstr ""
 #, fuzzy
 msgid "Export SVG Options"
 msgstr "Funkce"
-
-#: build/OpenSCADLibInternal_autogen/include/ui_ExportSvgDialog.h:205
-msgid "Enable filling of exported geometry with a color."
-msgstr ""
-
-#: build/OpenSCADLibInternal_autogen/include/ui_ExportSvgDialog.h:212
-msgid "Enable outline stroke for exported geometry."
-msgstr ""
 
 #: build/OpenSCADLibInternal_autogen/include/ui_FontList.h:291
 #, fuzzy
@@ -1061,7 +997,7 @@ msgstr "Zobrazit pravítko"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_FontList.h:302
 #, fuzzy
-msgid "ShowFileName"
+msgid "Show File Name"
 msgstr "&Soubor"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_FontList.h:303
@@ -1857,13 +1793,13 @@ msgid "Ctrl+J"
 msgstr "Ctrl+N"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_MainWindow.h:1286
-#: src/gui/MainWindow.cc:1335 src/gui/MainWindow.cc:1342
-#: src/gui/MainWindow.cc:1355 src/gui/MainWindow.cc:1360
+#: src/gui/MainWindow.cc:1346 src/gui/MainWindow.cc:1353
+#: src/gui/MainWindow.cc:1366 src/gui/MainWindow.cc:1371
 msgid "Create Virtual Environment"
 msgstr ""
 
 #: build/OpenSCADLibInternal_autogen/include/ui_MainWindow.h:1287
-#: src/gui/MainWindow.cc:1377
+#: src/gui/MainWindow.cc:1388
 msgid "Select Virtual Environment"
 msgstr ""
 
@@ -1948,56 +1884,56 @@ msgstr "Hotovo"
 msgid "Customizer Widget"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_MouseConfigWidget.h:215
+#: build/OpenSCADLibInternal_autogen/include/ui_MouseConfigWidget.h:214
 msgid "Ctrl + Shift + Middle-click"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_MouseConfigWidget.h:216
+#: build/OpenSCADLibInternal_autogen/include/ui_MouseConfigWidget.h:215
 msgid "Left-click"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_MouseConfigWidget.h:217
+#: build/OpenSCADLibInternal_autogen/include/ui_MouseConfigWidget.h:216
 msgid "Ctrl + Left-click"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_MouseConfigWidget.h:218
+#: build/OpenSCADLibInternal_autogen/include/ui_MouseConfigWidget.h:217
 msgid "Shift + Left-click"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_MouseConfigWidget.h:219
+#: build/OpenSCADLibInternal_autogen/include/ui_MouseConfigWidget.h:218
 msgid "Ctrl + Shift + Right-click"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_MouseConfigWidget.h:220
+#: build/OpenSCADLibInternal_autogen/include/ui_MouseConfigWidget.h:219
 #, fuzzy
 msgid "Preset"
 msgstr "Výchozí pohled"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_MouseConfigWidget.h:221
+#: build/OpenSCADLibInternal_autogen/include/ui_MouseConfigWidget.h:220
 msgid "Right-click"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_MouseConfigWidget.h:222
+#: build/OpenSCADLibInternal_autogen/include/ui_MouseConfigWidget.h:221
 msgid "Ctrl + Middle-click"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_MouseConfigWidget.h:223
+#: build/OpenSCADLibInternal_autogen/include/ui_MouseConfigWidget.h:222
 msgid "Shift + Middle-click"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_MouseConfigWidget.h:224
+#: build/OpenSCADLibInternal_autogen/include/ui_MouseConfigWidget.h:223
 msgid "Ctrl + Right-click"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_MouseConfigWidget.h:225
+#: build/OpenSCADLibInternal_autogen/include/ui_MouseConfigWidget.h:224
 msgid "Ctrl + Shift + Left-click"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_MouseConfigWidget.h:226
+#: build/OpenSCADLibInternal_autogen/include/ui_MouseConfigWidget.h:225
 msgid "Shift + Right-click"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_MouseConfigWidget.h:227
+#: build/OpenSCADLibInternal_autogen/include/ui_MouseConfigWidget.h:226
 msgid "Middle-click"
 msgstr ""
 
@@ -2014,24 +1950,10 @@ msgid "OpenGL Warning"
 msgstr "OpenGL varování"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_OpenCSGWarningDialog.h:77
-msgid ""
-"<!DOCTYPE HTML PUBLIC \"-//W3C//DTD HTML 4.0//EN\" \"http://www.w3.org/TR/"
-"REC-html40/strict.dtd\">\n"
-"<html><head><meta name=\"qrichtext\" content=\"1\" /><style type=\"text/"
-"css\">\n"
-"p, li { white-space: pre-wrap; }\n"
-"</style></head><body style=\" font-family:'Lucida Grande'; font-size:13pt; "
-"font-weight:400; font-style:normal;\">\n"
-"<p style=\"-qt-paragraph-type:empty; margin-top:0px; margin-bottom:0px; "
-"margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;\"></"
-"p></body></html>"
-msgstr ""
-
-#: build/OpenSCADLibInternal_autogen/include/ui_OpenCSGWarningDialog.h:82
 msgid "Show this message again"
 msgstr "Zobrazit tuto zprávu znovu"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_OpenCSGWarningDialog.h:83
+#: build/OpenSCADLibInternal_autogen/include/ui_OpenCSGWarningDialog.h:78
 msgid "Close"
 msgstr "Zavřít"
 
@@ -2103,6 +2025,10 @@ msgstr ""
 #, fuzzy
 msgid "More actions"
 msgstr "&Dokumentace"
+
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2464
+msgid "Preferences"
+msgstr "Předvolby"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2465
 msgid "3D View"
@@ -3166,43 +3092,43 @@ msgstr ""
 msgid "Toggle Perspective"
 msgstr "Pe&rspektivně"
 
-#: src/gui/MainWindow.cc:861
+#: src/gui/MainWindow.cc:872
 msgid "Compile error."
 msgstr "Chyba kompilace."
 
-#: src/gui/MainWindow.cc:864
+#: src/gui/MainWindow.cc:875
 msgid "Error while compiling '%1'."
 msgstr "Chyba při kompilaci '%1'."
 
-#: src/gui/MainWindow.cc:869
+#: src/gui/MainWindow.cc:880
 msgid "Compilation generated %1 warning."
 msgid_plural "Compilation generated %1 warnings."
 msgstr[0] "Kompilace vyvolala %1 varování."
 msgstr[1] "Kompilace vyvolala %1 varování."
 msgstr[2] "Kompilace vyvolala %1 varování."
 
-#: src/gui/MainWindow.cc:882
+#: src/gui/MainWindow.cc:893
 #, fuzzy
 msgid ""
 " For details see the <a href=\"#errorlog\">error log</a> and <a "
 "href=\"#console\">console window</a>."
 msgstr " Pro podrobnosti nahlédněte do <a href=\"#console\">konzole</a>."
 
-#: src/gui/MainWindow.cc:1320
+#: src/gui/MainWindow.cc:1331
 msgid "Trusted Files"
 msgstr ""
 
-#: src/gui/MainWindow.cc:1704
+#: src/gui/MainWindow.cc:1715
 msgid ""
 "Python files can potentially contain harmful stuff.\n"
 "Do you trust this file ?\n"
 msgstr ""
 
-#: src/gui/MainWindow.cc:1810
+#: src/gui/MainWindow.cc:1821
 msgid "Application"
 msgstr "Aplikace"
 
-#: src/gui/MainWindow.cc:1811
+#: src/gui/MainWindow.cc:1822
 msgid ""
 "The document has been modified.\n"
 "Do you really want to reload the file?"
@@ -3210,74 +3136,74 @@ msgstr ""
 "Dokument byl pozměněn.\n"
 "Opravdu jej chcete znovu načíst?"
 
-#: src/gui/MainWindow.cc:2564
+#: src/gui/MainWindow.cc:2575
 msgid "Export %1 File"
 msgstr "Exportovat %s soubor(ů)"
 
-#: src/gui/MainWindow.cc:2565
+#: src/gui/MainWindow.cc:2576
 msgid "%1 Files (*%2)"
 msgstr "%1 Soubor(ů) (*%2)"
 
-#: src/gui/MainWindow.cc:2613
+#: src/gui/MainWindow.cc:2624
 msgid "Export CSG File"
 msgstr "Exportovat CSG soubor"
 
-#: src/gui/MainWindow.cc:2614
+#: src/gui/MainWindow.cc:2625
 msgid "CSG Files (*.csg)"
 msgstr "CSG soubory (*.csg)"
 
-#: src/gui/MainWindow.cc:2637
+#: src/gui/MainWindow.cc:2648
 msgid "Export Image"
 msgstr "Exportovat obrázek"
 
-#: src/gui/MainWindow.cc:2637
+#: src/gui/MainWindow.cc:2648
 msgid "PNG Files (*.png)"
 msgstr "PNG Soubory (*.png)"
 
-#: src/gui/MainWindow.cc:3027 src/gui/MainWindow.cc:3787
+#: src/gui/MainWindow.cc:3038 src/gui/MainWindow.cc:3798
 msgid "&AI Chat"
 msgstr ""
 
-#: src/gui/MainWindow.cc:3129 src/gui/TabManager.cc:735
+#: src/gui/MainWindow.cc:3140 src/gui/TabManager.cc:735
 #: src/gui/TabManager.cc:786
 msgid "Untitled.scad"
 msgstr "Bezejmenný.scad"
 
-#: src/gui/MainWindow.cc:3779
+#: src/gui/MainWindow.cc:3790
 #, fuzzy
 msgid "&Editor"
 msgstr "Editor"
 
-#: src/gui/MainWindow.cc:3780
+#: src/gui/MainWindow.cc:3791
 #, fuzzy
 msgid "&Console"
 msgstr "Konzole"
 
-#: src/gui/MainWindow.cc:3781
+#: src/gui/MainWindow.cc:3792
 #, fuzzy
 msgid "C&ustomizer"
 msgstr "Skrýt &terminál"
 
-#: src/gui/MainWindow.cc:3782
+#: src/gui/MainWindow.cc:3793
 #, fuzzy
 msgid "Error &Log"
 msgstr "Skrýt nástrojové lišty"
 
-#: src/gui/MainWindow.cc:3783
+#: src/gui/MainWindow.cc:3794
 #, fuzzy
 msgid "&Animate"
 msgstr "Animovat"
 
-#: src/gui/MainWindow.cc:3784
+#: src/gui/MainWindow.cc:3795
 msgid "&Font List"
 msgstr "Seznam &písem"
 
-#: src/gui/MainWindow.cc:3785
+#: src/gui/MainWindow.cc:3796
 #, fuzzy
 msgid "C&olor List"
 msgstr "Barevné téma:"
 
-#: src/gui/MainWindow.cc:3786
+#: src/gui/MainWindow.cc:3797
 #, fuzzy
 msgid "&Viewport Control"
 msgstr "Skrýt nástrojové lišty"
@@ -3541,8 +3467,12 @@ msgid "\"%1$s\" write error. (Disk full?)"
 msgstr ""
 
 #: examples
-msgid "Parametric"
-msgstr ""
+msgid "Advanced"
+msgstr "Pokročilé"
+
+#: examples
+msgid "Basics"
+msgstr "Základy"
 
 #: examples
 msgid "Functions"
@@ -3553,12 +3483,8 @@ msgid "Old"
 msgstr "Staré"
 
 #: examples
-msgid "Advanced"
-msgstr "Pokročilé"
-
-#: examples
-msgid "Basics"
-msgstr "Základy"
+msgid "Parametric"
+msgstr ""
 
 #. (itstool) path: component/summary
 #: openscad.appdata.xml.in2:6
@@ -3597,99 +3523,6 @@ msgid ""
 "parameters from DXF files. Besides DXF files OpenSCAD can read and create 3D "
 "models in the STL and OFF file formats."
 msgstr ""
-
-#~ msgid "Features"
-#~ msgstr "Funkce"
-
-#, fuzzy
-#~ msgid "Reset"
-#~ msgstr "Výchozí pohled"
-
-#, fuzzy
-#~ msgid "Search action..."
-#~ msgstr "Hledaný řetězec"
-
-#, fuzzy
-#~ msgid "ViewportControlWidget"
-#~ msgstr "Skrýt nástrojové lišty"
-
-#~ msgid "OpenSCAD Font List"
-#~ msgstr "Seznam OpenSCAD písem"
-
-#~ msgid "Copy to Clipboard"
-#~ msgstr "Kopírovat do schránky"
-
-#~ msgid "Filter:"
-#~ msgstr "Filtr:"
-
-#~ msgid ""
-#~ "<html><head/><body><p>This list shows the fonts currently registered with "
-#~ "OpenSCAD.</p><p>Example:</p><pre style=\" margin-top:12px; margin-"
-#~ "bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-"
-#~ "indent:0px;\"><span style=\" font-family:'Courier New,courier';\">  "
-#~ "text(&quot;OpenSCAD&quot;, font = &quot;DejaVu Sans&quot;);</span></"
-#~ "pre><pre style=\" margin-top:0px; margin-bottom:12px; margin-left:0px; "
-#~ "margin-right:0px; -qt-block-indent:0; text-indent:0px;\"><span style=\" "
-#~ "font-family:'Courier New,courier';\">  text(&quot;OpenSCAD&quot;, font = "
-#~ "&quot;Liberation Sans:style=Italic&quot;);</span></pre></body></html>"
-#~ msgstr ""
-#~ "<html><head/><body><p>Tento seznam zobrazuje písma momentálně dostupná "
-#~ "pro OpenSCAD.</p><p>Příklad:</p><pre style=\" margin-top:12px; margin-"
-#~ "bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-"
-#~ "indent:0px;\"><span style=\" font-family:'Courier New,courier';\">  "
-#~ "text(&quot;OpenSCAD&quot;, font = &quot;DejaVu Sans&quot;);</span></"
-#~ "pre><pre style=\" margin-top:0px; margin-bottom:12px; margin-left:0px; "
-#~ "margin-right:0px; -qt-block-indent:0; text-indent:0px;\"><span style=\" "
-#~ "font-family:'Courier New,courier';\">  text(&quot;OpenSCAD&quot;, font = "
-#~ "&quot;Liberation Sans:style=Italic&quot;);</span></pre></body></html>"
-
-#, fuzzy
-#~ msgid "Error-Log"
-#~ msgstr "Skrýt nástrojové lišty"
-
-#, fuzzy
-#~ msgid "Line"
-#~ msgstr "Zalamování řádek"
-
-#, fuzzy
-#~ msgid "Filename"
-#~ msgstr "&Soubor"
-
-#, fuzzy
-#~ msgid "Font Lists"
-#~ msgstr "Seznam &písem"
-
-#, fuzzy
-#~ msgid "Hide Editor"
-#~ msgstr "Skrýt &editor"
-
-#~ msgid "Surfaces"
-#~ msgstr "Povrchy"
-
-#~ msgid "F10"
-#~ msgstr "F10"
-
-#~ msgid "F11"
-#~ msgstr "F11"
-
-#, fuzzy
-#~ msgid "Hide Console"
-#~ msgstr "Skrýt &terminál"
-
-#, fuzzy
-#~ msgid "Hide Customizer"
-#~ msgstr "Skrýt &terminál"
-
-#, fuzzy
-#~ msgid "Hide Error Log"
-#~ msgstr "Skrýt nástrojové lišty"
-
-#, fuzzy
-#~ msgid "Hide Animation Toolbar/Window"
-#~ msgstr "Skrýt nástrojové lišty"
-
-#~ msgid "OpenCSG"
-#~ msgstr "OpenCSG"
 
 #, fuzzy
 #~ msgid "play animation"

--- a/locale/de.po
+++ b/locale/de.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: OpenSCAD 2014.01.05\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-09-06 23:38+0200\n"
+"POT-Creation-Date: 2026-09-06 17:48-0700\n"
 "PO-Revision-Date: 2026-09-02 14:00+0200\n"
 "Last-Translator: Torsten Paul <Torsten.Paul@gmx.de>\n"
 "Language-Team: German\n"
@@ -104,154 +104,119 @@ msgstr "Schritte:"
 msgid "Dump Pictures"
 msgstr "Bilder ausgeben"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:852
-#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:362
-#: build/OpenSCADLibInternal_autogen/include/ui_MouseConfigWidget.h:214
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2464
-msgid "Preferences"
-msgstr "Einstellungen"
-
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:853
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:854
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:858
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:862
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:864
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:866
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:868
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:870
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:881
+#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:860
+#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:861
+#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:865
+#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:869
+#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:871
+#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:873
+#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:875
+#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:877
+#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:888
 msgid "Trim"
 msgstr "Trim"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:855
+#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:862
 msgid "Reset Trim"
 msgstr ""
 "Trim\n"
 "zurücksetzen"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:856
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:859
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:860
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:861
 #: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:863
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:865
+#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:866
 #: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:867
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:869
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:880
+#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:868
+#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:870
+#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:872
+#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:874
+#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:876
+#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:887
 msgid "DeadZone"
 msgstr "Inaktiver Bereich"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:857
+#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:864
 msgid "Auto Trim Axes"
 msgstr ""
 "Automatisches\n"
 "Trimmen der Achsen"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:871
+#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:878
 msgid "Axis 2"
 msgstr "Achse 2"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:872
+#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:879
 msgid "Axis 0"
 msgstr "Achse 0"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:873
+#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:880
 msgid "Axis 3"
 msgstr "Achse 3"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:874
+#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:881
 msgid "Axis 6"
 msgstr "Achse 6"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:875
+#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:882
 msgid "Axis 8"
 msgstr "Achse 8"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:876
+#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:883
 msgid "Axis 7"
 msgstr "Achse 7"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:877
+#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:884
 msgid "Axis 5"
 msgstr "Achse 5"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:878
+#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:885
 msgid "Axis 1"
 msgstr "Achse 1"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:879
+#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:886
 msgid "Axis 4"
 msgstr "Achse 4"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:882
+#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:889
 #: build/OpenSCADLibInternal_autogen/include/ui_ViewportControl.h:279
 msgid "Rotation"
 msgstr "Rotation"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:883
+#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:890
 msgid "Zoom"
 msgstr "Zoom"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:884
-msgid "X"
-msgstr "X"
-
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:885
+#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:891
 msgid "Gain"
 msgstr "Verstärkung"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:886
-msgid "Y"
-msgstr "Y"
-
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:887
-msgid "Z"
-msgstr "Z"
-
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:888
+#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:892
 #: build/OpenSCADLibInternal_autogen/include/ui_ViewportControl.h:280
 msgid "Translation"
 msgstr "Verschiebung"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:889
+#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:893
 msgid "ViewPort rel.<br/>Translation"
 msgstr "Ansichtabhängige<br/>Translation"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:890
-msgid "ViewPort rel.<br />Rotation"
+#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:894
+msgid "ViewPort rel.<br/>Rotation"
 msgstr ""
 "Ansichtabhängige\n"
 "Rotation"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:891
+#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:895
 msgid "Axis Setup:"
 msgstr "Achseneinstellung:"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:892
+#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:896
 msgid "<b>Driver selection:</b> <i>(changes requires restarting OpenSCAD)</i>"
 msgstr ""
 "<b>Treiber Auswahl:</b> <i>Änderungen erfordern einen Neustart von "
 "OpenSCAD)</i>"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:893
-msgid "SpaceNav"
-msgstr "SpaceNav"
-
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:894
-msgid "HIDAPI"
-msgstr "HIDAPI"
-
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:895
-msgid "QGamepad"
-msgstr "QGamepad"
-
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:896
+#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:897
 msgid "Joystick"
 msgstr "Joystick"
-
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:897
-msgid "DBus"
-msgstr "DBus"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:898
 msgid "Axes Mapping:"
@@ -262,125 +227,117 @@ msgid "Status:"
 msgstr "Status:"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:900
-msgid "TextLabel"
-msgstr "TextLabel"
-
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:901
 #: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2468
 msgid "Update"
 msgstr "Aktualisieren"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:363
+#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:362
 msgid "Button 19"
 msgstr "Knopf 19"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:364
+#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:363
 msgid "Button 5"
 msgstr "Knopf 5"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:365
+#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:364
 msgid "Button 14"
 msgstr "Knopf 14"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:366
+#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:365
 msgid "Button 7"
 msgstr "Knopf 7"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:367
+#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:366
 msgid "Button 16"
 msgstr "Knopf 16"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:368
+#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:367
 msgid "Button 20"
 msgstr "Knopf 20"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:369
+#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:368
 msgid "Button 1"
 msgstr "Knopf 1"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:370
+#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:369
 msgid "Button 21"
 msgstr "Knopf 21"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:371
+#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:370
 msgid "Button 18"
 msgstr "Knopf 18"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:372
+#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:371
 msgid "Button 0"
 msgstr "Knopf 0"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:373
+#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:372
 msgid "Button 4"
 msgstr "Knopf 4"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:374
+#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:373
 msgid "Button 10"
 msgstr "Knopf 10"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:375
+#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:374
 msgid "Button 6"
 msgstr "Knopf 6"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:376
+#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:375
 msgid "Button 8"
 msgstr "Knopf 8"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:377
+#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:376
 msgid "Button 15"
 msgstr "Knopf 15"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:378
+#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:377
 msgid "Button 11"
 msgstr "Knopf 11"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:379
+#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:378
 msgid "Button 3"
 msgstr "Knopf 3"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:380
+#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:379
 msgid "Button 23"
 msgstr "Knopf 23"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:381
+#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:380
 msgid "Button 9"
 msgstr "Knopf 9"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:382
+#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:381
 msgid "Button 2"
 msgstr "Knopf 2"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:383
+#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:382
 msgid "Button 13"
 msgstr "Knopf 13"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:384
+#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:383
 msgid "Button 12"
 msgstr "Knopf 12"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:385
+#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:384
 msgid "Button 17"
 msgstr "Knopf 17"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:386
+#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:385
 msgid "Button 22"
 msgstr "Knopf 22"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_ChatWidget.h:194
+#: build/OpenSCADLibInternal_autogen/include/ui_ChatWidget.h:195
 msgid "AI Chat"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_ChatWidget.h:195
+#: build/OpenSCADLibInternal_autogen/include/ui_ChatWidget.h:196
 #: src/gui/ai/ChatWidget.cc:138
 msgid "AI Assistant"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_ChatWidget.h:197
+#: build/OpenSCADLibInternal_autogen/include/ui_ChatWidget.h:198
 msgid "Chat options"
-msgstr ""
-
-#: build/OpenSCADLibInternal_autogen/include/ui_ChatWidget.h:199
-msgid "☰"
 msgstr ""
 
 #: build/OpenSCADLibInternal_autogen/include/ui_ChatWidget.h:201
@@ -595,8 +552,8 @@ msgstr "Fehler&liste"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_ErrorLog.h:93
 #: build/OpenSCADLibInternal_autogen/include/ui_ViewportControl.h:267
-msgid "RowSelected"
-msgstr "RowSelected"
+msgid "Row Selected"
+msgstr ""
 
 #: build/OpenSCADLibInternal_autogen/include/ui_ErrorLog.h:95
 #: build/OpenSCADLibInternal_autogen/include/ui_ViewportControl.h:269
@@ -650,9 +607,7 @@ msgid "Export 3MF Options"
 msgstr "3MF-Exporteinstellungen"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_Export3mfDialog.h:459
-#: build/OpenSCADLibInternal_autogen/include/ui_ExportPdfDialog.h:552
-msgid ""
-"<html><head/><body><p>Set the PDF page (paper) size.  </p></body></html>"
+msgid "Set the unit used in the exported file"
 msgstr ""
 
 #: build/OpenSCADLibInternal_autogen/include/ui_Export3mfDialog.h:461
@@ -801,6 +756,10 @@ msgstr "Abbrechen"
 msgid "Export PDF Options"
 msgstr "PDF-Exporteinstellungen"
 
+#: build/OpenSCADLibInternal_autogen/include/ui_ExportPdfDialog.h:552
+msgid "Set the PDF page (paper) size."
+msgstr ""
+
 #: build/OpenSCADLibInternal_autogen/include/ui_ExportPdfDialog.h:554
 msgid "Page Size"
 msgstr "Seitengröße"
@@ -861,9 +820,7 @@ msgid "Author"
 msgstr "Verfasser"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_ExportPdfDialog.h:582
-msgid ""
-"<html><head/><body><p>Set the direction of the largest page dimension.</p></"
-"body></html>"
+msgid "Set the direction of the largest page dimension."
 msgstr ""
 
 #: build/OpenSCADLibInternal_autogen/include/ui_ExportPdfDialog.h:584
@@ -881,9 +838,7 @@ msgid "Landscape (Horizontal)"
 msgstr "Querformat (waagerecht)"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_ExportPdfDialog.h:589
-msgid ""
-"<html><head/><body><p>Determine best orientation based on maximum geometry "
-"dimension.</p></body></html>"
+msgid "Determine best orientation based on maximum geometry dimension."
 msgstr ""
 
 #: build/OpenSCADLibInternal_autogen/include/ui_ExportPdfDialog.h:591
@@ -896,8 +851,7 @@ msgid "Annotations"
 msgstr "Beschriftungen"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_ExportPdfDialog.h:594
-msgid ""
-"<html><head/><body><p>Include design filename on page.</p></body></html>"
+msgid "Include design filename on page."
 msgstr ""
 
 #: build/OpenSCADLibInternal_autogen/include/ui_ExportPdfDialog.h:596
@@ -905,9 +859,7 @@ msgid "Show Design Filename"
 msgstr "Dateinamen des Entwurfs anzeigen"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_ExportPdfDialog.h:598
-msgid ""
-"<html><head/><body><p>Include rulers on page to confirm 1:1 printing scale.</"
-"p></body></html>"
+msgid "Include rulers on page to confirm 1:1 printing scale."
 msgstr ""
 
 #: build/OpenSCADLibInternal_autogen/include/ui_ExportPdfDialog.h:600
@@ -915,9 +867,7 @@ msgid "Show Scale"
 msgstr "Maßstab anzeigen"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_ExportPdfDialog.h:602
-msgid ""
-"<html><head/><body><p>Include a grid of the selected size on the page.</p></"
-"body></html>"
+msgid "Include a grid of the selected size on the page."
 msgstr ""
 
 #: build/OpenSCADLibInternal_autogen/include/ui_ExportPdfDialog.h:604
@@ -945,9 +895,7 @@ msgid "10mm"
 msgstr ""
 
 #: build/OpenSCADLibInternal_autogen/include/ui_ExportPdfDialog.h:611
-msgid ""
-"<html><head/><body><p>Include text describing usage of scale.</p></body></"
-"html>"
+msgid "Include text describing usage of scale."
 msgstr ""
 
 #: build/OpenSCADLibInternal_autogen/include/ui_ExportPdfDialog.h:613
@@ -960,10 +908,9 @@ msgid "Fill and Stroke"
 msgstr "Füllung und Kontur"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_ExportPdfDialog.h:616
-msgid ""
-"<html><head/><body><p>Enable filling of exported geometry with a color.</p></"
-"body></html>"
-msgstr ""
+#: build/OpenSCADLibInternal_autogen/include/ui_ExportSvgDialog.h:205
+msgid "Enable filling of exported geometry with a color."
+msgstr "Exportierte Geometrie mit einer Farbe füllen."
 
 #: build/OpenSCADLibInternal_autogen/include/ui_ExportPdfDialog.h:618
 #: build/OpenSCADLibInternal_autogen/include/ui_ExportSvgDialog.h:207
@@ -971,10 +918,9 @@ msgid "Fill Geometry"
 msgstr "Geometrie füllen"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_ExportPdfDialog.h:623
-msgid ""
-"<html><head/><body><p>Enable outline stroke for exported geometry.</p></"
-"body></html>"
-msgstr ""
+#: build/OpenSCADLibInternal_autogen/include/ui_ExportSvgDialog.h:212
+msgid "Enable outline stroke for exported geometry."
+msgstr "Kontur der exportierten Geometrie zeichnen."
 
 #: build/OpenSCADLibInternal_autogen/include/ui_ExportPdfDialog.h:625
 #: build/OpenSCADLibInternal_autogen/include/ui_ExportSvgDialog.h:214
@@ -994,14 +940,6 @@ msgstr ""
 #: build/OpenSCADLibInternal_autogen/include/ui_ExportSvgDialog.h:202
 msgid "Export SVG Options"
 msgstr "SVG-Exporteinstellungen"
-
-#: build/OpenSCADLibInternal_autogen/include/ui_ExportSvgDialog.h:205
-msgid "Enable filling of exported geometry with a color."
-msgstr "Exportierte Geometrie mit einer Farbe füllen."
-
-#: build/OpenSCADLibInternal_autogen/include/ui_ExportSvgDialog.h:212
-msgid "Enable outline stroke for exported geometry."
-msgstr "Kontur der exportierten Geometrie zeichnen."
 
 #: build/OpenSCADLibInternal_autogen/include/ui_FontList.h:291
 msgid "Font List"
@@ -1044,8 +982,9 @@ msgid "Show Sample Text"
 msgstr "Beispieltext anzeigen"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_FontList.h:302
-msgid "ShowFileName"
-msgstr ""
+#, fuzzy
+msgid "Show File Name"
+msgstr "Dateipfad anzeigen"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_FontList.h:303
 msgid "Show File Path"
@@ -1813,13 +1752,13 @@ msgid "Ctrl+J"
 msgstr ""
 
 #: build/OpenSCADLibInternal_autogen/include/ui_MainWindow.h:1286
-#: src/gui/MainWindow.cc:1335 src/gui/MainWindow.cc:1342
-#: src/gui/MainWindow.cc:1355 src/gui/MainWindow.cc:1360
+#: src/gui/MainWindow.cc:1346 src/gui/MainWindow.cc:1353
+#: src/gui/MainWindow.cc:1366 src/gui/MainWindow.cc:1371
 msgid "Create Virtual Environment"
 msgstr "Virtuelle Umgebung anlegen"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_MainWindow.h:1287
-#: src/gui/MainWindow.cc:1377
+#: src/gui/MainWindow.cc:1388
 msgid "Select Virtual Environment"
 msgstr "Virtuelle Umgebung auswählen"
 
@@ -1901,55 +1840,55 @@ msgstr "Fertig"
 msgid "Customizer Widget"
 msgstr "Customizer"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_MouseConfigWidget.h:215
+#: build/OpenSCADLibInternal_autogen/include/ui_MouseConfigWidget.h:214
 msgid "Ctrl + Shift + Middle-click"
 msgstr "Strg + Umschalt + Mittelklick"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_MouseConfigWidget.h:216
+#: build/OpenSCADLibInternal_autogen/include/ui_MouseConfigWidget.h:215
 msgid "Left-click"
 msgstr "Linksklick"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_MouseConfigWidget.h:217
+#: build/OpenSCADLibInternal_autogen/include/ui_MouseConfigWidget.h:216
 msgid "Ctrl + Left-click"
 msgstr "Strg + Linksklick"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_MouseConfigWidget.h:218
+#: build/OpenSCADLibInternal_autogen/include/ui_MouseConfigWidget.h:217
 msgid "Shift + Left-click"
 msgstr "Umschalt + Linksklick"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_MouseConfigWidget.h:219
+#: build/OpenSCADLibInternal_autogen/include/ui_MouseConfigWidget.h:218
 msgid "Ctrl + Shift + Right-click"
 msgstr "Strg + Umschalt + Rechtsklick"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_MouseConfigWidget.h:220
+#: build/OpenSCADLibInternal_autogen/include/ui_MouseConfigWidget.h:219
 msgid "Preset"
 msgstr "Voreinstellung"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_MouseConfigWidget.h:221
+#: build/OpenSCADLibInternal_autogen/include/ui_MouseConfigWidget.h:220
 msgid "Right-click"
 msgstr "Rechtsklick"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_MouseConfigWidget.h:222
+#: build/OpenSCADLibInternal_autogen/include/ui_MouseConfigWidget.h:221
 msgid "Ctrl + Middle-click"
 msgstr "Strg + Mittelklick"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_MouseConfigWidget.h:223
+#: build/OpenSCADLibInternal_autogen/include/ui_MouseConfigWidget.h:222
 msgid "Shift + Middle-click"
 msgstr "Umschalt + Mittelklick"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_MouseConfigWidget.h:224
+#: build/OpenSCADLibInternal_autogen/include/ui_MouseConfigWidget.h:223
 msgid "Ctrl + Right-click"
 msgstr "Strg + Rechtsklick"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_MouseConfigWidget.h:225
+#: build/OpenSCADLibInternal_autogen/include/ui_MouseConfigWidget.h:224
 msgid "Ctrl + Shift + Left-click"
 msgstr "Strg + Umschalt + Linksklick"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_MouseConfigWidget.h:226
+#: build/OpenSCADLibInternal_autogen/include/ui_MouseConfigWidget.h:225
 msgid "Shift + Right-click"
 msgstr "Umschalt + Rechtsklick"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_MouseConfigWidget.h:227
+#: build/OpenSCADLibInternal_autogen/include/ui_MouseConfigWidget.h:226
 msgid "Middle-click"
 msgstr "Mittelklick"
 
@@ -1966,34 +1905,10 @@ msgid "OpenGL Warning"
 msgstr "OpenGL Warnung"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_OpenCSGWarningDialog.h:77
-msgid ""
-"<!DOCTYPE HTML PUBLIC \"-//W3C//DTD HTML 4.0//EN\" \"http://www.w3.org/TR/"
-"REC-html40/strict.dtd\">\n"
-"<html><head><meta name=\"qrichtext\" content=\"1\" /><style type=\"text/"
-"css\">\n"
-"p, li { white-space: pre-wrap; }\n"
-"</style></head><body style=\" font-family:'Lucida Grande'; font-size:13pt; "
-"font-weight:400; font-style:normal;\">\n"
-"<p style=\"-qt-paragraph-type:empty; margin-top:0px; margin-bottom:0px; "
-"margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;\"></"
-"p></body></html>"
-msgstr ""
-"<!DOCTYPE HTML PUBLIC \"-//W3C//DTD HTML 4.0//EN\" \"http://www.w3.org/TR/"
-"REC-html40/strict.dtd\">\n"
-"<html><head><meta name=\"qrichtext\" content=\"1\" /><style type=\"text/"
-"css\">\n"
-"p, li { white-space: pre-wrap; }\n"
-"</style></head><body style=\" font-family:'Lucida Grande'; font-size:13pt; "
-"font-weight:400; font-style:normal;\">\n"
-"<p style=\"-qt-paragraph-type:empty; margin-top:0px; margin-bottom:0px; "
-"margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;\"></"
-"p></body></html>"
-
-#: build/OpenSCADLibInternal_autogen/include/ui_OpenCSGWarningDialog.h:82
 msgid "Show this message again"
 msgstr "Diesen Dialog wieder anzeigen"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_OpenCSGWarningDialog.h:83
+#: build/OpenSCADLibInternal_autogen/include/ui_OpenCSGWarningDialog.h:78
 msgid "Close"
 msgstr "Schließen"
 
@@ -2061,6 +1976,10 @@ msgstr "-"
 #, fuzzy
 msgid "More actions"
 msgstr "Beschriftungen"
+
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2464
+msgid "Preferences"
+msgstr "Einstellungen"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2465
 msgid "3D View"
@@ -3119,21 +3038,21 @@ msgstr "Der QGamepad Treiber unterstützt Gamepads auf allen Platformen."
 msgid "Toggle Perspective"
 msgstr "Perspektive umschalten"
 
-#: src/gui/MainWindow.cc:861
+#: src/gui/MainWindow.cc:872
 msgid "Compile error."
 msgstr "Fehler."
 
-#: src/gui/MainWindow.cc:864
+#: src/gui/MainWindow.cc:875
 msgid "Error while compiling '%1'."
 msgstr "Fehler beim Kompilieren von '%1'."
 
-#: src/gui/MainWindow.cc:869
+#: src/gui/MainWindow.cc:880
 msgid "Compilation generated %1 warning."
 msgid_plural "Compilation generated %1 warnings."
 msgstr[0] "%1 Warnung beim Kompilieren."
 msgstr[1] "%1 Warnungen beim Kompilieren."
 
-#: src/gui/MainWindow.cc:882
+#: src/gui/MainWindow.cc:893
 msgid ""
 " For details see the <a href=\"#errorlog\">error log</a> and <a "
 "href=\"#console\">console window</a>."
@@ -3141,11 +3060,11 @@ msgstr ""
 " Für Details die <a href=\"#errorlog\">Fehlerliste</a> oder <a "
 "href=\"#console\">Konsolen-Fenster</a> öffnen."
 
-#: src/gui/MainWindow.cc:1320
+#: src/gui/MainWindow.cc:1331
 msgid "Trusted Files"
 msgstr "Vertrauenswürdige Dateien"
 
-#: src/gui/MainWindow.cc:1704
+#: src/gui/MainWindow.cc:1715
 msgid ""
 "Python files can potentially contain harmful stuff.\n"
 "Do you trust this file ?\n"
@@ -3153,11 +3072,11 @@ msgstr ""
 "Python-Dateien können schädlichen Inhalt enthalten.\n"
 "Vertrauen Sie dieser Datei?\n"
 
-#: src/gui/MainWindow.cc:1810
+#: src/gui/MainWindow.cc:1821
 msgid "Application"
 msgstr "Application"
 
-#: src/gui/MainWindow.cc:1811
+#: src/gui/MainWindow.cc:1822
 msgid ""
 "The document has been modified.\n"
 "Do you really want to reload the file?"
@@ -3165,70 +3084,70 @@ msgstr ""
 "Das Dokument ist verändert.\n"
 "Möchten Sie die Datei wirklich neu laden?"
 
-#: src/gui/MainWindow.cc:2564
+#: src/gui/MainWindow.cc:2575
 msgid "Export %1 File"
 msgstr "%1 Datei exportieren"
 
-#: src/gui/MainWindow.cc:2565
+#: src/gui/MainWindow.cc:2576
 msgid "%1 Files (*%2)"
 msgstr "%1 Dateien (*%2)"
 
-#: src/gui/MainWindow.cc:2613
+#: src/gui/MainWindow.cc:2624
 msgid "Export CSG File"
 msgstr "Export CSG File"
 
-#: src/gui/MainWindow.cc:2614
+#: src/gui/MainWindow.cc:2625
 msgid "CSG Files (*.csg)"
 msgstr "CSG Dateien (*.csg)"
 
-#: src/gui/MainWindow.cc:2637
+#: src/gui/MainWindow.cc:2648
 msgid "Export Image"
 msgstr "Image exportieren"
 
-#: src/gui/MainWindow.cc:2637
+#: src/gui/MainWindow.cc:2648
 msgid "PNG Files (*.png)"
 msgstr "PNG Dateien (*.png)"
 
-#: src/gui/MainWindow.cc:3027 src/gui/MainWindow.cc:3787
+#: src/gui/MainWindow.cc:3038 src/gui/MainWindow.cc:3798
 msgid "&AI Chat"
 msgstr ""
 
-#: src/gui/MainWindow.cc:3129 src/gui/TabManager.cc:735
+#: src/gui/MainWindow.cc:3140 src/gui/TabManager.cc:735
 #: src/gui/TabManager.cc:786
 msgid "Untitled.scad"
 msgstr "Unbenannt.scad"
 
-#: src/gui/MainWindow.cc:3779
+#: src/gui/MainWindow.cc:3790
 msgid "&Editor"
 msgstr "&Editor"
 
-#: src/gui/MainWindow.cc:3780
+#: src/gui/MainWindow.cc:3791
 msgid "&Console"
 msgstr "&Konsole"
 
-#: src/gui/MainWindow.cc:3781
+#: src/gui/MainWindow.cc:3792
 msgid "C&ustomizer"
 msgstr "C&ustomizer"
 
-#: src/gui/MainWindow.cc:3782
+#: src/gui/MainWindow.cc:3793
 msgid "Error &Log"
 msgstr "Fehler&liste"
 
-#: src/gui/MainWindow.cc:3783
+#: src/gui/MainWindow.cc:3794
 #, fuzzy
 msgid "&Animate"
 msgstr "Animation"
 
-#: src/gui/MainWindow.cc:3784
+#: src/gui/MainWindow.cc:3795
 msgid "&Font List"
 msgstr "&Fontliste"
 
-#: src/gui/MainWindow.cc:3785
+#: src/gui/MainWindow.cc:3796
 #, fuzzy
 msgid "C&olor List"
 msgstr "Farbliste"
 
-#: src/gui/MainWindow.cc:3786
+#: src/gui/MainWindow.cc:3797
 #, fuzzy
 msgid "&Viewport Control"
 msgstr "Ansichtssteuerung"
@@ -3493,8 +3412,12 @@ msgid "\"%1$s\" write error. (Disk full?)"
 msgstr "\"%1$s\" Schreibfehler. (Speicher voll?)"
 
 #: examples
-msgid "Parametric"
-msgstr "Parametrische Beispiele"
+msgid "Advanced"
+msgstr "Weiterführende Beispiele"
+
+#: examples
+msgid "Basics"
+msgstr "Grundlagen"
 
 #: examples
 msgid "Functions"
@@ -3505,12 +3428,8 @@ msgid "Old"
 msgstr "Frühere"
 
 #: examples
-msgid "Advanced"
-msgstr "Weiterführende Beispiele"
-
-#: examples
-msgid "Basics"
-msgstr "Grundlagen"
+msgid "Parametric"
+msgstr "Parametrische Beispiele"
 
 #. (itstool) path: component/summary
 #: openscad.appdata.xml.in2:6
@@ -3567,118 +3486,6 @@ msgstr ""
 "addition to 2D paths for extrusion it is also possible to read design "
 "parameters from DXF files. Besides DXF files OpenSCAD can read and create 3D "
 "models in the STL and OFF file formats."
-
-#~ msgid "Features"
-#~ msgstr "Funktionen"
-
-#~ msgid "Shortcut"
-#~ msgstr "Shortcut"
-
-#, fuzzy
-#~ msgid "Reset"
-#~ msgstr "Voreinstellung"
-
-#, fuzzy
-#~ msgid "Search action..."
-#~ msgstr "Suchtext"
-
-#~ msgid "OpenSCAD Font List"
-#~ msgstr "OpenSCAD Fontliste"
-
-#~ msgid "Copy to Clipboard"
-#~ msgstr "Kopieren"
-
-#~ msgid "Filter:"
-#~ msgstr "Filter:"
-
-#~ msgid ""
-#~ "<html><head/><body><p>This list shows the fonts currently registered with "
-#~ "OpenSCAD.</p><p>Example:</p><pre style=\" margin-top:12px; margin-"
-#~ "bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-"
-#~ "indent:0px;\"><span style=\" font-family:'Courier New,courier';\">  "
-#~ "text(&quot;OpenSCAD&quot;, font = &quot;DejaVu Sans&quot;);</span></"
-#~ "pre><pre style=\" margin-top:0px; margin-bottom:12px; margin-left:0px; "
-#~ "margin-right:0px; -qt-block-indent:0; text-indent:0px;\"><span style=\" "
-#~ "font-family:'Courier New,courier';\">  text(&quot;OpenSCAD&quot;, font = "
-#~ "&quot;Liberation Sans:style=Italic&quot;);</span></pre></body></html>"
-#~ msgstr ""
-#~ "<html><head/><body><p>Diese Liste zeigt die Fonts, die momentan mit "
-#~ "OpenSCAD registriert sind.</p><p>Beispiele:</p><pre style=\" margin-"
-#~ "top:12px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-"
-#~ "indent:0; text-indent:0px;\"><span style=\" font-family:'Courier "
-#~ "New,courier';\">  text(&quot;OpenSCAD&quot;, font = &quot;DejaVu "
-#~ "Sans&quot;);</span></pre><pre style=\" margin-top:0px; margin-"
-#~ "bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-"
-#~ "indent:0px;\"><span style=\" font-family:'Courier New,courier';\">  "
-#~ "text(&quot;OpenSCAD&quot;, font = &quot;Liberation "
-#~ "Sans:style=Italic&quot;);</span></pre></body></html>"
-
-#~ msgid "Error-Log"
-#~ msgstr "Fehlerliste"
-
-#~ msgid "F7"
-#~ msgstr "F7"
-
-#, fuzzy
-#~ msgid "Swap Mouse Buttons"
-#~ msgstr "Left Mouse Button"
-
-#, fuzzy
-#~ msgid "Line"
-#~ msgstr "Zeilenumbruch"
-
-#, fuzzy
-#~ msgid "Filename"
-#~ msgstr "Dateiname kopieren"
-
-#, fuzzy
-#~ msgid "Font Lists"
-#~ msgstr "&Fontliste"
-
-#, fuzzy
-#~ msgid "PushButton"
-#~ msgstr "Knöpfe"
-
-#~ msgid "Hide Editor"
-#~ msgstr "Editor ausblenden"
-
-#~ msgid "Surfaces"
-#~ msgstr "&Flächen anzeigen"
-
-#~ msgid "F10"
-#~ msgstr "F10"
-
-#~ msgid "F11"
-#~ msgstr "F11"
-
-#~ msgid "Hide Console"
-#~ msgstr "Konsole ausblenden"
-
-#~ msgid "Hide Customizer"
-#~ msgstr "Customizer ausblenden"
-
-#~ msgid "Hide Error Log"
-#~ msgstr "Fehlerliste ausblenden"
-
-#, fuzzy
-#~ msgid "Hide Animation Toolbar/Window"
-#~ msgstr "Editor Symbolleiste ausblenden"
-
-#~ msgid "OpenCSG"
-#~ msgstr "OpenCSG"
-
-#~ msgid "CGAL"
-#~ msgstr "CGAL"
-
-#, fuzzy
-#~ msgid "WRL"
-#~ msgstr "URL"
-
-#~ msgid "Default to ASCII STL export"
-#~ msgstr "STL Export im ASCII format"
-
-#~ msgid "%1"
-#~ msgstr "%1"
 
 #, fuzzy
 #~ msgid "translate"

--- a/locale/es.po
+++ b/locale/es.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: OpenSCAD 2015.03\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-09-06 23:38+0200\n"
+"POT-Creation-Date: 2026-09-06 17:48-0700\n"
 "PO-Revision-Date: 2025-04-10 09:14-0300\n"
 "Last-Translator: Alexandre Folle de Menezes\n"
 "Language-Team: Español\n"
@@ -101,145 +101,110 @@ msgstr "Pasos:"
 msgid "Dump Pictures"
 msgstr "Grabar imágenes"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:852
-#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:362
-#: build/OpenSCADLibInternal_autogen/include/ui_MouseConfigWidget.h:214
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2464
-msgid "Preferences"
-msgstr "Preferencias"
-
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:853
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:854
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:858
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:862
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:864
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:866
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:868
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:870
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:881
+#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:860
+#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:861
+#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:865
+#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:869
+#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:871
+#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:873
+#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:875
+#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:877
+#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:888
 msgid "Trim"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:855
+#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:862
 msgid "Reset Trim"
 msgstr "Reiniciar ajuste"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:856
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:859
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:860
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:861
 #: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:863
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:865
+#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:866
 #: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:867
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:869
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:880
+#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:868
+#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:870
+#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:872
+#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:874
+#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:876
+#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:887
 msgid "DeadZone"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:857
+#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:864
 msgid "Auto Trim Axes"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:871
+#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:878
 msgid "Axis 2"
 msgstr "Eje 2"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:872
+#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:879
 msgid "Axis 0"
 msgstr "Eje 0"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:873
+#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:880
 msgid "Axis 3"
 msgstr "Eje 3"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:874
+#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:881
 msgid "Axis 6"
 msgstr "Eje 6"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:875
+#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:882
 msgid "Axis 8"
 msgstr "Eje 8"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:876
+#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:883
 msgid "Axis 7"
 msgstr "Eje 7"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:877
+#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:884
 msgid "Axis 5"
 msgstr "Eje 5"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:878
+#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:885
 msgid "Axis 1"
 msgstr "Eje 1"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:879
+#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:886
 msgid "Axis 4"
 msgstr "Eje 4"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:882
+#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:889
 #: build/OpenSCADLibInternal_autogen/include/ui_ViewportControl.h:279
 msgid "Rotation"
 msgstr "Rotación"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:883
+#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:890
 msgid "Zoom"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:884
-msgid "X"
-msgstr ""
-
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:885
+#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:891
 msgid "Gain"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:886
-msgid "Y"
-msgstr ""
-
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:887
-msgid "Z"
-msgstr ""
-
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:888
+#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:892
 #: build/OpenSCADLibInternal_autogen/include/ui_ViewportControl.h:280
 msgid "Translation"
 msgstr "Translación"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:889
+#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:893
 msgid "ViewPort rel.<br/>Translation"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:890
-msgid "ViewPort rel.<br />Rotation"
-msgstr ""
-
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:891
-msgid "Axis Setup:"
-msgstr ""
-
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:892
-msgid "<b>Driver selection:</b> <i>(changes requires restarting OpenSCAD)</i>"
-msgstr ""
-
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:893
-msgid "SpaceNav"
-msgstr ""
-
 #: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:894
-msgid "HIDAPI"
+msgid "ViewPort rel.<br/>Rotation"
 msgstr ""
 
 #: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:895
-msgid "QGamepad"
+msgid "Axis Setup:"
 msgstr ""
 
 #: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:896
-msgid "Joystick"
+msgid "<b>Driver selection:</b> <i>(changes requires restarting OpenSCAD)</i>"
 msgstr ""
 
 #: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:897
-msgid "DBus"
+msgid "Joystick"
 msgstr ""
 
 #: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:898
@@ -251,125 +216,117 @@ msgid "Status:"
 msgstr ""
 
 #: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:900
-msgid "TextLabel"
-msgstr ""
-
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:901
 #: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2468
 msgid "Update"
 msgstr "Actualizar"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:363
+#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:362
 msgid "Button 19"
 msgstr "Botón 19"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:364
+#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:363
 msgid "Button 5"
 msgstr "Botón 5"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:365
+#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:364
 msgid "Button 14"
 msgstr "Botón 14"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:366
+#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:365
 msgid "Button 7"
 msgstr "Botón 7"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:367
+#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:366
 msgid "Button 16"
 msgstr "Botón 16"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:368
+#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:367
 msgid "Button 20"
 msgstr "Botón 20"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:369
+#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:368
 msgid "Button 1"
 msgstr "Botón 1"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:370
+#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:369
 msgid "Button 21"
 msgstr "Botón 21"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:371
+#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:370
 msgid "Button 18"
 msgstr "Botón 18"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:372
+#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:371
 msgid "Button 0"
 msgstr "Botón 0"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:373
+#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:372
 msgid "Button 4"
 msgstr "Botón 4"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:374
+#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:373
 msgid "Button 10"
 msgstr "Botón 10"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:375
+#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:374
 msgid "Button 6"
 msgstr "Botón 6"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:376
+#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:375
 msgid "Button 8"
 msgstr "Botón 8"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:377
+#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:376
 msgid "Button 15"
 msgstr "Botón 15"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:378
+#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:377
 msgid "Button 11"
 msgstr "Botón 11"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:379
+#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:378
 msgid "Button 3"
 msgstr "Botón 3"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:380
+#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:379
 msgid "Button 23"
 msgstr "Botón 23"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:381
+#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:380
 msgid "Button 9"
 msgstr "Botón 9"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:382
+#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:381
 msgid "Button 2"
 msgstr "Botón 2"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:383
+#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:382
 msgid "Button 13"
 msgstr "Botón 13"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:384
+#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:383
 msgid "Button 12"
 msgstr "Botón 12"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:385
+#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:384
 msgid "Button 17"
 msgstr "Botón 17"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:386
+#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:385
 msgid "Button 22"
 msgstr "Botón 22"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_ChatWidget.h:194
+#: build/OpenSCADLibInternal_autogen/include/ui_ChatWidget.h:195
 msgid "AI Chat"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_ChatWidget.h:195
+#: build/OpenSCADLibInternal_autogen/include/ui_ChatWidget.h:196
 #: src/gui/ai/ChatWidget.cc:138
 msgid "AI Assistant"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_ChatWidget.h:197
+#: build/OpenSCADLibInternal_autogen/include/ui_ChatWidget.h:198
 msgid "Chat options"
-msgstr ""
-
-#: build/OpenSCADLibInternal_autogen/include/ui_ChatWidget.h:199
-msgid "☰"
 msgstr ""
 
 #: build/OpenSCADLibInternal_autogen/include/ui_ChatWidget.h:201
@@ -593,7 +550,7 @@ msgstr ""
 
 #: build/OpenSCADLibInternal_autogen/include/ui_ErrorLog.h:93
 #: build/OpenSCADLibInternal_autogen/include/ui_ViewportControl.h:267
-msgid "RowSelected"
+msgid "Row Selected"
 msgstr ""
 
 #: build/OpenSCADLibInternal_autogen/include/ui_ErrorLog.h:95
@@ -648,9 +605,7 @@ msgid "Export 3MF Options"
 msgstr ""
 
 #: build/OpenSCADLibInternal_autogen/include/ui_Export3mfDialog.h:459
-#: build/OpenSCADLibInternal_autogen/include/ui_ExportPdfDialog.h:552
-msgid ""
-"<html><head/><body><p>Set the PDF page (paper) size.  </p></body></html>"
+msgid "Set the unit used in the exported file"
 msgstr ""
 
 #: build/OpenSCADLibInternal_autogen/include/ui_Export3mfDialog.h:461
@@ -800,6 +755,10 @@ msgstr ""
 msgid "Export PDF Options"
 msgstr ""
 
+#: build/OpenSCADLibInternal_autogen/include/ui_ExportPdfDialog.h:552
+msgid "Set the PDF page (paper) size."
+msgstr ""
+
 #: build/OpenSCADLibInternal_autogen/include/ui_ExportPdfDialog.h:554
 #, fuzzy
 msgid "Page Size"
@@ -859,9 +818,7 @@ msgid "Author"
 msgstr ""
 
 #: build/OpenSCADLibInternal_autogen/include/ui_ExportPdfDialog.h:582
-msgid ""
-"<html><head/><body><p>Set the direction of the largest page dimension.</p></"
-"body></html>"
+msgid "Set the direction of the largest page dimension."
 msgstr ""
 
 #: build/OpenSCADLibInternal_autogen/include/ui_ExportPdfDialog.h:584
@@ -880,9 +837,7 @@ msgid "Landscape (Horizontal)"
 msgstr ""
 
 #: build/OpenSCADLibInternal_autogen/include/ui_ExportPdfDialog.h:589
-msgid ""
-"<html><head/><body><p>Determine best orientation based on maximum geometry "
-"dimension.</p></body></html>"
+msgid "Determine best orientation based on maximum geometry dimension."
 msgstr ""
 
 #: build/OpenSCADLibInternal_autogen/include/ui_ExportPdfDialog.h:591
@@ -895,8 +850,7 @@ msgid "Annotations"
 msgstr "Anotaciones"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_ExportPdfDialog.h:594
-msgid ""
-"<html><head/><body><p>Include design filename on page.</p></body></html>"
+msgid "Include design filename on page."
 msgstr ""
 
 #: build/OpenSCADLibInternal_autogen/include/ui_ExportPdfDialog.h:596
@@ -904,9 +858,7 @@ msgid "Show Design Filename"
 msgstr ""
 
 #: build/OpenSCADLibInternal_autogen/include/ui_ExportPdfDialog.h:598
-msgid ""
-"<html><head/><body><p>Include rulers on page to confirm 1:1 printing scale.</"
-"p></body></html>"
+msgid "Include rulers on page to confirm 1:1 printing scale."
 msgstr ""
 
 #: build/OpenSCADLibInternal_autogen/include/ui_ExportPdfDialog.h:600
@@ -914,9 +866,7 @@ msgid "Show Scale"
 msgstr "Mostar Escala"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_ExportPdfDialog.h:602
-msgid ""
-"<html><head/><body><p>Include a grid of the selected size on the page.</p></"
-"body></html>"
+msgid "Include a grid of the selected size on the page."
 msgstr ""
 
 #: build/OpenSCADLibInternal_autogen/include/ui_ExportPdfDialog.h:604
@@ -944,9 +894,7 @@ msgid "10mm"
 msgstr ""
 
 #: build/OpenSCADLibInternal_autogen/include/ui_ExportPdfDialog.h:611
-msgid ""
-"<html><head/><body><p>Include text describing usage of scale.</p></body></"
-"html>"
+msgid "Include text describing usage of scale."
 msgstr ""
 
 #: build/OpenSCADLibInternal_autogen/include/ui_ExportPdfDialog.h:613
@@ -959,9 +907,8 @@ msgid "Fill and Stroke"
 msgstr ""
 
 #: build/OpenSCADLibInternal_autogen/include/ui_ExportPdfDialog.h:616
-msgid ""
-"<html><head/><body><p>Enable filling of exported geometry with a color.</p></"
-"body></html>"
+#: build/OpenSCADLibInternal_autogen/include/ui_ExportSvgDialog.h:205
+msgid "Enable filling of exported geometry with a color."
 msgstr ""
 
 #: build/OpenSCADLibInternal_autogen/include/ui_ExportPdfDialog.h:618
@@ -970,9 +917,8 @@ msgid "Fill Geometry"
 msgstr ""
 
 #: build/OpenSCADLibInternal_autogen/include/ui_ExportPdfDialog.h:623
-msgid ""
-"<html><head/><body><p>Enable outline stroke for exported geometry.</p></"
-"body></html>"
+#: build/OpenSCADLibInternal_autogen/include/ui_ExportSvgDialog.h:212
+msgid "Enable outline stroke for exported geometry."
 msgstr ""
 
 #: build/OpenSCADLibInternal_autogen/include/ui_ExportPdfDialog.h:625
@@ -994,14 +940,6 @@ msgstr ""
 #, fuzzy
 msgid "Export SVG Options"
 msgstr "Exportar archivo CSG"
-
-#: build/OpenSCADLibInternal_autogen/include/ui_ExportSvgDialog.h:205
-msgid "Enable filling of exported geometry with a color."
-msgstr ""
-
-#: build/OpenSCADLibInternal_autogen/include/ui_ExportSvgDialog.h:212
-msgid "Enable outline stroke for exported geometry."
-msgstr ""
 
 #: build/OpenSCADLibInternal_autogen/include/ui_FontList.h:291
 #, fuzzy
@@ -1048,8 +986,9 @@ msgid "Show Sample Text"
 msgstr "Mostar Escala"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_FontList.h:302
-msgid "ShowFileName"
-msgstr ""
+#, fuzzy
+msgid "Show File Name"
+msgstr "Mostrar Uso de la Escala"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_FontList.h:303
 #, fuzzy
@@ -1814,13 +1753,13 @@ msgid "Ctrl+J"
 msgstr ""
 
 #: build/OpenSCADLibInternal_autogen/include/ui_MainWindow.h:1286
-#: src/gui/MainWindow.cc:1335 src/gui/MainWindow.cc:1342
-#: src/gui/MainWindow.cc:1355 src/gui/MainWindow.cc:1360
+#: src/gui/MainWindow.cc:1346 src/gui/MainWindow.cc:1353
+#: src/gui/MainWindow.cc:1366 src/gui/MainWindow.cc:1371
 msgid "Create Virtual Environment"
 msgstr ""
 
 #: build/OpenSCADLibInternal_autogen/include/ui_MainWindow.h:1287
-#: src/gui/MainWindow.cc:1377
+#: src/gui/MainWindow.cc:1388
 msgid "Select Virtual Environment"
 msgstr ""
 
@@ -1902,56 +1841,56 @@ msgstr "Hecho"
 msgid "Customizer Widget"
 msgstr "Widget de parámetros"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_MouseConfigWidget.h:215
+#: build/OpenSCADLibInternal_autogen/include/ui_MouseConfigWidget.h:214
 msgid "Ctrl + Shift + Middle-click"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_MouseConfigWidget.h:216
+#: build/OpenSCADLibInternal_autogen/include/ui_MouseConfigWidget.h:215
 msgid "Left-click"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_MouseConfigWidget.h:217
+#: build/OpenSCADLibInternal_autogen/include/ui_MouseConfigWidget.h:216
 msgid "Ctrl + Left-click"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_MouseConfigWidget.h:218
+#: build/OpenSCADLibInternal_autogen/include/ui_MouseConfigWidget.h:217
 msgid "Shift + Left-click"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_MouseConfigWidget.h:219
+#: build/OpenSCADLibInternal_autogen/include/ui_MouseConfigWidget.h:218
 msgid "Ctrl + Shift + Right-click"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_MouseConfigWidget.h:220
+#: build/OpenSCADLibInternal_autogen/include/ui_MouseConfigWidget.h:219
 #, fuzzy
 msgid "Preset"
 msgstr "Restablecer"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_MouseConfigWidget.h:221
+#: build/OpenSCADLibInternal_autogen/include/ui_MouseConfigWidget.h:220
 msgid "Right-click"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_MouseConfigWidget.h:222
+#: build/OpenSCADLibInternal_autogen/include/ui_MouseConfigWidget.h:221
 msgid "Ctrl + Middle-click"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_MouseConfigWidget.h:223
+#: build/OpenSCADLibInternal_autogen/include/ui_MouseConfigWidget.h:222
 msgid "Shift + Middle-click"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_MouseConfigWidget.h:224
+#: build/OpenSCADLibInternal_autogen/include/ui_MouseConfigWidget.h:223
 msgid "Ctrl + Right-click"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_MouseConfigWidget.h:225
+#: build/OpenSCADLibInternal_autogen/include/ui_MouseConfigWidget.h:224
 msgid "Ctrl + Shift + Left-click"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_MouseConfigWidget.h:226
+#: build/OpenSCADLibInternal_autogen/include/ui_MouseConfigWidget.h:225
 msgid "Shift + Right-click"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_MouseConfigWidget.h:227
+#: build/OpenSCADLibInternal_autogen/include/ui_MouseConfigWidget.h:226
 msgid "Middle-click"
 msgstr ""
 
@@ -1968,24 +1907,10 @@ msgid "OpenGL Warning"
 msgstr "Advertencia OpenGL"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_OpenCSGWarningDialog.h:77
-msgid ""
-"<!DOCTYPE HTML PUBLIC \"-//W3C//DTD HTML 4.0//EN\" \"http://www.w3.org/TR/"
-"REC-html40/strict.dtd\">\n"
-"<html><head><meta name=\"qrichtext\" content=\"1\" /><style type=\"text/"
-"css\">\n"
-"p, li { white-space: pre-wrap; }\n"
-"</style></head><body style=\" font-family:'Lucida Grande'; font-size:13pt; "
-"font-weight:400; font-style:normal;\">\n"
-"<p style=\"-qt-paragraph-type:empty; margin-top:0px; margin-bottom:0px; "
-"margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;\"></"
-"p></body></html>"
-msgstr ""
-
-#: build/OpenSCADLibInternal_autogen/include/ui_OpenCSGWarningDialog.h:82
 msgid "Show this message again"
 msgstr "Mostrar este mensaje nuevamente"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_OpenCSGWarningDialog.h:83
+#: build/OpenSCADLibInternal_autogen/include/ui_OpenCSGWarningDialog.h:78
 msgid "Close"
 msgstr "Cerrar"
 
@@ -2053,6 +1978,10 @@ msgstr ""
 #, fuzzy
 msgid "More actions"
 msgstr "Anotaciones"
+
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2464
+msgid "Preferences"
+msgstr "Preferencias"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2465
 msgid "3D View"
@@ -3104,41 +3033,41 @@ msgstr ""
 msgid "Toggle Perspective"
 msgstr ""
 
-#: src/gui/MainWindow.cc:861
+#: src/gui/MainWindow.cc:872
 msgid "Compile error."
 msgstr "Error de compilación."
 
-#: src/gui/MainWindow.cc:864
+#: src/gui/MainWindow.cc:875
 msgid "Error while compiling '%1'."
 msgstr "Error durante la compilación '%1'."
 
-#: src/gui/MainWindow.cc:869
+#: src/gui/MainWindow.cc:880
 msgid "Compilation generated %1 warning."
 msgid_plural "Compilation generated %1 warnings."
 msgstr[0] "La compilación generó %1 advertencia."
 msgstr[1] "La compilación generó %1 advertencies."
 
-#: src/gui/MainWindow.cc:882
+#: src/gui/MainWindow.cc:893
 msgid ""
 " For details see the <a href=\"#errorlog\">error log</a> and <a "
 "href=\"#console\">console window</a>."
 msgstr ""
 
-#: src/gui/MainWindow.cc:1320
+#: src/gui/MainWindow.cc:1331
 msgid "Trusted Files"
 msgstr ""
 
-#: src/gui/MainWindow.cc:1704
+#: src/gui/MainWindow.cc:1715
 msgid ""
 "Python files can potentially contain harmful stuff.\n"
 "Do you trust this file ?\n"
 msgstr ""
 
-#: src/gui/MainWindow.cc:1810
+#: src/gui/MainWindow.cc:1821
 msgid "Application"
 msgstr "Aplicación"
 
-#: src/gui/MainWindow.cc:1811
+#: src/gui/MainWindow.cc:1822
 msgid ""
 "The document has been modified.\n"
 "Do you really want to reload the file?"
@@ -3146,71 +3075,71 @@ msgstr ""
 "El documento ha sido modificado.\n"
 "¿Realmente desea volver a cargar el archivo?"
 
-#: src/gui/MainWindow.cc:2564
+#: src/gui/MainWindow.cc:2575
 msgid "Export %1 File"
 msgstr "Exportar el archivo %1"
 
-#: src/gui/MainWindow.cc:2565
+#: src/gui/MainWindow.cc:2576
 msgid "%1 Files (*%2)"
 msgstr "%1 Archivos (*%2)"
 
-#: src/gui/MainWindow.cc:2613
+#: src/gui/MainWindow.cc:2624
 msgid "Export CSG File"
 msgstr "Exportar archivo CSG"
 
-#: src/gui/MainWindow.cc:2614
+#: src/gui/MainWindow.cc:2625
 msgid "CSG Files (*.csg)"
 msgstr "Archivos CSG (*.csg)"
 
-#: src/gui/MainWindow.cc:2637
+#: src/gui/MainWindow.cc:2648
 msgid "Export Image"
 msgstr "Exportar una imagen"
 
-#: src/gui/MainWindow.cc:2637
+#: src/gui/MainWindow.cc:2648
 msgid "PNG Files (*.png)"
 msgstr "Archivos PNG (*.png)"
 
-#: src/gui/MainWindow.cc:3027 src/gui/MainWindow.cc:3787
+#: src/gui/MainWindow.cc:3038 src/gui/MainWindow.cc:3798
 msgid "&AI Chat"
 msgstr ""
 
-#: src/gui/MainWindow.cc:3129 src/gui/TabManager.cc:735
+#: src/gui/MainWindow.cc:3140 src/gui/TabManager.cc:735
 #: src/gui/TabManager.cc:786
 msgid "Untitled.scad"
 msgstr "Sintitulo.scad"
 
-#: src/gui/MainWindow.cc:3779
+#: src/gui/MainWindow.cc:3790
 #, fuzzy
 msgid "&Editor"
 msgstr "Editar"
 
-#: src/gui/MainWindow.cc:3780
+#: src/gui/MainWindow.cc:3791
 msgid "&Console"
 msgstr "&Consola"
 
-#: src/gui/MainWindow.cc:3781
+#: src/gui/MainWindow.cc:3792
 #, fuzzy
 msgid "C&ustomizer"
 msgstr "Widget de parámetros"
 
-#: src/gui/MainWindow.cc:3782
+#: src/gui/MainWindow.cc:3793
 msgid "Error &Log"
 msgstr ""
 
-#: src/gui/MainWindow.cc:3783
+#: src/gui/MainWindow.cc:3794
 msgid "&Animate"
 msgstr "&Animar"
 
-#: src/gui/MainWindow.cc:3784
+#: src/gui/MainWindow.cc:3795
 msgid "&Font List"
 msgstr "Lista de &Fuentes"
 
-#: src/gui/MainWindow.cc:3785
+#: src/gui/MainWindow.cc:3796
 #, fuzzy
 msgid "C&olor List"
 msgstr "Paleta de colores:"
 
-#: src/gui/MainWindow.cc:3786
+#: src/gui/MainWindow.cc:3797
 msgid "&Viewport Control"
 msgstr ""
 
@@ -3468,9 +3397,12 @@ msgid "\"%1$s\" write error. (Disk full?)"
 msgstr ""
 
 #: examples
-#, fuzzy
-msgid "Parametric"
-msgstr "Parámetro"
+msgid "Advanced"
+msgstr "Avanzado"
+
+#: examples
+msgid "Basics"
+msgstr "Puntos Básicos"
 
 #: examples
 msgid "Functions"
@@ -3481,12 +3413,9 @@ msgid "Old"
 msgstr "Viejo"
 
 #: examples
-msgid "Advanced"
-msgstr "Avanzado"
-
-#: examples
-msgid "Basics"
-msgstr "Puntos Básicos"
+#, fuzzy
+msgid "Parametric"
+msgstr "Parámetro"
 
 #. (itstool) path: component/summary
 #: openscad.appdata.xml.in2:6
@@ -3525,65 +3454,6 @@ msgid ""
 "parameters from DXF files. Besides DXF files OpenSCAD can read and create 3D "
 "models in the STL and OFF file formats."
 msgstr ""
-
-#, fuzzy
-#~ msgid "meter"
-#~ msgstr "Parámetro"
-
-#~ msgid "Features"
-#~ msgstr "Características"
-
-#, fuzzy
-#~ msgid "Reset"
-#~ msgstr "Restablecer"
-
-#, fuzzy
-#~ msgid "Search action..."
-#~ msgstr "Buscar palabra"
-
-#~ msgid "OpenSCAD Font List"
-#~ msgstr "Lista de fuentes OpenSCAD"
-
-#~ msgid "Copy to Clipboard"
-#~ msgstr "Copiar al portapapeles"
-
-#~ msgid "Filter:"
-#~ msgstr "Filtro:"
-
-#~ msgid ""
-#~ "<html><head/><body><p>This list shows the fonts currently registered with "
-#~ "OpenSCAD.</p><p>Example:</p><pre style=\" margin-top:12px; margin-"
-#~ "bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-"
-#~ "indent:0px;\"><span style=\" font-family:'Courier New,courier';\">  "
-#~ "text(&quot;OpenSCAD&quot;, font = &quot;DejaVu Sans&quot;);</span></"
-#~ "pre><pre style=\" margin-top:0px; margin-bottom:12px; margin-left:0px; "
-#~ "margin-right:0px; -qt-block-indent:0; text-indent:0px;\"><span style=\" "
-#~ "font-family:'Courier New,courier';\">  text(&quot;OpenSCAD&quot;, font = "
-#~ "&quot;Liberation Sans:style=Italic&quot;);</span></pre></body></html>"
-#~ msgstr ""
-#~ "<html><head/><body><p>Esta lista muestra los tipos de letra registrados "
-#~ "actualmente en OpenSCAD.</p><p>Ejemplo:</p><pre style=\" margin-top:12px; "
-#~ "margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; "
-#~ "text-indent:0px;\"><span style=\" font-family:'Courier New,courier';\">  "
-#~ "text(&quot;OpenSCAD&quot;, font = &quot;DejaVu Sans&quot;);</span></"
-#~ "pre><pre style=\" margin-top:0px; margin-bottom:12px; margin-left:0px; "
-#~ "margin-right:0px; -qt-block-indent:0; text-indent:0px;\"><span style=\" "
-#~ "font-family:'Courier New,courier';\">  text(&quot;OpenSCAD&quot;, font = "
-#~ "&quot;Liberation Sans:style=Italic&quot;);</span></pre></body></html>"
-
-#, fuzzy
-#~ msgid "Line"
-#~ msgstr "Ajuste de línea"
-
-#, fuzzy
-#~ msgid "Font Lists"
-#~ msgstr "Lista de &Fuentes"
-
-#~ msgid "Surfaces"
-#~ msgstr "Superficies"
-
-#~ msgid "Hide Console"
-#~ msgstr "Ocultar Consola"
 
 #~ msgid "Untitled"
 #~ msgstr "Sin Título"

--- a/locale/fr.po
+++ b/locale/fr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: OpenSCAD 2013.02.07\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-09-06 23:38+0200\n"
+"POT-Creation-Date: 2026-09-06 17:48-0700\n"
 "PO-Revision-Date: 2019-09-17 \n"
 "Last-Translator: Pierre ROUZEAU <github.com/PRouzeau>\n"
 "Language-Team: French\n"
@@ -104,146 +104,111 @@ msgstr "Étapes :"
 msgid "Dump Pictures"
 msgstr "Exporter images"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:852
-#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:362
-#: build/OpenSCADLibInternal_autogen/include/ui_MouseConfigWidget.h:214
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2464
-msgid "Preferences"
-msgstr "Préférences"
-
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:853
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:854
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:858
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:862
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:864
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:866
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:868
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:870
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:881
+#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:860
+#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:861
+#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:865
+#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:869
+#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:871
+#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:873
+#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:875
+#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:877
+#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:888
 msgid "Trim"
 msgstr "'Trim'(Rognage)"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:855
+#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:862
 msgid "Reset Trim"
 msgstr "Réinitialise le \"Trim\""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:856
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:859
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:860
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:861
 #: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:863
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:865
+#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:866
 #: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:867
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:869
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:880
+#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:868
+#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:870
+#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:872
+#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:874
+#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:876
+#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:887
 msgid "DeadZone"
 msgstr "Zone morte"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:857
+#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:864
 msgid "Auto Trim Axes"
 msgstr "Ajuste automatiquement les axes"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:871
+#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:878
 msgid "Axis 2"
 msgstr "Axe 2"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:872
+#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:879
 msgid "Axis 0"
 msgstr "Axe 0"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:873
+#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:880
 msgid "Axis 3"
 msgstr "Axe 3"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:874
+#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:881
 msgid "Axis 6"
 msgstr "Axe 6"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:875
+#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:882
 msgid "Axis 8"
 msgstr "Axe 8"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:876
+#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:883
 msgid "Axis 7"
 msgstr "Axe 7"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:877
+#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:884
 msgid "Axis 5"
 msgstr "Axe 5"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:878
+#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:885
 msgid "Axis 1"
 msgstr "Axe 1"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:879
+#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:886
 msgid "Axis 4"
 msgstr "Axe 4"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:882
+#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:889
 #: build/OpenSCADLibInternal_autogen/include/ui_ViewportControl.h:279
 msgid "Rotation"
 msgstr "Rotation"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:883
+#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:890
 msgid "Zoom"
 msgstr "Zoom"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:884
-msgid "X"
-msgstr "X"
-
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:885
+#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:891
 msgid "Gain"
 msgstr "Gain"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:886
-msgid "Y"
-msgstr "Y"
-
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:887
-msgid "Z"
-msgstr "Z"
-
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:888
+#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:892
 #: build/OpenSCADLibInternal_autogen/include/ui_ViewportControl.h:280
 msgid "Translation"
 msgstr "Translation"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:889
+#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:893
 msgid "ViewPort rel.<br/>Translation"
 msgstr "Translation<br/>relative à la vue"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:890
-msgid "ViewPort rel.<br />Rotation"
+#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:894
+msgid "ViewPort rel.<br/>Rotation"
 msgstr "Rotation<br/>relative à la vue"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:891
+#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:895
 msgid "Axis Setup:"
 msgstr "Paramètres des axes :"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:892
+#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:896
 msgid "<b>Driver selection:</b> <i>(changes requires restarting OpenSCAD)</i>"
 msgstr "<b>Choix du pilote :</b> <i>(nécessite un redémarrage d’OpenSCAD)</i>"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:893
-msgid "SpaceNav"
-msgstr "SpaceNav"
-
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:894
-msgid "HIDAPI"
-msgstr "HIDAPI"
-
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:895
-msgid "QGamepad"
-msgstr "QGamepad"
-
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:896
+#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:897
 msgid "Joystick"
 msgstr "Joystick"
-
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:897
-msgid "DBus"
-msgstr "DBus"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:898
 msgid "Axes Mapping:"
@@ -254,125 +219,117 @@ msgid "Status:"
 msgstr "État :"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:900
-msgid "TextLabel"
-msgstr "TextLabel"
-
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:901
 #: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2468
 msgid "Update"
 msgstr "Mettre à jour"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:363
+#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:362
 msgid "Button 19"
 msgstr "Bouton 19"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:364
+#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:363
 msgid "Button 5"
 msgstr "Bouton 5"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:365
+#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:364
 msgid "Button 14"
 msgstr "Bouton 14"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:366
+#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:365
 msgid "Button 7"
 msgstr "Bouton 7"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:367
+#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:366
 msgid "Button 16"
 msgstr "Bouton 16"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:368
+#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:367
 msgid "Button 20"
 msgstr "Bouton 20"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:369
+#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:368
 msgid "Button 1"
 msgstr "Bouton 1"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:370
+#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:369
 msgid "Button 21"
 msgstr "Bouton 21"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:371
+#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:370
 msgid "Button 18"
 msgstr "Bouton 18"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:372
+#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:371
 msgid "Button 0"
 msgstr "Bouton 0"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:373
+#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:372
 msgid "Button 4"
 msgstr "Bouton 4"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:374
+#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:373
 msgid "Button 10"
 msgstr "Bouton 10"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:375
+#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:374
 msgid "Button 6"
 msgstr "Bouton 6"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:376
+#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:375
 msgid "Button 8"
 msgstr "Bouton 8"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:377
+#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:376
 msgid "Button 15"
 msgstr "Bouton 15"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:378
+#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:377
 msgid "Button 11"
 msgstr "Bouton 11"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:379
+#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:378
 msgid "Button 3"
 msgstr "Bouton 3"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:380
+#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:379
 msgid "Button 23"
 msgstr "Bouton 23"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:381
+#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:380
 msgid "Button 9"
 msgstr "Bouton 9"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:382
+#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:381
 msgid "Button 2"
 msgstr "Bouton 2"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:383
+#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:382
 msgid "Button 13"
 msgstr "Bouton 13"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:384
+#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:383
 msgid "Button 12"
 msgstr "Bouton 12"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:385
+#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:384
 msgid "Button 17"
 msgstr "Bouton 17"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:386
+#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:385
 msgid "Button 22"
 msgstr "Bouton 22"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_ChatWidget.h:194
+#: build/OpenSCADLibInternal_autogen/include/ui_ChatWidget.h:195
 msgid "AI Chat"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_ChatWidget.h:195
+#: build/OpenSCADLibInternal_autogen/include/ui_ChatWidget.h:196
 #: src/gui/ai/ChatWidget.cc:138
 msgid "AI Assistant"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_ChatWidget.h:197
+#: build/OpenSCADLibInternal_autogen/include/ui_ChatWidget.h:198
 msgid "Chat options"
-msgstr ""
-
-#: build/OpenSCADLibInternal_autogen/include/ui_ChatWidget.h:199
-msgid "☰"
 msgstr ""
 
 #: build/OpenSCADLibInternal_autogen/include/ui_ChatWidget.h:201
@@ -587,8 +544,8 @@ msgstr "Journal des erreurs"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_ErrorLog.h:93
 #: build/OpenSCADLibInternal_autogen/include/ui_ViewportControl.h:267
-msgid "RowSelected"
-msgstr "RowSelected"
+msgid "Row Selected"
+msgstr ""
 
 #: build/OpenSCADLibInternal_autogen/include/ui_ErrorLog.h:95
 #: build/OpenSCADLibInternal_autogen/include/ui_ViewportControl.h:269
@@ -642,12 +599,8 @@ msgid "Export 3MF Options"
 msgstr "Options d'export 3MF"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_Export3mfDialog.h:459
-#: build/OpenSCADLibInternal_autogen/include/ui_ExportPdfDialog.h:552
-msgid ""
-"<html><head/><body><p>Set the PDF page (paper) size.  </p></body></html>"
+msgid "Set the unit used in the exported file"
 msgstr ""
-"<html><head/><body><p>Définit la taille de la page (papier) du PDF.</p></"
-"body></html>"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_Export3mfDialog.h:461
 msgid "Unit"
@@ -795,6 +748,10 @@ msgstr "Annuler"
 msgid "Export PDF Options"
 msgstr "Options d'export PDF"
 
+#: build/OpenSCADLibInternal_autogen/include/ui_ExportPdfDialog.h:552
+msgid "Set the PDF page (paper) size."
+msgstr "Définit la taille de la page (papier) du PDF."
+
 #: build/OpenSCADLibInternal_autogen/include/ui_ExportPdfDialog.h:554
 msgid "Page Size"
 msgstr "Taille de la page"
@@ -855,12 +812,8 @@ msgid "Author"
 msgstr "Auteur"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_ExportPdfDialog.h:582
-msgid ""
-"<html><head/><body><p>Set the direction of the largest page dimension.</p></"
-"body></html>"
-msgstr ""
-"<html><head/><body><p>Définit la direction de la plus grande dimension de la "
-"page.</p></body></html>"
+msgid "Set the direction of the largest page dimension."
+msgstr "Définit la direction de la plus grande dimension de la page."
 
 #: build/OpenSCADLibInternal_autogen/include/ui_ExportPdfDialog.h:584
 msgid "Page Orientation"
@@ -877,12 +830,10 @@ msgid "Landscape (Horizontal)"
 msgstr "Paysage (horizontal)"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_ExportPdfDialog.h:589
-msgid ""
-"<html><head/><body><p>Determine best orientation based on maximum geometry "
-"dimension.</p></body></html>"
+msgid "Determine best orientation based on maximum geometry dimension."
 msgstr ""
-"<html><head/><body><p>Détermine la meilleure orientation selon la dimension "
-"maximale de la géométrie.</p></body></html>"
+"Détermine la meilleure orientation selon la dimension maximale de la "
+"géométrie."
 
 #: build/OpenSCADLibInternal_autogen/include/ui_ExportPdfDialog.h:591
 #: src/core/Settings.cc:400
@@ -894,35 +845,25 @@ msgid "Annotations"
 msgstr "Annotations"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_ExportPdfDialog.h:594
-msgid ""
-"<html><head/><body><p>Include design filename on page.</p></body></html>"
-msgstr ""
-"<html><head/><body><p>Inclure le nom du fichier de conception sur la page.</"
-"p></body></html>"
+msgid "Include design filename on page."
+msgstr "Inclure le nom du fichier de conception sur la page."
 
 #: build/OpenSCADLibInternal_autogen/include/ui_ExportPdfDialog.h:596
 msgid "Show Design Filename"
 msgstr "Afficher le nom du fichier de conception"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_ExportPdfDialog.h:598
-msgid ""
-"<html><head/><body><p>Include rulers on page to confirm 1:1 printing scale.</"
-"p></body></html>"
+msgid "Include rulers on page to confirm 1:1 printing scale."
 msgstr ""
-"<html><head/><body><p>Inclure des règles sur la page pour vérifier l'échelle "
-"d'impression 1:1.</p></body></html>"
+"Inclure des règles sur la page pour vérifier l'échelle d'impression 1:1."
 
 #: build/OpenSCADLibInternal_autogen/include/ui_ExportPdfDialog.h:600
 msgid "Show Scale"
 msgstr "Afficher l'échelle"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_ExportPdfDialog.h:602
-msgid ""
-"<html><head/><body><p>Include a grid of the selected size on the page.</p></"
-"body></html>"
-msgstr ""
-"<html><head/><body><p>Inclure une grille de la taille sélectionnée sur la "
-"page.</p></body></html>"
+msgid "Include a grid of the selected size on the page."
+msgstr "Inclure une grille de la taille sélectionnée sur la page."
 
 #: build/OpenSCADLibInternal_autogen/include/ui_ExportPdfDialog.h:604
 msgid "Show Grid"
@@ -949,12 +890,8 @@ msgid "10mm"
 msgstr "10 mm"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_ExportPdfDialog.h:611
-msgid ""
-"<html><head/><body><p>Include text describing usage of scale.</p></body></"
-"html>"
-msgstr ""
-"<html><head/><body><p>Inclure un texte décrivant l'utilisation de l'échelle."
-"</p></body></html>"
+msgid "Include text describing usage of scale."
+msgstr "Inclure un texte décrivant l'utilisation de l'échelle."
 
 #: build/OpenSCADLibInternal_autogen/include/ui_ExportPdfDialog.h:613
 msgid "Show Scale Usage"
@@ -966,12 +903,9 @@ msgid "Fill and Stroke"
 msgstr "Remplissage et contour"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_ExportPdfDialog.h:616
-msgid ""
-"<html><head/><body><p>Enable filling of exported geometry with a color.</p></"
-"body></html>"
-msgstr ""
-"<html><head/><body><p>Active le remplissage de la géométrie exportée avec "
-"une couleur.</p></body></html>"
+#: build/OpenSCADLibInternal_autogen/include/ui_ExportSvgDialog.h:205
+msgid "Enable filling of exported geometry with a color."
+msgstr "Active le remplissage de la géométrie exportée avec une couleur."
 
 #: build/OpenSCADLibInternal_autogen/include/ui_ExportPdfDialog.h:618
 #: build/OpenSCADLibInternal_autogen/include/ui_ExportSvgDialog.h:207
@@ -979,12 +913,9 @@ msgid "Fill Geometry"
 msgstr "Remplir la géométrie"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_ExportPdfDialog.h:623
-msgid ""
-"<html><head/><body><p>Enable outline stroke for exported geometry.</p></"
-"body></html>"
-msgstr ""
-"<html><head/><body><p>Active le contour de la géométrie exportée.</p></"
-"body></html>"
+#: build/OpenSCADLibInternal_autogen/include/ui_ExportSvgDialog.h:212
+msgid "Enable outline stroke for exported geometry."
+msgstr "Active le contour de la géométrie exportée."
 
 #: build/OpenSCADLibInternal_autogen/include/ui_ExportPdfDialog.h:625
 #: build/OpenSCADLibInternal_autogen/include/ui_ExportSvgDialog.h:214
@@ -1004,14 +935,6 @@ msgstr " mm"
 #: build/OpenSCADLibInternal_autogen/include/ui_ExportSvgDialog.h:202
 msgid "Export SVG Options"
 msgstr "Options d'export SVG"
-
-#: build/OpenSCADLibInternal_autogen/include/ui_ExportSvgDialog.h:205
-msgid "Enable filling of exported geometry with a color."
-msgstr "Active le remplissage de la géométrie exportée avec une couleur."
-
-#: build/OpenSCADLibInternal_autogen/include/ui_ExportSvgDialog.h:212
-msgid "Enable outline stroke for exported geometry."
-msgstr "Active le contour de la géométrie exportée."
 
 #: build/OpenSCADLibInternal_autogen/include/ui_FontList.h:291
 msgid "Font List"
@@ -1054,7 +977,7 @@ msgid "Show Sample Text"
 msgstr "Afficher le texte d'exemple"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_FontList.h:302
-msgid "ShowFileName"
+msgid "Show File Name"
 msgstr "Afficher le nom du fichier"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_FontList.h:303
@@ -1418,17 +1341,17 @@ msgstr "&Vérifier la validité"
 #: build/OpenSCADLibInternal_autogen/include/ui_MainWindow.h:1129
 #, fuzzy
 msgid "Display A&ST"
-msgstr "Afficher A&ST..."
+msgstr "Afficher A&ST"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_MainWindow.h:1130
 #, fuzzy
 msgid "Display CSG &Tree"
-msgstr "Afficher l’&arbre CSG..."
+msgstr "Afficher l’&arbre CSG"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_MainWindow.h:1131
 #, fuzzy
 msgid "Display CSG Pr&oducts"
-msgstr "Afficher les &produits CSG..."
+msgstr "Afficher les &produits CSG"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_MainWindow.h:1132
 msgid "Export as &STL (binary)..."
@@ -1823,13 +1746,13 @@ msgid "Ctrl+J"
 msgstr "Ctrl+J"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_MainWindow.h:1286
-#: src/gui/MainWindow.cc:1335 src/gui/MainWindow.cc:1342
-#: src/gui/MainWindow.cc:1355 src/gui/MainWindow.cc:1360
+#: src/gui/MainWindow.cc:1346 src/gui/MainWindow.cc:1353
+#: src/gui/MainWindow.cc:1366 src/gui/MainWindow.cc:1371
 msgid "Create Virtual Environment"
 msgstr "Créer un environnement virtuel"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_MainWindow.h:1287
-#: src/gui/MainWindow.cc:1377
+#: src/gui/MainWindow.cc:1388
 msgid "Select Virtual Environment"
 msgstr "Sélectionner un environnement virtuel"
 
@@ -1911,55 +1834,55 @@ msgstr "Terminer"
 msgid "Customizer Widget"
 msgstr "Panneau de personnalisation"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_MouseConfigWidget.h:215
+#: build/OpenSCADLibInternal_autogen/include/ui_MouseConfigWidget.h:214
 msgid "Ctrl + Shift + Middle-click"
 msgstr "Ctrl + Maj + Clic milieu"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_MouseConfigWidget.h:216
+#: build/OpenSCADLibInternal_autogen/include/ui_MouseConfigWidget.h:215
 msgid "Left-click"
 msgstr "Clic gauche"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_MouseConfigWidget.h:217
+#: build/OpenSCADLibInternal_autogen/include/ui_MouseConfigWidget.h:216
 msgid "Ctrl + Left-click"
 msgstr "Ctrl + Clic gauche"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_MouseConfigWidget.h:218
+#: build/OpenSCADLibInternal_autogen/include/ui_MouseConfigWidget.h:217
 msgid "Shift + Left-click"
 msgstr "Maj + Clic gauche"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_MouseConfigWidget.h:219
+#: build/OpenSCADLibInternal_autogen/include/ui_MouseConfigWidget.h:218
 msgid "Ctrl + Shift + Right-click"
 msgstr "Ctrl + Maj + Clic droit"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_MouseConfigWidget.h:220
+#: build/OpenSCADLibInternal_autogen/include/ui_MouseConfigWidget.h:219
 msgid "Preset"
 msgstr "Jeu de paramètres"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_MouseConfigWidget.h:221
+#: build/OpenSCADLibInternal_autogen/include/ui_MouseConfigWidget.h:220
 msgid "Right-click"
 msgstr "Clic droit"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_MouseConfigWidget.h:222
+#: build/OpenSCADLibInternal_autogen/include/ui_MouseConfigWidget.h:221
 msgid "Ctrl + Middle-click"
 msgstr "Ctrl + Clic milieu"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_MouseConfigWidget.h:223
+#: build/OpenSCADLibInternal_autogen/include/ui_MouseConfigWidget.h:222
 msgid "Shift + Middle-click"
 msgstr "Maj + Clic milieu"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_MouseConfigWidget.h:224
+#: build/OpenSCADLibInternal_autogen/include/ui_MouseConfigWidget.h:223
 msgid "Ctrl + Right-click"
 msgstr "Ctrl + Clic droit"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_MouseConfigWidget.h:225
+#: build/OpenSCADLibInternal_autogen/include/ui_MouseConfigWidget.h:224
 msgid "Ctrl + Shift + Left-click"
 msgstr "Ctrl + Maj + Clic gauche"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_MouseConfigWidget.h:226
+#: build/OpenSCADLibInternal_autogen/include/ui_MouseConfigWidget.h:225
 msgid "Shift + Right-click"
 msgstr "Maj + Clic droit"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_MouseConfigWidget.h:227
+#: build/OpenSCADLibInternal_autogen/include/ui_MouseConfigWidget.h:226
 msgid "Middle-click"
 msgstr "Clic milieu"
 
@@ -1976,34 +1899,10 @@ msgid "OpenGL Warning"
 msgstr "Avertissements OpenGL"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_OpenCSGWarningDialog.h:77
-msgid ""
-"<!DOCTYPE HTML PUBLIC \"-//W3C//DTD HTML 4.0//EN\" \"http://www.w3.org/TR/"
-"REC-html40/strict.dtd\">\n"
-"<html><head><meta name=\"qrichtext\" content=\"1\" /><style type=\"text/"
-"css\">\n"
-"p, li { white-space: pre-wrap; }\n"
-"</style></head><body style=\" font-family:'Lucida Grande'; font-size:13pt; "
-"font-weight:400; font-style:normal;\">\n"
-"<p style=\"-qt-paragraph-type:empty; margin-top:0px; margin-bottom:0px; "
-"margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;\"></"
-"p></body></html>"
-msgstr ""
-"<!DOCTYPE HTML PUBLIC \"-//W3C//DTD HTML 4.0//EN\" \"http://www.w3.org/TR/"
-"REC-html40/strict.dtd\">\n"
-"<html><head><meta name=\"qrichtext\" content=\"1\" /><style type=\"text/"
-"css\">\n"
-"p, li { white-space: pre-wrap; }\n"
-"</style></head><body style=\" font-family:'Lucida Grande'; font-size:13pt; "
-"font-weight:400; font-style:normal;\">\n"
-"<p style=\"-qt-paragraph-type:empty; margin-top:0px; margin-bottom:0px; "
-"margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;\"></"
-"p></body></html>"
-
-#: build/OpenSCADLibInternal_autogen/include/ui_OpenCSGWarningDialog.h:82
 msgid "Show this message again"
 msgstr "Afficher ce message à nouveau"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_OpenCSGWarningDialog.h:83
+#: build/OpenSCADLibInternal_autogen/include/ui_OpenCSGWarningDialog.h:78
 msgid "Close"
 msgstr "Fermer"
 
@@ -2072,6 +1971,10 @@ msgstr "-"
 msgid "More actions"
 msgstr "Annotations"
 
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2464
+msgid "Preferences"
+msgstr "Préférences"
+
 #: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2465
 msgid "3D View"
 msgstr "Vue 3D"
@@ -2088,7 +1991,7 @@ msgstr "Éditeur"
 #: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2469
 #, fuzzy
 msgid "Experimental"
-msgstr "Fonctionnalités d'export"
+msgstr "Expérimentale"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2471
 msgid "Enable/Disable experimental features"
@@ -2422,7 +2325,7 @@ msgstr "Dernière vérification : "
 #: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2570
 #, fuzzy
 msgid "Experimental Features"
-msgstr "Fonctionnalités d'export"
+msgstr "Fonctionnalités expérimentales"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2571
 msgid ""
@@ -3144,21 +3047,21 @@ msgstr ""
 msgid "Toggle Perspective"
 msgstr "Basculer la perspective"
 
-#: src/gui/MainWindow.cc:861
+#: src/gui/MainWindow.cc:872
 msgid "Compile error."
 msgstr "Erreur de compilation."
 
-#: src/gui/MainWindow.cc:864
+#: src/gui/MainWindow.cc:875
 msgid "Error while compiling '%1'."
 msgstr "Erreur lors de la compilation de '%1'."
 
-#: src/gui/MainWindow.cc:869
+#: src/gui/MainWindow.cc:880
 msgid "Compilation generated %1 warning."
 msgid_plural "Compilation generated %1 warnings."
 msgstr[0] "La compilation a généré %1 avertissement."
 msgstr[1] "La compilation a généré %1 avertissements."
 
-#: src/gui/MainWindow.cc:882
+#: src/gui/MainWindow.cc:893
 msgid ""
 " For details see the <a href=\"#errorlog\">error log</a> and <a "
 "href=\"#console\">console window</a>."
@@ -3166,11 +3069,11 @@ msgstr ""
 " Pour plus de détails, voir le <a href=\"#errorlog\">journal des erreurs</a> "
 "et la <a href=\"#console\">console</a>."
 
-#: src/gui/MainWindow.cc:1320
+#: src/gui/MainWindow.cc:1331
 msgid "Trusted Files"
 msgstr "Fichiers de confiance"
 
-#: src/gui/MainWindow.cc:1704
+#: src/gui/MainWindow.cc:1715
 msgid ""
 "Python files can potentially contain harmful stuff.\n"
 "Do you trust this file ?\n"
@@ -3178,11 +3081,11 @@ msgstr ""
 "Les fichiers Python peuvent potentiellement contenir du code dangereux.\n"
 "Faites-vous confiance à ce fichier ?\n"
 
-#: src/gui/MainWindow.cc:1810
+#: src/gui/MainWindow.cc:1821
 msgid "Application"
 msgstr "Application"
 
-#: src/gui/MainWindow.cc:1811
+#: src/gui/MainWindow.cc:1822
 msgid ""
 "The document has been modified.\n"
 "Do you really want to reload the file?"
@@ -3190,75 +3093,75 @@ msgstr ""
 "Ce document a été modifié.\n"
 "Voulez-vous vraiment recharger le fichier?"
 
-#: src/gui/MainWindow.cc:2564
+#: src/gui/MainWindow.cc:2575
 msgid "Export %1 File"
 msgstr "Exporter le fichier %1"
 
-#: src/gui/MainWindow.cc:2565
+#: src/gui/MainWindow.cc:2576
 msgid "%1 Files (*%2)"
 msgstr "%1 Fichiers (*%2)"
 
-#: src/gui/MainWindow.cc:2613
+#: src/gui/MainWindow.cc:2624
 msgid "Export CSG File"
 msgstr "Exporter un fichier CSG"
 
-#: src/gui/MainWindow.cc:2614
+#: src/gui/MainWindow.cc:2625
 msgid "CSG Files (*.csg)"
 msgstr "Fichiers CSG (*.csg)"
 
-#: src/gui/MainWindow.cc:2637
+#: src/gui/MainWindow.cc:2648
 msgid "Export Image"
 msgstr "Exporter une Image"
 
-#: src/gui/MainWindow.cc:2637
+#: src/gui/MainWindow.cc:2648
 msgid "PNG Files (*.png)"
 msgstr "Fichiers PNG (*.png)"
 
-#: src/gui/MainWindow.cc:3027 src/gui/MainWindow.cc:3787
+#: src/gui/MainWindow.cc:3038 src/gui/MainWindow.cc:3798
 msgid "&AI Chat"
 msgstr ""
 
-#: src/gui/MainWindow.cc:3129 src/gui/TabManager.cc:735
+#: src/gui/MainWindow.cc:3140 src/gui/TabManager.cc:735
 #: src/gui/TabManager.cc:786
 msgid "Untitled.scad"
 msgstr "Untitled.scad"
 
-#: src/gui/MainWindow.cc:3779
+#: src/gui/MainWindow.cc:3790
 #, fuzzy
 msgid "&Editor"
 msgstr "Éditeur"
 
-#: src/gui/MainWindow.cc:3780
+#: src/gui/MainWindow.cc:3791
 #, fuzzy
 msgid "&Console"
 msgstr "Console"
 
-#: src/gui/MainWindow.cc:3781
+#: src/gui/MainWindow.cc:3792
 #, fuzzy
 msgid "C&ustomizer"
 msgstr "Panneau de personnalisation"
 
-#: src/gui/MainWindow.cc:3782
+#: src/gui/MainWindow.cc:3793
 #, fuzzy
 msgid "Error &Log"
 msgstr "Journal des erreurs"
 
-#: src/gui/MainWindow.cc:3783
+#: src/gui/MainWindow.cc:3794
 #, fuzzy
 msgid "&Animate"
 msgstr "Animer"
 
-#: src/gui/MainWindow.cc:3784
+#: src/gui/MainWindow.cc:3795
 #, fuzzy
 msgid "&Font List"
 msgstr "Liste des polices"
 
-#: src/gui/MainWindow.cc:3785
+#: src/gui/MainWindow.cc:3796
 #, fuzzy
 msgid "C&olor List"
 msgstr "Liste des couleurs"
 
-#: src/gui/MainWindow.cc:3786
+#: src/gui/MainWindow.cc:3797
 #, fuzzy
 msgid "&Viewport Control"
 msgstr "Contrôle de la vue"
@@ -3519,8 +3422,12 @@ msgid "\"%1$s\" write error. (Disk full?)"
 msgstr "\"%1$s\" erreur d'écriture. (Disque plein ?)"
 
 #: examples
-msgid "Parametric"
-msgstr "Paramétrique"
+msgid "Advanced"
+msgstr "Avancé"
+
+#: examples
+msgid "Basics"
+msgstr "Bases"
 
 #: examples
 msgid "Functions"
@@ -3531,12 +3438,8 @@ msgid "Old"
 msgstr "Ancien"
 
 #: examples
-msgid "Advanced"
-msgstr "Avancé"
-
-#: examples
-msgid "Basics"
-msgstr "Bases"
+msgid "Parametric"
+msgstr "Paramétrique"
 
 #. (itstool) path: component/summary
 #: openscad.appdata.xml.in2:6
@@ -3595,107 +3498,3 @@ msgstr ""
 "2D pour l'extrusion il est aussi possible de lire les paramètres des "
 "fichiers DXF. En sus des fichiers DXF, OpenSCAD peut lire et créer des "
 "modèles 3D aux formats STL et OFF."
-
-#~ msgid "micron"
-#~ msgstr "micron"
-
-#~ msgid "millimeter"
-#~ msgstr "millimeter"
-
-#~ msgid "centimeter"
-#~ msgstr "centimeter"
-
-#~ msgid "meter"
-#~ msgstr "meter"
-
-#~ msgid "inch"
-#~ msgstr "inch"
-
-#~ msgid "foot"
-#~ msgstr "foot"
-
-#~ msgid "model"
-#~ msgstr "model"
-
-#~ msgid "none"
-#~ msgstr "none"
-
-#~ msgid "selected-only"
-#~ msgstr "selected-only"
-
-#~ msgid "a6"
-#~ msgstr "a6"
-
-#~ msgid "a5"
-#~ msgstr "a5"
-
-#~ msgid "a4"
-#~ msgstr "a4"
-
-#~ msgid "a3"
-#~ msgstr "a3"
-
-#~ msgid "letter"
-#~ msgstr "letter"
-
-#~ msgid "legal"
-#~ msgstr "legal"
-
-#~ msgid "tabloid"
-#~ msgstr "tabloid"
-
-#~ msgid "landscape"
-#~ msgstr "landscape"
-
-#~ msgid "auto"
-#~ msgstr "auto"
-
-#~ msgid "ResetSampleText"
-#~ msgstr "ResetSampleText"
-
-#~ msgid "Features"
-#~ msgstr "Fonctionnalités"
-
-#, fuzzy
-#~ msgid "Reset"
-#~ msgstr "Jeu de paramètres"
-
-#, fuzzy
-#~ msgid "Search action..."
-#~ msgstr "Rechercher une chaîne de caractères"
-
-#~ msgid "ViewportControlWidget"
-#~ msgstr "ViewportControlWidget"
-
-#~ msgid "OpenSCAD Font List"
-#~ msgstr "Liste des polices OpenSCAD"
-
-#~ msgid "Copy to Clipboard"
-#~ msgstr "Copier dans le presse-papier"
-
-#~ msgid "Filter:"
-#~ msgstr "Filtre :"
-
-#~ msgid ""
-#~ "<html><head/><body><p>This list shows the fonts currently registered with "
-#~ "OpenSCAD.</p><p>Example:</p><pre style=\" margin-top:12px; margin-"
-#~ "bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-"
-#~ "indent:0px;\"><span style=\" font-family:'Courier New,courier';\">  "
-#~ "text(&quot;OpenSCAD&quot;, font = &quot;DejaVu Sans&quot;);</span></"
-#~ "pre><pre style=\" margin-top:0px; margin-bottom:12px; margin-left:0px; "
-#~ "margin-right:0px; -qt-block-indent:0; text-indent:0px;\"><span style=\" "
-#~ "font-family:'Courier New,courier';\">  text(&quot;OpenSCAD&quot;, font = "
-#~ "&quot;Liberation Sans:style=Italic&quot;);</span></pre></body></html>"
-#~ msgstr ""
-#~ "<html><head/><body><p>Cette liste affiche les polices actuellement "
-#~ "déclarées dans OpenSCAD</p><p>Exemple:</p><pre style=\" margin-top:12px; "
-#~ "margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; "
-#~ "text-indent:0px;\"><span style=\" font-family:'Courier New,courier';\">  "
-#~ "text(&quot;OpenSCAD&quot;, font = &quot;DejaVu Sans&quot;);</span></"
-#~ "pre><pre style=\" margin-top:0px; margin-bottom:12px; margin-left:0px; "
-#~ "margin-right:0px; -qt-block-indent:0; text-indent:0px;\"><span style=\" "
-#~ "font-family:'Courier New,courier';\">  text(&quot;OpenSCAD&quot;, font = "
-#~ "&quot;Liberation Sans:style=Italic&quot;);</span></pre></body></html>"
-
-#~ msgid "Error-Log"
-#~ msgstr "Journal des erreurs"

--- a/locale/hy.po
+++ b/locale/hy.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: OpenSCAD 2020.02.01\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-09-06 23:38+0200\n"
+"POT-Creation-Date: 2026-09-06 17:48-0700\n"
 "PO-Revision-Date: 2020-04-20 17:00+0400\n"
 "Last-Translator: Sargis Malkonyan <melkonyansarg@gmail.com>\n"
 "Language-Team: Agarak Armath Engineering Laboratories\n"
@@ -100,148 +100,113 @@ msgstr "Քայլեր։"
 msgid "Dump Pictures"
 msgstr "Թափոն նկարները"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:852
-#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:362
-#: build/OpenSCADLibInternal_autogen/include/ui_MouseConfigWidget.h:214
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2464
-msgid "Preferences"
-msgstr "Կարգավորումներ"
-
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:853
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:854
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:858
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:862
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:864
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:866
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:868
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:870
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:881
+#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:860
+#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:861
+#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:865
+#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:869
+#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:871
+#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:873
+#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:875
+#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:877
+#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:888
 msgid "Trim"
 msgstr "Կտրել"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:855
+#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:862
 msgid "Reset Trim"
 msgstr "Չեղարկել կտրումը"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:856
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:859
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:860
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:861
 #: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:863
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:865
+#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:866
 #: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:867
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:869
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:880
+#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:868
+#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:870
+#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:872
+#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:874
+#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:876
+#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:887
 msgid "DeadZone"
 msgstr "Մեռյալ գոտի"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:857
+#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:864
 msgid "Auto Trim Axes"
 msgstr "Ավտոմատ հետ բերել կտրած հատվածը"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:871
+#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:878
 msgid "Axis 2"
 msgstr "Առանցք 2"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:872
+#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:879
 msgid "Axis 0"
 msgstr "Առանցք 0"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:873
+#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:880
 msgid "Axis 3"
 msgstr "Առանցք 3"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:874
+#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:881
 msgid "Axis 6"
 msgstr "Առանցք 6"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:875
+#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:882
 msgid "Axis 8"
 msgstr "Առանցք 8"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:876
+#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:883
 msgid "Axis 7"
 msgstr "Առանցք 7"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:877
+#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:884
 msgid "Axis 5"
 msgstr "Առանցք 5"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:878
+#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:885
 msgid "Axis 1"
 msgstr "Առանցք 1"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:879
+#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:886
 msgid "Axis 4"
 msgstr "Առանցք 4"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:882
+#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:889
 #: build/OpenSCADLibInternal_autogen/include/ui_ViewportControl.h:279
 msgid "Rotation"
 msgstr "Պտտում"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:883
+#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:890
 msgid "Zoom"
 msgstr "Խոշորացում"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:884
-msgid "X"
-msgstr "X"
-
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:885
+#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:891
 msgid "Gain"
 msgstr "Աճացնել"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:886
-msgid "Y"
-msgstr "Y"
-
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:887
-msgid "Z"
-msgstr "Z"
-
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:888
+#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:892
 #: build/OpenSCADLibInternal_autogen/include/ui_ViewportControl.h:280
 msgid "Translation"
 msgstr "Մոդելի թարգմանություն"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:889
+#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:893
 msgid "ViewPort rel.<br/>Translation"
 msgstr "ViewPort rel.<br/>Թարգմանություն"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:890
-msgid "ViewPort rel.<br />Rotation"
-msgstr "ViewPort rel.<br />Պտտում"
+#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:894
+msgid "ViewPort rel.<br/>Rotation"
+msgstr "ViewPort rel.<br/>Պտտում"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:891
+#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:895
 msgid "Axis Setup:"
 msgstr "Առանցքի կարգաբերում ՝"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:892
+#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:896
 msgid "<b>Driver selection:</b> <i>(changes requires restarting OpenSCAD)</i>"
 msgstr ""
 "<b>Driver֊ի ընտրություն:</b> <i>(փոփոխությունից հետո անհրաժեշտ է "
 "վերագործարկել OpenSCAD֊ը)</i>"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:893
-msgid "SpaceNav"
-msgstr "SpaceNav"
-
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:894
-msgid "HIDAPI"
-msgstr "HIDAPI"
-
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:895
-msgid "QGamepad"
-msgstr "QGamepad"
-
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:896
+#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:897
 msgid "Joystick"
 msgstr "Joystick"
-
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:897
-msgid "DBus"
-msgstr "DBus"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:898
 msgid "Axes Mapping:"
@@ -252,134 +217,125 @@ msgid "Status:"
 msgstr ""
 
 #: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:900
-#, fuzzy
-msgid "TextLabel"
-msgstr "Տեքստ"
-
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:901
 #: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2468
 msgid "Update"
 msgstr "Թարմացնել"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:363
+#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:362
 #, fuzzy
 msgid "Button 19"
 msgstr "Կոճակ 1"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:364
+#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:363
 msgid "Button 5"
 msgstr "Կոճակ 5"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:365
+#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:364
 msgid "Button 14"
 msgstr "Կոճակ 14"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:366
+#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:365
 msgid "Button 7"
 msgstr "Կոճակ 7"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:367
+#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:366
 #, fuzzy
 msgid "Button 16"
 msgstr "Կոճակ 1"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:368
+#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:367
 #, fuzzy
 msgid "Button 20"
 msgstr "Կոճակ 2"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:369
+#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:368
 msgid "Button 1"
 msgstr "Կոճակ 1"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:370
+#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:369
 #, fuzzy
 msgid "Button 21"
 msgstr "Կոճակ 2"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:371
+#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:370
 #, fuzzy
 msgid "Button 18"
 msgstr "Կոճակ 1"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:372
+#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:371
 msgid "Button 0"
 msgstr "Կոճակ 0"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:373
+#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:372
 msgid "Button 4"
 msgstr "Կոճակ 4"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:374
+#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:373
 msgid "Button 10"
 msgstr "Կոճակ 10"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:375
+#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:374
 msgid "Button 6"
 msgstr "Կոճակ 6"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:376
+#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:375
 msgid "Button 8"
 msgstr "Կոճակ 8"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:377
+#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:376
 msgid "Button 15"
 msgstr "Կոճակ 15"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:378
+#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:377
 msgid "Button 11"
 msgstr "Կոճակ 11"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:379
+#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:378
 msgid "Button 3"
 msgstr "Կոճակ 3"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:380
+#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:379
 #, fuzzy
 msgid "Button 23"
 msgstr "Կոճակ 2"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:381
+#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:380
 msgid "Button 9"
 msgstr "Կոճակ 9"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:382
+#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:381
 msgid "Button 2"
 msgstr "Կոճակ 2"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:383
+#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:382
 msgid "Button 13"
 msgstr "Կոճակ 13"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:384
+#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:383
 msgid "Button 12"
 msgstr "Կոճակ 12"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:385
+#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:384
 #, fuzzy
 msgid "Button 17"
 msgstr "Կոճակ 1"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:386
+#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:385
 #, fuzzy
 msgid "Button 22"
 msgstr "Կոճակ 2"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_ChatWidget.h:194
+#: build/OpenSCADLibInternal_autogen/include/ui_ChatWidget.h:195
 msgid "AI Chat"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_ChatWidget.h:195
+#: build/OpenSCADLibInternal_autogen/include/ui_ChatWidget.h:196
 #: src/gui/ai/ChatWidget.cc:138
 msgid "AI Assistant"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_ChatWidget.h:197
+#: build/OpenSCADLibInternal_autogen/include/ui_ChatWidget.h:198
 msgid "Chat options"
-msgstr ""
-
-#: build/OpenSCADLibInternal_autogen/include/ui_ChatWidget.h:199
-msgid "☰"
 msgstr ""
 
 #: build/OpenSCADLibInternal_autogen/include/ui_ChatWidget.h:201
@@ -599,13 +555,12 @@ msgid "Save console content to file"
 msgstr "Պահել վահանակի պարունակությունը նիշքում"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_ErrorLog.h:92
-#, fuzzy
 msgid "Error Log"
 msgstr "Սխալմունք"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_ErrorLog.h:93
 #: build/OpenSCADLibInternal_autogen/include/ui_ViewportControl.h:267
-msgid "RowSelected"
+msgid "Row Selected"
 msgstr ""
 
 #: build/OpenSCADLibInternal_autogen/include/ui_ErrorLog.h:95
@@ -662,9 +617,7 @@ msgid "Export 3MF Options"
 msgstr "Հնարավորություններ"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_Export3mfDialog.h:459
-#: build/OpenSCADLibInternal_autogen/include/ui_ExportPdfDialog.h:552
-msgid ""
-"<html><head/><body><p>Set the PDF page (paper) size.  </p></body></html>"
+msgid "Set the unit used in the exported file"
 msgstr ""
 
 #: build/OpenSCADLibInternal_autogen/include/ui_Export3mfDialog.h:461
@@ -815,6 +768,10 @@ msgstr "Չեղարկել"
 msgid "Export PDF Options"
 msgstr "Հնարավորություններ"
 
+#: build/OpenSCADLibInternal_autogen/include/ui_ExportPdfDialog.h:552
+msgid "Set the PDF page (paper) size."
+msgstr ""
+
 #: build/OpenSCADLibInternal_autogen/include/ui_ExportPdfDialog.h:554
 #, fuzzy
 msgid "Page Size"
@@ -874,9 +831,7 @@ msgid "Author"
 msgstr ""
 
 #: build/OpenSCADLibInternal_autogen/include/ui_ExportPdfDialog.h:582
-msgid ""
-"<html><head/><body><p>Set the direction of the largest page dimension.</p></"
-"body></html>"
+msgid "Set the direction of the largest page dimension."
 msgstr ""
 
 #: build/OpenSCADLibInternal_autogen/include/ui_ExportPdfDialog.h:584
@@ -895,9 +850,7 @@ msgid "Landscape (Horizontal)"
 msgstr ""
 
 #: build/OpenSCADLibInternal_autogen/include/ui_ExportPdfDialog.h:589
-msgid ""
-"<html><head/><body><p>Determine best orientation based on maximum geometry "
-"dimension.</p></body></html>"
+msgid "Determine best orientation based on maximum geometry dimension."
 msgstr ""
 
 #: build/OpenSCADLibInternal_autogen/include/ui_ExportPdfDialog.h:591
@@ -911,8 +864,7 @@ msgid "Annotations"
 msgstr "Պտտում"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_ExportPdfDialog.h:594
-msgid ""
-"<html><head/><body><p>Include design filename on page.</p></body></html>"
+msgid "Include design filename on page."
 msgstr ""
 
 #: build/OpenSCADLibInternal_autogen/include/ui_ExportPdfDialog.h:596
@@ -920,9 +872,7 @@ msgid "Show Design Filename"
 msgstr ""
 
 #: build/OpenSCADLibInternal_autogen/include/ui_ExportPdfDialog.h:598
-msgid ""
-"<html><head/><body><p>Include rulers on page to confirm 1:1 printing scale.</"
-"p></body></html>"
+msgid "Include rulers on page to confirm 1:1 printing scale."
 msgstr ""
 
 #: build/OpenSCADLibInternal_autogen/include/ui_ExportPdfDialog.h:600
@@ -931,9 +881,7 @@ msgid "Show Scale"
 msgstr "Ցուցադրել մասշատբի նշումները"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_ExportPdfDialog.h:602
-msgid ""
-"<html><head/><body><p>Include a grid of the selected size on the page.</p></"
-"body></html>"
+msgid "Include a grid of the selected size on the page."
 msgstr ""
 
 #: build/OpenSCADLibInternal_autogen/include/ui_ExportPdfDialog.h:604
@@ -962,9 +910,7 @@ msgid "10mm"
 msgstr ""
 
 #: build/OpenSCADLibInternal_autogen/include/ui_ExportPdfDialog.h:611
-msgid ""
-"<html><head/><body><p>Include text describing usage of scale.</p></body></"
-"html>"
+msgid "Include text describing usage of scale."
 msgstr ""
 
 #: build/OpenSCADLibInternal_autogen/include/ui_ExportPdfDialog.h:613
@@ -978,9 +924,8 @@ msgid "Fill and Stroke"
 msgstr ""
 
 #: build/OpenSCADLibInternal_autogen/include/ui_ExportPdfDialog.h:616
-msgid ""
-"<html><head/><body><p>Enable filling of exported geometry with a color.</p></"
-"body></html>"
+#: build/OpenSCADLibInternal_autogen/include/ui_ExportSvgDialog.h:205
+msgid "Enable filling of exported geometry with a color."
 msgstr ""
 
 #: build/OpenSCADLibInternal_autogen/include/ui_ExportPdfDialog.h:618
@@ -989,9 +934,8 @@ msgid "Fill Geometry"
 msgstr ""
 
 #: build/OpenSCADLibInternal_autogen/include/ui_ExportPdfDialog.h:623
-msgid ""
-"<html><head/><body><p>Enable outline stroke for exported geometry.</p></"
-"body></html>"
+#: build/OpenSCADLibInternal_autogen/include/ui_ExportSvgDialog.h:212
+msgid "Enable outline stroke for exported geometry."
 msgstr ""
 
 #: build/OpenSCADLibInternal_autogen/include/ui_ExportPdfDialog.h:625
@@ -1013,14 +957,6 @@ msgstr ""
 #, fuzzy
 msgid "Export SVG Options"
 msgstr "Հնարավորություններ"
-
-#: build/OpenSCADLibInternal_autogen/include/ui_ExportSvgDialog.h:205
-msgid "Enable filling of exported geometry with a color."
-msgstr ""
-
-#: build/OpenSCADLibInternal_autogen/include/ui_ExportSvgDialog.h:212
-msgid "Enable outline stroke for exported geometry."
-msgstr ""
 
 #: build/OpenSCADLibInternal_autogen/include/ui_FontList.h:291
 #, fuzzy
@@ -1071,7 +1007,7 @@ msgstr "Ցուցադրել մասշատբի նշումները"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_FontList.h:302
 #, fuzzy
-msgid "ShowFileName"
+msgid "Show File Name"
 msgstr "&Նիշք"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_FontList.h:303
@@ -1859,13 +1795,13 @@ msgid "Ctrl+J"
 msgstr "Ctrl+N"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_MainWindow.h:1286
-#: src/gui/MainWindow.cc:1335 src/gui/MainWindow.cc:1342
-#: src/gui/MainWindow.cc:1355 src/gui/MainWindow.cc:1360
+#: src/gui/MainWindow.cc:1346 src/gui/MainWindow.cc:1353
+#: src/gui/MainWindow.cc:1366 src/gui/MainWindow.cc:1371
 msgid "Create Virtual Environment"
 msgstr ""
 
 #: build/OpenSCADLibInternal_autogen/include/ui_MainWindow.h:1287
-#: src/gui/MainWindow.cc:1377
+#: src/gui/MainWindow.cc:1388
 msgid "Select Virtual Environment"
 msgstr ""
 
@@ -1949,56 +1885,56 @@ msgstr "Կատարված"
 msgid "Customizer Widget"
 msgstr "Հարմարեցնել Widget֊ը"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_MouseConfigWidget.h:215
+#: build/OpenSCADLibInternal_autogen/include/ui_MouseConfigWidget.h:214
 msgid "Ctrl + Shift + Middle-click"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_MouseConfigWidget.h:216
+#: build/OpenSCADLibInternal_autogen/include/ui_MouseConfigWidget.h:215
 msgid "Left-click"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_MouseConfigWidget.h:217
+#: build/OpenSCADLibInternal_autogen/include/ui_MouseConfigWidget.h:216
 msgid "Ctrl + Left-click"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_MouseConfigWidget.h:218
+#: build/OpenSCADLibInternal_autogen/include/ui_MouseConfigWidget.h:217
 msgid "Shift + Left-click"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_MouseConfigWidget.h:219
+#: build/OpenSCADLibInternal_autogen/include/ui_MouseConfigWidget.h:218
 msgid "Ctrl + Shift + Right-click"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_MouseConfigWidget.h:220
+#: build/OpenSCADLibInternal_autogen/include/ui_MouseConfigWidget.h:219
 #, fuzzy
 msgid "Preset"
 msgstr "Բերել սկզբնական վիճակի"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_MouseConfigWidget.h:221
+#: build/OpenSCADLibInternal_autogen/include/ui_MouseConfigWidget.h:220
 msgid "Right-click"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_MouseConfigWidget.h:222
+#: build/OpenSCADLibInternal_autogen/include/ui_MouseConfigWidget.h:221
 msgid "Ctrl + Middle-click"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_MouseConfigWidget.h:223
+#: build/OpenSCADLibInternal_autogen/include/ui_MouseConfigWidget.h:222
 msgid "Shift + Middle-click"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_MouseConfigWidget.h:224
+#: build/OpenSCADLibInternal_autogen/include/ui_MouseConfigWidget.h:223
 msgid "Ctrl + Right-click"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_MouseConfigWidget.h:225
+#: build/OpenSCADLibInternal_autogen/include/ui_MouseConfigWidget.h:224
 msgid "Ctrl + Shift + Left-click"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_MouseConfigWidget.h:226
+#: build/OpenSCADLibInternal_autogen/include/ui_MouseConfigWidget.h:225
 msgid "Shift + Right-click"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_MouseConfigWidget.h:227
+#: build/OpenSCADLibInternal_autogen/include/ui_MouseConfigWidget.h:226
 msgid "Middle-click"
 msgstr ""
 
@@ -2015,34 +1951,10 @@ msgid "OpenGL Warning"
 msgstr "OpenGL զգուշացում"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_OpenCSGWarningDialog.h:77
-msgid ""
-"<!DOCTYPE HTML PUBLIC \"-//W3C//DTD HTML 4.0//EN\" \"http://www.w3.org/TR/"
-"REC-html40/strict.dtd\">\n"
-"<html><head><meta name=\"qrichtext\" content=\"1\" /><style type=\"text/"
-"css\">\n"
-"p, li { white-space: pre-wrap; }\n"
-"</style></head><body style=\" font-family:'Lucida Grande'; font-size:13pt; "
-"font-weight:400; font-style:normal;\">\n"
-"<p style=\"-qt-paragraph-type:empty; margin-top:0px; margin-bottom:0px; "
-"margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;\"></"
-"p></body></html>"
-msgstr ""
-"<!DOCTYPE HTML PUBLIC \"-//W3C//DTD HTML 4.0//EN\" \"http://www.w3.org/TR/"
-"REC-html40/strict.dtd\">\n"
-"<html><head><meta name=\"qrichtext\" content=\"1\" /><style type=\"text/"
-"css\">\n"
-"p, li { white-space: pre-wrap; }\n"
-"</style></head><body style=\" font-family:'Lucida Grande'; font-size:13pt; "
-"font-weight:400; font-style:normal;\">\n"
-"<p style=\"-qt-paragraph-type:empty; margin-top:0px; margin-bottom:0px; "
-"margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;\"></"
-"p></body></html>"
-
-#: build/OpenSCADLibInternal_autogen/include/ui_OpenCSGWarningDialog.h:82
 msgid "Show this message again"
 msgstr "Կրկին ցուցադրել այս հաղորդագրությունը"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_OpenCSGWarningDialog.h:83
+#: build/OpenSCADLibInternal_autogen/include/ui_OpenCSGWarningDialog.h:78
 msgid "Close"
 msgstr "Փակել"
 
@@ -2113,6 +2025,10 @@ msgstr "-"
 #, fuzzy
 msgid "More actions"
 msgstr "Պտտում"
+
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2464
+msgid "Preferences"
+msgstr "Կարգավորումներ"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2465
 msgid "3D View"
@@ -3190,42 +3106,42 @@ msgstr "The QGAMEPAD դրայվերը  multiplattform Gamepad֊ի աւակցմա
 msgid "Toggle Perspective"
 msgstr "Փոխարկել հեռանկարը"
 
-#: src/gui/MainWindow.cc:861
+#: src/gui/MainWindow.cc:872
 msgid "Compile error."
 msgstr "Կառուցման/կամպիլիացիայի/ սխալմունք։"
 
-#: src/gui/MainWindow.cc:864
+#: src/gui/MainWindow.cc:875
 msgid "Error while compiling '%1'."
 msgstr "Կոմպիլացիայի ժամանակ խնդիր է ծագել '%1'."
 
-#: src/gui/MainWindow.cc:869
+#: src/gui/MainWindow.cc:880
 msgid "Compilation generated %1 warning."
 msgid_plural "Compilation generated %1 warnings."
 msgstr[0] " Կառուցումը իրականացվել %1 Զգուշացում։"
 msgstr[1] "Կոմպիլացիան ստեղծված է %1 զգուշացումներ։"
 
-#: src/gui/MainWindow.cc:882
+#: src/gui/MainWindow.cc:893
 #, fuzzy
 msgid ""
 " For details see the <a href=\"#errorlog\">error log</a> and <a "
 "href=\"#console\">console window</a>."
 msgstr "Տեսնել ավելին՝ <a href=\"#console\">վահանակի պատուհանը</a>."
 
-#: src/gui/MainWindow.cc:1320
+#: src/gui/MainWindow.cc:1331
 msgid "Trusted Files"
 msgstr ""
 
-#: src/gui/MainWindow.cc:1704
+#: src/gui/MainWindow.cc:1715
 msgid ""
 "Python files can potentially contain harmful stuff.\n"
 "Do you trust this file ?\n"
 msgstr ""
 
-#: src/gui/MainWindow.cc:1810
+#: src/gui/MainWindow.cc:1821
 msgid "Application"
 msgstr "Ծրագիր"
 
-#: src/gui/MainWindow.cc:1811
+#: src/gui/MainWindow.cc:1822
 msgid ""
 "The document has been modified.\n"
 "Do you really want to reload the file?"
@@ -3233,74 +3149,74 @@ msgstr ""
 "Փաստաթուղթը փոփոխված է.\n"
 "Իսկապե՞ս ցանկանում եք այն վերաբեռնել։"
 
-#: src/gui/MainWindow.cc:2564
+#: src/gui/MainWindow.cc:2575
 msgid "Export %1 File"
 msgstr "Արտահանել նիշք %1"
 
-#: src/gui/MainWindow.cc:2565
+#: src/gui/MainWindow.cc:2576
 msgid "%1 Files (*%2)"
 msgstr "%1 Նիշքեր (*%2)"
 
-#: src/gui/MainWindow.cc:2613
+#: src/gui/MainWindow.cc:2624
 msgid "Export CSG File"
 msgstr "Արտահանել CSG նիշքը"
 
-#: src/gui/MainWindow.cc:2614
+#: src/gui/MainWindow.cc:2625
 msgid "CSG Files (*.csg)"
 msgstr "CSG Նիշքեր (*.csg)"
 
-#: src/gui/MainWindow.cc:2637
+#: src/gui/MainWindow.cc:2648
 msgid "Export Image"
 msgstr "Արտահանել նկար"
 
-#: src/gui/MainWindow.cc:2637
+#: src/gui/MainWindow.cc:2648
 msgid "PNG Files (*.png)"
 msgstr "PNG Նիշքեր (*.png)"
 
-#: src/gui/MainWindow.cc:3027 src/gui/MainWindow.cc:3787
+#: src/gui/MainWindow.cc:3038 src/gui/MainWindow.cc:3798
 msgid "&AI Chat"
 msgstr ""
 
-#: src/gui/MainWindow.cc:3129 src/gui/TabManager.cc:735
+#: src/gui/MainWindow.cc:3140 src/gui/TabManager.cc:735
 #: src/gui/TabManager.cc:786
 msgid "Untitled.scad"
 msgstr "Անանուն.scad"
 
-#: src/gui/MainWindow.cc:3779
+#: src/gui/MainWindow.cc:3790
 #, fuzzy
 msgid "&Editor"
 msgstr "Խմբագիր"
 
-#: src/gui/MainWindow.cc:3780
+#: src/gui/MainWindow.cc:3791
 #, fuzzy
 msgid "&Console"
 msgstr "Վահանակ"
 
-#: src/gui/MainWindow.cc:3781
+#: src/gui/MainWindow.cc:3792
 #, fuzzy
 msgid "C&ustomizer"
 msgstr "Անհատական հարմարեցում"
 
-#: src/gui/MainWindow.cc:3782
+#: src/gui/MainWindow.cc:3793
 #, fuzzy
 msgid "Error &Log"
 msgstr "Սխալմունք"
 
-#: src/gui/MainWindow.cc:3783
+#: src/gui/MainWindow.cc:3794
 #, fuzzy
 msgid "&Animate"
 msgstr "Կենդանացնել"
 
-#: src/gui/MainWindow.cc:3784
+#: src/gui/MainWindow.cc:3795
 msgid "&Font List"
 msgstr "&Տառատեսակի ցանկ"
 
-#: src/gui/MainWindow.cc:3785
+#: src/gui/MainWindow.cc:3796
 #, fuzzy
 msgid "C&olor List"
 msgstr "Գունային համակարգ։"
 
-#: src/gui/MainWindow.cc:3786
+#: src/gui/MainWindow.cc:3797
 #, fuzzy
 msgid "&Viewport Control"
 msgstr "Թաքցնել գործիքների վահանակը"
@@ -3566,8 +3482,12 @@ msgid "\"%1$s\" write error. (Disk full?)"
 msgstr "ՍԽԱԼՄՈՒՆՔ: \"%1$s\" չստացվեց պահել/գրել (Սկավառակը լցված է?)"
 
 #: examples
-msgid "Parametric"
-msgstr "Նախընտրանքային"
+msgid "Advanced"
+msgstr "Բարդ"
+
+#: examples
+msgid "Basics"
+msgstr "Հիմունքներ"
 
 #: examples
 msgid "Functions"
@@ -3578,12 +3498,8 @@ msgid "Old"
 msgstr "Նախկինում օգտագործած"
 
 #: examples
-msgid "Advanced"
-msgstr "Բարդ"
-
-#: examples
-msgid "Basics"
-msgstr "Հիմունքներ"
+msgid "Parametric"
+msgstr "Նախընտրանքային"
 
 #. (itstool) path: component/summary
 #: openscad.appdata.xml.in2:6
@@ -3642,120 +3558,6 @@ msgstr ""
 "հնարավոր է նաև կարդալ դիզայնի կարգաբերումները DXF նիշքերից: Բացի DXF "
 "նիշքերից, OpenSCAD- ը կարող է կարդալ և ստեղծել 3D մոդելներ STL և OFF նիշքերի "
 "ձևաչափերով:"
-
-#, fuzzy
-#~ msgid "meter"
-#~ msgstr "Պարամետր"
-
-#~ msgid "Features"
-#~ msgstr "Հնարավորություններ"
-
-#, fuzzy
-#~ msgid "Reset"
-#~ msgstr "Բերել սկզբնական վիճակի"
-
-#, fuzzy
-#~ msgid "Search action..."
-#~ msgstr "Գտնել շարք"
-
-#, fuzzy
-#~ msgid "ViewportControlWidget"
-#~ msgstr "Թաքցնել գործիքների վահանակը"
-
-#~ msgid "OpenSCAD Font List"
-#~ msgstr "OpenSCAD Տառատեսակների ցանկ"
-
-#~ msgid "Copy to Clipboard"
-#~ msgstr "Պատճենել պատկերը"
-
-#~ msgid "Filter:"
-#~ msgstr "Զտիչ ՝"
-
-#~ msgid ""
-#~ "<html><head/><body><p>This list shows the fonts currently registered with "
-#~ "OpenSCAD.</p><p>Example:</p><pre style=\" margin-top:12px; margin-"
-#~ "bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-"
-#~ "indent:0px;\"><span style=\" font-family:'Courier New,courier';\">  "
-#~ "text(&quot;OpenSCAD&quot;, font = &quot;DejaVu Sans&quot;);</span></"
-#~ "pre><pre style=\" margin-top:0px; margin-bottom:12px; margin-left:0px; "
-#~ "margin-right:0px; -qt-block-indent:0; text-indent:0px;\"><span style=\" "
-#~ "font-family:'Courier New,courier';\">  text(&quot;OpenSCAD&quot;, font = "
-#~ "&quot;Liberation Sans:style=Italic&quot;);</span></pre></body></html>"
-#~ msgstr ""
-#~ "<html><head/><body><p>Այս ցանկը ցույց է տալիս այն տառատեսակները, որոնք "
-#~ "արդեն իսկ գրանցված են OpenSCAD֊ում.</p><p>Օրինակ:</p><pre style=\" margin-"
-#~ "top:12px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-"
-#~ "indent:0; text-indent:0px;\"><span style=\" font-family:'Courier "
-#~ "New,courier';\">  Տեքստ(&quot;OpenSCAD&quot;, տառատեսակը = &quot;DejaVu "
-#~ "Sans&quot;);</span></pre><pre style=\" margin-top:0px; margin-"
-#~ "bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-"
-#~ "indent:0px;\"><span style=\" font-family:'Courier New,courier';\">  "
-#~ "text(&quot;OpenSCAD&quot;, font = &quot;Liberation "
-#~ "Sans:style=Italic&quot;);</span></pre></body></html>"
-
-#, fuzzy
-#~ msgid "Error-Log"
-#~ msgstr "Սխալմունք"
-
-#~ msgid "F7"
-#~ msgstr "F7"
-
-#, fuzzy
-#~ msgid "Line"
-#~ msgstr "Գծի փաթաթում"
-
-#, fuzzy
-#~ msgid "Filename"
-#~ msgstr "&Նիշք"
-
-#, fuzzy
-#~ msgid "Font Lists"
-#~ msgstr "&Տառատեսակի ցանկ"
-
-#, fuzzy
-#~ msgid "PushButton"
-#~ msgstr "Կոճակներ"
-
-#, fuzzy
-#~ msgid "Hide Editor"
-#~ msgstr "Թաքցնել խմբագիչը"
-
-#~ msgid "Surfaces"
-#~ msgstr "Հարթություններ"
-
-#~ msgid "F10"
-#~ msgstr "F10"
-
-#~ msgid "F11"
-#~ msgstr "F11"
-
-#, fuzzy
-#~ msgid "Hide Console"
-#~ msgstr "&Թաքցնել վահանակը"
-
-#~ msgid "Hide Customizer"
-#~ msgstr "Թաքցնել հարմարեցման վահանակը "
-
-#, fuzzy
-#~ msgid "Hide Error Log"
-#~ msgstr "Թաքցնել գործիքների վահանակը"
-
-#, fuzzy
-#~ msgid "Hide Animation Toolbar/Window"
-#~ msgstr "Թաքցնել գործիքների վահանակը"
-
-#~ msgid "OpenCSG"
-#~ msgstr "OpenCSG"
-
-#~ msgid "CGAL"
-#~ msgstr "CGAL"
-
-#, fuzzy
-#~ msgid "WRL"
-#~ msgstr "URL"
-
-#~ msgid "%1"
-#~ msgstr "%1"
 
 #, fuzzy
 #~ msgid "translate"
@@ -3842,10 +3644,6 @@ msgstr ""
 
 #~ msgid "(not supported)"
 #~ msgstr "(չի աջակցվում)"
-
-#, fuzzy
-#~ msgid "ErrorLog"
-#~ msgstr "Սխալմունք"
 
 #, fuzzy
 #~ msgid "Find Next"

--- a/locale/it.po
+++ b/locale/it.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: OpenSCAD 2024.01.06\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-09-06 23:38+0200\n"
+"POT-Creation-Date: 2026-09-06 17:48-0700\n"
 "PO-Revision-Date: 2025-08-02 19:25+0200\n"
 "Last-Translator: \n"
 "Language-Team: Italian\n"
@@ -104,148 +104,113 @@ msgstr "Iterazioni (steps):"
 msgid "Dump Pictures"
 msgstr "Genera sequenza d'immagini"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:852
-#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:362
-#: build/OpenSCADLibInternal_autogen/include/ui_MouseConfigWidget.h:214
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2464
-msgid "Preferences"
-msgstr "Preferenze"
-
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:853
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:854
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:858
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:862
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:864
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:866
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:868
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:870
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:881
+#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:860
+#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:861
+#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:865
+#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:869
+#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:871
+#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:873
+#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:875
+#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:877
+#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:888
 msgid "Trim"
 msgstr "Taglio"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:855
+#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:862
 msgid "Reset Trim"
 msgstr "Ripristina Taglio"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:856
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:859
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:860
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:861
 #: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:863
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:865
+#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:866
 #: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:867
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:869
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:880
+#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:868
+#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:870
+#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:872
+#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:874
+#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:876
+#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:887
 msgid "DeadZone"
 msgstr "Zona Morta"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:857
+#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:864
 msgid "Auto Trim Axes"
 msgstr "Taglio Assi Automatico"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:871
+#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:878
 msgid "Axis 2"
 msgstr "Asse 2"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:872
+#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:879
 msgid "Axis 0"
 msgstr "Asse 0"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:873
+#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:880
 msgid "Axis 3"
 msgstr "Asse 3"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:874
+#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:881
 msgid "Axis 6"
 msgstr "Asse 6"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:875
+#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:882
 msgid "Axis 8"
 msgstr "Asse 8"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:876
+#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:883
 msgid "Axis 7"
 msgstr "Asse 7"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:877
+#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:884
 msgid "Axis 5"
 msgstr "Asse 5"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:878
+#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:885
 msgid "Axis 1"
 msgstr "Asse 1"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:879
+#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:886
 msgid "Axis 4"
 msgstr "Asse 4"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:882
+#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:889
 #: build/OpenSCADLibInternal_autogen/include/ui_ViewportControl.h:279
 msgid "Rotation"
 msgstr "Rotazione"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:883
+#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:890
 msgid "Zoom"
 msgstr "Ingrandimento"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:884
-msgid "X"
-msgstr "X"
-
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:885
+#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:891
 msgid "Gain"
 msgstr "Guadagno"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:886
-msgid "Y"
-msgstr "Y"
-
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:887
-msgid "Z"
-msgstr "Z"
-
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:888
+#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:892
 #: build/OpenSCADLibInternal_autogen/include/ui_ViewportControl.h:280
 msgid "Translation"
 msgstr "Translazione"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:889
+#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:893
 msgid "ViewPort rel.<br/>Translation"
 msgstr "Inquadratura rel.<br/>Translazione"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:890
-msgid "ViewPort rel.<br />Rotation"
+#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:894
+msgid "ViewPort rel.<br/>Rotation"
 msgstr "Inquadratura rel.<br/>Rotazione"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:891
+#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:895
 msgid "Axis Setup:"
 msgstr "Impostazione Assi:"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:892
+#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:896
 msgid "<b>Driver selection:</b> <i>(changes requires restarting OpenSCAD)</i>"
 msgstr ""
 "<b>Selezione Driver :</b> <i>(i cambiamenti richiedono il riavvio di "
 "OpenSCAD)</i>"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:893
-msgid "SpaceNav"
-msgstr "SpaceNav"
-
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:894
-msgid "HIDAPI"
-msgstr "HIDAPI"
-
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:895
-msgid "QGamepad"
-msgstr "QGamepad"
-
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:896
+#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:897
 msgid "Joystick"
 msgstr "Joystick"
-
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:897
-msgid "DBus"
-msgstr "DBus"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:898
 msgid "Axes Mapping:"
@@ -256,125 +221,117 @@ msgid "Status:"
 msgstr "Stato:"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:900
-msgid "TextLabel"
-msgstr "TextLabel"
-
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:901
 #: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2468
 msgid "Update"
 msgstr "Aggiornamento"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:363
+#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:362
 msgid "Button 19"
 msgstr "Tasto 19"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:364
+#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:363
 msgid "Button 5"
 msgstr "Tasto 5"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:365
+#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:364
 msgid "Button 14"
 msgstr "Tasto 14"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:366
+#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:365
 msgid "Button 7"
 msgstr "Tasto 7"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:367
+#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:366
 msgid "Button 16"
 msgstr "Tasto 16"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:368
+#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:367
 msgid "Button 20"
 msgstr "Tasto 20"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:369
+#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:368
 msgid "Button 1"
 msgstr "Tasto 1"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:370
+#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:369
 msgid "Button 21"
 msgstr "Tasto 21"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:371
+#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:370
 msgid "Button 18"
 msgstr "Tasto 18"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:372
+#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:371
 msgid "Button 0"
 msgstr "Tasto 0"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:373
+#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:372
 msgid "Button 4"
 msgstr "Tasto 4"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:374
+#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:373
 msgid "Button 10"
 msgstr "Tasto 10"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:375
+#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:374
 msgid "Button 6"
 msgstr "Tasto 6"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:376
+#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:375
 msgid "Button 8"
 msgstr "Tasto 8"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:377
+#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:376
 msgid "Button 15"
 msgstr "Tasto 15"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:378
+#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:377
 msgid "Button 11"
 msgstr "Tasto 11"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:379
+#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:378
 msgid "Button 3"
 msgstr "Tasto 3"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:380
+#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:379
 msgid "Button 23"
 msgstr "Tasto 23"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:381
+#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:380
 msgid "Button 9"
 msgstr "Tasto 9"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:382
+#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:381
 msgid "Button 2"
 msgstr "Tasto 2"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:383
+#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:382
 msgid "Button 13"
 msgstr "Tasto 13"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:384
+#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:383
 msgid "Button 12"
 msgstr "Tasto 12"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:385
+#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:384
 msgid "Button 17"
 msgstr "Tasto 17"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:386
+#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:385
 msgid "Button 22"
 msgstr "Tasto 22"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_ChatWidget.h:194
+#: build/OpenSCADLibInternal_autogen/include/ui_ChatWidget.h:195
 msgid "AI Chat"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_ChatWidget.h:195
+#: build/OpenSCADLibInternal_autogen/include/ui_ChatWidget.h:196
 #: src/gui/ai/ChatWidget.cc:138
 msgid "AI Assistant"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_ChatWidget.h:197
+#: build/OpenSCADLibInternal_autogen/include/ui_ChatWidget.h:198
 msgid "Chat options"
-msgstr ""
-
-#: build/OpenSCADLibInternal_autogen/include/ui_ChatWidget.h:199
-msgid "☰"
 msgstr ""
 
 #: build/OpenSCADLibInternal_autogen/include/ui_ChatWidget.h:201
@@ -597,7 +554,8 @@ msgstr "Errori"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_ErrorLog.h:93
 #: build/OpenSCADLibInternal_autogen/include/ui_ViewportControl.h:267
-msgid "RowSelected"
+#, fuzzy
+msgid "Row Selected"
 msgstr "Riga Selezionata"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_ErrorLog.h:95
@@ -653,11 +611,8 @@ msgid "Export 3MF Options"
 msgstr "Opzioni Esportazione PDF"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_Export3mfDialog.h:459
-#: build/OpenSCADLibInternal_autogen/include/ui_ExportPdfDialog.h:552
-msgid ""
-"<html><head/><body><p>Set the PDF page (paper) size.  </p></body></html>"
+msgid "Set the unit used in the exported file"
 msgstr ""
-"<html><head/><body><p>Impostazione dimensione pagina PDF.  </p></body></html>"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_Export3mfDialog.h:461
 msgid "Unit"
@@ -806,6 +761,10 @@ msgstr "Annulla"
 msgid "Export PDF Options"
 msgstr "Opzioni Esportazione PDF"
 
+#: build/OpenSCADLibInternal_autogen/include/ui_ExportPdfDialog.h:552
+msgid "Set the PDF page (paper) size."
+msgstr "Impostazione dimensione pagina PDF."
+
 #: build/OpenSCADLibInternal_autogen/include/ui_ExportPdfDialog.h:554
 #, fuzzy
 msgid "Page Size"
@@ -865,12 +824,8 @@ msgid "Author"
 msgstr ""
 
 #: build/OpenSCADLibInternal_autogen/include/ui_ExportPdfDialog.h:582
-msgid ""
-"<html><head/><body><p>Set the direction of the largest page dimension.</p></"
-"body></html>"
-msgstr ""
-"<html><head/><body><p>Imposta l'orientamento della pagina più larga.</p></"
-"body></html>"
+msgid "Set the direction of the largest page dimension."
+msgstr "Imposta l'orientamento della pagina più larga."
 
 #: build/OpenSCADLibInternal_autogen/include/ui_ExportPdfDialog.h:584
 #, fuzzy
@@ -888,12 +843,10 @@ msgid "Landscape (Horizontal)"
 msgstr "Paesaggio (Orizzontale)"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_ExportPdfDialog.h:589
-msgid ""
-"<html><head/><body><p>Determine best orientation based on maximum geometry "
-"dimension.</p></body></html>"
+#, fuzzy
+msgid "Determine best orientation based on maximum geometry dimension."
 msgstr ""
-"<html><head/><body><p>Determina l'orientamento migliore in base alla massima "
-"dimensione geometrica.</p></body></html>"
+"Determina l'orientamento migliore in base alla massima dimensione geometrica."
 
 #: build/OpenSCADLibInternal_autogen/include/ui_ExportPdfDialog.h:591
 #: src/core/Settings.cc:400
@@ -905,35 +858,25 @@ msgid "Annotations"
 msgstr "Annotazioni"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_ExportPdfDialog.h:594
-msgid ""
-"<html><head/><body><p>Include design filename on page.</p></body></html>"
-msgstr ""
-"<html><head/><body><p>Includi il nome del progetto sulla pagina.</p></body></"
-"html>"
+#, fuzzy
+msgid "Include design filename on page."
+msgstr "Includi il nome del progetto sulla pagina."
 
 #: build/OpenSCADLibInternal_autogen/include/ui_ExportPdfDialog.h:596
 msgid "Show Design Filename"
 msgstr "&Mostra Nome Progetto"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_ExportPdfDialog.h:598
-msgid ""
-"<html><head/><body><p>Include rulers on page to confirm 1:1 printing scale.</"
-"p></body></html>"
-msgstr ""
-"<html><head/><body><p>Includi i righelli nella pagina per confermare la "
-"scala 1:1 di stampa.</p></body></html>"
+msgid "Include rulers on page to confirm 1:1 printing scale."
+msgstr "Includi i righelli nella pagina per confermare la scala 1:1 di stampa."
 
 #: build/OpenSCADLibInternal_autogen/include/ui_ExportPdfDialog.h:600
 msgid "Show Scale"
 msgstr "Mostra scala"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_ExportPdfDialog.h:602
-msgid ""
-"<html><head/><body><p>Include a grid of the selected size on the page.</p></"
-"body></html>"
-msgstr ""
-"<html><head/><body><p>Includi la griglia della dimensione selezionata sulla "
-"pagina.</p></body></html>"
+msgid "Include a grid of the selected size on the page."
+msgstr "Includi la griglia della dimensione selezionata sulla pagina."
 
 #: build/OpenSCADLibInternal_autogen/include/ui_ExportPdfDialog.h:604
 msgid "Show Grid"
@@ -960,12 +903,8 @@ msgid "10mm"
 msgstr ""
 
 #: build/OpenSCADLibInternal_autogen/include/ui_ExportPdfDialog.h:611
-msgid ""
-"<html><head/><body><p>Include text describing usage of scale.</p></body></"
-"html>"
-msgstr ""
-"<html><head/><body><p>Includi la descrizione dell'uso della scala.</p></"
-"body></html>"
+msgid "Include text describing usage of scale."
+msgstr "Includi la descrizione dell'uso della scala."
 
 #: build/OpenSCADLibInternal_autogen/include/ui_ExportPdfDialog.h:613
 msgid "Show Scale Usage"
@@ -977,13 +916,9 @@ msgid "Fill and Stroke"
 msgstr ""
 
 #: build/OpenSCADLibInternal_autogen/include/ui_ExportPdfDialog.h:616
-#, fuzzy
-msgid ""
-"<html><head/><body><p>Enable filling of exported geometry with a color.</p></"
-"body></html>"
-msgstr ""
-"<html><head/><body><p>Includi la griglia della dimensione selezionata sulla "
-"pagina.</p></body></html>"
+#: build/OpenSCADLibInternal_autogen/include/ui_ExportSvgDialog.h:205
+msgid "Enable filling of exported geometry with a color."
+msgstr "Abilita il riempimento della geometria esportata con un colore."
 
 #: build/OpenSCADLibInternal_autogen/include/ui_ExportPdfDialog.h:618
 #: build/OpenSCADLibInternal_autogen/include/ui_ExportSvgDialog.h:207
@@ -991,13 +926,9 @@ msgid "Fill Geometry"
 msgstr ""
 
 #: build/OpenSCADLibInternal_autogen/include/ui_ExportPdfDialog.h:623
-#, fuzzy
-msgid ""
-"<html><head/><body><p>Enable outline stroke for exported geometry.</p></"
-"body></html>"
-msgstr ""
-"<html><head/><body><p>Includi il nome del progetto sulla pagina.</p></body></"
-"html>"
+#: build/OpenSCADLibInternal_autogen/include/ui_ExportSvgDialog.h:212
+msgid "Enable outline stroke for exported geometry."
+msgstr "Abilita il tratto del contorno per la geometria esportata."
 
 #: build/OpenSCADLibInternal_autogen/include/ui_ExportPdfDialog.h:625
 #: build/OpenSCADLibInternal_autogen/include/ui_ExportSvgDialog.h:214
@@ -1017,21 +948,7 @@ msgstr ""
 #: build/OpenSCADLibInternal_autogen/include/ui_ExportSvgDialog.h:202
 #, fuzzy
 msgid "Export SVG Options"
-msgstr "Opzioni Esportazione PDF"
-
-#: build/OpenSCADLibInternal_autogen/include/ui_ExportSvgDialog.h:205
-#, fuzzy
-msgid "Enable filling of exported geometry with a color."
-msgstr ""
-"<html><head/><body><p>Includi la griglia della dimensione selezionata sulla "
-"pagina.</p></body></html>"
-
-#: build/OpenSCADLibInternal_autogen/include/ui_ExportSvgDialog.h:212
-#, fuzzy
-msgid "Enable outline stroke for exported geometry."
-msgstr ""
-"<html><head/><body><p>Includi il nome del progetto sulla pagina.</p></body></"
-"html>"
+msgstr "Opzioni Esportazione SVG"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_FontList.h:291
 #, fuzzy
@@ -1083,7 +1000,7 @@ msgstr "Mostra scala"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_FontList.h:302
 #, fuzzy
-msgid "ShowFileName"
+msgid "Show File Name"
 msgstr "Nome file"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_FontList.h:303
@@ -1861,13 +1778,13 @@ msgid "Ctrl+J"
 msgstr "Ctrl+N"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_MainWindow.h:1286
-#: src/gui/MainWindow.cc:1335 src/gui/MainWindow.cc:1342
-#: src/gui/MainWindow.cc:1355 src/gui/MainWindow.cc:1360
+#: src/gui/MainWindow.cc:1346 src/gui/MainWindow.cc:1353
+#: src/gui/MainWindow.cc:1366 src/gui/MainWindow.cc:1371
 msgid "Create Virtual Environment"
 msgstr ""
 
 #: build/OpenSCADLibInternal_autogen/include/ui_MainWindow.h:1287
-#: src/gui/MainWindow.cc:1377
+#: src/gui/MainWindow.cc:1388
 msgid "Select Virtual Environment"
 msgstr ""
 
@@ -1949,55 +1866,55 @@ msgstr "Chiudi"
 msgid "Customizer Widget"
 msgstr "Configuratore"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_MouseConfigWidget.h:215
+#: build/OpenSCADLibInternal_autogen/include/ui_MouseConfigWidget.h:214
 msgid "Ctrl + Shift + Middle-click"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_MouseConfigWidget.h:216
+#: build/OpenSCADLibInternal_autogen/include/ui_MouseConfigWidget.h:215
 msgid "Left-click"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_MouseConfigWidget.h:217
+#: build/OpenSCADLibInternal_autogen/include/ui_MouseConfigWidget.h:216
 msgid "Ctrl + Left-click"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_MouseConfigWidget.h:218
+#: build/OpenSCADLibInternal_autogen/include/ui_MouseConfigWidget.h:217
 msgid "Shift + Left-click"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_MouseConfigWidget.h:219
+#: build/OpenSCADLibInternal_autogen/include/ui_MouseConfigWidget.h:218
 msgid "Ctrl + Shift + Right-click"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_MouseConfigWidget.h:220
+#: build/OpenSCADLibInternal_autogen/include/ui_MouseConfigWidget.h:219
 msgid "Preset"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_MouseConfigWidget.h:221
+#: build/OpenSCADLibInternal_autogen/include/ui_MouseConfigWidget.h:220
 msgid "Right-click"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_MouseConfigWidget.h:222
+#: build/OpenSCADLibInternal_autogen/include/ui_MouseConfigWidget.h:221
 msgid "Ctrl + Middle-click"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_MouseConfigWidget.h:223
+#: build/OpenSCADLibInternal_autogen/include/ui_MouseConfigWidget.h:222
 msgid "Shift + Middle-click"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_MouseConfigWidget.h:224
+#: build/OpenSCADLibInternal_autogen/include/ui_MouseConfigWidget.h:223
 msgid "Ctrl + Right-click"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_MouseConfigWidget.h:225
+#: build/OpenSCADLibInternal_autogen/include/ui_MouseConfigWidget.h:224
 msgid "Ctrl + Shift + Left-click"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_MouseConfigWidget.h:226
+#: build/OpenSCADLibInternal_autogen/include/ui_MouseConfigWidget.h:225
 msgid "Shift + Right-click"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_MouseConfigWidget.h:227
+#: build/OpenSCADLibInternal_autogen/include/ui_MouseConfigWidget.h:226
 msgid "Middle-click"
 msgstr ""
 
@@ -2014,34 +1931,10 @@ msgid "OpenGL Warning"
 msgstr "Notifiche OpenGL"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_OpenCSGWarningDialog.h:77
-msgid ""
-"<!DOCTYPE HTML PUBLIC \"-//W3C//DTD HTML 4.0//EN\" \"http://www.w3.org/TR/"
-"REC-html40/strict.dtd\">\n"
-"<html><head><meta name=\"qrichtext\" content=\"1\" /><style type=\"text/"
-"css\">\n"
-"p, li { white-space: pre-wrap; }\n"
-"</style></head><body style=\" font-family:'Lucida Grande'; font-size:13pt; "
-"font-weight:400; font-style:normal;\">\n"
-"<p style=\"-qt-paragraph-type:empty; margin-top:0px; margin-bottom:0px; "
-"margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;\"></"
-"p></body></html>"
-msgstr ""
-"<!DOCTYPE HTML PUBLIC \"-//W3C//DTD HTML 4.0//EN\" \"http://www.w3.org/TR/"
-"REC-html40/strict.dtd\">\n"
-"<html><head><meta name=\"qrichtext\" content=\"1\" /><style type=\"text/"
-"css\">\n"
-"p, li { white-space: pre-wrap; }\n"
-"</style></head><body style=\" font-family:'Lucida Grande'; font-size:13pt; "
-"font-weight:400; font-style:normal;\">\n"
-"<p style=\"-qt-paragraph-type:empty; margin-top:0px; margin-bottom:0px; "
-"margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;\"></"
-"p></body></html>"
-
-#: build/OpenSCADLibInternal_autogen/include/ui_OpenCSGWarningDialog.h:82
 msgid "Show this message again"
 msgstr "Mostra ancora questo messaggio"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_OpenCSGWarningDialog.h:83
+#: build/OpenSCADLibInternal_autogen/include/ui_OpenCSGWarningDialog.h:78
 msgid "Close"
 msgstr "Chiudi"
 
@@ -2109,6 +2002,10 @@ msgstr ""
 #, fuzzy
 msgid "More actions"
 msgstr "Annotazioni"
+
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2464
+msgid "Preferences"
+msgstr "Preferenze"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2465
 msgid "3D View"
@@ -3178,21 +3075,21 @@ msgstr "Il driver multi-piattaforma QGAMEPAD consente la gestione di Gamepad."
 msgid "Toggle Perspective"
 msgstr "Commuta Prospettiva"
 
-#: src/gui/MainWindow.cc:861
+#: src/gui/MainWindow.cc:872
 msgid "Compile error."
 msgstr "Errore di compilazione."
 
-#: src/gui/MainWindow.cc:864
+#: src/gui/MainWindow.cc:875
 msgid "Error while compiling '%1'."
 msgstr "Errore di compilazione '%1'."
 
-#: src/gui/MainWindow.cc:869
+#: src/gui/MainWindow.cc:880
 msgid "Compilation generated %1 warning."
 msgid_plural "Compilation generated %1 warnings."
 msgstr[0] "La compilation ha generato %1 Notifiche."
 msgstr[1] "Compilation generated %1 warnings."
 
-#: src/gui/MainWindow.cc:882
+#: src/gui/MainWindow.cc:893
 msgid ""
 " For details see the <a href=\"#errorlog\">error log</a> and <a "
 "href=\"#console\">console window</a>."
@@ -3200,11 +3097,11 @@ msgstr ""
 " Per i dettagli guardare la <a href=\"#errorlog\">finestra degli Errori</a> "
 "e <a href=\"#console\">la Console</a>."
 
-#: src/gui/MainWindow.cc:1320
+#: src/gui/MainWindow.cc:1331
 msgid "Trusted Files"
 msgstr "Files attendibili"
 
-#: src/gui/MainWindow.cc:1704
+#: src/gui/MainWindow.cc:1715
 #, fuzzy
 msgid ""
 "Python files can potentially contain harmful stuff.\n"
@@ -3213,11 +3110,11 @@ msgstr ""
 "I files Python possono essere potenzialmente dannosi.\n"
 "I files considerati sono attendibili ?\n"
 
-#: src/gui/MainWindow.cc:1810
+#: src/gui/MainWindow.cc:1821
 msgid "Application"
 msgstr "Applicazione"
 
-#: src/gui/MainWindow.cc:1811
+#: src/gui/MainWindow.cc:1822
 msgid ""
 "The document has been modified.\n"
 "Do you really want to reload the file?"
@@ -3225,69 +3122,69 @@ msgstr ""
 "Il documento è stato modificato.\n"
 "Si desidera veramente ricaricarlo perdendo le modifiche?"
 
-#: src/gui/MainWindow.cc:2564
+#: src/gui/MainWindow.cc:2575
 msgid "Export %1 File"
 msgstr "Esportato %1 File"
 
-#: src/gui/MainWindow.cc:2565
+#: src/gui/MainWindow.cc:2576
 msgid "%1 Files (*%2)"
 msgstr "%1 Files (*%2)"
 
-#: src/gui/MainWindow.cc:2613
+#: src/gui/MainWindow.cc:2624
 msgid "Export CSG File"
 msgstr "Esporta file CSG"
 
-#: src/gui/MainWindow.cc:2614
+#: src/gui/MainWindow.cc:2625
 msgid "CSG Files (*.csg)"
 msgstr "Files CSG (*.csg)"
 
-#: src/gui/MainWindow.cc:2637
+#: src/gui/MainWindow.cc:2648
 msgid "Export Image"
 msgstr "Esporta Immagine"
 
-#: src/gui/MainWindow.cc:2637
+#: src/gui/MainWindow.cc:2648
 msgid "PNG Files (*.png)"
 msgstr "Files PNG (*.png)"
 
-#: src/gui/MainWindow.cc:3027 src/gui/MainWindow.cc:3787
+#: src/gui/MainWindow.cc:3038 src/gui/MainWindow.cc:3798
 msgid "&AI Chat"
 msgstr ""
 
-#: src/gui/MainWindow.cc:3129 src/gui/TabManager.cc:735
+#: src/gui/MainWindow.cc:3140 src/gui/TabManager.cc:735
 #: src/gui/TabManager.cc:786
 msgid "Untitled.scad"
 msgstr "SenzaNome.scad"
 
-#: src/gui/MainWindow.cc:3779
+#: src/gui/MainWindow.cc:3790
 msgid "&Editor"
 msgstr "&Editor"
 
-#: src/gui/MainWindow.cc:3780
+#: src/gui/MainWindow.cc:3791
 msgid "&Console"
 msgstr "&Console"
 
-#: src/gui/MainWindow.cc:3781
+#: src/gui/MainWindow.cc:3792
 msgid "C&ustomizer"
 msgstr "&Configuratore"
 
-#: src/gui/MainWindow.cc:3782
+#: src/gui/MainWindow.cc:3793
 msgid "Error &Log"
 msgstr "&Errori"
 
-#: src/gui/MainWindow.cc:3783
+#: src/gui/MainWindow.cc:3794
 msgid "&Animate"
 msgstr "&Animazione"
 
-#: src/gui/MainWindow.cc:3784
+#: src/gui/MainWindow.cc:3795
 msgid "&Font List"
 msgstr "&Caratteri usati"
 
-#: src/gui/MainWindow.cc:3785
+#: src/gui/MainWindow.cc:3796
 #, fuzzy
 msgid "C&olor List"
 msgstr "Schema Colori:"
 
-#: src/gui/MainWindow.cc:3786
+#: src/gui/MainWindow.cc:3797
 #, fuzzy
 msgid "&Viewport Control"
 msgstr "Inquadratura"
@@ -3551,8 +3448,12 @@ msgid "\"%1$s\" write error. (Disk full?)"
 msgstr ""
 
 #: examples
-msgid "Parametric"
-msgstr "Parametrici"
+msgid "Advanced"
+msgstr "Avanzati"
+
+#: examples
+msgid "Basics"
+msgstr "Semplici"
 
 #: examples
 msgid "Functions"
@@ -3563,12 +3464,8 @@ msgid "Old"
 msgstr "Datati"
 
 #: examples
-msgid "Advanced"
-msgstr "Avanzati"
-
-#: examples
-msgid "Basics"
-msgstr "Semplici"
+msgid "Parametric"
+msgstr "Parametrici"
 
 #. (itstool) path: component/summary
 #: openscad.appdata.xml.in2:6
@@ -3625,129 +3522,6 @@ msgstr ""
 "di file DXF di Autocad. Oltre a poter leggere i profili 2D per estrusione è "
 "anche possibile leggere dai file DXF i parametri di progetto. Oltre ai files "
 "DXF, OpenSCAD può leggere e creare modelli 3D nei formati di file STL e OFF."
-
-#, fuzzy
-#~ msgid "meter"
-#~ msgstr "Parametro"
-
-#~ msgid "none"
-#~ msgstr "nessuno"
-
-#~ msgid "Features"
-#~ msgstr "Funzionalità"
-
-#, fuzzy
-#~ msgid "Reset"
-#~ msgstr "Ripristina Taglio"
-
-#, fuzzy
-#~ msgid "Search action..."
-#~ msgstr "Stringa ricercata"
-
-#, fuzzy
-#~ msgid "ViewportControlWidget"
-#~ msgstr "Inquadratura"
-
-#~ msgid "OpenSCAD Font List"
-#~ msgstr "Elenco Caratteri di OpenSCAD"
-
-#~ msgid "Copy to Clipboard"
-#~ msgstr "Copia in Appunti"
-
-#~ msgid "Filter:"
-#~ msgstr "Filtro:"
-
-#~ msgid ""
-#~ "<html><head/><body><p>This list shows the fonts currently registered with "
-#~ "OpenSCAD.</p><p>Example:</p><pre style=\" margin-top:12px; margin-"
-#~ "bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-"
-#~ "indent:0px;\"><span style=\" font-family:'Courier New,courier';\">  "
-#~ "text(&quot;OpenSCAD&quot;, font = &quot;DejaVu Sans&quot;);</span></"
-#~ "pre><pre style=\" margin-top:0px; margin-bottom:12px; margin-left:0px; "
-#~ "margin-right:0px; -qt-block-indent:0; text-indent:0px;\"><span style=\" "
-#~ "font-family:'Courier New,courier';\">  text(&quot;OpenSCAD&quot;, font = "
-#~ "&quot;Liberation Sans:style=Italic&quot;);</span></pre></body></html>"
-#~ msgstr ""
-#~ "<html><head/><body><p>Questo elenco mostra i caratteri attualmente "
-#~ "registrati da OpenSCAD.</p><p>Esempio:</p><pre style=\" margin-top:12px; "
-#~ "margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; "
-#~ "text-indent:0px;\"><span style=\" font-family:'Courier New,courier';\">  "
-#~ "text(&quot;OpenSCAD&quot;, font = &quot;DejaVu Sans&quot;);</span></"
-#~ "pre><pre style=\" margin-top:0px; margin-bottom:12px; margin-left:0px; "
-#~ "margin-right:0px; -qt-block-indent:0; text-indent:0px;\"><span style=\" "
-#~ "font-family:'Courier New,courier';\">  text(&quot;OpenSCAD&quot;, font = "
-#~ "&quot;Liberation Sans:style=Italic&quot;);</span></pre></body></html>"
-
-#~ msgid "Error-Log"
-#~ msgstr "Errori"
-
-#~ msgid "F7"
-#~ msgstr "F7"
-
-#~ msgid "Swap Mouse Buttons"
-#~ msgstr "Commuta tasti Mouse"
-
-#, fuzzy
-#~ msgid "Line"
-#~ msgstr "Accapo linea"
-
-#~ msgid "Filename"
-#~ msgstr "Nome file"
-
-#, fuzzy
-#~ msgid "Font Lists"
-#~ msgstr "&Caratteri usati"
-
-#~ msgid "Page Layout"
-#~ msgstr "Disposizione Pagina"
-
-#~ msgid "Hide Editor"
-#~ msgstr "Nascondi Editor"
-
-#~ msgid "Surfaces"
-#~ msgstr "Superfici"
-
-#~ msgid "F10"
-#~ msgstr "F10"
-
-#~ msgid "Wireframe"
-#~ msgstr "Reticolato"
-
-#~ msgid "F11"
-#~ msgstr "F11"
-
-#~ msgid "Hide Console"
-#~ msgstr "Nascondi Console"
-
-#~ msgid "Hide Customizer"
-#~ msgstr "Nascondi Configuratore"
-
-#~ msgid "Hide Error Log"
-#~ msgstr "Nascondi Errori"
-
-#~ msgid "Hide Animation Toolbar/Window"
-#~ msgstr "Nascondi Animazione"
-
-#~ msgid "Hide Viewport-Control"
-#~ msgstr "Nascondi Inquadratura"
-
-#~ msgid "OpenCSG"
-#~ msgstr "OpenCSG"
-
-#~ msgid "CGAL"
-#~ msgstr "CGAL"
-
-#~ msgid "Toolbar Export Format 3D"
-#~ msgstr "Barra Strumenti Formato Esportazione 3D"
-
-#~ msgid "Toolbar Export Format 2D"
-#~ msgstr "Barra Strumenti Formato Esportazione 2D"
-
-#~ msgid "Default to ASCII STL export"
-#~ msgstr "Esportazione Predefinita ASCII STL"
-
-#~ msgid "%1"
-#~ msgstr "%1"
 
 #~ msgid "absolute"
 #~ msgstr "assoluto"

--- a/locale/ka.po
+++ b/locale/ka.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: OpenSCAD 2022.03.05\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-09-06 23:38+0200\n"
+"POT-Creation-Date: 2026-09-06 17:48-0700\n"
 "PO-Revision-Date: 2023-02-14 16:47+0100\n"
 "Last-Translator: Temuri Doghonadze <temuri.doghonadze@gmail.com>\n"
 "Language-Team: Georgian <(nothing)>\n"
@@ -103,148 +103,113 @@ msgstr "ნაბიჯები:"
 msgid "Dump Pictures"
 msgstr "კადრების შენახვა"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:852
-#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:362
-#: build/OpenSCADLibInternal_autogen/include/ui_MouseConfigWidget.h:214
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2464
-msgid "Preferences"
-msgstr "პარამეტრები"
-
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:853
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:854
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:858
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:862
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:864
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:866
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:868
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:870
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:881
+#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:860
+#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:861
+#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:865
+#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:869
+#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:871
+#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:873
+#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:875
+#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:877
+#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:888
 msgid "Trim"
 msgstr "დაჭრა"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:855
+#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:862
 msgid "Reset Trim"
 msgstr "წაჭრის დაბრუნება"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:856
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:859
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:860
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:861
 #: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:863
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:865
+#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:866
 #: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:867
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:869
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:880
+#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:868
+#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:870
+#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:872
+#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:874
+#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:876
+#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:887
 msgid "DeadZone"
 msgstr "მკვდარიზონა"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:857
+#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:864
 msgid "Auto Trim Axes"
 msgstr "ღერძების ავტომატური წაჭრა"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:871
+#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:878
 msgid "Axis 2"
 msgstr "ღერძი 2"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:872
+#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:879
 msgid "Axis 0"
 msgstr "ღერძი 0"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:873
+#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:880
 msgid "Axis 3"
 msgstr "ღერძი 3"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:874
+#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:881
 msgid "Axis 6"
 msgstr "ღერძი 6"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:875
+#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:882
 msgid "Axis 8"
 msgstr "ღერძი 8"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:876
+#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:883
 msgid "Axis 7"
 msgstr "ღერძი 7"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:877
+#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:884
 msgid "Axis 5"
 msgstr "ღერძი 5"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:878
+#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:885
 msgid "Axis 1"
 msgstr "ღერძი 1"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:879
+#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:886
 msgid "Axis 4"
 msgstr "ღერძი 4"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:882
+#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:889
 #: build/OpenSCADLibInternal_autogen/include/ui_ViewportControl.h:279
 msgid "Rotation"
 msgstr "შემობრუნება"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:883
+#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:890
 msgid "Zoom"
 msgstr "გადიდება"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:884
-msgid "X"
-msgstr "X"
-
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:885
+#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:891
 msgid "Gain"
 msgstr "გაძლიერება"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:886
-msgid "Y"
-msgstr "Y"
-
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:887
-msgid "Z"
-msgstr "ზ"
-
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:888
+#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:892
 #: build/OpenSCADLibInternal_autogen/include/ui_ViewportControl.h:280
 msgid "Translation"
 msgstr "თარგმანი"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:889
+#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:893
 msgid "ViewPort rel.<br/>Translation"
 msgstr "ვიუპორტის <br/>წანაცვლება"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:890
-msgid "ViewPort rel.<br />Rotation"
+#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:894
+msgid "ViewPort rel.<br/>Rotation"
 msgstr "ვიუპორტის <br/>მობრუნება"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:891
+#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:895
 msgid "Axis Setup:"
 msgstr "ღერძების მორგება:"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:892
+#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:896
 msgid "<b>Driver selection:</b> <i>(changes requires restarting OpenSCAD)</i>"
 msgstr ""
 "<b>დრაივერის არჩევანი:</b> <i>(ცვლილებისთვის აუცილებელია OpenSCAD-ის "
 "გადატვირთვა)</i>"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:893
-msgid "SpaceNav"
-msgstr "SpaceNav"
-
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:894
-msgid "HIDAPI"
-msgstr "HIDAPI"
-
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:895
-msgid "QGamepad"
-msgstr "QGamepad"
-
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:896
+#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:897
 msgid "Joystick"
 msgstr "ჯოისტიკი"
-
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:897
-msgid "DBus"
-msgstr "DBus"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:898
 msgid "Axes Mapping:"
@@ -255,125 +220,117 @@ msgid "Status:"
 msgstr "მდგომარეობა:"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:900
-msgid "TextLabel"
-msgstr "ტექსტური ჭდე"
-
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:901
 #: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2468
 msgid "Update"
 msgstr "განახლება"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:363
+#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:362
 msgid "Button 19"
 msgstr "ღილაკი 19"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:364
+#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:363
 msgid "Button 5"
 msgstr "ღილაკი 5"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:365
+#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:364
 msgid "Button 14"
 msgstr "ღილაკი 14"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:366
+#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:365
 msgid "Button 7"
 msgstr "ღილაკი 7"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:367
+#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:366
 msgid "Button 16"
 msgstr "ღილაკი 16"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:368
+#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:367
 msgid "Button 20"
 msgstr "ღილაკი 20"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:369
+#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:368
 msgid "Button 1"
 msgstr "ღილაკი 1"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:370
+#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:369
 msgid "Button 21"
 msgstr "ღილაკი 21"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:371
+#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:370
 msgid "Button 18"
 msgstr "ღილაკი 18"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:372
+#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:371
 msgid "Button 0"
 msgstr "ღილაკი 0"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:373
+#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:372
 msgid "Button 4"
 msgstr "ღილაკი 4"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:374
+#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:373
 msgid "Button 10"
 msgstr "ღილაკი 10"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:375
+#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:374
 msgid "Button 6"
 msgstr "ღილაკი 6"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:376
+#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:375
 msgid "Button 8"
 msgstr "ღილაკი 8"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:377
+#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:376
 msgid "Button 15"
 msgstr "ღილაკი 15"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:378
+#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:377
 msgid "Button 11"
 msgstr "ღილაკი 11"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:379
+#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:378
 msgid "Button 3"
 msgstr "ღილაკი 3"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:380
+#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:379
 msgid "Button 23"
 msgstr "ღილაკი 23"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:381
+#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:380
 msgid "Button 9"
 msgstr "ღილაკი 9"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:382
+#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:381
 msgid "Button 2"
 msgstr "ღილაკი 2"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:383
+#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:382
 msgid "Button 13"
 msgstr "ღილაკი 13"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:384
+#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:383
 msgid "Button 12"
 msgstr "ღილაკი 12"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:385
+#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:384
 msgid "Button 17"
 msgstr "ღილაკი 17"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:386
+#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:385
 msgid "Button 22"
 msgstr "ღილაკი 22"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_ChatWidget.h:194
+#: build/OpenSCADLibInternal_autogen/include/ui_ChatWidget.h:195
 msgid "AI Chat"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_ChatWidget.h:195
+#: build/OpenSCADLibInternal_autogen/include/ui_ChatWidget.h:196
 #: src/gui/ai/ChatWidget.cc:138
 msgid "AI Assistant"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_ChatWidget.h:197
+#: build/OpenSCADLibInternal_autogen/include/ui_ChatWidget.h:198
 msgid "Chat options"
-msgstr ""
-
-#: build/OpenSCADLibInternal_autogen/include/ui_ChatWidget.h:199
-msgid "☰"
 msgstr ""
 
 #: build/OpenSCADLibInternal_autogen/include/ui_ChatWidget.h:201
@@ -597,7 +554,8 @@ msgstr "შეცდომების ჟურნალი"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_ErrorLog.h:93
 #: build/OpenSCADLibInternal_autogen/include/ui_ViewportControl.h:267
-msgid "RowSelected"
+#, fuzzy
+msgid "Row Selected"
 msgstr "არჩეულიმწკრივი"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_ErrorLog.h:95
@@ -653,9 +611,7 @@ msgid "Export 3MF Options"
 msgstr "გატანის მორგება"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_Export3mfDialog.h:459
-#: build/OpenSCADLibInternal_autogen/include/ui_ExportPdfDialog.h:552
-msgid ""
-"<html><head/><body><p>Set the PDF page (paper) size.  </p></body></html>"
+msgid "Set the unit used in the exported file"
 msgstr ""
 
 #: build/OpenSCADLibInternal_autogen/include/ui_Export3mfDialog.h:461
@@ -806,6 +762,10 @@ msgstr "გაუქმება"
 msgid "Export PDF Options"
 msgstr "გატანის მორგება"
 
+#: build/OpenSCADLibInternal_autogen/include/ui_ExportPdfDialog.h:552
+msgid "Set the PDF page (paper) size."
+msgstr ""
+
 #: build/OpenSCADLibInternal_autogen/include/ui_ExportPdfDialog.h:554
 #, fuzzy
 msgid "Page Size"
@@ -865,9 +825,7 @@ msgid "Author"
 msgstr ""
 
 #: build/OpenSCADLibInternal_autogen/include/ui_ExportPdfDialog.h:582
-msgid ""
-"<html><head/><body><p>Set the direction of the largest page dimension.</p></"
-"body></html>"
+msgid "Set the direction of the largest page dimension."
 msgstr ""
 
 #: build/OpenSCADLibInternal_autogen/include/ui_ExportPdfDialog.h:584
@@ -886,9 +844,7 @@ msgid "Landscape (Horizontal)"
 msgstr ""
 
 #: build/OpenSCADLibInternal_autogen/include/ui_ExportPdfDialog.h:589
-msgid ""
-"<html><head/><body><p>Determine best orientation based on maximum geometry "
-"dimension.</p></body></html>"
+msgid "Determine best orientation based on maximum geometry dimension."
 msgstr ""
 
 #: build/OpenSCADLibInternal_autogen/include/ui_ExportPdfDialog.h:591
@@ -902,8 +858,7 @@ msgid "Annotations"
 msgstr "შემობრუნება"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_ExportPdfDialog.h:594
-msgid ""
-"<html><head/><body><p>Include design filename on page.</p></body></html>"
+msgid "Include design filename on page."
 msgstr ""
 
 #: build/OpenSCADLibInternal_autogen/include/ui_ExportPdfDialog.h:596
@@ -911,9 +866,7 @@ msgid "Show Design Filename"
 msgstr ""
 
 #: build/OpenSCADLibInternal_autogen/include/ui_ExportPdfDialog.h:598
-msgid ""
-"<html><head/><body><p>Include rulers on page to confirm 1:1 printing scale.</"
-"p></body></html>"
+msgid "Include rulers on page to confirm 1:1 printing scale."
 msgstr ""
 
 #: build/OpenSCADLibInternal_autogen/include/ui_ExportPdfDialog.h:600
@@ -922,9 +875,7 @@ msgid "Show Scale"
 msgstr "მასშტაბის ჭდეების ჩვენება"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_ExportPdfDialog.h:602
-msgid ""
-"<html><head/><body><p>Include a grid of the selected size on the page.</p></"
-"body></html>"
+msgid "Include a grid of the selected size on the page."
 msgstr ""
 
 #: build/OpenSCADLibInternal_autogen/include/ui_ExportPdfDialog.h:604
@@ -953,9 +904,7 @@ msgid "10mm"
 msgstr ""
 
 #: build/OpenSCADLibInternal_autogen/include/ui_ExportPdfDialog.h:611
-msgid ""
-"<html><head/><body><p>Include text describing usage of scale.</p></body></"
-"html>"
+msgid "Include text describing usage of scale."
 msgstr ""
 
 #: build/OpenSCADLibInternal_autogen/include/ui_ExportPdfDialog.h:613
@@ -969,9 +918,8 @@ msgid "Fill and Stroke"
 msgstr ""
 
 #: build/OpenSCADLibInternal_autogen/include/ui_ExportPdfDialog.h:616
-msgid ""
-"<html><head/><body><p>Enable filling of exported geometry with a color.</p></"
-"body></html>"
+#: build/OpenSCADLibInternal_autogen/include/ui_ExportSvgDialog.h:205
+msgid "Enable filling of exported geometry with a color."
 msgstr ""
 
 #: build/OpenSCADLibInternal_autogen/include/ui_ExportPdfDialog.h:618
@@ -980,9 +928,8 @@ msgid "Fill Geometry"
 msgstr ""
 
 #: build/OpenSCADLibInternal_autogen/include/ui_ExportPdfDialog.h:623
-msgid ""
-"<html><head/><body><p>Enable outline stroke for exported geometry.</p></"
-"body></html>"
+#: build/OpenSCADLibInternal_autogen/include/ui_ExportSvgDialog.h:212
+msgid "Enable outline stroke for exported geometry."
 msgstr ""
 
 #: build/OpenSCADLibInternal_autogen/include/ui_ExportPdfDialog.h:625
@@ -1004,14 +951,6 @@ msgstr ""
 #, fuzzy
 msgid "Export SVG Options"
 msgstr "გატანის მორგება"
-
-#: build/OpenSCADLibInternal_autogen/include/ui_ExportSvgDialog.h:205
-msgid "Enable filling of exported geometry with a color."
-msgstr ""
-
-#: build/OpenSCADLibInternal_autogen/include/ui_ExportSvgDialog.h:212
-msgid "Enable outline stroke for exported geometry."
-msgstr ""
 
 #: build/OpenSCADLibInternal_autogen/include/ui_FontList.h:291
 #, fuzzy
@@ -1063,7 +1002,7 @@ msgstr "მასშტაბის ჭდეების ჩვენება"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_FontList.h:302
 #, fuzzy
-msgid "ShowFileName"
+msgid "Show File Name"
 msgstr "ფაილის სახელის კოპირება"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_FontList.h:303
@@ -1842,13 +1781,13 @@ msgid "Ctrl+J"
 msgstr "Ctrl+N"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_MainWindow.h:1286
-#: src/gui/MainWindow.cc:1335 src/gui/MainWindow.cc:1342
-#: src/gui/MainWindow.cc:1355 src/gui/MainWindow.cc:1360
+#: src/gui/MainWindow.cc:1346 src/gui/MainWindow.cc:1353
+#: src/gui/MainWindow.cc:1366 src/gui/MainWindow.cc:1371
 msgid "Create Virtual Environment"
 msgstr ""
 
 #: build/OpenSCADLibInternal_autogen/include/ui_MainWindow.h:1287
-#: src/gui/MainWindow.cc:1377
+#: src/gui/MainWindow.cc:1388
 msgid "Select Virtual Environment"
 msgstr ""
 
@@ -1930,55 +1869,55 @@ msgstr "დასრულებულია"
 msgid "Customizer Widget"
 msgstr "მომრგების ვიჯეტი"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_MouseConfigWidget.h:215
+#: build/OpenSCADLibInternal_autogen/include/ui_MouseConfigWidget.h:214
 msgid "Ctrl + Shift + Middle-click"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_MouseConfigWidget.h:216
+#: build/OpenSCADLibInternal_autogen/include/ui_MouseConfigWidget.h:215
 msgid "Left-click"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_MouseConfigWidget.h:217
+#: build/OpenSCADLibInternal_autogen/include/ui_MouseConfigWidget.h:216
 msgid "Ctrl + Left-click"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_MouseConfigWidget.h:218
+#: build/OpenSCADLibInternal_autogen/include/ui_MouseConfigWidget.h:217
 msgid "Shift + Left-click"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_MouseConfigWidget.h:219
+#: build/OpenSCADLibInternal_autogen/include/ui_MouseConfigWidget.h:218
 msgid "Ctrl + Shift + Right-click"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_MouseConfigWidget.h:220
+#: build/OpenSCADLibInternal_autogen/include/ui_MouseConfigWidget.h:219
 msgid "Preset"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_MouseConfigWidget.h:221
+#: build/OpenSCADLibInternal_autogen/include/ui_MouseConfigWidget.h:220
 msgid "Right-click"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_MouseConfigWidget.h:222
+#: build/OpenSCADLibInternal_autogen/include/ui_MouseConfigWidget.h:221
 msgid "Ctrl + Middle-click"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_MouseConfigWidget.h:223
+#: build/OpenSCADLibInternal_autogen/include/ui_MouseConfigWidget.h:222
 msgid "Shift + Middle-click"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_MouseConfigWidget.h:224
+#: build/OpenSCADLibInternal_autogen/include/ui_MouseConfigWidget.h:223
 msgid "Ctrl + Right-click"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_MouseConfigWidget.h:225
+#: build/OpenSCADLibInternal_autogen/include/ui_MouseConfigWidget.h:224
 msgid "Ctrl + Shift + Left-click"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_MouseConfigWidget.h:226
+#: build/OpenSCADLibInternal_autogen/include/ui_MouseConfigWidget.h:225
 msgid "Shift + Right-click"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_MouseConfigWidget.h:227
+#: build/OpenSCADLibInternal_autogen/include/ui_MouseConfigWidget.h:226
 msgid "Middle-click"
 msgstr ""
 
@@ -1995,34 +1934,10 @@ msgid "OpenGL Warning"
 msgstr "OpenGL-ის გაფრთხილება"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_OpenCSGWarningDialog.h:77
-msgid ""
-"<!DOCTYPE HTML PUBLIC \"-//W3C//DTD HTML 4.0//EN\" \"http://www.w3.org/TR/"
-"REC-html40/strict.dtd\">\n"
-"<html><head><meta name=\"qrichtext\" content=\"1\" /><style type=\"text/"
-"css\">\n"
-"p, li { white-space: pre-wrap; }\n"
-"</style></head><body style=\" font-family:'Lucida Grande'; font-size:13pt; "
-"font-weight:400; font-style:normal;\">\n"
-"<p style=\"-qt-paragraph-type:empty; margin-top:0px; margin-bottom:0px; "
-"margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;\"></"
-"p></body></html>"
-msgstr ""
-"<!DOCTYPE HTML PUBLIC \"-//W3C//DTD HTML 4.0//EN\" \"http://www.w3.org/TR/"
-"REC-html40/strict.dtd\">\n"
-"<html><head><meta name=\"qrichtext\" content=\"1\" /><style type=\"text/"
-"css\">\n"
-"p, li { white-space: pre-wrap; }\n"
-"</style></head><body style=\" font-family:'Lucida Grande'; font-size:13pt; "
-"font-weight:400; font-style:normal;\">\n"
-"<p style=\"-qt-paragraph-type:empty; margin-top:0px; margin-bottom:0px; "
-"margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;\"></"
-"p></body></html>"
-
-#: build/OpenSCADLibInternal_autogen/include/ui_OpenCSGWarningDialog.h:82
 msgid "Show this message again"
 msgstr "ამ შეტყობინების კიდევ ჩვენება"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_OpenCSGWarningDialog.h:83
+#: build/OpenSCADLibInternal_autogen/include/ui_OpenCSGWarningDialog.h:78
 msgid "Close"
 msgstr "დახურვა"
 
@@ -2090,6 +2005,10 @@ msgstr "-"
 #, fuzzy
 msgid "More actions"
 msgstr "შემობრუნება"
+
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2464
+msgid "Preferences"
+msgstr "პარამეტრები"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2465
 msgid "3D View"
@@ -3163,21 +3082,21 @@ msgstr "QGAMEPAD მრავალპლატფორმული გეი�
 msgid "Toggle Perspective"
 msgstr "პერსპექტივის გადართვა"
 
-#: src/gui/MainWindow.cc:861
+#: src/gui/MainWindow.cc:872
 msgid "Compile error."
 msgstr "აგების შეცდომა."
 
-#: src/gui/MainWindow.cc:864
+#: src/gui/MainWindow.cc:875
 msgid "Error while compiling '%1'."
 msgstr "შეცდომა '%1'-ის აგებისას."
 
-#: src/gui/MainWindow.cc:869
+#: src/gui/MainWindow.cc:880
 msgid "Compilation generated %1 warning."
 msgid_plural "Compilation generated %1 warnings."
 msgstr[0] "აგებისას ნაპოვნია %1 გაფრთხილება."
 msgstr[1] "აგებისას ნაპოვნია %1 გაფრთხილება."
 
-#: src/gui/MainWindow.cc:882
+#: src/gui/MainWindow.cc:893
 msgid ""
 " For details see the <a href=\"#errorlog\">error log</a> and <a "
 "href=\"#console\">console window</a>."
@@ -3185,21 +3104,21 @@ msgstr ""
 " დეტალებისთვის იხილეთ <a href=\"#errorlog\">შეცდომების ჟურნალი</a> და <a "
 "href=\"#console\">კონსოლის ფანჯარა</a>."
 
-#: src/gui/MainWindow.cc:1320
+#: src/gui/MainWindow.cc:1331
 msgid "Trusted Files"
 msgstr ""
 
-#: src/gui/MainWindow.cc:1704
+#: src/gui/MainWindow.cc:1715
 msgid ""
 "Python files can potentially contain harmful stuff.\n"
 "Do you trust this file ?\n"
 msgstr ""
 
-#: src/gui/MainWindow.cc:1810
+#: src/gui/MainWindow.cc:1821
 msgid "Application"
 msgstr "აპლიკაცია"
 
-#: src/gui/MainWindow.cc:1811
+#: src/gui/MainWindow.cc:1822
 msgid ""
 "The document has been modified.\n"
 "Do you really want to reload the file?"
@@ -3207,70 +3126,70 @@ msgstr ""
 "დოკუმენტი შეიცვალა.\n"
 "მართლა გნებავთ ფაილის თავიდან ჩატვირთვა?"
 
-#: src/gui/MainWindow.cc:2564
+#: src/gui/MainWindow.cc:2575
 msgid "Export %1 File"
 msgstr "%1 ფაილის გატანა"
 
-#: src/gui/MainWindow.cc:2565
+#: src/gui/MainWindow.cc:2576
 msgid "%1 Files (*%2)"
 msgstr "%1 ფაილი (*%2)"
 
-#: src/gui/MainWindow.cc:2613
+#: src/gui/MainWindow.cc:2624
 msgid "Export CSG File"
 msgstr "CSG ფაილის გატანა"
 
-#: src/gui/MainWindow.cc:2614
+#: src/gui/MainWindow.cc:2625
 msgid "CSG Files (*.csg)"
 msgstr "CSG ფაილები (*.csg)"
 
-#: src/gui/MainWindow.cc:2637
+#: src/gui/MainWindow.cc:2648
 msgid "Export Image"
 msgstr "გამოსახულების გატანა"
 
-#: src/gui/MainWindow.cc:2637
+#: src/gui/MainWindow.cc:2648
 msgid "PNG Files (*.png)"
 msgstr "PNG ფაილები (*.png)"
 
-#: src/gui/MainWindow.cc:3027 src/gui/MainWindow.cc:3787
+#: src/gui/MainWindow.cc:3038 src/gui/MainWindow.cc:3798
 msgid "&AI Chat"
 msgstr ""
 
-#: src/gui/MainWindow.cc:3129 src/gui/TabManager.cc:735
+#: src/gui/MainWindow.cc:3140 src/gui/TabManager.cc:735
 #: src/gui/TabManager.cc:786
 msgid "Untitled.scad"
 msgstr "Untitled.scad"
 
-#: src/gui/MainWindow.cc:3779
+#: src/gui/MainWindow.cc:3790
 msgid "&Editor"
 msgstr "&რედაქტორი"
 
-#: src/gui/MainWindow.cc:3780
+#: src/gui/MainWindow.cc:3791
 msgid "&Console"
 msgstr "&კონსოლი"
 
-#: src/gui/MainWindow.cc:3781
+#: src/gui/MainWindow.cc:3792
 msgid "C&ustomizer"
 msgstr "&მომრგები"
 
-#: src/gui/MainWindow.cc:3782
+#: src/gui/MainWindow.cc:3793
 msgid "Error &Log"
 msgstr "შეცდომების &ჟურნალი"
 
-#: src/gui/MainWindow.cc:3783
+#: src/gui/MainWindow.cc:3794
 #, fuzzy
 msgid "&Animate"
 msgstr "ან_იმაცია"
 
-#: src/gui/MainWindow.cc:3784
+#: src/gui/MainWindow.cc:3795
 msgid "&Font List"
 msgstr "&ფონტების სია"
 
-#: src/gui/MainWindow.cc:3785
+#: src/gui/MainWindow.cc:3796
 #, fuzzy
 msgid "C&olor List"
 msgstr "ფერების სქემა:"
 
-#: src/gui/MainWindow.cc:3786
+#: src/gui/MainWindow.cc:3797
 #, fuzzy
 msgid "&Viewport Control"
 msgstr "3D ხელსაწყოთა ზოლის დამალვა"
@@ -3535,8 +3454,12 @@ msgid "\"%1$s\" write error. (Disk full?)"
 msgstr "\"%1$s\"-ის ჩაწერის შეცდოა. (დისკი გადაივსო?)"
 
 #: examples
-msgid "Parametric"
-msgstr "პარამეტრული"
+msgid "Advanced"
+msgstr "დაწინაურებული"
+
+#: examples
+msgid "Basics"
+msgstr "საწყისები"
 
 #: examples
 msgid "Functions"
@@ -3547,12 +3470,8 @@ msgid "Old"
 msgstr "ძველი"
 
 #: examples
-msgid "Advanced"
-msgstr "დაწინაურებული"
-
-#: examples
-msgid "Basics"
-msgstr "საწყისები"
+msgid "Parametric"
+msgstr "პარამეტრული"
 
 #. (itstool) path: component/summary
 #: openscad.appdata.xml.in2:6
@@ -3602,147 +3521,8 @@ msgid ""
 "models in the STL and OFF file formats."
 msgstr ""
 
-#, fuzzy
-#~ msgid "meter"
-#~ msgstr "პარამეტრი"
-
-#~ msgid "none"
-#~ msgstr "არა"
-
-#~ msgid "Features"
-#~ msgstr "თვისებები"
-
-#, fuzzy
-#~ msgid "Reset"
-#~ msgstr "წაჭრის დაბრუნება"
-
-#, fuzzy
-#~ msgid "Search action..."
-#~ msgstr "საძებნი სტრიქონი"
-
-#, fuzzy
-#~ msgid "ViewportControlWidget"
-#~ msgstr "3D ხელსაწყოთა ზოლის დამალვა"
-
-#~ msgid "OpenSCAD Font List"
-#~ msgstr "OpenSCAD-ის ფონტების სია"
-
-#~ msgid "Copy to Clipboard"
-#~ msgstr "გაცვლის ბუფერში კოპირება"
-
-#~ msgid "Filter:"
-#~ msgstr "ფილტრი:"
-
-#~ msgid ""
-#~ "<html><head/><body><p>This list shows the fonts currently registered with "
-#~ "OpenSCAD.</p><p>Example:</p><pre style=\" margin-top:12px; margin-"
-#~ "bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-"
-#~ "indent:0px;\"><span style=\" font-family:'Courier New,courier';\">  "
-#~ "text(&quot;OpenSCAD&quot;, font = &quot;DejaVu Sans&quot;);</span></"
-#~ "pre><pre style=\" margin-top:0px; margin-bottom:12px; margin-left:0px; "
-#~ "margin-right:0px; -qt-block-indent:0; text-indent:0px;\"><span style=\" "
-#~ "font-family:'Courier New,courier';\">  text(&quot;OpenSCAD&quot;, font = "
-#~ "&quot;Liberation Sans:style=Italic&quot;);</span></pre></body></html>"
-#~ msgstr ""
-#~ "<html><head/><body><p>ეს სია OpenSCAD-ში დარეგისტრირებული ფონტების სიას "
-#~ "აჩვენებს.</p><p>მაგალითად:</p><pre style=\" margin-top:12px; margin-"
-#~ "bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-"
-#~ "indent:0px;\"><span style=\" font-family:'Courier New,courier';\">  "
-#~ "text(&quot;OpenSCAD&quot;, font = &quot;DejaVu Sans&quot;);</span></"
-#~ "pre><pre style=\" margin-top:0px; margin-bottom:12px; margin-left:0px; "
-#~ "margin-right:0px; -qt-block-indent:0; text-indent:0px;\"><span style=\" "
-#~ "font-family:'Courier New,courier';\">  text(&quot;OpenSCAD&quot;, font = "
-#~ "&quot;Liberation Sans:style=Italic&quot;);</span></pre></body></html>"
-
-#~ msgid "Error-Log"
-#~ msgstr "შეცდომების-ჟურნალი"
-
-#~ msgid "F7"
-#~ msgstr "F7"
-
-#, fuzzy
-#~ msgid "Swap Mouse Buttons"
-#~ msgstr "თაგუნას მარცხენა ღილაკი"
-
-#, fuzzy
-#~ msgid "Line"
-#~ msgstr "ხაზების გადატანა"
-
-#, fuzzy
-#~ msgid "Filename"
-#~ msgstr "ფაილის სახელის კოპირება"
-
-#, fuzzy
-#~ msgid "Font Lists"
-#~ msgstr "&ფონტების სია"
-
-#, fuzzy
-#~ msgid "PushButton"
-#~ msgstr "ღილაკები"
-
-#~ msgid "Hide Editor"
-#~ msgstr "რედაქტორის დამალვა"
-
-#~ msgid "Surfaces"
-#~ msgstr "ზედაპირები"
-
-#~ msgid "F10"
-#~ msgstr "F10"
-
-#~ msgid "F11"
-#~ msgstr "F11"
-
-#~ msgid "Hide Console"
-#~ msgstr "კონსოლის დამალვა"
-
-#~ msgid "Hide Customizer"
-#~ msgstr "მომრგების დამალვა"
-
-#~ msgid "Hide Error Log"
-#~ msgstr "შეცდომების ჟურნალის დამალვა"
-
-#, fuzzy
-#~ msgid "Hide Animation Toolbar/Window"
-#~ msgstr "რედაქტორის პანელის დამალვა"
-
-#~ msgid "OpenCSG"
-#~ msgstr "OpenCSG"
-
-#~ msgid "CGAL"
-#~ msgstr "CGAL"
-
-#~ msgid "Toolbar Export Format 3D"
-#~ msgstr "3D გატანის ფორმატის პანელი"
-
-#~ msgid "STL"
-#~ msgstr "STL"
-
-#~ msgid "OFF"
-#~ msgstr "გამორთული"
-
-#~ msgid "WRL"
-#~ msgstr "WRL"
-
-#~ msgid "3MF"
-#~ msgstr "3MF"
-
-#~ msgid "Toolbar Export Format 2D"
-#~ msgstr "2D გატანის ფორმატის პანელი"
-
-#~ msgid "DXF"
-#~ msgstr "DXF"
-
-#~ msgid "SVG"
-#~ msgstr "SVG"
-
-#~ msgid "PDF"
-#~ msgstr "PDF"
-
-#~ msgid "Default to ASCII STL export"
-#~ msgstr "ნაგულისხმებად ASCII STL-ში გატანა"
-
-#~ msgid "%1"
-#~ msgstr "%1"
+#~ msgid "Z"
+#~ msgstr "ზ"
 
 #, fuzzy
 #~ msgid "translate"

--- a/locale/openscad.pot
+++ b/locale/openscad.pot
@@ -10,7 +10,7 @@ msgstr ""
 "#-#-#-#-#  openscad-tmp.pot (OpenSCAD 2026.09.06)  #-#-#-#-#\n"
 "Project-Id-Version: OpenSCAD 2026.09.06\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-09-06 23:38+0200\n"
+"POT-Creation-Date: 2026-09-06 18:07-0700\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -21,7 +21,7 @@ msgstr ""
 "Plural-Forms: nplurals=INTEGER; plural=EXPRESSION;\n"
 "#-#-#-#-#  appdata-strings.pot (PACKAGE VERSION)  #-#-#-#-#\n"
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2026-09-06 23:38+0200\n"
+"POT-Creation-Date: 2026-09-06 18:07-0700\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -103,145 +103,110 @@ msgstr ""
 msgid "Dump Pictures"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:852
-#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:362
-#: build/OpenSCADLibInternal_autogen/include/ui_MouseConfigWidget.h:214
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2464
-msgid "Preferences"
-msgstr ""
-
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:853
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:854
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:858
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:862
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:864
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:866
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:868
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:870
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:881
+#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:860
+#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:861
+#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:865
+#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:869
+#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:871
+#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:873
+#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:875
+#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:877
+#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:888
 msgid "Trim"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:855
+#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:862
 msgid "Reset Trim"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:856
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:859
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:860
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:861
 #: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:863
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:865
+#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:866
 #: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:867
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:869
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:880
+#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:868
+#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:870
+#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:872
+#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:874
+#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:876
+#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:887
 msgid "DeadZone"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:857
+#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:864
 msgid "Auto Trim Axes"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:871
+#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:878
 msgid "Axis 2"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:872
+#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:879
 msgid "Axis 0"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:873
+#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:880
 msgid "Axis 3"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:874
+#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:881
 msgid "Axis 6"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:875
+#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:882
 msgid "Axis 8"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:876
+#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:883
 msgid "Axis 7"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:877
+#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:884
 msgid "Axis 5"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:878
+#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:885
 msgid "Axis 1"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:879
+#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:886
 msgid "Axis 4"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:882
+#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:889
 #: build/OpenSCADLibInternal_autogen/include/ui_ViewportControl.h:279
 msgid "Rotation"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:883
+#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:890
 msgid "Zoom"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:884
-msgid "X"
-msgstr ""
-
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:885
+#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:891
 msgid "Gain"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:886
-msgid "Y"
-msgstr ""
-
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:887
-msgid "Z"
-msgstr ""
-
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:888
+#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:892
 #: build/OpenSCADLibInternal_autogen/include/ui_ViewportControl.h:280
 msgid "Translation"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:889
+#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:893
 msgid "ViewPort rel.<br/>Translation"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:890
-msgid "ViewPort rel.<br />Rotation"
-msgstr ""
-
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:891
-msgid "Axis Setup:"
-msgstr ""
-
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:892
-msgid "<b>Driver selection:</b> <i>(changes requires restarting OpenSCAD)</i>"
-msgstr ""
-
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:893
-msgid "SpaceNav"
-msgstr ""
-
 #: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:894
-msgid "HIDAPI"
+msgid "ViewPort rel.<br/>Rotation"
 msgstr ""
 
 #: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:895
-msgid "QGamepad"
+msgid "Axis Setup:"
 msgstr ""
 
 #: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:896
-msgid "Joystick"
+msgid "<b>Driver selection:</b> <i>(changes requires restarting OpenSCAD)</i>"
 msgstr ""
 
 #: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:897
-msgid "DBus"
+msgid "Joystick"
 msgstr ""
 
 #: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:898
@@ -253,125 +218,117 @@ msgid "Status:"
 msgstr ""
 
 #: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:900
-msgid "TextLabel"
-msgstr ""
-
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:901
 #: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2468
 msgid "Update"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:363
+#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:362
 msgid "Button 19"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:364
+#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:363
 msgid "Button 5"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:365
+#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:364
 msgid "Button 14"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:366
+#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:365
 msgid "Button 7"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:367
+#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:366
 msgid "Button 16"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:368
+#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:367
 msgid "Button 20"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:369
+#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:368
 msgid "Button 1"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:370
+#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:369
 msgid "Button 21"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:371
+#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:370
 msgid "Button 18"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:372
+#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:371
 msgid "Button 0"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:373
+#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:372
 msgid "Button 4"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:374
+#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:373
 msgid "Button 10"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:375
+#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:374
 msgid "Button 6"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:376
+#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:375
 msgid "Button 8"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:377
+#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:376
 msgid "Button 15"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:378
+#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:377
 msgid "Button 11"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:379
+#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:378
 msgid "Button 3"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:380
+#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:379
 msgid "Button 23"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:381
+#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:380
 msgid "Button 9"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:382
+#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:381
 msgid "Button 2"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:383
+#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:382
 msgid "Button 13"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:384
+#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:383
 msgid "Button 12"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:385
+#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:384
 msgid "Button 17"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:386
+#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:385
 msgid "Button 22"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_ChatWidget.h:194
+#: build/OpenSCADLibInternal_autogen/include/ui_ChatWidget.h:195
 msgid "AI Chat"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_ChatWidget.h:195
+#: build/OpenSCADLibInternal_autogen/include/ui_ChatWidget.h:196
 #: src/gui/ai/ChatWidget.cc:138
 msgid "AI Assistant"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_ChatWidget.h:197
+#: build/OpenSCADLibInternal_autogen/include/ui_ChatWidget.h:198
 msgid "Chat options"
-msgstr ""
-
-#: build/OpenSCADLibInternal_autogen/include/ui_ChatWidget.h:199
-msgid "☰"
 msgstr ""
 
 #: build/OpenSCADLibInternal_autogen/include/ui_ChatWidget.h:201
@@ -586,7 +543,7 @@ msgstr ""
 
 #: build/OpenSCADLibInternal_autogen/include/ui_ErrorLog.h:93
 #: build/OpenSCADLibInternal_autogen/include/ui_ViewportControl.h:267
-msgid "RowSelected"
+msgid "Row Selected"
 msgstr ""
 
 #: build/OpenSCADLibInternal_autogen/include/ui_ErrorLog.h:95
@@ -641,9 +598,7 @@ msgid "Export 3MF Options"
 msgstr ""
 
 #: build/OpenSCADLibInternal_autogen/include/ui_Export3mfDialog.h:459
-#: build/OpenSCADLibInternal_autogen/include/ui_ExportPdfDialog.h:552
-msgid ""
-"<html><head/><body><p>Set the PDF page (paper) size.  </p></body></html>"
+msgid "Set the unit used in the exported file"
 msgstr ""
 
 #: build/OpenSCADLibInternal_autogen/include/ui_Export3mfDialog.h:461
@@ -790,6 +745,10 @@ msgstr ""
 msgid "Export PDF Options"
 msgstr ""
 
+#: build/OpenSCADLibInternal_autogen/include/ui_ExportPdfDialog.h:552
+msgid "Set the PDF page (paper) size."
+msgstr ""
+
 #: build/OpenSCADLibInternal_autogen/include/ui_ExportPdfDialog.h:554
 msgid "Page Size"
 msgstr ""
@@ -848,9 +807,7 @@ msgid "Author"
 msgstr ""
 
 #: build/OpenSCADLibInternal_autogen/include/ui_ExportPdfDialog.h:582
-msgid ""
-"<html><head/><body><p>Set the direction of the largest page dimension.</p></"
-"body></html>"
+msgid "Set the direction of the largest page dimension."
 msgstr ""
 
 #: build/OpenSCADLibInternal_autogen/include/ui_ExportPdfDialog.h:584
@@ -868,9 +825,7 @@ msgid "Landscape (Horizontal)"
 msgstr ""
 
 #: build/OpenSCADLibInternal_autogen/include/ui_ExportPdfDialog.h:589
-msgid ""
-"<html><head/><body><p>Determine best orientation based on maximum geometry "
-"dimension.</p></body></html>"
+msgid "Determine best orientation based on maximum geometry dimension."
 msgstr ""
 
 #: build/OpenSCADLibInternal_autogen/include/ui_ExportPdfDialog.h:591
@@ -883,8 +838,7 @@ msgid "Annotations"
 msgstr ""
 
 #: build/OpenSCADLibInternal_autogen/include/ui_ExportPdfDialog.h:594
-msgid ""
-"<html><head/><body><p>Include design filename on page.</p></body></html>"
+msgid "Include design filename on page."
 msgstr ""
 
 #: build/OpenSCADLibInternal_autogen/include/ui_ExportPdfDialog.h:596
@@ -892,9 +846,7 @@ msgid "Show Design Filename"
 msgstr ""
 
 #: build/OpenSCADLibInternal_autogen/include/ui_ExportPdfDialog.h:598
-msgid ""
-"<html><head/><body><p>Include rulers on page to confirm 1:1 printing scale.</"
-"p></body></html>"
+msgid "Include rulers on page to confirm 1:1 printing scale."
 msgstr ""
 
 #: build/OpenSCADLibInternal_autogen/include/ui_ExportPdfDialog.h:600
@@ -902,9 +854,7 @@ msgid "Show Scale"
 msgstr ""
 
 #: build/OpenSCADLibInternal_autogen/include/ui_ExportPdfDialog.h:602
-msgid ""
-"<html><head/><body><p>Include a grid of the selected size on the page.</p></"
-"body></html>"
+msgid "Include a grid of the selected size on the page."
 msgstr ""
 
 #: build/OpenSCADLibInternal_autogen/include/ui_ExportPdfDialog.h:604
@@ -932,9 +882,7 @@ msgid "10mm"
 msgstr ""
 
 #: build/OpenSCADLibInternal_autogen/include/ui_ExportPdfDialog.h:611
-msgid ""
-"<html><head/><body><p>Include text describing usage of scale.</p></body></"
-"html>"
+msgid "Include text describing usage of scale."
 msgstr ""
 
 #: build/OpenSCADLibInternal_autogen/include/ui_ExportPdfDialog.h:613
@@ -947,9 +895,8 @@ msgid "Fill and Stroke"
 msgstr ""
 
 #: build/OpenSCADLibInternal_autogen/include/ui_ExportPdfDialog.h:616
-msgid ""
-"<html><head/><body><p>Enable filling of exported geometry with a color.</p></"
-"body></html>"
+#: build/OpenSCADLibInternal_autogen/include/ui_ExportSvgDialog.h:205
+msgid "Enable filling of exported geometry with a color."
 msgstr ""
 
 #: build/OpenSCADLibInternal_autogen/include/ui_ExportPdfDialog.h:618
@@ -958,9 +905,8 @@ msgid "Fill Geometry"
 msgstr ""
 
 #: build/OpenSCADLibInternal_autogen/include/ui_ExportPdfDialog.h:623
-msgid ""
-"<html><head/><body><p>Enable outline stroke for exported geometry.</p></"
-"body></html>"
+#: build/OpenSCADLibInternal_autogen/include/ui_ExportSvgDialog.h:212
+msgid "Enable outline stroke for exported geometry."
 msgstr ""
 
 #: build/OpenSCADLibInternal_autogen/include/ui_ExportPdfDialog.h:625
@@ -980,14 +926,6 @@ msgstr ""
 
 #: build/OpenSCADLibInternal_autogen/include/ui_ExportSvgDialog.h:202
 msgid "Export SVG Options"
-msgstr ""
-
-#: build/OpenSCADLibInternal_autogen/include/ui_ExportSvgDialog.h:205
-msgid "Enable filling of exported geometry with a color."
-msgstr ""
-
-#: build/OpenSCADLibInternal_autogen/include/ui_ExportSvgDialog.h:212
-msgid "Enable outline stroke for exported geometry."
 msgstr ""
 
 #: build/OpenSCADLibInternal_autogen/include/ui_FontList.h:291
@@ -1031,7 +969,7 @@ msgid "Show Sample Text"
 msgstr ""
 
 #: build/OpenSCADLibInternal_autogen/include/ui_FontList.h:302
-msgid "ShowFileName"
+msgid "Show File Name"
 msgstr ""
 
 #: build/OpenSCADLibInternal_autogen/include/ui_FontList.h:303
@@ -1769,13 +1707,13 @@ msgid "Ctrl+J"
 msgstr ""
 
 #: build/OpenSCADLibInternal_autogen/include/ui_MainWindow.h:1286
-#: src/gui/MainWindow.cc:1335 src/gui/MainWindow.cc:1342
-#: src/gui/MainWindow.cc:1355 src/gui/MainWindow.cc:1360
+#: src/gui/MainWindow.cc:1346 src/gui/MainWindow.cc:1353
+#: src/gui/MainWindow.cc:1366 src/gui/MainWindow.cc:1371
 msgid "Create Virtual Environment"
 msgstr ""
 
 #: build/OpenSCADLibInternal_autogen/include/ui_MainWindow.h:1287
-#: src/gui/MainWindow.cc:1377
+#: src/gui/MainWindow.cc:1388
 msgid "Select Virtual Environment"
 msgstr ""
 
@@ -1857,55 +1795,55 @@ msgstr ""
 msgid "Customizer Widget"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_MouseConfigWidget.h:215
+#: build/OpenSCADLibInternal_autogen/include/ui_MouseConfigWidget.h:214
 msgid "Ctrl + Shift + Middle-click"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_MouseConfigWidget.h:216
+#: build/OpenSCADLibInternal_autogen/include/ui_MouseConfigWidget.h:215
 msgid "Left-click"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_MouseConfigWidget.h:217
+#: build/OpenSCADLibInternal_autogen/include/ui_MouseConfigWidget.h:216
 msgid "Ctrl + Left-click"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_MouseConfigWidget.h:218
+#: build/OpenSCADLibInternal_autogen/include/ui_MouseConfigWidget.h:217
 msgid "Shift + Left-click"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_MouseConfigWidget.h:219
+#: build/OpenSCADLibInternal_autogen/include/ui_MouseConfigWidget.h:218
 msgid "Ctrl + Shift + Right-click"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_MouseConfigWidget.h:220
+#: build/OpenSCADLibInternal_autogen/include/ui_MouseConfigWidget.h:219
 msgid "Preset"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_MouseConfigWidget.h:221
+#: build/OpenSCADLibInternal_autogen/include/ui_MouseConfigWidget.h:220
 msgid "Right-click"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_MouseConfigWidget.h:222
+#: build/OpenSCADLibInternal_autogen/include/ui_MouseConfigWidget.h:221
 msgid "Ctrl + Middle-click"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_MouseConfigWidget.h:223
+#: build/OpenSCADLibInternal_autogen/include/ui_MouseConfigWidget.h:222
 msgid "Shift + Middle-click"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_MouseConfigWidget.h:224
+#: build/OpenSCADLibInternal_autogen/include/ui_MouseConfigWidget.h:223
 msgid "Ctrl + Right-click"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_MouseConfigWidget.h:225
+#: build/OpenSCADLibInternal_autogen/include/ui_MouseConfigWidget.h:224
 msgid "Ctrl + Shift + Left-click"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_MouseConfigWidget.h:226
+#: build/OpenSCADLibInternal_autogen/include/ui_MouseConfigWidget.h:225
 msgid "Shift + Right-click"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_MouseConfigWidget.h:227
+#: build/OpenSCADLibInternal_autogen/include/ui_MouseConfigWidget.h:226
 msgid "Middle-click"
 msgstr ""
 
@@ -1922,24 +1860,10 @@ msgid "OpenGL Warning"
 msgstr ""
 
 #: build/OpenSCADLibInternal_autogen/include/ui_OpenCSGWarningDialog.h:77
-msgid ""
-"<!DOCTYPE HTML PUBLIC \"-//W3C//DTD HTML 4.0//EN\" \"http://www.w3.org/TR/"
-"REC-html40/strict.dtd\">\n"
-"<html><head><meta name=\"qrichtext\" content=\"1\" /><style type=\"text/"
-"css\">\n"
-"p, li { white-space: pre-wrap; }\n"
-"</style></head><body style=\" font-family:'Lucida Grande'; font-size:13pt; "
-"font-weight:400; font-style:normal;\">\n"
-"<p style=\"-qt-paragraph-type:empty; margin-top:0px; margin-bottom:0px; "
-"margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;\"></"
-"p></body></html>"
-msgstr ""
-
-#: build/OpenSCADLibInternal_autogen/include/ui_OpenCSGWarningDialog.h:82
 msgid "Show this message again"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_OpenCSGWarningDialog.h:83
+#: build/OpenSCADLibInternal_autogen/include/ui_OpenCSGWarningDialog.h:78
 msgid "Close"
 msgstr ""
 
@@ -2005,6 +1929,10 @@ msgstr ""
 
 #: build/OpenSCADLibInternal_autogen/include/ui_ParameterWidget.h:175
 msgid "More actions"
+msgstr ""
+
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2464
+msgid "Preferences"
 msgstr ""
 
 #: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2465
@@ -3027,108 +2955,108 @@ msgstr ""
 msgid "Toggle Perspective"
 msgstr ""
 
-#: src/gui/MainWindow.cc:861
+#: src/gui/MainWindow.cc:872
 msgid "Compile error."
 msgstr ""
 
-#: src/gui/MainWindow.cc:864
+#: src/gui/MainWindow.cc:875
 msgid "Error while compiling '%1'."
 msgstr ""
 
-#: src/gui/MainWindow.cc:869
+#: src/gui/MainWindow.cc:880
 msgid "Compilation generated %1 warning."
 msgid_plural "Compilation generated %1 warnings."
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/gui/MainWindow.cc:882
+#: src/gui/MainWindow.cc:893
 msgid ""
 " For details see the <a href=\"#errorlog\">error log</a> and <a "
 "href=\"#console\">console window</a>."
 msgstr ""
 
-#: src/gui/MainWindow.cc:1320
+#: src/gui/MainWindow.cc:1331
 msgid "Trusted Files"
 msgstr ""
 
-#: src/gui/MainWindow.cc:1704
+#: src/gui/MainWindow.cc:1715
 msgid ""
 "Python files can potentially contain harmful stuff.\n"
 "Do you trust this file ?\n"
 msgstr ""
 
-#: src/gui/MainWindow.cc:1810
+#: src/gui/MainWindow.cc:1821
 msgid "Application"
 msgstr ""
 
-#: src/gui/MainWindow.cc:1811
+#: src/gui/MainWindow.cc:1822
 msgid ""
 "The document has been modified.\n"
 "Do you really want to reload the file?"
 msgstr ""
 
-#: src/gui/MainWindow.cc:2564
+#: src/gui/MainWindow.cc:2575
 msgid "Export %1 File"
 msgstr ""
 
-#: src/gui/MainWindow.cc:2565
+#: src/gui/MainWindow.cc:2576
 msgid "%1 Files (*%2)"
 msgstr ""
 
-#: src/gui/MainWindow.cc:2613
+#: src/gui/MainWindow.cc:2624
 msgid "Export CSG File"
 msgstr ""
 
-#: src/gui/MainWindow.cc:2614
+#: src/gui/MainWindow.cc:2625
 msgid "CSG Files (*.csg)"
 msgstr ""
 
-#: src/gui/MainWindow.cc:2637
+#: src/gui/MainWindow.cc:2648
 msgid "Export Image"
 msgstr ""
 
-#: src/gui/MainWindow.cc:2637
+#: src/gui/MainWindow.cc:2648
 msgid "PNG Files (*.png)"
 msgstr ""
 
-#: src/gui/MainWindow.cc:3027 src/gui/MainWindow.cc:3787
+#: src/gui/MainWindow.cc:3038 src/gui/MainWindow.cc:3798
 msgid "&AI Chat"
 msgstr ""
 
-#: src/gui/MainWindow.cc:3129 src/gui/TabManager.cc:735
+#: src/gui/MainWindow.cc:3140 src/gui/TabManager.cc:735
 #: src/gui/TabManager.cc:786
 msgid "Untitled.scad"
 msgstr ""
 
-#: src/gui/MainWindow.cc:3779
+#: src/gui/MainWindow.cc:3790
 msgid "&Editor"
 msgstr ""
 
-#: src/gui/MainWindow.cc:3780
+#: src/gui/MainWindow.cc:3791
 msgid "&Console"
 msgstr ""
 
-#: src/gui/MainWindow.cc:3781
+#: src/gui/MainWindow.cc:3792
 msgid "C&ustomizer"
 msgstr ""
 
-#: src/gui/MainWindow.cc:3782
+#: src/gui/MainWindow.cc:3793
 msgid "Error &Log"
 msgstr ""
 
-#: src/gui/MainWindow.cc:3783
+#: src/gui/MainWindow.cc:3794
 msgid "&Animate"
 msgstr ""
 
-#: src/gui/MainWindow.cc:3784
+#: src/gui/MainWindow.cc:3795
 msgid "&Font List"
 msgstr ""
 
-#: src/gui/MainWindow.cc:3785
+#: src/gui/MainWindow.cc:3796
 msgid "C&olor List"
 msgstr ""
 
-#: src/gui/MainWindow.cc:3786
+#: src/gui/MainWindow.cc:3797
 msgid "&Viewport Control"
 msgstr ""
 
@@ -3364,7 +3292,11 @@ msgid "\"%1$s\" write error. (Disk full?)"
 msgstr ""
 
 #: examples
-msgid "Parametric"
+msgid "Advanced"
+msgstr ""
+
+#: examples
+msgid "Basics"
 msgstr ""
 
 #: examples
@@ -3376,11 +3308,7 @@ msgid "Old"
 msgstr ""
 
 #: examples
-msgid "Advanced"
-msgstr ""
-
-#: examples
-msgid "Basics"
+msgid "Parametric"
 msgstr ""
 
 #. (itstool) path: component/summary

--- a/locale/pl.po
+++ b/locale/pl.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: OpenSCAD 2015.03.05\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-09-06 23:38+0200\n"
+"POT-Creation-Date: 2026-09-06 17:48-0700\n"
 "PO-Revision-Date: 2021-06-19 19:07+0100\n"
 "Last-Translator: Jarosław Teterycz <openscad@jtk.com.pl>\n"
 "Language-Team: \n"
@@ -103,150 +103,114 @@ msgstr "Kroki:"
 msgid "Dump Pictures"
 msgstr "Eksportuj klatki"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:852
-#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:362
-#: build/OpenSCADLibInternal_autogen/include/ui_MouseConfigWidget.h:214
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2464
-msgid "Preferences"
-msgstr "Preferencje"
-
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:853
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:854
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:858
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:862
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:864
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:866
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:868
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:870
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:881
+#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:860
+#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:861
+#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:865
+#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:869
+#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:871
+#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:873
+#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:875
+#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:877
+#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:888
 msgid "Trim"
 msgstr "Przycięcie"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:855
+#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:862
 msgid "Reset Trim"
 msgstr "Resetuj przycięcie"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:856
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:859
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:860
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:861
 #: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:863
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:865
+#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:866
 #: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:867
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:869
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:880
+#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:868
+#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:870
+#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:872
+#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:874
+#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:876
+#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:887
 msgid "DeadZone"
 msgstr "Martwa strefa"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:857
+#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:864
 msgid "Auto Trim Axes"
 msgstr "Przycinaj osie automatycznie"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:871
+#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:878
 msgid "Axis 2"
 msgstr "Oś 2"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:872
+#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:879
 msgid "Axis 0"
 msgstr "Oś 0"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:873
+#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:880
 msgid "Axis 3"
 msgstr "Oś 3"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:874
+#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:881
 msgid "Axis 6"
 msgstr "Oś 6"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:875
+#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:882
 msgid "Axis 8"
 msgstr "Oś 8"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:876
+#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:883
 msgid "Axis 7"
 msgstr "Oś 7"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:877
+#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:884
 msgid "Axis 5"
 msgstr "Oś 5"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:878
+#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:885
 msgid "Axis 1"
 msgstr "Oś 1"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:879
+#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:886
 msgid "Axis 4"
 msgstr "Oś 4"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:882
+#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:889
 #: build/OpenSCADLibInternal_autogen/include/ui_ViewportControl.h:279
 msgid "Rotation"
 msgstr "Ob&rót"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:883
+#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:890
 #, fuzzy
 msgid "Zoom"
 msgstr "Powiększenie"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:884
-msgid "X"
-msgstr "X"
-
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:885
+#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:891
 msgid "Gain"
 msgstr "Wzmocnienie"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:886
-msgid "Y"
-msgstr "Y"
-
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:887
-msgid "Z"
-msgstr "Z"
-
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:888
+#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:892
 #: build/OpenSCADLibInternal_autogen/include/ui_ViewportControl.h:280
 msgid "Translation"
 msgstr "Translacja"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:889
+#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:893
 #, fuzzy
 msgid "ViewPort rel.<br/>Translation"
 msgstr "Względna translacja podglądu"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:890
+#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:894
 #, fuzzy
-msgid "ViewPort rel.<br />Rotation"
+msgid "ViewPort rel.<br/>Rotation"
 msgstr "Względny obrót podglądu"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:891
+#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:895
 msgid "Axis Setup:"
 msgstr "Ustawienia osi:"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:892
+#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:896
 msgid "<b>Driver selection:</b> <i>(changes requires restarting OpenSCAD)</i>"
 msgstr "<b>Wybór sterownika:</b> <i>(wymaga restartu)</i>"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:893
-#, fuzzy
-msgid "SpaceNav"
-msgstr "Spacji"
-
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:894
-msgid "HIDAPI"
-msgstr "HIDAPI"
-
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:895
-msgid "QGamepad"
-msgstr "QGamepad"
-
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:896
+#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:897
 msgid "Joystick"
 msgstr "Joystick"
-
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:897
-msgid "DBus"
-msgstr "DBus"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:898
 msgid "Axes Mapping:"
@@ -257,134 +221,125 @@ msgid "Status:"
 msgstr "Status:"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:900
-#, fuzzy
-msgid "TextLabel"
-msgstr "Tekst"
-
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:901
 #: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2468
 msgid "Update"
 msgstr "Aktualizuj"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:363
+#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:362
 #, fuzzy
 msgid "Button 19"
 msgstr "Przycisk 1"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:364
+#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:363
 msgid "Button 5"
 msgstr "Przycisk 5"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:365
+#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:364
 msgid "Button 14"
 msgstr "Przycisk 14"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:366
+#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:365
 msgid "Button 7"
 msgstr "Przycisk 7"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:367
+#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:366
 #, fuzzy
 msgid "Button 16"
 msgstr "Przycisk 1"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:368
+#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:367
 #, fuzzy
 msgid "Button 20"
 msgstr "Przycisk 2"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:369
+#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:368
 msgid "Button 1"
 msgstr "Przycisk 1"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:370
+#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:369
 #, fuzzy
 msgid "Button 21"
 msgstr "Przycisk 2"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:371
+#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:370
 #, fuzzy
 msgid "Button 18"
 msgstr "Przycisk 1"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:372
+#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:371
 msgid "Button 0"
 msgstr "Przycisk 0"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:373
+#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:372
 msgid "Button 4"
 msgstr "Przycisk 4"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:374
+#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:373
 msgid "Button 10"
 msgstr "Przycisk 10"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:375
+#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:374
 msgid "Button 6"
 msgstr "Przycisk 6"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:376
+#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:375
 msgid "Button 8"
 msgstr "Przycisk 8"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:377
+#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:376
 msgid "Button 15"
 msgstr "Przycisk 15"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:378
+#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:377
 msgid "Button 11"
 msgstr "Przycisk 11"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:379
+#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:378
 msgid "Button 3"
 msgstr "Przycisk 3"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:380
+#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:379
 #, fuzzy
 msgid "Button 23"
 msgstr "Przycisk 2"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:381
+#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:380
 msgid "Button 9"
 msgstr "Przycisk 9"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:382
+#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:381
 msgid "Button 2"
 msgstr "Przycisk 2"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:383
+#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:382
 msgid "Button 13"
 msgstr "Przycisk 13"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:384
+#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:383
 msgid "Button 12"
 msgstr "Przycisk 12"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:385
+#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:384
 #, fuzzy
 msgid "Button 17"
 msgstr "Przycisk 1"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:386
+#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:385
 #, fuzzy
 msgid "Button 22"
 msgstr "Przycisk 2"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_ChatWidget.h:194
+#: build/OpenSCADLibInternal_autogen/include/ui_ChatWidget.h:195
 msgid "AI Chat"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_ChatWidget.h:195
+#: build/OpenSCADLibInternal_autogen/include/ui_ChatWidget.h:196
 #: src/gui/ai/ChatWidget.cc:138
 msgid "AI Assistant"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_ChatWidget.h:197
+#: build/OpenSCADLibInternal_autogen/include/ui_ChatWidget.h:198
 msgid "Chat options"
-msgstr ""
-
-#: build/OpenSCADLibInternal_autogen/include/ui_ChatWidget.h:199
-msgid "☰"
 msgstr ""
 
 #: build/OpenSCADLibInternal_autogen/include/ui_ChatWidget.h:201
@@ -610,7 +565,8 @@ msgstr "Dziennik błędów"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_ErrorLog.h:93
 #: build/OpenSCADLibInternal_autogen/include/ui_ViewportControl.h:267
-msgid "RowSelected"
+#, fuzzy
+msgid "Row Selected"
 msgstr "ZaznaczonyWiersz"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_ErrorLog.h:95
@@ -667,9 +623,7 @@ msgid "Export 3MF Options"
 msgstr "Funkcje eksporu"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_Export3mfDialog.h:459
-#: build/OpenSCADLibInternal_autogen/include/ui_ExportPdfDialog.h:552
-msgid ""
-"<html><head/><body><p>Set the PDF page (paper) size.  </p></body></html>"
+msgid "Set the unit used in the exported file"
 msgstr ""
 
 #: build/OpenSCADLibInternal_autogen/include/ui_Export3mfDialog.h:461
@@ -820,6 +774,10 @@ msgstr "Anuluj"
 msgid "Export PDF Options"
 msgstr "Funkcje eksporu"
 
+#: build/OpenSCADLibInternal_autogen/include/ui_ExportPdfDialog.h:552
+msgid "Set the PDF page (paper) size."
+msgstr ""
+
 #: build/OpenSCADLibInternal_autogen/include/ui_ExportPdfDialog.h:554
 #, fuzzy
 msgid "Page Size"
@@ -879,9 +837,7 @@ msgid "Author"
 msgstr ""
 
 #: build/OpenSCADLibInternal_autogen/include/ui_ExportPdfDialog.h:582
-msgid ""
-"<html><head/><body><p>Set the direction of the largest page dimension.</p></"
-"body></html>"
+msgid "Set the direction of the largest page dimension."
 msgstr ""
 
 #: build/OpenSCADLibInternal_autogen/include/ui_ExportPdfDialog.h:584
@@ -900,9 +856,7 @@ msgid "Landscape (Horizontal)"
 msgstr ""
 
 #: build/OpenSCADLibInternal_autogen/include/ui_ExportPdfDialog.h:589
-msgid ""
-"<html><head/><body><p>Determine best orientation based on maximum geometry "
-"dimension.</p></body></html>"
+msgid "Determine best orientation based on maximum geometry dimension."
 msgstr ""
 
 #: build/OpenSCADLibInternal_autogen/include/ui_ExportPdfDialog.h:591
@@ -916,8 +870,7 @@ msgid "Annotations"
 msgstr "Ob&rót"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_ExportPdfDialog.h:594
-msgid ""
-"<html><head/><body><p>Include design filename on page.</p></body></html>"
+msgid "Include design filename on page."
 msgstr ""
 
 #: build/OpenSCADLibInternal_autogen/include/ui_ExportPdfDialog.h:596
@@ -925,9 +878,7 @@ msgid "Show Design Filename"
 msgstr ""
 
 #: build/OpenSCADLibInternal_autogen/include/ui_ExportPdfDialog.h:598
-msgid ""
-"<html><head/><body><p>Include rulers on page to confirm 1:1 printing scale.</"
-"p></body></html>"
+msgid "Include rulers on page to confirm 1:1 printing scale."
 msgstr ""
 
 #: build/OpenSCADLibInternal_autogen/include/ui_ExportPdfDialog.h:600
@@ -936,9 +887,7 @@ msgid "Show Scale"
 msgstr "Pokaż podziałkę"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_ExportPdfDialog.h:602
-msgid ""
-"<html><head/><body><p>Include a grid of the selected size on the page.</p></"
-"body></html>"
+msgid "Include a grid of the selected size on the page."
 msgstr ""
 
 #: build/OpenSCADLibInternal_autogen/include/ui_ExportPdfDialog.h:604
@@ -967,9 +916,7 @@ msgid "10mm"
 msgstr ""
 
 #: build/OpenSCADLibInternal_autogen/include/ui_ExportPdfDialog.h:611
-msgid ""
-"<html><head/><body><p>Include text describing usage of scale.</p></body></"
-"html>"
+msgid "Include text describing usage of scale."
 msgstr ""
 
 #: build/OpenSCADLibInternal_autogen/include/ui_ExportPdfDialog.h:613
@@ -983,9 +930,8 @@ msgid "Fill and Stroke"
 msgstr ""
 
 #: build/OpenSCADLibInternal_autogen/include/ui_ExportPdfDialog.h:616
-msgid ""
-"<html><head/><body><p>Enable filling of exported geometry with a color.</p></"
-"body></html>"
+#: build/OpenSCADLibInternal_autogen/include/ui_ExportSvgDialog.h:205
+msgid "Enable filling of exported geometry with a color."
 msgstr ""
 
 #: build/OpenSCADLibInternal_autogen/include/ui_ExportPdfDialog.h:618
@@ -994,9 +940,8 @@ msgid "Fill Geometry"
 msgstr ""
 
 #: build/OpenSCADLibInternal_autogen/include/ui_ExportPdfDialog.h:623
-msgid ""
-"<html><head/><body><p>Enable outline stroke for exported geometry.</p></"
-"body></html>"
+#: build/OpenSCADLibInternal_autogen/include/ui_ExportSvgDialog.h:212
+msgid "Enable outline stroke for exported geometry."
 msgstr ""
 
 #: build/OpenSCADLibInternal_autogen/include/ui_ExportPdfDialog.h:625
@@ -1018,14 +963,6 @@ msgstr ""
 #, fuzzy
 msgid "Export SVG Options"
 msgstr "Funkcje eksporu"
-
-#: build/OpenSCADLibInternal_autogen/include/ui_ExportSvgDialog.h:205
-msgid "Enable filling of exported geometry with a color."
-msgstr ""
-
-#: build/OpenSCADLibInternal_autogen/include/ui_ExportSvgDialog.h:212
-msgid "Enable outline stroke for exported geometry."
-msgstr ""
 
 #: build/OpenSCADLibInternal_autogen/include/ui_FontList.h:291
 #, fuzzy
@@ -1077,7 +1014,7 @@ msgstr "Pokaż podziałkę"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_FontList.h:302
 #, fuzzy
-msgid "ShowFileName"
+msgid "Show File Name"
 msgstr "Skopiuj nazwę pliku"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_FontList.h:303
@@ -1870,13 +1807,13 @@ msgid "Ctrl+J"
 msgstr "Ctrl+N"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_MainWindow.h:1286
-#: src/gui/MainWindow.cc:1335 src/gui/MainWindow.cc:1342
-#: src/gui/MainWindow.cc:1355 src/gui/MainWindow.cc:1360
+#: src/gui/MainWindow.cc:1346 src/gui/MainWindow.cc:1353
+#: src/gui/MainWindow.cc:1366 src/gui/MainWindow.cc:1371
 msgid "Create Virtual Environment"
 msgstr ""
 
 #: build/OpenSCADLibInternal_autogen/include/ui_MainWindow.h:1287
-#: src/gui/MainWindow.cc:1377
+#: src/gui/MainWindow.cc:1388
 msgid "Select Virtual Environment"
 msgstr ""
 
@@ -1960,56 +1897,56 @@ msgstr "Gotowe"
 msgid "Customizer Widget"
 msgstr "Panel dostosowania"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_MouseConfigWidget.h:215
+#: build/OpenSCADLibInternal_autogen/include/ui_MouseConfigWidget.h:214
 msgid "Ctrl + Shift + Middle-click"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_MouseConfigWidget.h:216
+#: build/OpenSCADLibInternal_autogen/include/ui_MouseConfigWidget.h:215
 msgid "Left-click"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_MouseConfigWidget.h:217
+#: build/OpenSCADLibInternal_autogen/include/ui_MouseConfigWidget.h:216
 msgid "Ctrl + Left-click"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_MouseConfigWidget.h:218
+#: build/OpenSCADLibInternal_autogen/include/ui_MouseConfigWidget.h:217
 msgid "Shift + Left-click"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_MouseConfigWidget.h:219
+#: build/OpenSCADLibInternal_autogen/include/ui_MouseConfigWidget.h:218
 msgid "Ctrl + Shift + Right-click"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_MouseConfigWidget.h:220
+#: build/OpenSCADLibInternal_autogen/include/ui_MouseConfigWidget.h:219
 #, fuzzy
 msgid "Preset"
 msgstr "Resetuj"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_MouseConfigWidget.h:221
+#: build/OpenSCADLibInternal_autogen/include/ui_MouseConfigWidget.h:220
 msgid "Right-click"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_MouseConfigWidget.h:222
+#: build/OpenSCADLibInternal_autogen/include/ui_MouseConfigWidget.h:221
 msgid "Ctrl + Middle-click"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_MouseConfigWidget.h:223
+#: build/OpenSCADLibInternal_autogen/include/ui_MouseConfigWidget.h:222
 msgid "Shift + Middle-click"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_MouseConfigWidget.h:224
+#: build/OpenSCADLibInternal_autogen/include/ui_MouseConfigWidget.h:223
 msgid "Ctrl + Right-click"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_MouseConfigWidget.h:225
+#: build/OpenSCADLibInternal_autogen/include/ui_MouseConfigWidget.h:224
 msgid "Ctrl + Shift + Left-click"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_MouseConfigWidget.h:226
+#: build/OpenSCADLibInternal_autogen/include/ui_MouseConfigWidget.h:225
 msgid "Shift + Right-click"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_MouseConfigWidget.h:227
+#: build/OpenSCADLibInternal_autogen/include/ui_MouseConfigWidget.h:226
 msgid "Middle-click"
 msgstr ""
 
@@ -2026,34 +1963,10 @@ msgid "OpenGL Warning"
 msgstr "Ostrzeżenie OpenGL"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_OpenCSGWarningDialog.h:77
-msgid ""
-"<!DOCTYPE HTML PUBLIC \"-//W3C//DTD HTML 4.0//EN\" \"http://www.w3.org/TR/"
-"REC-html40/strict.dtd\">\n"
-"<html><head><meta name=\"qrichtext\" content=\"1\" /><style type=\"text/"
-"css\">\n"
-"p, li { white-space: pre-wrap; }\n"
-"</style></head><body style=\" font-family:'Lucida Grande'; font-size:13pt; "
-"font-weight:400; font-style:normal;\">\n"
-"<p style=\"-qt-paragraph-type:empty; margin-top:0px; margin-bottom:0px; "
-"margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;\"></"
-"p></body></html>"
-msgstr ""
-"<!DOCTYPE HTML PUBLIC \"-//W3C//DTD HTML 4.0//EN\" \"http://www.w3.org/TR/"
-"REC-html40/strict.dtd\">\n"
-"<html><head><meta name=\"qrichtext\" content=\"1\" /><style type=\"text/"
-"css\">\n"
-"p, li { white-space: pre-wrap; }\n"
-"</style></head><body style=\" font-family:'Lucida Grande'; font-size:13pt; "
-"font-weight:400; font-style:normal;\">\n"
-"<p style=\"-qt-paragraph-type:empty; margin-top:0px; margin-bottom:0px; "
-"margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;\"></"
-"p></body></html>"
-
-#: build/OpenSCADLibInternal_autogen/include/ui_OpenCSGWarningDialog.h:82
 msgid "Show this message again"
 msgstr "Pokazuj tę wiadomość ponownie"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_OpenCSGWarningDialog.h:83
+#: build/OpenSCADLibInternal_autogen/include/ui_OpenCSGWarningDialog.h:78
 msgid "Close"
 msgstr "Zamknij"
 
@@ -2126,6 +2039,10 @@ msgstr "-"
 #, fuzzy
 msgid "More actions"
 msgstr "Ob&rót"
+
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2464
+msgid "Preferences"
+msgstr "Preferencje"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2465
 msgid "3D View"
@@ -3204,43 +3121,43 @@ msgstr "Sterownik QGAMEPAD obsługuje pady na wielu platformach."
 msgid "Toggle Perspective"
 msgstr "Przełącz perspektywę"
 
-#: src/gui/MainWindow.cc:861
+#: src/gui/MainWindow.cc:872
 msgid "Compile error."
 msgstr "Błąd kompilacji."
 
-#: src/gui/MainWindow.cc:864
+#: src/gui/MainWindow.cc:875
 msgid "Error while compiling '%1'."
 msgstr "Błąd podczas kompilowania '%1'."
 
-#: src/gui/MainWindow.cc:869
+#: src/gui/MainWindow.cc:880
 msgid "Compilation generated %1 warning."
 msgid_plural "Compilation generated %1 warnings."
 msgstr[0] "Podczas kompilacji wygenerowano %1 ostrzeżenie."
 msgstr[1] "Podczas kompilacji wygenerowano %1 ostrzeżenia."
 msgstr[2] "Podczas kompilacji wygenerowano %1 ostrzeżeń."
 
-#: src/gui/MainWindow.cc:882
+#: src/gui/MainWindow.cc:893
 #, fuzzy
 msgid ""
 " For details see the <a href=\"#errorlog\">error log</a> and <a "
 "href=\"#console\">console window</a>."
 msgstr " Szczegóły w <a href=\"#console\">oknie konsoli</a>."
 
-#: src/gui/MainWindow.cc:1320
+#: src/gui/MainWindow.cc:1331
 msgid "Trusted Files"
 msgstr ""
 
-#: src/gui/MainWindow.cc:1704
+#: src/gui/MainWindow.cc:1715
 msgid ""
 "Python files can potentially contain harmful stuff.\n"
 "Do you trust this file ?\n"
 msgstr ""
 
-#: src/gui/MainWindow.cc:1810
+#: src/gui/MainWindow.cc:1821
 msgid "Application"
 msgstr "Aplikacja"
 
-#: src/gui/MainWindow.cc:1811
+#: src/gui/MainWindow.cc:1822
 msgid ""
 "The document has been modified.\n"
 "Do you really want to reload the file?"
@@ -3248,73 +3165,73 @@ msgstr ""
 "Dokument został zmodyfikowany.\n"
 "Czy na pewno chcesz go przeładować?"
 
-#: src/gui/MainWindow.cc:2564
+#: src/gui/MainWindow.cc:2575
 msgid "Export %1 File"
 msgstr "Eksportuj plik %1"
 
-#: src/gui/MainWindow.cc:2565
+#: src/gui/MainWindow.cc:2576
 msgid "%1 Files (*%2)"
 msgstr "Pliki %1 (*%2)"
 
-#: src/gui/MainWindow.cc:2613
+#: src/gui/MainWindow.cc:2624
 msgid "Export CSG File"
 msgstr "Eksportuj plik CSG"
 
-#: src/gui/MainWindow.cc:2614
+#: src/gui/MainWindow.cc:2625
 msgid "CSG Files (*.csg)"
 msgstr "Pliki CSG (*.csg)"
 
-#: src/gui/MainWindow.cc:2637
+#: src/gui/MainWindow.cc:2648
 msgid "Export Image"
 msgstr "Eksportuj obrazek"
 
-#: src/gui/MainWindow.cc:2637
+#: src/gui/MainWindow.cc:2648
 msgid "PNG Files (*.png)"
 msgstr "Pliki PNG (*.png)"
 
-#: src/gui/MainWindow.cc:3027 src/gui/MainWindow.cc:3787
+#: src/gui/MainWindow.cc:3038 src/gui/MainWindow.cc:3798
 msgid "&AI Chat"
 msgstr ""
 
-#: src/gui/MainWindow.cc:3129 src/gui/TabManager.cc:735
+#: src/gui/MainWindow.cc:3140 src/gui/TabManager.cc:735
 #: src/gui/TabManager.cc:786
 msgid "Untitled.scad"
 msgstr "Bez tytułu.scad"
 
-#: src/gui/MainWindow.cc:3779
+#: src/gui/MainWindow.cc:3790
 #, fuzzy
 msgid "&Editor"
 msgstr "Edytor"
 
-#: src/gui/MainWindow.cc:3780
+#: src/gui/MainWindow.cc:3791
 #, fuzzy
 msgid "&Console"
 msgstr "Konsola"
 
-#: src/gui/MainWindow.cc:3781
+#: src/gui/MainWindow.cc:3792
 msgid "C&ustomizer"
 msgstr "Panel dostosowania"
 
-#: src/gui/MainWindow.cc:3782
+#: src/gui/MainWindow.cc:3793
 #, fuzzy
 msgid "Error &Log"
 msgstr "Dziennik błędów"
 
-#: src/gui/MainWindow.cc:3783
+#: src/gui/MainWindow.cc:3794
 #, fuzzy
 msgid "&Animate"
 msgstr "Animuj"
 
-#: src/gui/MainWindow.cc:3784
+#: src/gui/MainWindow.cc:3795
 msgid "&Font List"
 msgstr "Lista &czcionek"
 
-#: src/gui/MainWindow.cc:3785
+#: src/gui/MainWindow.cc:3796
 #, fuzzy
 msgid "C&olor List"
 msgstr "Schemat kolorów:"
 
-#: src/gui/MainWindow.cc:3786
+#: src/gui/MainWindow.cc:3797
 #, fuzzy
 msgid "&Viewport Control"
 msgstr "Ukryj pasek narzędzi podglądu 3D"
@@ -3578,8 +3495,12 @@ msgid "\"%1$s\" write error. (Disk full?)"
 msgstr "Błąd: \"%1$s\" – błąd zapisu. (Pełny dysk?)"
 
 #: examples
-msgid "Parametric"
-msgstr "Parametryczny"
+msgid "Advanced"
+msgstr "Zaawansowane"
+
+#: examples
+msgid "Basics"
+msgstr "Podstawy"
 
 #: examples
 msgid "Functions"
@@ -3590,12 +3511,8 @@ msgid "Old"
 msgstr "Stare"
 
 #: examples
-msgid "Advanced"
-msgstr "Zaawansowane"
-
-#: examples
-msgid "Basics"
-msgstr "Podstawy"
+msgid "Parametric"
+msgstr "Parametryczny"
 
 #. (itstool) path: component/summary
 #: openscad.appdata.xml.in2:6
@@ -3651,127 +3568,6 @@ msgstr ""
 "2D można użyć plików w formacie Autocad DXF. Oprócz ścieżek 2D można z tych "
 "plików wczytywać parametry projektu. Dodatkowo OpenSCAD może wczytywać i "
 "tworzyć modele 3D w formacie STL i OFF."
-
-#, fuzzy
-#~ msgid "meter"
-#~ msgstr "Parametr"
-
-#~ msgid "Features"
-#~ msgstr "Właściwości"
-
-#, fuzzy
-#~ msgid "Reset"
-#~ msgstr "Resetuj"
-
-#, fuzzy
-#~ msgid "Search action..."
-#~ msgstr "Wyszukaj tekst"
-
-#, fuzzy
-#~ msgid "ViewportControlWidget"
-#~ msgstr "Ukryj pasek narzędzi podglądu 3D"
-
-#~ msgid "OpenSCAD Font List"
-#~ msgstr "&Lista czcionek OpenSCAD"
-
-#~ msgid "Copy to Clipboard"
-#~ msgstr "Kopiuj do schowka"
-
-#~ msgid "Filter:"
-#~ msgstr "Filtr:"
-
-#~ msgid ""
-#~ "<html><head/><body><p>This list shows the fonts currently registered with "
-#~ "OpenSCAD.</p><p>Example:</p><pre style=\" margin-top:12px; margin-"
-#~ "bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-"
-#~ "indent:0px;\"><span style=\" font-family:'Courier New,courier';\">  "
-#~ "text(&quot;OpenSCAD&quot;, font = &quot;DejaVu Sans&quot;);</span></"
-#~ "pre><pre style=\" margin-top:0px; margin-bottom:12px; margin-left:0px; "
-#~ "margin-right:0px; -qt-block-indent:0; text-indent:0px;\"><span style=\" "
-#~ "font-family:'Courier New,courier';\">  text(&quot;OpenSCAD&quot;, font = "
-#~ "&quot;Liberation Sans:style=Italic&quot;);</span></pre></body></html>"
-#~ msgstr ""
-#~ "<html><head/><body><p>Na liście są czcionki aktualnie zarejestrowane z "
-#~ "programem OpenSCAD.</p><p>Przykład:</p><pre style=\" margin-top:12px; "
-#~ "margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; "
-#~ "text-indent:0px;\"><span style=\" font-family:'Courier New,courier';\">  "
-#~ "text(&quot;OpenSCAD&quot;, font = &quot;DejaVu Sans&quot;);</span></"
-#~ "pre><pre style=\" margin-top:0px; margin-bottom:12px; margin-left:0px; "
-#~ "margin-right:0px; -qt-block-indent:0; text-indent:0px;\"><span style=\" "
-#~ "font-family:'Courier New,courier';\">  text(&quot;OpenSCAD&quot;, font = "
-#~ "&quot;Liberation Sans:style=Italic&quot;);</span></pre></body></html>"
-
-#, fuzzy
-#~ msgid "Error-Log"
-#~ msgstr "Dziennik błędów"
-
-#~ msgid "F7"
-#~ msgstr "F7"
-
-#, fuzzy
-#~ msgid "Swap Mouse Buttons"
-#~ msgstr "Lewy przycisk myszki"
-
-#, fuzzy
-#~ msgid "Line"
-#~ msgstr "Zawijanie wierszy"
-
-#, fuzzy
-#~ msgid "Filename"
-#~ msgstr "Skopiuj nazwę pliku"
-
-#, fuzzy
-#~ msgid "Font Lists"
-#~ msgstr "Lista &czcionek"
-
-#, fuzzy
-#~ msgid "PushButton"
-#~ msgstr "Przyciski"
-
-#, fuzzy
-#~ msgid "Hide Editor"
-#~ msgstr "Ukryj ed&ytor"
-
-#~ msgid "Surfaces"
-#~ msgstr "Ściany"
-
-#~ msgid "F10"
-#~ msgstr "F10"
-
-#~ msgid "F11"
-#~ msgstr "F11"
-
-#, fuzzy
-#~ msgid "Hide Console"
-#~ msgstr "Ukryj &konsolę"
-
-#, fuzzy
-#~ msgid "Hide Customizer"
-#~ msgstr "Ukryj panel dostosowania"
-
-#, fuzzy
-#~ msgid "Hide Error Log"
-#~ msgstr "Ukryj dziennik błędów"
-
-#, fuzzy
-#~ msgid "Hide Animation Toolbar/Window"
-#~ msgstr "Ukryj paski narzędzi"
-
-#~ msgid "OpenCSG"
-#~ msgstr "OpenCSG"
-
-#~ msgid "CGAL"
-#~ msgstr "CGAL"
-
-#, fuzzy
-#~ msgid "WRL"
-#~ msgstr "URL"
-
-#~ msgid "Default to ASCII STL export"
-#~ msgstr "Domyślny eksport do ASCII STL"
-
-#~ msgid "%1"
-#~ msgstr "%1"
 
 #, fuzzy
 #~ msgid "translate"
@@ -3843,10 +3639,6 @@ msgstr ""
 #~ msgstr "(niewspierane)"
 
 #, fuzzy
-#~ msgid "ErrorLog"
-#~ msgstr "Dziennik błędów"
-
-#, fuzzy
 #~ msgid "Find Next"
 #~ msgstr "Zn&ajdź następny"
 
@@ -3860,9 +3652,6 @@ msgstr ""
 
 #~ msgid "Saved design '%s'."
 #~ msgstr "Zapisano projekt „%s”."
-
-#~ msgid "Save As"
-#~ msgstr "Zapisz &jako"
 
 #~ msgid "Prev."
 #~ msgstr "Podgląd"

--- a/locale/pt_BR.po
+++ b/locale/pt_BR.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: OpenSCAD 2015.03\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-09-06 23:38+0200\n"
+"POT-Creation-Date: 2026-09-06 17:48-0700\n"
 "PO-Revision-Date: 2025-04-10 09:02-0300\n"
 "Last-Translator: Alexandre Folle de Menezes\n"
 "Language-Team: \n"
@@ -104,151 +104,116 @@ msgstr "Passos:"
 msgid "Dump Pictures"
 msgstr "Gravar imagens"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:852
-#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:362
-#: build/OpenSCADLibInternal_autogen/include/ui_MouseConfigWidget.h:214
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2464
-msgid "Preferences"
-msgstr "Preferências"
-
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:853
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:854
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:858
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:862
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:864
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:866
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:868
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:870
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:881
+#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:860
+#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:861
+#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:865
+#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:869
+#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:871
+#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:873
+#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:875
+#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:877
+#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:888
 msgid "Trim"
 msgstr "Ajuste"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:855
+#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:862
 msgid "Reset Trim"
 msgstr "Redefinir Ajuste"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:856
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:859
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:860
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:861
 #: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:863
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:865
+#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:866
 #: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:867
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:869
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:880
+#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:868
+#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:870
+#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:872
+#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:874
+#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:876
+#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:887
 msgid "DeadZone"
 msgstr "ZonaMorta"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:857
+#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:864
 msgid "Auto Trim Axes"
 msgstr "Ajustar Eixos Automaticamente"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:871
+#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:878
 msgid "Axis 2"
 msgstr "Eixo 2"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:872
+#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:879
 msgid "Axis 0"
 msgstr "Eixo 0"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:873
+#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:880
 msgid "Axis 3"
 msgstr "Eixo 3"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:874
+#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:881
 msgid "Axis 6"
 msgstr "Eixo 6"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:875
+#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:882
 msgid "Axis 8"
 msgstr "Eixo 8"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:876
+#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:883
 msgid "Axis 7"
 msgstr "Eixo 7"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:877
+#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:884
 msgid "Axis 5"
 msgstr "Eixo 5"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:878
+#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:885
 msgid "Axis 1"
 msgstr "Eixo 1"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:879
+#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:886
 msgid "Axis 4"
 msgstr "Eixo 4"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:882
+#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:889
 #: build/OpenSCADLibInternal_autogen/include/ui_ViewportControl.h:279
 msgid "Rotation"
 msgstr "Rotação"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:883
+#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:890
 msgid "Zoom"
 msgstr "Ampliação"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:884
-msgid "X"
-msgstr ""
-
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:885
+#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:891
 msgid "Gain"
 msgstr "Ganho"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:886
-msgid "Y"
-msgstr ""
-
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:887
-msgid "Z"
-msgstr ""
-
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:888
+#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:892
 #: build/OpenSCADLibInternal_autogen/include/ui_ViewportControl.h:280
 msgid "Translation"
 msgstr "Translação"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:889
+#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:893
 #, fuzzy
 msgid "ViewPort rel.<br/>Translation"
 msgstr "ViewPort rel.<br/>Translação"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:890
+#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:894
 #, fuzzy
-msgid "ViewPort rel.<br />Rotation"
+msgid "ViewPort rel.<br/>Rotation"
 msgstr "ViewPort rel.<br/>Rotação"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:891
+#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:895
 msgid "Axis Setup:"
 msgstr "Definição de Eixo:"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:892
+#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:896
 #, fuzzy
 msgid "<b>Driver selection:</b> <i>(changes requires restarting OpenSCAD)</i>"
 msgstr ""
 "<b>Seleção de driver:</b> <i>(alterações exigem a reinicialização do "
 "OpenSCAD)</i>"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:893
-msgid "SpaceNav"
-msgstr ""
-
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:894
-msgid "HIDAPI"
-msgstr ""
-
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:895
-msgid "QGamepad"
-msgstr ""
-
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:896
+#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:897
 msgid "Joystick"
 msgstr "Joystick"
-
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:897
-msgid "DBus"
-msgstr ""
 
 #: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:898
 msgid "Axes Mapping:"
@@ -259,125 +224,117 @@ msgid "Status:"
 msgstr "Estado:"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:900
-msgid "TextLabel"
-msgstr ""
-
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:901
 #: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2468
 msgid "Update"
 msgstr "Atualizar"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:363
+#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:362
 msgid "Button 19"
 msgstr "Botão 19"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:364
+#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:363
 msgid "Button 5"
 msgstr "Botão 5"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:365
+#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:364
 msgid "Button 14"
 msgstr "Botão 14"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:366
+#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:365
 msgid "Button 7"
 msgstr "Botão 7"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:367
+#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:366
 msgid "Button 16"
 msgstr "Botão 16"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:368
+#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:367
 msgid "Button 20"
 msgstr "Botão 20"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:369
+#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:368
 msgid "Button 1"
 msgstr "Botão 1"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:370
+#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:369
 msgid "Button 21"
 msgstr "Botão 21"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:371
+#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:370
 msgid "Button 18"
 msgstr "Botão 18"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:372
+#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:371
 msgid "Button 0"
 msgstr "Botão 0"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:373
+#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:372
 msgid "Button 4"
 msgstr "Botão 4"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:374
+#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:373
 msgid "Button 10"
 msgstr "Botão 10"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:375
+#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:374
 msgid "Button 6"
 msgstr "Botão 6"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:376
+#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:375
 msgid "Button 8"
 msgstr "Botão 8"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:377
+#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:376
 msgid "Button 15"
 msgstr "Botão 15"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:378
+#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:377
 msgid "Button 11"
 msgstr "Botão 11"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:379
+#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:378
 msgid "Button 3"
 msgstr "Botão 3"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:380
+#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:379
 msgid "Button 23"
 msgstr "Botão 23"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:381
+#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:380
 msgid "Button 9"
 msgstr "Botão 9"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:382
+#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:381
 msgid "Button 2"
 msgstr "Botão 2"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:383
+#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:382
 msgid "Button 13"
 msgstr "Botão 13"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:384
+#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:383
 msgid "Button 12"
 msgstr "Botão 12"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:385
+#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:384
 msgid "Button 17"
 msgstr "Botão 17"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:386
+#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:385
 msgid "Button 22"
 msgstr "Botão 22"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_ChatWidget.h:194
+#: build/OpenSCADLibInternal_autogen/include/ui_ChatWidget.h:195
 msgid "AI Chat"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_ChatWidget.h:195
+#: build/OpenSCADLibInternal_autogen/include/ui_ChatWidget.h:196
 #: src/gui/ai/ChatWidget.cc:138
 msgid "AI Assistant"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_ChatWidget.h:197
+#: build/OpenSCADLibInternal_autogen/include/ui_ChatWidget.h:198
 msgid "Chat options"
-msgstr ""
-
-#: build/OpenSCADLibInternal_autogen/include/ui_ChatWidget.h:199
-msgid "☰"
 msgstr ""
 
 #: build/OpenSCADLibInternal_autogen/include/ui_ChatWidget.h:201
@@ -601,7 +558,7 @@ msgstr "Log de Erros"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_ErrorLog.h:93
 #: build/OpenSCADLibInternal_autogen/include/ui_ViewportControl.h:267
-msgid "RowSelected"
+msgid "Row Selected"
 msgstr ""
 
 #: build/OpenSCADLibInternal_autogen/include/ui_ErrorLog.h:95
@@ -654,15 +611,11 @@ msgstr ""
 #: build/OpenSCADLibInternal_autogen/include/ui_Export3mfDialog.h:457
 #, fuzzy
 msgid "Export 3MF Options"
-msgstr "Opções de Exportação de PDF"
+msgstr "Opções de Exportação de 3MF"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_Export3mfDialog.h:459
-#: build/OpenSCADLibInternal_autogen/include/ui_ExportPdfDialog.h:552
-msgid ""
-"<html><head/><body><p>Set the PDF page (paper) size.  </p></body></html>"
+msgid "Set the unit used in the exported file"
 msgstr ""
-"<html><head/><body><p>Definir o tamanho da página PDF (papel).</p></body></"
-"html>"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_Export3mfDialog.h:461
 msgid "Unit"
@@ -811,6 +764,10 @@ msgstr "Cancelar"
 msgid "Export PDF Options"
 msgstr "Opções de Exportação de PDF"
 
+#: build/OpenSCADLibInternal_autogen/include/ui_ExportPdfDialog.h:552
+msgid "Set the PDF page (paper) size."
+msgstr "Definir o tamanho da página PDF (papel)."
+
 #: build/OpenSCADLibInternal_autogen/include/ui_ExportPdfDialog.h:554
 #, fuzzy
 msgid "Page Size"
@@ -870,12 +827,8 @@ msgid "Author"
 msgstr ""
 
 #: build/OpenSCADLibInternal_autogen/include/ui_ExportPdfDialog.h:582
-msgid ""
-"<html><head/><body><p>Set the direction of the largest page dimension.</p></"
-"body></html>"
-msgstr ""
-"<html><head/><body><p>Definir a direção da maior dimensão da página.</p></"
-"body></html>"
+msgid "Set the direction of the largest page dimension."
+msgstr "Definir a direção da maior dimensão da página."
 
 #: build/OpenSCADLibInternal_autogen/include/ui_ExportPdfDialog.h:584
 #, fuzzy
@@ -893,12 +846,8 @@ msgid "Landscape (Horizontal)"
 msgstr "Paisagem (Horizontal)"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_ExportPdfDialog.h:589
-msgid ""
-"<html><head/><body><p>Determine best orientation based on maximum geometry "
-"dimension.</p></body></html>"
-msgstr ""
-"<html><head/><body><p>Determinar a melhor orientação com base na dimensão "
-"geométrica máxima.</p></body></html>"
+msgid "Determine best orientation based on maximum geometry dimension."
+msgstr "Determinar a melhor orientação com base na dimensão geométrica máxima."
 
 #: build/OpenSCADLibInternal_autogen/include/ui_ExportPdfDialog.h:591
 #: src/core/Settings.cc:400
@@ -910,35 +859,27 @@ msgid "Annotations"
 msgstr "Anotações"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_ExportPdfDialog.h:594
-msgid ""
-"<html><head/><body><p>Include design filename on page.</p></body></html>"
-msgstr ""
-"<html><head/><body><p>Incluir nome do arquivo de design na página.</p></"
-"body></html>"
+#, fuzzy
+msgid "Include design filename on page."
+msgstr "Incluir nome do arquivo de design na página."
 
 #: build/OpenSCADLibInternal_autogen/include/ui_ExportPdfDialog.h:596
 msgid "Show Design Filename"
 msgstr "Mostrar Nome do Arquivo de Design"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_ExportPdfDialog.h:598
-msgid ""
-"<html><head/><body><p>Include rulers on page to confirm 1:1 printing scale.</"
-"p></body></html>"
-msgstr ""
-"<html><head/><body><p>Incluir réguas na página para confirmar a escala de "
-"impressão 1:1.</p></body></html>"
+#, fuzzy
+msgid "Include rulers on page to confirm 1:1 printing scale."
+msgstr "Incluir réguas na página para confirmar a escala de impressão 1:1."
 
 #: build/OpenSCADLibInternal_autogen/include/ui_ExportPdfDialog.h:600
 msgid "Show Scale"
 msgstr "Mostar Escala"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_ExportPdfDialog.h:602
-msgid ""
-"<html><head/><body><p>Include a grid of the selected size on the page.</p></"
-"body></html>"
-msgstr ""
-"<html><head/><body><p>Incluir uma grade do tamanho selecionado na página.</"
-"p></body></html>"
+#, fuzzy
+msgid "Include a grid of the selected size on the page."
+msgstr "Incluir uma grade do tamanho selecionado na página."
 
 #: build/OpenSCADLibInternal_autogen/include/ui_ExportPdfDialog.h:604
 msgid "Show Grid"
@@ -965,12 +906,9 @@ msgid "10mm"
 msgstr ""
 
 #: build/OpenSCADLibInternal_autogen/include/ui_ExportPdfDialog.h:611
-msgid ""
-"<html><head/><body><p>Include text describing usage of scale.</p></body></"
-"html>"
-msgstr ""
-"<html><head/><body><p>Incluir texto descrevendo o uso da escala.</p></body></"
-"html>"
+#, fuzzy
+msgid "Include text describing usage of scale."
+msgstr "Incluir texto descrevendo o uso da escala."
 
 #: build/OpenSCADLibInternal_autogen/include/ui_ExportPdfDialog.h:613
 msgid "Show Scale Usage"
@@ -982,13 +920,9 @@ msgid "Fill and Stroke"
 msgstr ""
 
 #: build/OpenSCADLibInternal_autogen/include/ui_ExportPdfDialog.h:616
-#, fuzzy
-msgid ""
-"<html><head/><body><p>Enable filling of exported geometry with a color.</p></"
-"body></html>"
-msgstr ""
-"<html><head/><body><p>Incluir uma grade do tamanho selecionado na página.</"
-"p></body></html>"
+#: build/OpenSCADLibInternal_autogen/include/ui_ExportSvgDialog.h:205
+msgid "Enable filling of exported geometry with a color."
+msgstr "Habilitar o preenchimento da geometria exportada com uma cor."
 
 #: build/OpenSCADLibInternal_autogen/include/ui_ExportPdfDialog.h:618
 #: build/OpenSCADLibInternal_autogen/include/ui_ExportSvgDialog.h:207
@@ -996,13 +930,9 @@ msgid "Fill Geometry"
 msgstr ""
 
 #: build/OpenSCADLibInternal_autogen/include/ui_ExportPdfDialog.h:623
-#, fuzzy
-msgid ""
-"<html><head/><body><p>Enable outline stroke for exported geometry.</p></"
-"body></html>"
-msgstr ""
-"<html><head/><body><p>Incluir nome do arquivo de design na página.</p></"
-"body></html>"
+#: build/OpenSCADLibInternal_autogen/include/ui_ExportSvgDialog.h:212
+msgid "Enable outline stroke for exported geometry."
+msgstr "Habilitar contorno para a geometria exportada."
 
 #: build/OpenSCADLibInternal_autogen/include/ui_ExportPdfDialog.h:625
 #: build/OpenSCADLibInternal_autogen/include/ui_ExportSvgDialog.h:214
@@ -1023,20 +953,6 @@ msgstr ""
 #, fuzzy
 msgid "Export SVG Options"
 msgstr "Opções de Exportação de PDF"
-
-#: build/OpenSCADLibInternal_autogen/include/ui_ExportSvgDialog.h:205
-#, fuzzy
-msgid "Enable filling of exported geometry with a color."
-msgstr ""
-"<html><head/><body><p>Incluir uma grade do tamanho selecionado na página.</"
-"p></body></html>"
-
-#: build/OpenSCADLibInternal_autogen/include/ui_ExportSvgDialog.h:212
-#, fuzzy
-msgid "Enable outline stroke for exported geometry."
-msgstr ""
-"<html><head/><body><p>Incluir nome do arquivo de design na página.</p></"
-"body></html>"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_FontList.h:291
 #, fuzzy
@@ -1088,7 +1004,7 @@ msgstr "Mostar Escala"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_FontList.h:302
 #, fuzzy
-msgid "ShowFileName"
+msgid "Show File Name"
 msgstr "Nome de Arquivo"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_FontList.h:303
@@ -1868,13 +1784,13 @@ msgid "Ctrl+J"
 msgstr ""
 
 #: build/OpenSCADLibInternal_autogen/include/ui_MainWindow.h:1286
-#: src/gui/MainWindow.cc:1335 src/gui/MainWindow.cc:1342
-#: src/gui/MainWindow.cc:1355 src/gui/MainWindow.cc:1360
+#: src/gui/MainWindow.cc:1346 src/gui/MainWindow.cc:1353
+#: src/gui/MainWindow.cc:1366 src/gui/MainWindow.cc:1371
 msgid "Create Virtual Environment"
 msgstr ""
 
 #: build/OpenSCADLibInternal_autogen/include/ui_MainWindow.h:1287
-#: src/gui/MainWindow.cc:1377
+#: src/gui/MainWindow.cc:1388
 msgid "Select Virtual Environment"
 msgstr ""
 
@@ -1957,55 +1873,55 @@ msgstr "Pronto"
 msgid "Customizer Widget"
 msgstr "Customizar Widget"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_MouseConfigWidget.h:215
+#: build/OpenSCADLibInternal_autogen/include/ui_MouseConfigWidget.h:214
 msgid "Ctrl + Shift + Middle-click"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_MouseConfigWidget.h:216
+#: build/OpenSCADLibInternal_autogen/include/ui_MouseConfigWidget.h:215
 msgid "Left-click"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_MouseConfigWidget.h:217
+#: build/OpenSCADLibInternal_autogen/include/ui_MouseConfigWidget.h:216
 msgid "Ctrl + Left-click"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_MouseConfigWidget.h:218
+#: build/OpenSCADLibInternal_autogen/include/ui_MouseConfigWidget.h:217
 msgid "Shift + Left-click"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_MouseConfigWidget.h:219
+#: build/OpenSCADLibInternal_autogen/include/ui_MouseConfigWidget.h:218
 msgid "Ctrl + Shift + Right-click"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_MouseConfigWidget.h:220
+#: build/OpenSCADLibInternal_autogen/include/ui_MouseConfigWidget.h:219
 msgid "Preset"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_MouseConfigWidget.h:221
+#: build/OpenSCADLibInternal_autogen/include/ui_MouseConfigWidget.h:220
 msgid "Right-click"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_MouseConfigWidget.h:222
+#: build/OpenSCADLibInternal_autogen/include/ui_MouseConfigWidget.h:221
 msgid "Ctrl + Middle-click"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_MouseConfigWidget.h:223
+#: build/OpenSCADLibInternal_autogen/include/ui_MouseConfigWidget.h:222
 msgid "Shift + Middle-click"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_MouseConfigWidget.h:224
+#: build/OpenSCADLibInternal_autogen/include/ui_MouseConfigWidget.h:223
 msgid "Ctrl + Right-click"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_MouseConfigWidget.h:225
+#: build/OpenSCADLibInternal_autogen/include/ui_MouseConfigWidget.h:224
 msgid "Ctrl + Shift + Left-click"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_MouseConfigWidget.h:226
+#: build/OpenSCADLibInternal_autogen/include/ui_MouseConfigWidget.h:225
 msgid "Shift + Right-click"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_MouseConfigWidget.h:227
+#: build/OpenSCADLibInternal_autogen/include/ui_MouseConfigWidget.h:226
 msgid "Middle-click"
 msgstr ""
 
@@ -2022,24 +1938,10 @@ msgid "OpenGL Warning"
 msgstr "Aviso OpenGL"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_OpenCSGWarningDialog.h:77
-msgid ""
-"<!DOCTYPE HTML PUBLIC \"-//W3C//DTD HTML 4.0//EN\" \"http://www.w3.org/TR/"
-"REC-html40/strict.dtd\">\n"
-"<html><head><meta name=\"qrichtext\" content=\"1\" /><style type=\"text/"
-"css\">\n"
-"p, li { white-space: pre-wrap; }\n"
-"</style></head><body style=\" font-family:'Lucida Grande'; font-size:13pt; "
-"font-weight:400; font-style:normal;\">\n"
-"<p style=\"-qt-paragraph-type:empty; margin-top:0px; margin-bottom:0px; "
-"margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;\"></"
-"p></body></html>"
-msgstr ""
-
-#: build/OpenSCADLibInternal_autogen/include/ui_OpenCSGWarningDialog.h:82
 msgid "Show this message again"
 msgstr "Mostrar esta mensagem novamente"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_OpenCSGWarningDialog.h:83
+#: build/OpenSCADLibInternal_autogen/include/ui_OpenCSGWarningDialog.h:78
 msgid "Close"
 msgstr "Fechar"
 
@@ -2108,6 +2010,10 @@ msgstr ""
 #, fuzzy
 msgid "More actions"
 msgstr "Anotações"
+
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2464
+msgid "Preferences"
+msgstr "Preferências"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2465
 msgid "3D View"
@@ -3186,21 +3092,21 @@ msgstr "O driver QGAMEPAD é para suporte a gamepad multiplataforma."
 msgid "Toggle Perspective"
 msgstr "Alternar Perspectiva"
 
-#: src/gui/MainWindow.cc:861
+#: src/gui/MainWindow.cc:872
 msgid "Compile error."
 msgstr "Erro de compilação."
 
-#: src/gui/MainWindow.cc:864
+#: src/gui/MainWindow.cc:875
 msgid "Error while compiling '%1'."
 msgstr "Erro durante a compilação '%1'."
 
-#: src/gui/MainWindow.cc:869
+#: src/gui/MainWindow.cc:880
 msgid "Compilation generated %1 warning."
 msgid_plural "Compilation generated %1 warnings."
 msgstr[0] "A compilação gerou %1 aviso."
 msgstr[1] "A compilação gerou %1 avisos."
 
-#: src/gui/MainWindow.cc:882
+#: src/gui/MainWindow.cc:893
 msgid ""
 " For details see the <a href=\"#errorlog\">error log</a> and <a "
 "href=\"#console\">console window</a>."
@@ -3208,11 +3114,11 @@ msgstr ""
 " Para mais detalhes veja o <a href=\"#errorlog\">log de erros</a> e a <a "
 "href=\"#console\">janela do console</a>."
 
-#: src/gui/MainWindow.cc:1320
+#: src/gui/MainWindow.cc:1331
 msgid "Trusted Files"
 msgstr "Arquivos Confiáveis"
 
-#: src/gui/MainWindow.cc:1704
+#: src/gui/MainWindow.cc:1715
 #, fuzzy
 msgid ""
 "Python files can potentially contain harmful stuff.\n"
@@ -3221,11 +3127,11 @@ msgstr ""
 "Arquivos Python podem potencialmente conter coisas prejudiciais.\n"
 "Você confia nesse arquivo?\n"
 
-#: src/gui/MainWindow.cc:1810
+#: src/gui/MainWindow.cc:1821
 msgid "Application"
 msgstr "Aplicação"
 
-#: src/gui/MainWindow.cc:1811
+#: src/gui/MainWindow.cc:1822
 msgid ""
 "The document has been modified.\n"
 "Do you really want to reload the file?"
@@ -3233,69 +3139,69 @@ msgstr ""
 "O documento foi modificado.\n"
 "Deseja realmente recarregar o arquivo?"
 
-#: src/gui/MainWindow.cc:2564
+#: src/gui/MainWindow.cc:2575
 msgid "Export %1 File"
 msgstr "Exportar o arquivo %1"
 
-#: src/gui/MainWindow.cc:2565
+#: src/gui/MainWindow.cc:2576
 msgid "%1 Files (*%2)"
 msgstr "%1 Arquivos (*%2)"
 
-#: src/gui/MainWindow.cc:2613
+#: src/gui/MainWindow.cc:2624
 msgid "Export CSG File"
 msgstr "Exportar arquivo CSG"
 
-#: src/gui/MainWindow.cc:2614
+#: src/gui/MainWindow.cc:2625
 msgid "CSG Files (*.csg)"
 msgstr "Arquivos CSG (*.csg)"
 
-#: src/gui/MainWindow.cc:2637
+#: src/gui/MainWindow.cc:2648
 msgid "Export Image"
 msgstr "Exportar una imagen"
 
-#: src/gui/MainWindow.cc:2637
+#: src/gui/MainWindow.cc:2648
 msgid "PNG Files (*.png)"
 msgstr "Arquivos PNG (*.png)"
 
-#: src/gui/MainWindow.cc:3027 src/gui/MainWindow.cc:3787
+#: src/gui/MainWindow.cc:3038 src/gui/MainWindow.cc:3798
 msgid "&AI Chat"
 msgstr ""
 
-#: src/gui/MainWindow.cc:3129 src/gui/TabManager.cc:735
+#: src/gui/MainWindow.cc:3140 src/gui/TabManager.cc:735
 #: src/gui/TabManager.cc:786
 msgid "Untitled.scad"
 msgstr "Semtitulo.scad"
 
-#: src/gui/MainWindow.cc:3779
+#: src/gui/MainWindow.cc:3790
 msgid "&Editor"
 msgstr "&Editor"
 
-#: src/gui/MainWindow.cc:3780
+#: src/gui/MainWindow.cc:3791
 msgid "&Console"
 msgstr "&Console"
 
-#: src/gui/MainWindow.cc:3781
+#: src/gui/MainWindow.cc:3792
 msgid "C&ustomizer"
 msgstr "C&ustomizador"
 
-#: src/gui/MainWindow.cc:3782
+#: src/gui/MainWindow.cc:3793
 msgid "Error &Log"
 msgstr "&Log de Erros"
 
-#: src/gui/MainWindow.cc:3783
+#: src/gui/MainWindow.cc:3794
 msgid "&Animate"
 msgstr "&Animar"
 
-#: src/gui/MainWindow.cc:3784
+#: src/gui/MainWindow.cc:3795
 msgid "&Font List"
 msgstr "Lista de &Fontes"
 
-#: src/gui/MainWindow.cc:3785
+#: src/gui/MainWindow.cc:3796
 #, fuzzy
 msgid "C&olor List"
 msgstr "Esquema de colores:"
 
-#: src/gui/MainWindow.cc:3786
+#: src/gui/MainWindow.cc:3797
 #, fuzzy
 msgid "&Viewport Control"
 msgstr "Controle-Viewport"
@@ -3557,8 +3463,12 @@ msgid "\"%1$s\" write error. (Disk full?)"
 msgstr ""
 
 #: examples
-msgid "Parametric"
-msgstr "Paramétrico"
+msgid "Advanced"
+msgstr "Avançado"
+
+#: examples
+msgid "Basics"
+msgstr "Pontos Básicos"
 
 #: examples
 msgid "Functions"
@@ -3569,12 +3479,8 @@ msgid "Old"
 msgstr "Antigo"
 
 #: examples
-msgid "Advanced"
-msgstr "Avançado"
-
-#: examples
-msgid "Basics"
-msgstr "Pontos Básicos"
+msgid "Parametric"
+msgstr "Paramétrico"
 
 #. (itstool) path: component/summary
 #: openscad.appdata.xml.in2:6
@@ -3632,106 +3538,6 @@ msgstr ""
 "usados ​​arquivos DXF do Autocad. Além dos caminhos 2D para extrusão, também é "
 "possível ler parâmetros de projeto de arquivos DXF. Além dos arquivos DXF, o "
 "OpenSCAD pode ler e criar modelos 3D nos formatos de arquivo STL e OFF."
-
-#, fuzzy
-#~ msgid "meter"
-#~ msgstr "Parâmetros"
-
-#~ msgid "none"
-#~ msgstr "nenhum"
-
-#~ msgid "Features"
-#~ msgstr "Recursos"
-
-#, fuzzy
-#~ msgid "Reset"
-#~ msgstr "Redefinir Ajuste"
-
-#, fuzzy
-#~ msgid "Search action..."
-#~ msgstr "String de busca"
-
-#, fuzzy
-#~ msgid "ViewportControlWidget"
-#~ msgstr "Controle-Viewport"
-
-#~ msgid "OpenSCAD Font List"
-#~ msgstr "Lista de Fontes do OpenSCAD"
-
-#~ msgid "Copy to Clipboard"
-#~ msgstr "Copiar para a Área de Transferência"
-
-#~ msgid "Filter:"
-#~ msgstr "Filtro:"
-
-#~ msgid ""
-#~ "<html><head/><body><p>This list shows the fonts currently registered with "
-#~ "OpenSCAD.</p><p>Example:</p><pre style=\" margin-top:12px; margin-"
-#~ "bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-"
-#~ "indent:0px;\"><span style=\" font-family:'Courier New,courier';\">  "
-#~ "text(&quot;OpenSCAD&quot;, font = &quot;DejaVu Sans&quot;);</span></"
-#~ "pre><pre style=\" margin-top:0px; margin-bottom:12px; margin-left:0px; "
-#~ "margin-right:0px; -qt-block-indent:0; text-indent:0px;\"><span style=\" "
-#~ "font-family:'Courier New,courier';\">  text(&quot;OpenSCAD&quot;, font = "
-#~ "&quot;Liberation Sans:style=Italic&quot;);</span></pre></body></html>"
-#~ msgstr ""
-#~ "<html><head/><body><p>Esta lista mostra as fontes registradas atualmente "
-#~ "no OpenSCAD.</p><p>Exemplo:</p><pre style=\" margin-top:12px; margin-"
-#~ "bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-"
-#~ "indent:0px;\"><span style=\" font-family:'Courier New,courier';\">  "
-#~ "text(&quot;OpenSCAD&quot;, font = &quot;DejaVu Sans&quot;);</span></"
-#~ "pre><pre style=\" margin-top:0px; margin-bottom:12px; margin-left:0px; "
-#~ "margin-right:0px; -qt-block-indent:0; text-indent:0px;\"><span style=\" "
-#~ "font-family:'Courier New,courier';\">  text(&quot;OpenSCAD&quot;, font = "
-#~ "&quot;Liberation Sans:style=Italic&quot;);</span></pre></body></html>"
-
-#~ msgid "Swap Mouse Buttons"
-#~ msgstr "Trocar Botões do Mouse"
-
-#, fuzzy
-#~ msgid "Line"
-#~ msgstr "Quebra de linha"
-
-#~ msgid "Filename"
-#~ msgstr "Nome de Arquivo"
-
-#, fuzzy
-#~ msgid "Font Lists"
-#~ msgstr "Lista de &Fontes"
-
-#~ msgid "Page Layout"
-#~ msgstr "Layout da Página"
-
-#~ msgid "Hide Editor"
-#~ msgstr "Ocultar Editor"
-
-#~ msgid "Surfaces"
-#~ msgstr "Superfícies"
-
-#~ msgid "Hide Console"
-#~ msgstr "Ocultar Console"
-
-#~ msgid "Hide Customizer"
-#~ msgstr "Esconder Customizador"
-
-#~ msgid "Hide Error Log"
-#~ msgstr "Esconder Log de Erros"
-
-#~ msgid "Hide Animation Toolbar/Window"
-#~ msgstr "Esconder Barra de Ferramentas/Janela de Animação"
-
-#, fuzzy
-#~ msgid "Hide Viewport-Control"
-#~ msgstr "Esconder Controle-Viewport"
-
-#~ msgid "Toolbar Export Format 3D"
-#~ msgstr "Formato de Exportação da Barra de Ferramentas 3D"
-
-#~ msgid "Toolbar Export Format 2D"
-#~ msgstr "Formato de Exportação da Barra de Ferramentas 2D"
-
-#~ msgid "Default to ASCII STL export"
-#~ msgstr "Exportação para ASCII STL por padrão"
 
 #~ msgid "absolute"
 #~ msgstr "absoluto"

--- a/locale/ru.po
+++ b/locale/ru.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: OpenSCAD 2015.03\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-09-06 23:38+0200\n"
+"POT-Creation-Date: 2026-09-06 17:48-0700\n"
 "PO-Revision-Date: 2022-09-30 00:36+0300\n"
 "Last-Translator: Konstantin Podsvirov <konstantin@podsvirov.pro>\n"
 "Language-Team: \n"
@@ -107,146 +107,111 @@ msgstr "Шагов:"
 msgid "Dump Pictures"
 msgstr "Сохранять кадры"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:852
-#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:362
-#: build/OpenSCADLibInternal_autogen/include/ui_MouseConfigWidget.h:214
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2464
-msgid "Preferences"
-msgstr "Параметры"
-
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:853
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:854
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:858
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:862
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:864
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:866
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:868
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:870
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:881
+#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:860
+#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:861
+#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:865
+#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:869
+#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:871
+#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:873
+#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:875
+#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:877
+#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:888
 msgid "Trim"
 msgstr "Обрезать"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:855
+#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:862
 msgid "Reset Trim"
 msgstr "Сбросить обрезку"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:856
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:859
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:860
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:861
 #: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:863
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:865
+#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:866
 #: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:867
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:869
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:880
+#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:868
+#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:870
+#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:872
+#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:874
+#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:876
+#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:887
 msgid "DeadZone"
 msgstr "Мёртвая зона"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:857
+#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:864
 msgid "Auto Trim Axes"
 msgstr "Автоматически обрезать оси"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:871
+#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:878
 msgid "Axis 2"
 msgstr "Ось 2"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:872
+#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:879
 msgid "Axis 0"
 msgstr "Ось 0"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:873
+#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:880
 msgid "Axis 3"
 msgstr "Ось 3"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:874
+#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:881
 msgid "Axis 6"
 msgstr "Ось 6"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:875
+#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:882
 msgid "Axis 8"
 msgstr "Ось 8"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:876
+#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:883
 msgid "Axis 7"
 msgstr "Ось 7"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:877
+#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:884
 msgid "Axis 5"
 msgstr "Ось 5"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:878
+#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:885
 msgid "Axis 1"
 msgstr "Ось 1"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:879
+#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:886
 msgid "Axis 4"
 msgstr "Ось 4"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:882
+#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:889
 #: build/OpenSCADLibInternal_autogen/include/ui_ViewportControl.h:279
 msgid "Rotation"
 msgstr "Вращение"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:883
+#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:890
 msgid "Zoom"
 msgstr "Увеличение"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:884
-msgid "X"
-msgstr "X"
-
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:885
+#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:891
 msgid "Gain"
 msgstr "Усиление"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:886
-msgid "Y"
-msgstr "Y"
-
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:887
-msgid "Z"
-msgstr "Z"
-
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:888
+#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:892
 #: build/OpenSCADLibInternal_autogen/include/ui_ViewportControl.h:280
 msgid "Translation"
 msgstr "Сдвиг"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:889
+#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:893
 msgid "ViewPort rel.<br/>Translation"
 msgstr "Отн. сдвиг<br/>вьюпорта"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:890
-msgid "ViewPort rel.<br />Rotation"
-msgstr "Отн. вращение<br />вьюпорта"
+#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:894
+msgid "ViewPort rel.<br/>Rotation"
+msgstr "Отн. вращение<br/>вьюпорта"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:891
+#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:895
 msgid "Axis Setup:"
 msgstr "Настройка осей:"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:892
+#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:896
 msgid "<b>Driver selection:</b> <i>(changes requires restarting OpenSCAD)</i>"
 msgstr "<b>Выбор драйвера:</b> <i>(требует перезапуска OpenSCAD)</i>"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:893
-msgid "SpaceNav"
-msgstr "SpaceNav"
-
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:894
-msgid "HIDAPI"
-msgstr "HIDAPI"
-
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:895
-msgid "QGamepad"
-msgstr "QGamepad"
-
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:896
+#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:897
 msgid "Joystick"
 msgstr "Джойстик"
-
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:897
-msgid "DBus"
-msgstr "DBus"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:898
 msgid "Axes Mapping:"
@@ -257,125 +222,117 @@ msgid "Status:"
 msgstr "Состояние:"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:900
-msgid "TextLabel"
-msgstr "Текст"
-
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:901
 #: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2468
 msgid "Update"
 msgstr "Обновления"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:363
+#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:362
 msgid "Button 19"
 msgstr "Кнопка 19"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:364
+#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:363
 msgid "Button 5"
 msgstr "Кнопка 5"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:365
+#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:364
 msgid "Button 14"
 msgstr "Кнопка 14"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:366
+#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:365
 msgid "Button 7"
 msgstr "Кнопка 7"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:367
+#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:366
 msgid "Button 16"
 msgstr "Кнопка 16"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:368
+#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:367
 msgid "Button 20"
 msgstr "Кнопка 20"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:369
+#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:368
 msgid "Button 1"
 msgstr "Кнопка 1"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:370
+#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:369
 msgid "Button 21"
 msgstr "Кнопка 21"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:371
+#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:370
 msgid "Button 18"
 msgstr "Кнопка 18"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:372
+#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:371
 msgid "Button 0"
 msgstr "Кнопка 0"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:373
+#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:372
 msgid "Button 4"
 msgstr "Кнопка 4"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:374
+#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:373
 msgid "Button 10"
 msgstr "Кнопка 10"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:375
+#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:374
 msgid "Button 6"
 msgstr "Кнопка 6"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:376
+#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:375
 msgid "Button 8"
 msgstr "Кнопка 8"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:377
+#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:376
 msgid "Button 15"
 msgstr "Кнопка 15"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:378
+#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:377
 msgid "Button 11"
 msgstr "Кнопка 11"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:379
+#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:378
 msgid "Button 3"
 msgstr "Кнопка 3"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:380
+#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:379
 msgid "Button 23"
 msgstr "Кнопка 23"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:381
+#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:380
 msgid "Button 9"
 msgstr "Кнопка 9"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:382
+#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:381
 msgid "Button 2"
 msgstr "Кнопка 2"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:383
+#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:382
 msgid "Button 13"
 msgstr "Кнопка 13"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:384
+#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:383
 msgid "Button 12"
 msgstr "Кнопка 12"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:385
+#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:384
 msgid "Button 17"
 msgstr "Кнопка 17"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:386
+#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:385
 msgid "Button 22"
 msgstr "Кнопка 22"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_ChatWidget.h:194
+#: build/OpenSCADLibInternal_autogen/include/ui_ChatWidget.h:195
 msgid "AI Chat"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_ChatWidget.h:195
+#: build/OpenSCADLibInternal_autogen/include/ui_ChatWidget.h:196
 #: src/gui/ai/ChatWidget.cc:138
 msgid "AI Assistant"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_ChatWidget.h:197
+#: build/OpenSCADLibInternal_autogen/include/ui_ChatWidget.h:198
 msgid "Chat options"
-msgstr ""
-
-#: build/OpenSCADLibInternal_autogen/include/ui_ChatWidget.h:199
-msgid "☰"
 msgstr ""
 
 #: build/OpenSCADLibInternal_autogen/include/ui_ChatWidget.h:201
@@ -599,8 +556,9 @@ msgstr "Журнал ошибок"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_ErrorLog.h:93
 #: build/OpenSCADLibInternal_autogen/include/ui_ViewportControl.h:267
-msgid "RowSelected"
-msgstr ""
+#, fuzzy
+msgid "Row Selected"
+msgstr "Предустановка не выбрана"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_ErrorLog.h:95
 #: build/OpenSCADLibInternal_autogen/include/ui_ViewportControl.h:269
@@ -655,9 +613,7 @@ msgid "Export 3MF Options"
 msgstr "Особенности экспорта"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_Export3mfDialog.h:459
-#: build/OpenSCADLibInternal_autogen/include/ui_ExportPdfDialog.h:552
-msgid ""
-"<html><head/><body><p>Set the PDF page (paper) size.  </p></body></html>"
+msgid "Set the unit used in the exported file"
 msgstr ""
 
 #: build/OpenSCADLibInternal_autogen/include/ui_Export3mfDialog.h:461
@@ -808,6 +764,10 @@ msgstr "Отмена"
 msgid "Export PDF Options"
 msgstr "Особенности экспорта"
 
+#: build/OpenSCADLibInternal_autogen/include/ui_ExportPdfDialog.h:552
+msgid "Set the PDF page (paper) size."
+msgstr ""
+
 #: build/OpenSCADLibInternal_autogen/include/ui_ExportPdfDialog.h:554
 #, fuzzy
 msgid "Page Size"
@@ -867,9 +827,7 @@ msgid "Author"
 msgstr ""
 
 #: build/OpenSCADLibInternal_autogen/include/ui_ExportPdfDialog.h:582
-msgid ""
-"<html><head/><body><p>Set the direction of the largest page dimension.</p></"
-"body></html>"
+msgid "Set the direction of the largest page dimension."
 msgstr ""
 
 #: build/OpenSCADLibInternal_autogen/include/ui_ExportPdfDialog.h:584
@@ -888,9 +846,7 @@ msgid "Landscape (Horizontal)"
 msgstr ""
 
 #: build/OpenSCADLibInternal_autogen/include/ui_ExportPdfDialog.h:589
-msgid ""
-"<html><head/><body><p>Determine best orientation based on maximum geometry "
-"dimension.</p></body></html>"
+msgid "Determine best orientation based on maximum geometry dimension."
 msgstr ""
 
 #: build/OpenSCADLibInternal_autogen/include/ui_ExportPdfDialog.h:591
@@ -904,8 +860,7 @@ msgid "Annotations"
 msgstr "Вращение"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_ExportPdfDialog.h:594
-msgid ""
-"<html><head/><body><p>Include design filename on page.</p></body></html>"
+msgid "Include design filename on page."
 msgstr ""
 
 #: build/OpenSCADLibInternal_autogen/include/ui_ExportPdfDialog.h:596
@@ -913,9 +868,7 @@ msgid "Show Design Filename"
 msgstr ""
 
 #: build/OpenSCADLibInternal_autogen/include/ui_ExportPdfDialog.h:598
-msgid ""
-"<html><head/><body><p>Include rulers on page to confirm 1:1 printing scale.</"
-"p></body></html>"
+msgid "Include rulers on page to confirm 1:1 printing scale."
 msgstr ""
 
 #: build/OpenSCADLibInternal_autogen/include/ui_ExportPdfDialog.h:600
@@ -924,9 +877,7 @@ msgid "Show Scale"
 msgstr "Показывать метки масштаба"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_ExportPdfDialog.h:602
-msgid ""
-"<html><head/><body><p>Include a grid of the selected size on the page.</p></"
-"body></html>"
+msgid "Include a grid of the selected size on the page."
 msgstr ""
 
 #: build/OpenSCADLibInternal_autogen/include/ui_ExportPdfDialog.h:604
@@ -955,9 +906,7 @@ msgid "10mm"
 msgstr ""
 
 #: build/OpenSCADLibInternal_autogen/include/ui_ExportPdfDialog.h:611
-msgid ""
-"<html><head/><body><p>Include text describing usage of scale.</p></body></"
-"html>"
+msgid "Include text describing usage of scale."
 msgstr ""
 
 #: build/OpenSCADLibInternal_autogen/include/ui_ExportPdfDialog.h:613
@@ -971,9 +920,8 @@ msgid "Fill and Stroke"
 msgstr ""
 
 #: build/OpenSCADLibInternal_autogen/include/ui_ExportPdfDialog.h:616
-msgid ""
-"<html><head/><body><p>Enable filling of exported geometry with a color.</p></"
-"body></html>"
+#: build/OpenSCADLibInternal_autogen/include/ui_ExportSvgDialog.h:205
+msgid "Enable filling of exported geometry with a color."
 msgstr ""
 
 #: build/OpenSCADLibInternal_autogen/include/ui_ExportPdfDialog.h:618
@@ -982,9 +930,8 @@ msgid "Fill Geometry"
 msgstr ""
 
 #: build/OpenSCADLibInternal_autogen/include/ui_ExportPdfDialog.h:623
-msgid ""
-"<html><head/><body><p>Enable outline stroke for exported geometry.</p></"
-"body></html>"
+#: build/OpenSCADLibInternal_autogen/include/ui_ExportSvgDialog.h:212
+msgid "Enable outline stroke for exported geometry."
 msgstr ""
 
 #: build/OpenSCADLibInternal_autogen/include/ui_ExportPdfDialog.h:625
@@ -1006,14 +953,6 @@ msgstr ""
 #, fuzzy
 msgid "Export SVG Options"
 msgstr "Особенности экспорта"
-
-#: build/OpenSCADLibInternal_autogen/include/ui_ExportSvgDialog.h:205
-msgid "Enable filling of exported geometry with a color."
-msgstr ""
-
-#: build/OpenSCADLibInternal_autogen/include/ui_ExportSvgDialog.h:212
-msgid "Enable outline stroke for exported geometry."
-msgstr ""
 
 #: build/OpenSCADLibInternal_autogen/include/ui_FontList.h:291
 #, fuzzy
@@ -1065,7 +1004,7 @@ msgstr "Показывать метки масштаба"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_FontList.h:302
 #, fuzzy
-msgid "ShowFileName"
+msgid "Show File Name"
 msgstr "Скопировать имя файла"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_FontList.h:303
@@ -1843,13 +1782,13 @@ msgid "Ctrl+J"
 msgstr "Ctrl+N"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_MainWindow.h:1286
-#: src/gui/MainWindow.cc:1335 src/gui/MainWindow.cc:1342
-#: src/gui/MainWindow.cc:1355 src/gui/MainWindow.cc:1360
+#: src/gui/MainWindow.cc:1346 src/gui/MainWindow.cc:1353
+#: src/gui/MainWindow.cc:1366 src/gui/MainWindow.cc:1371
 msgid "Create Virtual Environment"
 msgstr ""
 
 #: build/OpenSCADLibInternal_autogen/include/ui_MainWindow.h:1287
-#: src/gui/MainWindow.cc:1377
+#: src/gui/MainWindow.cc:1388
 msgid "Select Virtual Environment"
 msgstr ""
 
@@ -1931,56 +1870,56 @@ msgstr "Готово"
 msgid "Customizer Widget"
 msgstr "Виджет настрощика"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_MouseConfigWidget.h:215
+#: build/OpenSCADLibInternal_autogen/include/ui_MouseConfigWidget.h:214
 msgid "Ctrl + Shift + Middle-click"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_MouseConfigWidget.h:216
+#: build/OpenSCADLibInternal_autogen/include/ui_MouseConfigWidget.h:215
 msgid "Left-click"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_MouseConfigWidget.h:217
+#: build/OpenSCADLibInternal_autogen/include/ui_MouseConfigWidget.h:216
 msgid "Ctrl + Left-click"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_MouseConfigWidget.h:218
+#: build/OpenSCADLibInternal_autogen/include/ui_MouseConfigWidget.h:217
 msgid "Shift + Left-click"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_MouseConfigWidget.h:219
+#: build/OpenSCADLibInternal_autogen/include/ui_MouseConfigWidget.h:218
 msgid "Ctrl + Shift + Right-click"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_MouseConfigWidget.h:220
+#: build/OpenSCADLibInternal_autogen/include/ui_MouseConfigWidget.h:219
 #, fuzzy
 msgid "Preset"
 msgstr "Сбросить"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_MouseConfigWidget.h:221
+#: build/OpenSCADLibInternal_autogen/include/ui_MouseConfigWidget.h:220
 msgid "Right-click"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_MouseConfigWidget.h:222
+#: build/OpenSCADLibInternal_autogen/include/ui_MouseConfigWidget.h:221
 msgid "Ctrl + Middle-click"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_MouseConfigWidget.h:223
+#: build/OpenSCADLibInternal_autogen/include/ui_MouseConfigWidget.h:222
 msgid "Shift + Middle-click"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_MouseConfigWidget.h:224
+#: build/OpenSCADLibInternal_autogen/include/ui_MouseConfigWidget.h:223
 msgid "Ctrl + Right-click"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_MouseConfigWidget.h:225
+#: build/OpenSCADLibInternal_autogen/include/ui_MouseConfigWidget.h:224
 msgid "Ctrl + Shift + Left-click"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_MouseConfigWidget.h:226
+#: build/OpenSCADLibInternal_autogen/include/ui_MouseConfigWidget.h:225
 msgid "Shift + Right-click"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_MouseConfigWidget.h:227
+#: build/OpenSCADLibInternal_autogen/include/ui_MouseConfigWidget.h:226
 msgid "Middle-click"
 msgstr ""
 
@@ -1997,34 +1936,10 @@ msgid "OpenGL Warning"
 msgstr "Предупреждение OpenGL"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_OpenCSGWarningDialog.h:77
-msgid ""
-"<!DOCTYPE HTML PUBLIC \"-//W3C//DTD HTML 4.0//EN\" \"http://www.w3.org/TR/"
-"REC-html40/strict.dtd\">\n"
-"<html><head><meta name=\"qrichtext\" content=\"1\" /><style type=\"text/"
-"css\">\n"
-"p, li { white-space: pre-wrap; }\n"
-"</style></head><body style=\" font-family:'Lucida Grande'; font-size:13pt; "
-"font-weight:400; font-style:normal;\">\n"
-"<p style=\"-qt-paragraph-type:empty; margin-top:0px; margin-bottom:0px; "
-"margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;\"></"
-"p></body></html>"
-msgstr ""
-"<!DOCTYPE HTML PUBLIC \"-//W3C//DTD HTML 4.0//EN\" \"http://www.w3.org/TR/"
-"REC-html40/strict.dtd\">\n"
-"<html><head><meta name=\"qrichtext\" content=\"1\" /><style type=\"text/"
-"css\">\n"
-"p, li { white-space: pre-wrap; }\n"
-"</style></head><body style=\" font-family:'Lucida Grande'; font-size:13pt; "
-"font-weight:400; font-style:normal;\">\n"
-"<p style=\"-qt-paragraph-type:empty; margin-top:0px; margin-bottom:0px; "
-"margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;\"></"
-"p></body></html>"
-
-#: build/OpenSCADLibInternal_autogen/include/ui_OpenCSGWarningDialog.h:82
 msgid "Show this message again"
 msgstr "Показывать снова"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_OpenCSGWarningDialog.h:83
+#: build/OpenSCADLibInternal_autogen/include/ui_OpenCSGWarningDialog.h:78
 msgid "Close"
 msgstr "Закрыть"
 
@@ -2092,6 +2007,10 @@ msgstr "-"
 #, fuzzy
 msgid "More actions"
 msgstr "Вращение"
+
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2464
+msgid "Preferences"
+msgstr "Параметры"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2465
 msgid "3D View"
@@ -3156,22 +3075,22 @@ msgstr "Драйвер QGAMEPAD для мультиплатформенной п
 msgid "Toggle Perspective"
 msgstr "Переключить перспективу"
 
-#: src/gui/MainWindow.cc:861
+#: src/gui/MainWindow.cc:872
 msgid "Compile error."
 msgstr "Ошибка компиляции."
 
-#: src/gui/MainWindow.cc:864
+#: src/gui/MainWindow.cc:875
 msgid "Error while compiling '%1'."
 msgstr "«%1»: ошибка компиляции"
 
-#: src/gui/MainWindow.cc:869
+#: src/gui/MainWindow.cc:880
 msgid "Compilation generated %1 warning."
 msgid_plural "Compilation generated %1 warnings."
 msgstr[0] "При компиляции создано %1 предупреждение."
 msgstr[1] "При компиляции создано %1 предупреждения."
 msgstr[2] "При компиляции выведено %1 предупреждений."
 
-#: src/gui/MainWindow.cc:882
+#: src/gui/MainWindow.cc:893
 msgid ""
 " For details see the <a href=\"#errorlog\">error log</a> and <a "
 "href=\"#console\">console window</a>."
@@ -3179,21 +3098,21 @@ msgstr ""
 "Подробнее см. в <a href=\"#errorlog\">журнале ошибок</a> и <a "
 "href=\"#console\">окне консоли</a>."
 
-#: src/gui/MainWindow.cc:1320
+#: src/gui/MainWindow.cc:1331
 msgid "Trusted Files"
 msgstr ""
 
-#: src/gui/MainWindow.cc:1704
+#: src/gui/MainWindow.cc:1715
 msgid ""
 "Python files can potentially contain harmful stuff.\n"
 "Do you trust this file ?\n"
 msgstr ""
 
-#: src/gui/MainWindow.cc:1810
+#: src/gui/MainWindow.cc:1821
 msgid "Application"
 msgstr "Приложение"
 
-#: src/gui/MainWindow.cc:1811
+#: src/gui/MainWindow.cc:1822
 msgid ""
 "The document has been modified.\n"
 "Do you really want to reload the file?"
@@ -3201,69 +3120,69 @@ msgstr ""
 "Документ был изменён.\n"
 "Перезагрузить файл?"
 
-#: src/gui/MainWindow.cc:2564
+#: src/gui/MainWindow.cc:2575
 msgid "Export %1 File"
 msgstr "Экспортировать файл %1"
 
-#: src/gui/MainWindow.cc:2565
+#: src/gui/MainWindow.cc:2576
 msgid "%1 Files (*%2)"
 msgstr "Файлы %1 (*%2)"
 
-#: src/gui/MainWindow.cc:2613
+#: src/gui/MainWindow.cc:2624
 msgid "Export CSG File"
 msgstr "Экспортировать файл CSG"
 
-#: src/gui/MainWindow.cc:2614
+#: src/gui/MainWindow.cc:2625
 msgid "CSG Files (*.csg)"
 msgstr "Файлы CSG (*.csg)"
 
-#: src/gui/MainWindow.cc:2637
+#: src/gui/MainWindow.cc:2648
 msgid "Export Image"
 msgstr "Экспортировать изображение"
 
-#: src/gui/MainWindow.cc:2637
+#: src/gui/MainWindow.cc:2648
 msgid "PNG Files (*.png)"
 msgstr "Файлы PNG (*.png)"
 
-#: src/gui/MainWindow.cc:3027 src/gui/MainWindow.cc:3787
+#: src/gui/MainWindow.cc:3038 src/gui/MainWindow.cc:3798
 msgid "&AI Chat"
 msgstr ""
 
-#: src/gui/MainWindow.cc:3129 src/gui/TabManager.cc:735
+#: src/gui/MainWindow.cc:3140 src/gui/TabManager.cc:735
 #: src/gui/TabManager.cc:786
 msgid "Untitled.scad"
 msgstr "Безымянный.scad"
 
-#: src/gui/MainWindow.cc:3779
+#: src/gui/MainWindow.cc:3790
 msgid "&Editor"
 msgstr "&Редактор"
 
-#: src/gui/MainWindow.cc:3780
+#: src/gui/MainWindow.cc:3791
 msgid "&Console"
 msgstr "&Консоль"
 
-#: src/gui/MainWindow.cc:3781
+#: src/gui/MainWindow.cc:3792
 msgid "C&ustomizer"
 msgstr "Настройщик"
 
-#: src/gui/MainWindow.cc:3782
+#: src/gui/MainWindow.cc:3793
 msgid "Error &Log"
 msgstr "&Журнал ошибок"
 
-#: src/gui/MainWindow.cc:3783
+#: src/gui/MainWindow.cc:3794
 msgid "&Animate"
 msgstr "&Анимация"
 
-#: src/gui/MainWindow.cc:3784
+#: src/gui/MainWindow.cc:3795
 msgid "&Font List"
 msgstr "Список &шрифтов"
 
-#: src/gui/MainWindow.cc:3785
+#: src/gui/MainWindow.cc:3796
 #, fuzzy
 msgid "C&olor List"
 msgstr "Цветовая схема:"
 
-#: src/gui/MainWindow.cc:3786
+#: src/gui/MainWindow.cc:3797
 #, fuzzy
 msgid "&Viewport Control"
 msgstr "Управление вьюпортом"
@@ -3527,8 +3446,12 @@ msgid "\"%1$s\" write error. (Disk full?)"
 msgstr "Ошибка записи: \"%1$s\". (Диск переполнен?)"
 
 #: examples
-msgid "Parametric"
-msgstr "Параметрические"
+msgid "Advanced"
+msgstr "Дополнительные"
+
+#: examples
+msgid "Basics"
+msgstr "Примитивы"
 
 #: examples
 msgid "Functions"
@@ -3539,12 +3462,8 @@ msgid "Old"
 msgstr "Устаревшие"
 
 #: examples
-msgid "Advanced"
-msgstr "Дополнительные"
-
-#: examples
-msgid "Basics"
-msgstr "Примитивы"
+msgid "Parametric"
+msgstr "Параметрические"
 
 #. (itstool) path: component/summary
 #: openscad.appdata.xml.in2:6
@@ -3599,116 +3518,6 @@ msgstr ""
 "файлы Autocad DXF. В дополнение к двухмерному пути экструзии, возможно "
 "чтение проектных параметров из файлов DX. Помимо файлов DXF, OpenSCAD может "
 "читать и создавать 3D-модели в форматах STL и OFF."
-
-#, fuzzy
-#~ msgid "meter"
-#~ msgstr "Параметр"
-
-#~ msgid "Features"
-#~ msgstr "Функции"
-
-#, fuzzy
-#~ msgid "Reset"
-#~ msgstr "Сбросить"
-
-#, fuzzy
-#~ msgid "Search action..."
-#~ msgstr "Искать строчку"
-
-#, fuzzy
-#~ msgid "ViewportControlWidget"
-#~ msgstr "Управление вьюпортом"
-
-#~ msgid "OpenSCAD Font List"
-#~ msgstr "Список шрифтов, доступных в OpenSCAD"
-
-#~ msgid "Copy to Clipboard"
-#~ msgstr "Скопировать в буфер"
-
-#~ msgid "Filter:"
-#~ msgstr "Фильтр:"
-
-#~ msgid ""
-#~ "<html><head/><body><p>This list shows the fonts currently registered with "
-#~ "OpenSCAD.</p><p>Example:</p><pre style=\" margin-top:12px; margin-"
-#~ "bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-"
-#~ "indent:0px;\"><span style=\" font-family:'Courier New,courier';\">  "
-#~ "text(&quot;OpenSCAD&quot;, font = &quot;DejaVu Sans&quot;);</span></"
-#~ "pre><pre style=\" margin-top:0px; margin-bottom:12px; margin-left:0px; "
-#~ "margin-right:0px; -qt-block-indent:0; text-indent:0px;\"><span style=\" "
-#~ "font-family:'Courier New,courier';\">  text(&quot;OpenSCAD&quot;, font = "
-#~ "&quot;Liberation Sans:style=Italic&quot;);</span></pre></body></html>"
-#~ msgstr ""
-#~ "<html><head/><body><p>В этом списке перечислены шрифты, которые можно "
-#~ "использовать в OpenSCAD.</p><p>Пример кода:</p><pre style=\" margin-"
-#~ "top:12px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-"
-#~ "indent:0; text-indent:0px;\"><span style=\" font-family:'Courier "
-#~ "New,courier';\">  text(&quot;OpenSCAD&quot;, font = &quot;DejaVu "
-#~ "Sans&quot;);</span></pre><pre style=\" margin-top:0px; margin-"
-#~ "bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-"
-#~ "indent:0px;\"><span style=\" font-family:'Courier New,courier';\">  "
-#~ "text(&quot;OpenSCAD&quot;, font = &quot;Liberation "
-#~ "Sans:style=Italic&quot;);</span></pre></body></html>"
-
-#~ msgid "Error-Log"
-#~ msgstr "Журнал ошибок"
-
-#~ msgid "F7"
-#~ msgstr "F7"
-
-#~ msgid "Swap Mouse Buttons"
-#~ msgstr "Поменять кнопки мыши"
-
-#, fuzzy
-#~ msgid "Line"
-#~ msgstr "Перенос строк"
-
-#, fuzzy
-#~ msgid "Filename"
-#~ msgstr "Скопировать имя файла"
-
-#, fuzzy
-#~ msgid "Font Lists"
-#~ msgstr "Список &шрифтов"
-
-#~ msgid "Hide Editor"
-#~ msgstr "Скрыть редактор"
-
-#~ msgid "Surfaces"
-#~ msgstr "Поверхности"
-
-#~ msgid "F10"
-#~ msgstr "F10"
-
-#~ msgid "F11"
-#~ msgstr "F11"
-
-#~ msgid "Hide Console"
-#~ msgstr "Скрыть консоль"
-
-#~ msgid "Hide Customizer"
-#~ msgstr "Скрыть настройщик"
-
-#~ msgid "Hide Error Log"
-#~ msgstr "Скрыть журнал ошибок"
-
-#~ msgid "Hide Animation Toolbar/Window"
-#~ msgstr "Скрыть анимацию"
-
-#~ msgid "Hide Viewport-Control"
-#~ msgstr "Скрыть управление вьюпортом"
-
-#~ msgid "OpenCSG"
-#~ msgstr "OpenCSG"
-
-#~ msgid "CGAL"
-#~ msgstr "CGAL"
-
-#~ msgid "Default to ASCII STL export"
-#~ msgstr "По умолчанию экспорт в ASCII STL"
-
-#~ msgid "%1"
-#~ msgstr "%1"
 
 #~ msgid "absolute"
 #~ msgstr "Абсолютные значения"
@@ -3803,10 +3612,6 @@ msgstr ""
 #~ msgstr "(не поддерживается)"
 
 #, fuzzy
-#~ msgid "ErrorLog"
-#~ msgstr "Ошибка"
-
-#, fuzzy
 #~ msgid "Find Next"
 #~ msgstr "Искать следую&щее"
 
@@ -3820,9 +3625,6 @@ msgstr ""
 
 #~ msgid "Saved design '%s'."
 #~ msgstr "Проект «%s» сохранён."
-
-#~ msgid "Save As"
-#~ msgstr "Сохранить как"
 
 #~ msgid "Prev."
 #~ msgstr "Пред."
@@ -3856,9 +3658,6 @@ msgstr ""
 
 #~ msgid "Untitled.png"
 #~ msgstr "Безымянный.png"
-
-#~ msgid "no preset selected"
-#~ msgstr "Предустановка не выбрана"
 
 #~ msgid "<"
 #~ msgstr "<"

--- a/locale/sv.po
+++ b/locale/sv.po
@@ -7,31 +7,26 @@
 #, fuzzy
 msgid ""
 msgstr ""
-"Project-Id-Version: OpenSCAD 2024.01.06\n"
 "Project-Id-Version: OpenSCAD\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-01-06 21:29+0100\n"
-"POT-Creation-Date: 2024-01-06 21:29+0100\n"
+"POT-Creation-Date: 2026-09-06 18:07-0700\n"
 "PO-Revision-Date: 2025-06-16 09:59+0200\n"
-"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Daniel Nylander <github@danielnylander.se>\n"
 "Language-Team: sv\n"
 "Language: sv\n"
 "MIME-Version: 1.0\n"
-"MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
-"Content-Type: text/plain; charset=UTF-8\n"
-"Content-Transfer-Encoding: 8bit\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 "X-Generator: Poedit 3.6\n"
 
-#: build/OpenSCAD_autogen/include/ui_AboutDialog.h:100 src/gui/AboutDialog.h:13
+#: build/OpenSCADLibInternal_autogen/include/ui_AboutDialog.h:102
+#: src/gui/AboutDialog.h:20
 msgid "About OpenSCAD"
 msgstr "Om OpenSCAD"
 
-#: build/OpenSCAD_autogen/include/ui_AboutDialog.h:102
-#: build/OpenSCAD_autogen/include/ui_LaunchingScreen.h:306
+#: build/OpenSCADLibInternal_autogen/include/ui_AboutDialog.h:104
+#: build/OpenSCADLibInternal_autogen/include/ui_LaunchingScreen.h:304
 msgid ""
 "<html><head/><body>\n"
 "<p style=\"font-family: 'Open Sans', 'Droid Sans', 'sans-serif'; font-"
@@ -55,2116 +50,3038 @@ msgstr ""
 "\n"
 "\n"
 
-#: build/OpenSCAD_autogen/include/ui_AboutDialog.h:109
+#: build/OpenSCADLibInternal_autogen/include/ui_AboutDialog.h:111
+#: build/OpenSCADLibInternal_autogen/include/ui_Export3mfDialog.h:516
+#: build/OpenSCADLibInternal_autogen/include/ui_ExportPdfDialog.h:634
+#: build/OpenSCADLibInternal_autogen/include/ui_ExportSvgDialog.h:222
+#: build/OpenSCADLibInternal_autogen/include/ui_OctoPrintApiKeyDialog.h:110
+#: build/OpenSCADLibInternal_autogen/include/ui_PrintInitDialog.h:186
 msgid "OK"
 msgstr "OK"
 
-#: build/OpenSCAD_autogen/include/ui_Animate.h:219 src/gui/MainWindow.cc:3166
-#: src/gui/MainWindow.cc:3172
+#: build/OpenSCADLibInternal_autogen/include/ui_Animate.h:275
 msgid "Animate"
 msgstr "Animera"
 
-#: build/OpenSCAD_autogen/include/ui_Animate.h:220
-#: build/OpenSCAD_autogen/include/ui_ErrorLog.h:93
-#: build/OpenSCAD_autogen/include/ui_ViewportControl.h:199
-msgid "RowSelected"
-msgstr "RowSelected"
+#: build/OpenSCADLibInternal_autogen/include/ui_Animate.h:276
+#: build/OpenSCADLibInternal_autogen/include/ui_Animate.h:278
+#, fuzzy
+msgid "Toggle animation pause/unpause"
+msgstr "växla mellan paus/avpaus"
 
-#: build/OpenSCAD_autogen/include/ui_Animate.h:222
-#: build/OpenSCAD_autogen/include/ui_ErrorLog.h:95
-#: build/OpenSCAD_autogen/include/ui_ViewportControl.h:201
-msgid "Return"
-msgstr "Tillbaka"
+#: build/OpenSCADLibInternal_autogen/include/ui_Animate.h:280
+#: build/OpenSCADLibInternal_autogen/include/ui_Animate.h:282
+msgid "Move to beginning (first frame)"
+msgstr "Flytta till början (första bildrutan)"
 
-#: build/OpenSCAD_autogen/include/ui_Animate.h:224
+#: build/OpenSCADLibInternal_autogen/include/ui_Animate.h:284
+#: build/OpenSCADLibInternal_autogen/include/ui_Animate.h:286
+#, fuzzy
+msgid "Step one frame back"
+msgstr "stega en bildruta bakåt"
+
+#: build/OpenSCADLibInternal_autogen/include/ui_Animate.h:288
+#: build/OpenSCADLibInternal_autogen/include/ui_Animate.h:290
+#, fuzzy
+msgid "Step one frame forward"
+msgstr "stega en bildruta framåt"
+
+#: build/OpenSCADLibInternal_autogen/include/ui_Animate.h:292
+#: build/OpenSCADLibInternal_autogen/include/ui_Animate.h:294
+msgid "Move to end (last frame)"
+msgstr "Hoppa till slutet (sista bildrutan)"
+
+#: build/OpenSCADLibInternal_autogen/include/ui_Animate.h:296
 msgid "Time:"
 msgstr "Tid:"
 
-#: build/OpenSCAD_autogen/include/ui_Animate.h:225
+#: build/OpenSCADLibInternal_autogen/include/ui_Animate.h:297
 msgid "FPS:"
 msgstr "Bildfrekvens:"
 
-#: build/OpenSCAD_autogen/include/ui_Animate.h:226
+#: build/OpenSCADLibInternal_autogen/include/ui_Animate.h:298
 msgid "Steps:"
 msgstr "Steg:"
 
-#: build/OpenSCAD_autogen/include/ui_Animate.h:228
+#: build/OpenSCADLibInternal_autogen/include/ui_Animate.h:299
 msgid "Dump Pictures"
 msgstr "Dumpning av bilder"
 
-#: build/OpenSCAD_autogen/include/ui_Animate.h:229
-#: build/OpenSCAD_autogen/include/ui_Animate.h:230
-#: build/OpenSCAD_autogen/include/ui_Animate.h:231
-#: build/OpenSCAD_autogen/include/ui_Animate.h:232
-#: build/OpenSCAD_autogen/include/ui_Animate.h:233
-#: build/OpenSCAD_autogen/include/ui_Animate.h:234
-msgid "PushButton"
-msgstr "Tryckknapp"
-
-#: build/OpenSCAD_autogen/include/ui_AxisConfigWidget.h:853
-#: build/OpenSCAD_autogen/include/ui_ButtonConfigWidget.h:362
-#: build/OpenSCAD_autogen/include/ui_Preferences.h:1839
-msgid "Preferences"
-msgstr "Inställningar"
-
-#: build/OpenSCAD_autogen/include/ui_AxisConfigWidget.h:854
-#: build/OpenSCAD_autogen/include/ui_AxisConfigWidget.h:855
-#: build/OpenSCAD_autogen/include/ui_AxisConfigWidget.h:859
-#: build/OpenSCAD_autogen/include/ui_AxisConfigWidget.h:863
-#: build/OpenSCAD_autogen/include/ui_AxisConfigWidget.h:865
-#: build/OpenSCAD_autogen/include/ui_AxisConfigWidget.h:867
-#: build/OpenSCAD_autogen/include/ui_AxisConfigWidget.h:869
-#: build/OpenSCAD_autogen/include/ui_AxisConfigWidget.h:871
-#: build/OpenSCAD_autogen/include/ui_AxisConfigWidget.h:882
+#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:860
+#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:861
+#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:865
+#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:869
+#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:871
+#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:873
+#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:875
+#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:877
+#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:888
 msgid "Trim"
 msgstr "Trim"
 
-#: build/OpenSCAD_autogen/include/ui_AxisConfigWidget.h:856
+#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:862
 msgid "Reset Trim"
 msgstr "Återställ trim"
 
-#: build/OpenSCAD_autogen/include/ui_AxisConfigWidget.h:857
-#: build/OpenSCAD_autogen/include/ui_AxisConfigWidget.h:860
-#: build/OpenSCAD_autogen/include/ui_AxisConfigWidget.h:861
-#: build/OpenSCAD_autogen/include/ui_AxisConfigWidget.h:862
-#: build/OpenSCAD_autogen/include/ui_AxisConfigWidget.h:864
-#: build/OpenSCAD_autogen/include/ui_AxisConfigWidget.h:866
-#: build/OpenSCAD_autogen/include/ui_AxisConfigWidget.h:868
-#: build/OpenSCAD_autogen/include/ui_AxisConfigWidget.h:870
-#: build/OpenSCAD_autogen/include/ui_AxisConfigWidget.h:881
+#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:863
+#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:866
+#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:867
+#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:868
+#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:870
+#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:872
+#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:874
+#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:876
+#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:887
 msgid "DeadZone"
 msgstr "Dödzon"
 
-#: build/OpenSCAD_autogen/include/ui_AxisConfigWidget.h:858
+#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:864
 msgid "Auto Trim Axes"
 msgstr "Automatisk trim av axlar"
 
-#: build/OpenSCAD_autogen/include/ui_AxisConfigWidget.h:872
+#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:878
 msgid "Axis 2"
 msgstr "Axel 2"
 
-#: build/OpenSCAD_autogen/include/ui_AxisConfigWidget.h:873
+#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:879
 msgid "Axis 0"
 msgstr "Axel 0"
 
-#: build/OpenSCAD_autogen/include/ui_AxisConfigWidget.h:874
+#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:880
 msgid "Axis 3"
 msgstr "Axel 3"
 
-#: build/OpenSCAD_autogen/include/ui_AxisConfigWidget.h:875
+#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:881
 msgid "Axis 6"
 msgstr "Axel 6"
 
-#: build/OpenSCAD_autogen/include/ui_AxisConfigWidget.h:876
+#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:882
 msgid "Axis 8"
 msgstr "Axel 8"
 
-#: build/OpenSCAD_autogen/include/ui_AxisConfigWidget.h:877
+#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:883
 msgid "Axis 7"
 msgstr "Axel 7"
 
-#: build/OpenSCAD_autogen/include/ui_AxisConfigWidget.h:878
+#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:884
 msgid "Axis 5"
 msgstr "Axel 5"
 
-#: build/OpenSCAD_autogen/include/ui_AxisConfigWidget.h:879
+#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:885
 msgid "Axis 1"
 msgstr "Axel 1"
 
-#: build/OpenSCAD_autogen/include/ui_AxisConfigWidget.h:880
+#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:886
 msgid "Axis 4"
 msgstr "Axel 4"
 
-#: build/OpenSCAD_autogen/include/ui_AxisConfigWidget.h:883
+#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:889
+#: build/OpenSCADLibInternal_autogen/include/ui_ViewportControl.h:279
 msgid "Rotation"
 msgstr "Rotation"
 
-#: build/OpenSCAD_autogen/include/ui_AxisConfigWidget.h:884
+#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:890
 msgid "Zoom"
 msgstr "Zooma"
 
-#: build/OpenSCAD_autogen/include/ui_AxisConfigWidget.h:885
-msgid "X"
-msgstr "X"
-
-#: build/OpenSCAD_autogen/include/ui_AxisConfigWidget.h:886
+#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:891
 msgid "Gain"
 msgstr "Ökning"
 
-#: build/OpenSCAD_autogen/include/ui_AxisConfigWidget.h:887
-msgid "Y"
-msgstr "Y"
-
-#: build/OpenSCAD_autogen/include/ui_AxisConfigWidget.h:888
-msgid "Z"
-msgstr "Z"
-
-#: build/OpenSCAD_autogen/include/ui_AxisConfigWidget.h:889
+#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:892
+#: build/OpenSCADLibInternal_autogen/include/ui_ViewportControl.h:280
 msgid "Translation"
 msgstr "Översättning"
 
-#: build/OpenSCAD_autogen/include/ui_AxisConfigWidget.h:890
+#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:893
 msgid "ViewPort rel.<br/>Translation"
 msgstr "ViewPort rel.<br/>översättning"
 
-#: build/OpenSCAD_autogen/include/ui_AxisConfigWidget.h:891
-msgid "ViewPort rel.<br />Rotation"
-msgstr "ViewPort rel.<br />rotation"
+#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:894
+msgid "ViewPort rel.<br/>Rotation"
+msgstr "ViewPort rel.<br/>rotation"
 
-#: build/OpenSCAD_autogen/include/ui_AxisConfigWidget.h:892
+#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:895
 msgid "Axis Setup:"
 msgstr "Inställning av axel:"
 
-#: build/OpenSCAD_autogen/include/ui_AxisConfigWidget.h:893
+#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:896
 msgid "<b>Driver selection:</b> <i>(changes requires restarting OpenSCAD)</i>"
 msgstr "<b>Val av drivrutin:</b> <i>(ändringar kräver omstart av OpenSCAD)</i>"
 
-#: build/OpenSCAD_autogen/include/ui_AxisConfigWidget.h:894
-msgid "SpaceNav"
-msgstr "SpaceNav"
-
-#: build/OpenSCAD_autogen/include/ui_AxisConfigWidget.h:895
-msgid "HIDAPI"
-msgstr "HIDAPI"
-
-#: build/OpenSCAD_autogen/include/ui_AxisConfigWidget.h:896
-msgid "QGamepad"
-msgstr "QGamepad"
-
-#: build/OpenSCAD_autogen/include/ui_AxisConfigWidget.h:897
+#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:897
 msgid "Joystick"
 msgstr "Styrspak"
 
-#: build/OpenSCAD_autogen/include/ui_AxisConfigWidget.h:898
-msgid "DBus"
-msgstr "DBus"
-
-#: build/OpenSCAD_autogen/include/ui_AxisConfigWidget.h:899
+#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:898
 msgid "Axes Mapping:"
 msgstr "Axelmappning:"
 
-#: build/OpenSCAD_autogen/include/ui_AxisConfigWidget.h:900
+#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:899
 msgid "Status:"
 msgstr "Status:"
 
-#: build/OpenSCAD_autogen/include/ui_AxisConfigWidget.h:901
-msgid "TextLabel"
-msgstr "TextLabel"
-
-#: build/OpenSCAD_autogen/include/ui_AxisConfigWidget.h:902
-#: build/OpenSCAD_autogen/include/ui_Preferences.h:1843
+#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:900
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2468
 msgid "Update"
 msgstr "Uppdatera"
 
-#: build/OpenSCAD_autogen/include/ui_ButtonConfigWidget.h:363
+#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:362
 msgid "Button 19"
 msgstr "Knapp 19"
 
-#: build/OpenSCAD_autogen/include/ui_ButtonConfigWidget.h:364
+#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:363
 msgid "Button 5"
 msgstr "Knapp 5"
 
-#: build/OpenSCAD_autogen/include/ui_ButtonConfigWidget.h:365
+#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:364
 msgid "Button 14"
 msgstr "Knapp 14"
 
-#: build/OpenSCAD_autogen/include/ui_ButtonConfigWidget.h:366
+#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:365
 msgid "Button 7"
 msgstr "Knapp 7"
 
-#: build/OpenSCAD_autogen/include/ui_ButtonConfigWidget.h:367
+#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:366
 msgid "Button 16"
 msgstr "Knapp 16"
 
-#: build/OpenSCAD_autogen/include/ui_ButtonConfigWidget.h:368
+#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:367
 msgid "Button 20"
 msgstr "Knapp 20"
 
-#: build/OpenSCAD_autogen/include/ui_ButtonConfigWidget.h:369
+#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:368
 msgid "Button 1"
 msgstr "Knapp 1"
 
-#: build/OpenSCAD_autogen/include/ui_ButtonConfigWidget.h:370
+#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:369
 msgid "Button 21"
 msgstr "Knapp 21"
 
-#: build/OpenSCAD_autogen/include/ui_ButtonConfigWidget.h:371
+#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:370
 msgid "Button 18"
 msgstr "Knapp 18"
 
-#: build/OpenSCAD_autogen/include/ui_ButtonConfigWidget.h:372
+#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:371
 msgid "Button 0"
 msgstr "Knapp 0"
 
-#: build/OpenSCAD_autogen/include/ui_ButtonConfigWidget.h:373
+#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:372
 msgid "Button 4"
 msgstr "Knapp 4"
 
-#: build/OpenSCAD_autogen/include/ui_ButtonConfigWidget.h:374
+#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:373
 msgid "Button 10"
 msgstr "Knapp 10"
 
-#: build/OpenSCAD_autogen/include/ui_ButtonConfigWidget.h:375
+#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:374
 msgid "Button 6"
 msgstr "Knapp 6"
 
-#: build/OpenSCAD_autogen/include/ui_ButtonConfigWidget.h:376
+#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:375
 msgid "Button 8"
 msgstr "Knapp 8"
 
-#: build/OpenSCAD_autogen/include/ui_ButtonConfigWidget.h:377
+#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:376
 msgid "Button 15"
 msgstr "Knapp 15"
 
-#: build/OpenSCAD_autogen/include/ui_ButtonConfigWidget.h:378
+#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:377
 msgid "Button 11"
 msgstr "Knapp 11"
 
-#: build/OpenSCAD_autogen/include/ui_ButtonConfigWidget.h:379
+#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:378
 msgid "Button 3"
 msgstr "Knapp 3"
 
-#: build/OpenSCAD_autogen/include/ui_ButtonConfigWidget.h:380
+#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:379
 msgid "Button 23"
 msgstr "Knapp 23"
 
-#: build/OpenSCAD_autogen/include/ui_ButtonConfigWidget.h:381
+#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:380
 msgid "Button 9"
 msgstr "Knapp 9"
 
-#: build/OpenSCAD_autogen/include/ui_ButtonConfigWidget.h:382
+#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:381
 msgid "Button 2"
 msgstr "Knapp 2"
 
-#: build/OpenSCAD_autogen/include/ui_ButtonConfigWidget.h:383
+#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:382
 msgid "Button 13"
 msgstr "Knapp 13"
 
-#: build/OpenSCAD_autogen/include/ui_ButtonConfigWidget.h:384
+#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:383
 msgid "Button 12"
 msgstr "Knapp 12"
 
-#: build/OpenSCAD_autogen/include/ui_ButtonConfigWidget.h:385
+#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:384
 msgid "Button 17"
 msgstr "Knapp 17"
 
-#: build/OpenSCAD_autogen/include/ui_ButtonConfigWidget.h:386
+#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:385
 msgid "Button 22"
 msgstr "Knapp 22"
 
-#: build/OpenSCAD_autogen/include/ui_Console.h:42
+#: build/OpenSCADLibInternal_autogen/include/ui_ChatWidget.h:195
+msgid "AI Chat"
+msgstr ""
+
+#: build/OpenSCADLibInternal_autogen/include/ui_ChatWidget.h:196
+#: src/gui/ai/ChatWidget.cc:138
+msgid "AI Assistant"
+msgstr ""
+
+#: build/OpenSCADLibInternal_autogen/include/ui_ChatWidget.h:198
+msgid "Chat options"
+msgstr ""
+
+#: build/OpenSCADLibInternal_autogen/include/ui_ChatWidget.h:201
+#: src/gui/ai/ChatWidget.cc:140
+msgid "Clear chat history"
+msgstr ""
+
+#: build/OpenSCADLibInternal_autogen/include/ui_ChatWidget.h:203
+#: build/OpenSCADLibInternal_autogen/include/ui_Console.h:42
+#: src/gui/ai/ChatWidget.cc:139
 msgid "Clear"
 msgstr "Töm"
 
-#: build/OpenSCAD_autogen/include/ui_Console.h:44
+#: build/OpenSCADLibInternal_autogen/include/ui_ChatWidget.h:204
+#: src/gui/ai/ChatWidget.cc:141 src/gui/ai/ChatWidget.cc:630
+msgid "Send"
+msgstr ""
+
+#: build/OpenSCADLibInternal_autogen/include/ui_ChatWidget.h:206
+msgid "Grab active 3D viewport frame and camera metadata"
+msgstr ""
+
+#: build/OpenSCADLibInternal_autogen/include/ui_ChatWidget.h:208
+msgid "Analyze Screen"
+msgstr ""
+
+#: build/OpenSCADLibInternal_autogen/include/ui_ChatWidget.h:210
+msgid "Attach local image file"
+msgstr ""
+
+#: build/OpenSCADLibInternal_autogen/include/ui_ChatWidget.h:212
+#: src/gui/ai/ChatWidget.cc:508
+msgid "Attach Image"
+msgstr ""
+
+#: build/OpenSCADLibInternal_autogen/include/ui_ChatWidget.h:214
+msgid ""
+"Agentic mode: allow the AI to call tools in multiple automatic turns per "
+"request"
+msgstr ""
+
+#: build/OpenSCADLibInternal_autogen/include/ui_ChatWidget.h:216
+msgid "Agentic"
+msgstr ""
+
+#: build/OpenSCADLibInternal_autogen/include/ui_ColorList.h:399
+msgid "Color List"
+msgstr "Färglista"
+
+#: build/OpenSCADLibInternal_autogen/include/ui_ColorList.h:400
+#: build/OpenSCADLibInternal_autogen/include/ui_ColorList.h:402
+#: build/OpenSCADLibInternal_autogen/include/ui_ColorList.h:404
+#: build/OpenSCADLibInternal_autogen/include/ui_ColorList.h:406
+#: build/OpenSCADLibInternal_autogen/include/ui_FontList.h:292
+msgid "Reset Sample Text"
+msgstr ""
+
+#: build/OpenSCADLibInternal_autogen/include/ui_ColorList.h:408
+#: build/OpenSCADLibInternal_autogen/include/ui_ColorList.h:410
+#, fuzzy
+msgid "Copy Color Name"
+msgstr ""
+
+#: build/OpenSCADLibInternal_autogen/include/ui_ColorList.h:412
+#: build/OpenSCADLibInternal_autogen/include/ui_ColorList.h:414
+msgid "Copy Color RGB"
+msgstr ""
+
+#: build/OpenSCADLibInternal_autogen/include/ui_ColorList.h:416
+#: build/OpenSCADLibInternal_autogen/include/ui_FontList.h:305
+#, fuzzy
+msgid "Filter"
+msgstr "Filtrera"
+
+#: build/OpenSCADLibInternal_autogen/include/ui_ColorList.h:417
+#: build/OpenSCADLibInternal_autogen/include/ui_ColorList.h:446
+#, fuzzy
+msgid "Color name"
+msgstr ""
+
+#: build/OpenSCADLibInternal_autogen/include/ui_ColorList.h:418
+#: build/OpenSCADLibInternal_autogen/include/ui_FontList.h:309
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2522
+#: src/core/Settings.cc:161 src/core/Settings.cc:498
+msgid "Fixed"
+msgstr "Fast"
+
+#: build/OpenSCADLibInternal_autogen/include/ui_ColorList.h:419
+#: build/OpenSCADLibInternal_autogen/include/ui_FontList.h:310
+#: src/core/Settings.cc:499
+msgid "Wildcard"
+msgstr ""
+
+#: build/OpenSCADLibInternal_autogen/include/ui_ColorList.h:420
+#: build/OpenSCADLibInternal_autogen/include/ui_FontList.h:311
+#: src/core/Settings.cc:500
+msgid "RegExp"
+msgstr ""
+
+#: build/OpenSCADLibInternal_autogen/include/ui_ColorList.h:422
+msgid "Sort order"
+msgstr ""
+
+#: build/OpenSCADLibInternal_autogen/include/ui_ColorList.h:423
+msgid "Ascending"
+msgstr ""
+
+#: build/OpenSCADLibInternal_autogen/include/ui_ColorList.h:424
+msgid "Descending"
+msgstr ""
+
+#: build/OpenSCADLibInternal_autogen/include/ui_ColorList.h:425
+msgid "Alphabetically"
+msgstr ""
+
+#: build/OpenSCADLibInternal_autogen/include/ui_ColorList.h:426
+#: src/core/Settings.cc:510
+msgid "By color"
+msgstr ""
+
+#: build/OpenSCADLibInternal_autogen/include/ui_ColorList.h:427
+#: src/core/Settings.cc:511
+msgid "By color warmth"
+msgstr ""
+
+#: build/OpenSCADLibInternal_autogen/include/ui_ColorList.h:428
+#: src/core/Settings.cc:512
+msgid "By lightness"
+msgstr ""
+
+#: build/OpenSCADLibInternal_autogen/include/ui_ColorList.h:430
+#: build/OpenSCADLibInternal_autogen/include/ui_FontList.h:316
+msgid "Selection"
+msgstr ""
+
+#: build/OpenSCADLibInternal_autogen/include/ui_ColorList.h:433
+msgid "Reset background color"
+msgstr ""
+
+#: build/OpenSCADLibInternal_autogen/include/ui_ColorList.h:435
+#: build/OpenSCADLibInternal_autogen/include/ui_ColorList.h:439
+#: build/OpenSCADLibInternal_autogen/include/ui_ColorList.h:451
+#: build/OpenSCADLibInternal_autogen/include/ui_ColorList.h:455
+#: build/OpenSCADLibInternal_autogen/include/ui_Export3mfDialog.h:476
+#: build/OpenSCADLibInternal_autogen/include/ui_Export3mfDialog.h:477
+#: build/OpenSCADLibInternal_autogen/include/ui_Export3mfDialog.h:513
+#: build/OpenSCADLibInternal_autogen/include/ui_ExportPdfDialog.h:620
+#: build/OpenSCADLibInternal_autogen/include/ui_ExportPdfDialog.h:621
+#: build/OpenSCADLibInternal_autogen/include/ui_ExportPdfDialog.h:627
+#: build/OpenSCADLibInternal_autogen/include/ui_ExportPdfDialog.h:628
+#: build/OpenSCADLibInternal_autogen/include/ui_ExportPdfDialog.h:631
+#: build/OpenSCADLibInternal_autogen/include/ui_ExportSvgDialog.h:209
+#: build/OpenSCADLibInternal_autogen/include/ui_ExportSvgDialog.h:210
+#: build/OpenSCADLibInternal_autogen/include/ui_ExportSvgDialog.h:216
+#: build/OpenSCADLibInternal_autogen/include/ui_ExportSvgDialog.h:217
+#: build/OpenSCADLibInternal_autogen/include/ui_ExportSvgDialog.h:220
+#: build/OpenSCADLibInternal_autogen/include/ui_ParameterWidget.h:177
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2597
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2604
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2652
+msgid "..."
+msgstr ""
+
+#: build/OpenSCADLibInternal_autogen/include/ui_ColorList.h:437
+msgid "Select background color"
+msgstr ""
+
+#: build/OpenSCADLibInternal_autogen/include/ui_ColorList.h:440
+msgid "Color RGB"
+msgstr ""
+
+#: build/OpenSCADLibInternal_autogen/include/ui_ColorList.h:441
+msgid "As Foreground"
+msgstr ""
+
+#: build/OpenSCADLibInternal_autogen/include/ui_ColorList.h:442
+msgid "As Background"
+msgstr ""
+
+#: build/OpenSCADLibInternal_autogen/include/ui_ColorList.h:443
+#, fuzzy
+msgid "R:"
+msgstr ""
+
+#: build/OpenSCADLibInternal_autogen/include/ui_ColorList.h:444
+#, fuzzy
+msgid "G:"
+msgstr ""
+
+#: build/OpenSCADLibInternal_autogen/include/ui_ColorList.h:445
+#, fuzzy
+msgid "B:"
+msgstr ""
+
+#: build/OpenSCADLibInternal_autogen/include/ui_ColorList.h:449
+msgid "Reset foreground color"
+msgstr ""
+
+#: build/OpenSCADLibInternal_autogen/include/ui_ColorList.h:453
+msgid "Select foreground color"
+msgstr ""
+
+#: build/OpenSCADLibInternal_autogen/include/ui_Console.h:44
 msgid "Clear console"
 msgstr "Töm konsol"
 
-#: build/OpenSCAD_autogen/include/ui_Console.h:46
+#: build/OpenSCADLibInternal_autogen/include/ui_Console.h:46
 msgid "Save As..."
 msgstr "Spara som..."
 
-#: build/OpenSCAD_autogen/include/ui_Console.h:48
+#: build/OpenSCADLibInternal_autogen/include/ui_Console.h:48
 msgid "Save console content to file"
 msgstr "Spara konsolens innehåll i en fil"
 
-#: build/OpenSCAD_autogen/include/ui_ErrorLog.h:92
+#: build/OpenSCADLibInternal_autogen/include/ui_ErrorLog.h:92
 msgid "Error Log"
 msgstr "Fellogg"
 
-#: build/OpenSCAD_autogen/include/ui_ErrorLog.h:98
+#: build/OpenSCADLibInternal_autogen/include/ui_ErrorLog.h:93
+#: build/OpenSCADLibInternal_autogen/include/ui_ViewportControl.h:267
+#, fuzzy
+msgid "Row Selected"
+msgstr ""
+
+#: build/OpenSCADLibInternal_autogen/include/ui_ErrorLog.h:95
+#: build/OpenSCADLibInternal_autogen/include/ui_ViewportControl.h:269
+msgid "Return"
+msgstr "Tillbaka"
+
+#: build/OpenSCADLibInternal_autogen/include/ui_ErrorLog.h:98
 msgid "double click to jump to file and line"
 msgstr "dubbelklicka för att hoppa till fil och rad"
 
-#: build/OpenSCAD_autogen/include/ui_ErrorLog.h:100
+#: build/OpenSCADLibInternal_autogen/include/ui_ErrorLog.h:100
 msgid "&Show"
 msgstr "V&isa"
 
-#: build/OpenSCAD_autogen/include/ui_ErrorLog.h:101
-#: build/OpenSCAD_autogen/include/ui_MainWindow.h:1260
+#: build/OpenSCADLibInternal_autogen/include/ui_ErrorLog.h:101
+#: build/OpenSCADLibInternal_autogen/include/ui_FontList.h:306
+#: build/OpenSCADLibInternal_autogen/include/ui_MainWindow.h:1307
 msgid "All"
 msgstr "Alla"
 
-#: build/OpenSCAD_autogen/include/ui_ErrorLog.h:102
+#: build/OpenSCADLibInternal_autogen/include/ui_ErrorLog.h:102
 msgid "ERROR"
 msgstr "FEL"
 
-#: build/OpenSCAD_autogen/include/ui_ErrorLog.h:103
+#: build/OpenSCADLibInternal_autogen/include/ui_ErrorLog.h:103
 msgid "WARNING"
 msgstr "VARNING"
 
-#: build/OpenSCAD_autogen/include/ui_ErrorLog.h:104
+#: build/OpenSCADLibInternal_autogen/include/ui_ErrorLog.h:104
 msgid "UI-WARNING"
 msgstr "GRÄNSSNITTSVARNING"
 
-#: build/OpenSCAD_autogen/include/ui_ErrorLog.h:105
+#: build/OpenSCADLibInternal_autogen/include/ui_ErrorLog.h:105
 msgid "FONT-WARNING"
 msgstr "TYPSNITTSVARNING"
 
-#: build/OpenSCAD_autogen/include/ui_ErrorLog.h:106
+#: build/OpenSCADLibInternal_autogen/include/ui_ErrorLog.h:106
 msgid "EXPORT-WARNING"
 msgstr "EXPORTVARNING"
 
-#: build/OpenSCAD_autogen/include/ui_ErrorLog.h:107
+#: build/OpenSCADLibInternal_autogen/include/ui_ErrorLog.h:107
 msgid "EXPORT-ERROR"
 msgstr "EXPORTFEL"
 
-#: build/OpenSCAD_autogen/include/ui_ErrorLog.h:108
+#: build/OpenSCADLibInternal_autogen/include/ui_ErrorLog.h:108
 msgid "DEPRECATED"
 msgstr "FÖRÅLDRAD"
 
-#: build/OpenSCAD_autogen/include/ui_ExportPdfDialog.h:239
-msgid "Export PDF Options"
-msgstr "Alternativ för PDF-export"
+#: build/OpenSCADLibInternal_autogen/include/ui_Export3mfDialog.h:457
+msgid "Export 3MF Options"
+msgstr "Alternativ för 3MF-export"
 
-#: build/OpenSCAD_autogen/include/ui_ExportPdfDialog.h:240
-msgid "Page Layout"
-msgstr "Sidlayout"
-
-#: build/OpenSCAD_autogen/include/ui_ExportPdfDialog.h:242
-msgid ""
-"<html><head/><body><p>Set the PDF page (paper) size.  </p></body></html>"
+#: build/OpenSCADLibInternal_autogen/include/ui_Export3mfDialog.h:459
+msgid "Set the unit used in the exported file"
 msgstr ""
-"<html><head/><body><p>Ställ in PDF-sidans (papperets) storlek.  </p></body></"
-"html>"
 
-#: build/OpenSCAD_autogen/include/ui_ExportPdfDialog.h:244
-#: build/OpenSCAD_autogen/include/ui_Preferences.h:1923
-msgid "Size"
-msgstr "Storlek"
-
-#: build/OpenSCAD_autogen/include/ui_ExportPdfDialog.h:245
-msgid "A4 (210x297 mm)"
-msgstr "A4 (210x297 mm)"
-
-#: build/OpenSCAD_autogen/include/ui_ExportPdfDialog.h:246
-msgid "A3 (297x420 mm)"
-msgstr "A3 (297x420 mm)"
-
-#: build/OpenSCAD_autogen/include/ui_ExportPdfDialog.h:247
-msgid "Letter (8.5x11 in)"
-msgstr "Brev (8,5x11 tum)"
-
-#: build/OpenSCAD_autogen/include/ui_ExportPdfDialog.h:248
-msgid "Legal (8.5x14 in)"
-msgstr "Legal (8,5x14 tum)"
-
-#: build/OpenSCAD_autogen/include/ui_ExportPdfDialog.h:249
-msgid "Tabloid (11x17 in)"
-msgstr "Tabloidformat (11x17 tum)"
-
-#: build/OpenSCAD_autogen/include/ui_ExportPdfDialog.h:251
-msgid ""
-"<html><head/><body><p>Set the direction of the largest page dimension.</p></"
-"body></html>"
+#: build/OpenSCADLibInternal_autogen/include/ui_Export3mfDialog.h:461
+msgid "Unit"
 msgstr ""
-"<html><head/><body><p>Ställ in riktningen för den största siddimensionen.</"
-"p></body></html>"
 
-#: build/OpenSCAD_autogen/include/ui_ExportPdfDialog.h:253
-msgid "Orientation"
-msgstr "Orientering"
-
-#: build/OpenSCAD_autogen/include/ui_ExportPdfDialog.h:254
-msgid "Portrait (Vertical)"
-msgstr "Stående (vertikal)"
-
-#: build/OpenSCAD_autogen/include/ui_ExportPdfDialog.h:255
-msgid "Landscape (Horizontal)"
-msgstr "Liggande (horisontell)"
-
-#: build/OpenSCAD_autogen/include/ui_ExportPdfDialog.h:257
-msgid ""
-"<html><head/><body><p>Determine best orientation based on maximum geometry "
-"dimension.</p></body></html>"
+#: build/OpenSCADLibInternal_autogen/include/ui_Export3mfDialog.h:462
+#: src/core/Settings.cc:443
+msgid "Micron"
 msgstr ""
-"<html><head/><body><p>Bestäm bästa orientering baserat på maximal "
-"geometridimension.</p></body></html>"
 
-#: build/OpenSCAD_autogen/include/ui_ExportPdfDialog.h:259
-msgid "Auto"
-msgstr "Automatisk"
-
-#: build/OpenSCAD_autogen/include/ui_ExportPdfDialog.h:260
-msgid "Annotations"
-msgstr "Anteckningar"
-
-#: build/OpenSCAD_autogen/include/ui_ExportPdfDialog.h:262
-msgid ""
-"<html><head/><body><p>Include design filename on page.</p></body></html>"
+#: build/OpenSCADLibInternal_autogen/include/ui_Export3mfDialog.h:463
+msgid "Millimeter (default)"
 msgstr ""
-"<html><head/><body><p>Inkludera designens filnamn på sidan.</p></body></html>"
 
-#: build/OpenSCAD_autogen/include/ui_ExportPdfDialog.h:264
-msgid "Show Design Filename"
-msgstr "Visa designens filnamn"
-
-#: build/OpenSCAD_autogen/include/ui_ExportPdfDialog.h:266
-msgid ""
-"<html><head/><body><p>Include rulers on page to confirm 1:1 printing scale.</"
-"p></body></html>"
+#: build/OpenSCADLibInternal_autogen/include/ui_Export3mfDialog.h:464
+#: src/core/Settings.cc:445
+msgid "Centimeter"
 msgstr ""
-"<html><head/><body><p>Inkludera linjaler på sidan för att bekräfta "
-"tryckskalan 1:1.</p></body></html>"
 
-#: build/OpenSCAD_autogen/include/ui_ExportPdfDialog.h:268
-msgid "Show Scale"
-msgstr "Visa skala"
-
-#: build/OpenSCAD_autogen/include/ui_ExportPdfDialog.h:270
-msgid ""
-"<html><head/><body><p>Include text describing usage of scale.</p></body></"
-"html>"
+#: build/OpenSCADLibInternal_autogen/include/ui_Export3mfDialog.h:465
+#: src/core/Settings.cc:446
+msgid "Meter"
 msgstr ""
-"<html><head/><body><p>Inkludera text som beskriver användningen av skalan.</"
-"p></body></html>"
 
-#: build/OpenSCAD_autogen/include/ui_ExportPdfDialog.h:272
-msgid "Show Scale Usage"
-msgstr "Visa skalans användning"
-
-#: build/OpenSCAD_autogen/include/ui_ExportPdfDialog.h:274
-msgid ""
-"<html><head/><body><p>Include a grid of the selected size on the page.</p></"
-"body></html>"
+#: build/OpenSCADLibInternal_autogen/include/ui_Export3mfDialog.h:466
+#: src/core/Settings.cc:447
+msgid "Inch"
 msgstr ""
-"<html><head/><body><p>Inkludera ett rutnät av den valda storleken på sidan.</"
-"p></body></html>"
 
-#: build/OpenSCAD_autogen/include/ui_ExportPdfDialog.h:276
-msgid "Show Grid"
-msgstr "Visa rutnät"
-
-#: build/OpenSCAD_autogen/include/ui_ExportPdfDialog.h:277
-msgid "2mm"
-msgstr "2 mm"
-
-#: build/OpenSCAD_autogen/include/ui_ExportPdfDialog.h:278
-msgid "2.5mm"
-msgstr "2.5 mm"
-
-#: build/OpenSCAD_autogen/include/ui_ExportPdfDialog.h:279
-msgid "4mm"
-msgstr "4 mm"
-
-#: build/OpenSCAD_autogen/include/ui_ExportPdfDialog.h:280
-msgid "5mm"
-msgstr "5 mm"
-
-#: build/OpenSCAD_autogen/include/ui_ExportPdfDialog.h:281
-msgid "10mm"
-msgstr "10 mm"
-
-#: build/OpenSCAD_autogen/include/ui_FontListDialog.h:103
-msgid "OpenSCAD Font List"
-msgstr "OpenSCAD typsnittslista"
-
-#: build/OpenSCAD_autogen/include/ui_FontListDialog.h:104
-#: build/OpenSCAD_autogen/include/ui_LibraryInfoDialog.h:74
-#: build/OpenSCAD_autogen/include/ui_PrintInitDialog.h:110
-msgid "&OK"
-msgstr "&Ok"
-
-#: build/OpenSCAD_autogen/include/ui_FontListDialog.h:105
-msgid "Copy to Clipboard"
-msgstr "Kopiera till urklipp"
-
-#: build/OpenSCAD_autogen/include/ui_FontListDialog.h:106
-msgid "Filter:"
-msgstr "Filtrera:"
-
-#: build/OpenSCAD_autogen/include/ui_FontListDialog.h:107
-msgid ""
-"<html><head/><body><p>This list shows the fonts currently registered with "
-"OpenSCAD.</p><p>Example:</p><pre style=\" margin-top:12px; margin-"
-"bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-"
-"indent:0px;\"><span style=\" font-family:'Courier New,courier';\">  "
-"text(&quot;OpenSCAD&quot;, font = &quot;DejaVu Sans&quot;);</span></pre><pre "
-"style=\" margin-top:0px; margin-bottom:12px; margin-left:0px; margin-"
-"right:0px; -qt-block-indent:0; text-indent:0px;\"><span style=\" font-"
-"family:'Courier New,courier';\">  text(&quot;OpenSCAD&quot;, font = "
-"&quot;Liberation Sans:style=Italic&quot;);</span></pre></body></html>"
+#: build/OpenSCADLibInternal_autogen/include/ui_Export3mfDialog.h:467
+msgid "Foot"
 msgstr ""
-"<html><head/><body><p>Denna lista visar de teckensnitt som för närvarande är "
-"registrerade i OpenSCAD.</p><p>Exempel:</p><pre style=\" margin-top:12px; "
-"margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; "
-"text-indent:0px;\"><span style=\" font-family:'Courier New,courier';\">  "
-"text(&quot;OpenSCAD&quot;, font = &quot;DejaVu Sans&quot;);</span></pre><pre "
-"style=\" margin-top:0px; margin-bottom:12px; margin-left:0px; margin-"
-"right:0px; -qt-block-indent:0; text-indent:0px;\"><span style=\" font-"
-"family:'Courier New,courier';\">  text(&quot;OpenSCAD&quot;, font = "
-"&quot;Liberation Sans:style=Italic&quot;);</span></pre></body></html>"
 
-#: build/OpenSCAD_autogen/include/ui_LaunchingScreen.h:295
-msgid "Welcome to OpenSCAD"
-msgstr "Välkommen till OpenSCAD"
+#: build/OpenSCADLibInternal_autogen/include/ui_Export3mfDialog.h:471
+#, fuzzy
+msgid "Colors"
+msgstr "Färgschema:"
 
-#: build/OpenSCAD_autogen/include/ui_LaunchingScreen.h:296
-msgid "New"
-msgstr "Ny"
-
-#: build/OpenSCAD_autogen/include/ui_LaunchingScreen.h:297
-msgid "Open"
-msgstr "Öppna"
-
-#: build/OpenSCAD_autogen/include/ui_LaunchingScreen.h:298
-msgid "Help"
-msgstr "Hjälp"
-
-#: build/OpenSCAD_autogen/include/ui_LaunchingScreen.h:299
-msgid "Recents"
-msgstr "Tidigare"
-
-#: build/OpenSCAD_autogen/include/ui_LaunchingScreen.h:300
-msgid "Open Recent"
-msgstr "Öppna tidigare"
-
-#: build/OpenSCAD_autogen/include/ui_LaunchingScreen.h:301
-#: build/OpenSCAD_autogen/include/ui_LaunchingScreen.h:303
-msgid "Examples"
-msgstr "Exempel"
-
-#: build/OpenSCAD_autogen/include/ui_LaunchingScreen.h:304
-msgid "Open Example"
-msgstr "Öppna exempel"
-
-#: build/OpenSCAD_autogen/include/ui_LaunchingScreen.h:313
-msgid "Don't show again"
-msgstr "Visa inte igen"
-
-#: build/OpenSCAD_autogen/include/ui_LaunchingScreen.h:314
-msgid "Version"
-msgstr "Version"
-
-#: build/OpenSCAD_autogen/include/ui_LibraryInfoDialog.h:72
-msgid "Lib & Build Info"
-msgstr "Lib & Build-information"
-
-#: build/OpenSCAD_autogen/include/ui_LibraryInfoDialog.h:73
-msgid "OpenSCAD Detailed Library and Build Information"
-msgstr "OpenSCAD Detaljerad biblioteks- och bygginformation"
-
-#: build/OpenSCAD_autogen/include/ui_MainWindow.h:941
-msgid "&New File"
-msgstr "&Ny fil"
-
-#: build/OpenSCAD_autogen/include/ui_MainWindow.h:943
-msgid "Ctrl+N"
-msgstr "Ctrl+N"
-
-#: build/OpenSCAD_autogen/include/ui_MainWindow.h:945
-msgid "New Window"
-msgstr "Nytt fönster"
-
-#: build/OpenSCAD_autogen/include/ui_MainWindow.h:946
-msgid "&Open File"
-msgstr "Ö&ppna fil"
-
-#: build/OpenSCAD_autogen/include/ui_MainWindow.h:948
-msgid "Ctrl+O"
-msgstr "Ctrl+O"
-
-#: build/OpenSCAD_autogen/include/ui_MainWindow.h:950
-msgid "Open in New Window"
-msgstr "Öppna i nytt fönster"
-
-#: build/OpenSCAD_autogen/include/ui_MainWindow.h:951
-msgid "&Save"
-msgstr "&Spara"
-
-#: build/OpenSCAD_autogen/include/ui_MainWindow.h:953
-msgid "Ctrl+S"
-msgstr "Ctrl+S"
-
-#: build/OpenSCAD_autogen/include/ui_MainWindow.h:955
-msgid "Save &As..."
-msgstr "Spara s&om…"
-
-#: build/OpenSCAD_autogen/include/ui_MainWindow.h:957
-msgid "Ctrl+Shift+S"
-msgstr "Ctrl+Shift+S"
-
-#: build/OpenSCAD_autogen/include/ui_MainWindow.h:959 src/gui/TabManager.cc:729
-msgid "Save a Copy"
-msgstr "Spara en kopia"
-
-#: build/OpenSCAD_autogen/include/ui_MainWindow.h:960
-msgid "Save All"
-msgstr "Spara alla"
-
-#: build/OpenSCAD_autogen/include/ui_MainWindow.h:961
-msgid "&Reload"
-msgstr "Uppdat&era"
-
-#: build/OpenSCAD_autogen/include/ui_MainWindow.h:963
-msgid "Ctrl+R"
-msgstr "Ctrl+R"
-
-#: build/OpenSCAD_autogen/include/ui_MainWindow.h:965
-msgid "&Quit"
-msgstr "A&vsluta"
-
-#: build/OpenSCAD_autogen/include/ui_MainWindow.h:967
-msgid "Ctrl+Q"
-msgstr "Ctrl+Q"
-
-#: build/OpenSCAD_autogen/include/ui_MainWindow.h:969
-msgid "&Undo"
-msgstr "Å&ngra"
-
-#: build/OpenSCAD_autogen/include/ui_MainWindow.h:971
-msgid "Ctrl+Z"
-msgstr "Ctrl+Z"
-
-#: build/OpenSCAD_autogen/include/ui_MainWindow.h:973
-msgid "&Redo"
-msgstr "&Gör om"
-
-#: build/OpenSCAD_autogen/include/ui_MainWindow.h:975
-msgid "Ctrl+Shift+Z"
-msgstr "Ctrl+Shift+Z"
-
-#: build/OpenSCAD_autogen/include/ui_MainWindow.h:978
-msgid "Ctrl+Y"
-msgstr "Ctrl+Y"
-
-#: build/OpenSCAD_autogen/include/ui_MainWindow.h:980
-msgid "Cu&t"
-msgstr "Klipp &ut"
-
-#: build/OpenSCAD_autogen/include/ui_MainWindow.h:982
-msgid "Ctrl+X"
-msgstr "Ctrl+X"
-
-#: build/OpenSCAD_autogen/include/ui_MainWindow.h:984
-msgid "&Copy"
-msgstr "&Kopiera"
-
-#: build/OpenSCAD_autogen/include/ui_MainWindow.h:986
-msgid "Ctrl+C"
-msgstr "Ctrl+C"
-
-#: build/OpenSCAD_autogen/include/ui_MainWindow.h:988
-msgid "&Paste"
-msgstr "Klistra &in"
-
-#: build/OpenSCAD_autogen/include/ui_MainWindow.h:990
-msgid "Ctrl+V"
-msgstr "Ctrl+V"
-
-#: build/OpenSCAD_autogen/include/ui_MainWindow.h:992
-msgid "&Indent"
-msgstr "&Indrag"
-
-#: build/OpenSCAD_autogen/include/ui_MainWindow.h:994
-msgid "Ctrl+I"
-msgstr "Ctrl+I"
-
-#: build/OpenSCAD_autogen/include/ui_MainWindow.h:996
-msgid "C&omment"
-msgstr "K&ommentar"
-
-#: build/OpenSCAD_autogen/include/ui_MainWindow.h:998
-msgid "Ctrl+D"
-msgstr "Ctrl+D"
-
-#: build/OpenSCAD_autogen/include/ui_MainWindow.h:1000
-msgid "Unco&mment"
-msgstr "Ta bort kommenta&r"
-
-#: build/OpenSCAD_autogen/include/ui_MainWindow.h:1002
-msgid "Ctrl+Shift+D"
-msgstr "Ctrl+Shift+D"
-
-#: build/OpenSCAD_autogen/include/ui_MainWindow.h:1004
-msgid "Show Next Tab"
-msgstr "Visa nästa flik"
-
-#: build/OpenSCAD_autogen/include/ui_MainWindow.h:1006
-msgid "Ctrl+Tab"
-msgstr "Ctrl+Tab"
-
-#: build/OpenSCAD_autogen/include/ui_MainWindow.h:1008
-msgid "Show Previous Tab"
-msgstr "Visa föregående flik"
-
-#: build/OpenSCAD_autogen/include/ui_MainWindow.h:1010
-msgid "Ctrl+Shift+Tab"
-msgstr "Ctrl+Shift+Tab"
-
-#: build/OpenSCAD_autogen/include/ui_MainWindow.h:1012
-msgid "Copy viewport ima&ge"
-msgstr "Kopiera vyfältets &bild"
-
-#: build/OpenSCAD_autogen/include/ui_MainWindow.h:1014
-msgid "Ctrl+Shift+C"
-msgstr "Ctrl+Shift+C"
-
-#: build/OpenSCAD_autogen/include/ui_MainWindow.h:1016
-msgid "Copy viewport transl&ation"
-msgstr "Kopiera vyfältets översättnin&g"
-
-#: build/OpenSCAD_autogen/include/ui_MainWindow.h:1018
-msgid "Ctrl+T"
-msgstr "Ctrl+T"
-
-#: build/OpenSCAD_autogen/include/ui_MainWindow.h:1020
-msgid "Cop&y viewport rotation"
-msgstr "Kopiera vyfältets r&otation"
-
-#: build/OpenSCAD_autogen/include/ui_MainWindow.h:1021
-msgid "Copy vie&wport distance"
-msgstr "Kopiera vy&fältets avstånd"
-
-#: build/OpenSCAD_autogen/include/ui_MainWindow.h:1022
-msgid "Copy vie&wport fov"
-msgstr "Kopiera vyfältets s&ynfält"
-
-#: build/OpenSCAD_autogen/include/ui_MainWindow.h:1023
-msgid "Increase Font &Size"
-msgstr "Öka typsnittets s&torlek"
-
-#: build/OpenSCAD_autogen/include/ui_MainWindow.h:1025
-msgid "Ctrl++"
-msgstr "Ctrl + +"
-
-#: build/OpenSCAD_autogen/include/ui_MainWindow.h:1027
-msgid "Decrease Font Si&ze"
-msgstr "Minska typsnittets stor&lek"
-
-#: build/OpenSCAD_autogen/include/ui_MainWindow.h:1029
-msgid "Ctrl+-"
-msgstr "Ctrl+-"
-
-#: build/OpenSCAD_autogen/include/ui_MainWindow.h:1031
-msgid "Hide Editor"
-msgstr "Dölj redigerare"
-
-#: build/OpenSCAD_autogen/include/ui_MainWindow.h:1032
-msgid "&Reload and Preview"
-msgstr "&Uppdatera och förhandsvisa"
-
-#: build/OpenSCAD_autogen/include/ui_MainWindow.h:1034
-msgid "F4"
-msgstr "F4"
-
-#: build/OpenSCAD_autogen/include/ui_MainWindow.h:1036
-msgid "&Preview"
-msgstr "&Förhandsvisning"
-
-#: build/OpenSCAD_autogen/include/ui_MainWindow.h:1038
-msgid "F5"
-msgstr "F5"
-
-#: build/OpenSCAD_autogen/include/ui_MainWindow.h:1040
-msgid "R&ender"
-msgstr "R&endera"
-
-#: build/OpenSCAD_autogen/include/ui_MainWindow.h:1042
-msgid "F6"
-msgstr "F6"
-
-#: build/OpenSCAD_autogen/include/ui_MainWindow.h:1044
-msgid "&3D Print"
-msgstr "&3D-utskrift"
-
-#: build/OpenSCAD_autogen/include/ui_MainWindow.h:1046
-msgid "F8"
-msgstr "F8"
-
-#: build/OpenSCAD_autogen/include/ui_MainWindow.h:1048
-msgid "Measure &Distance"
-msgstr "Mät &avstånd"
-
-#: build/OpenSCAD_autogen/include/ui_MainWindow.h:1050
-msgid "d"
-msgstr "d"
-
-#: build/OpenSCAD_autogen/include/ui_MainWindow.h:1052
-msgid "Measure &Angle"
-msgstr "Mät &vinkel"
-
-#: build/OpenSCAD_autogen/include/ui_MainWindow.h:1054
-msgid "a"
-msgstr "en"
-
-#: build/OpenSCAD_autogen/include/ui_MainWindow.h:1056
-msgid "&Check Validity"
-msgstr "&Kontrollera giltighet"
-
-#: build/OpenSCAD_autogen/include/ui_MainWindow.h:1057
-msgid "Display A&ST..."
-msgstr "Visa A&ST..."
-
-#: build/OpenSCAD_autogen/include/ui_MainWindow.h:1058
-msgid "Display CSG &Tree..."
-msgstr "Visa CSG-&träd..."
-
-#: build/OpenSCAD_autogen/include/ui_MainWindow.h:1059
-msgid "Display CSG Pr&oducts..."
-msgstr "Visa CSG-pr&odukter..."
-
-#: build/OpenSCAD_autogen/include/ui_MainWindow.h:1060
-msgid "Export as &STL..."
-msgstr "Exportera som &STL..."
-
-#: build/OpenSCAD_autogen/include/ui_MainWindow.h:1062
-msgid "F7"
-msgstr "F7"
-
-#: build/OpenSCAD_autogen/include/ui_MainWindow.h:1064
-msgid "Export as &OBJ..."
-msgstr "Exportera som &OBJ..."
-
-#: build/OpenSCAD_autogen/include/ui_MainWindow.h:1065
-msgid "Export as &OFF..."
-msgstr "Exportera som O&FF..."
-
-#: build/OpenSCAD_autogen/include/ui_MainWindow.h:1066
-msgid "Export as &WRL..."
-msgstr "Exportera som &WRL..."
-
-#: build/OpenSCAD_autogen/include/ui_MainWindow.h:1067
-msgid "Preview"
-msgstr "Förhandsvisa"
-
-#: build/OpenSCAD_autogen/include/ui_MainWindow.h:1069
-msgid "F9"
-msgstr "F9"
-
-#: build/OpenSCAD_autogen/include/ui_MainWindow.h:1071
-msgid "Surfaces"
-msgstr "Ytor"
-
-#: build/OpenSCAD_autogen/include/ui_MainWindow.h:1073
-msgid "F10"
-msgstr "F10"
-
-#: build/OpenSCAD_autogen/include/ui_MainWindow.h:1077
-msgid "F11"
-msgstr "F11"
-
-#: build/OpenSCAD_autogen/include/ui_MainWindow.h:1079
-msgid "Thrown Together"
-msgstr "Kastade tillsammans"
-
-#: build/OpenSCAD_autogen/include/ui_MainWindow.h:1081
-msgid "F12"
-msgstr "F12"
-
-#: build/OpenSCAD_autogen/include/ui_MainWindow.h:1083
-msgid "Show Edges"
-msgstr "Visa kanter"
-
-#: build/OpenSCAD_autogen/include/ui_MainWindow.h:1085
-msgid "Ctrl+1"
-msgstr "Ctrl+1"
-
-#: build/OpenSCAD_autogen/include/ui_MainWindow.h:1087
-msgid "Show Axes"
-msgstr "Visa axlar"
-
-#: build/OpenSCAD_autogen/include/ui_MainWindow.h:1089
-msgid "Ctrl+2"
-msgstr "Ctrl+2"
-
-#: build/OpenSCAD_autogen/include/ui_MainWindow.h:1091
-msgid "Show Crosshairs"
-msgstr "Visa hårkors"
-
-#: build/OpenSCAD_autogen/include/ui_MainWindow.h:1093
-msgid "Ctrl+3"
-msgstr "Ctrl+3"
-
-#: build/OpenSCAD_autogen/include/ui_MainWindow.h:1095
-msgid "Show Scale Markers"
-msgstr "Visa skalmarkeringar"
-
-#: build/OpenSCAD_autogen/include/ui_MainWindow.h:1096
-msgid "&Top"
-msgstr "&Topp"
-
-#: build/OpenSCAD_autogen/include/ui_MainWindow.h:1098
-msgid "Ctrl+4"
-msgstr "Ctrl+4"
-
-#: build/OpenSCAD_autogen/include/ui_MainWindow.h:1100
-msgid "&Bottom"
-msgstr "&Botten"
-
-#: build/OpenSCAD_autogen/include/ui_MainWindow.h:1102
-msgid "Ctrl+5"
-msgstr "Ctrl+5"
-
-#: build/OpenSCAD_autogen/include/ui_MainWindow.h:1104
-msgid "&Left"
-msgstr "&Vänster"
-
-#: build/OpenSCAD_autogen/include/ui_MainWindow.h:1106
-msgid "Ctrl+6"
-msgstr "Ctrl+6"
-
-#: build/OpenSCAD_autogen/include/ui_MainWindow.h:1108
-msgid "&Right"
-msgstr "&Höger"
-
-#: build/OpenSCAD_autogen/include/ui_MainWindow.h:1110
-msgid "Ctrl+7"
-msgstr "Ctrl+7"
-
-#: build/OpenSCAD_autogen/include/ui_MainWindow.h:1112
-msgid "&Front"
-msgstr "&Fram"
-
-#: build/OpenSCAD_autogen/include/ui_MainWindow.h:1114
-msgid "Ctrl+8"
-msgstr "Ctrl+8"
-
-#: build/OpenSCAD_autogen/include/ui_MainWindow.h:1116
-msgid "Bac&k"
-msgstr "&Bak"
-
-#: build/OpenSCAD_autogen/include/ui_MainWindow.h:1118
-msgid "Ctrl+9"
-msgstr "Ctrl+9"
-
-#: build/OpenSCAD_autogen/include/ui_MainWindow.h:1120
-msgid "&Diagonal"
-msgstr "&Diagonal"
-
-#: build/OpenSCAD_autogen/include/ui_MainWindow.h:1122
-msgid "Ctrl+0"
-msgstr "Ctrl+0"
-
-#: build/OpenSCAD_autogen/include/ui_MainWindow.h:1124
-msgid "Ce&nter"
-msgstr "Ce&nter"
-
-#: build/OpenSCAD_autogen/include/ui_MainWindow.h:1126
-msgid "Ctrl+Shift+0"
-msgstr "Ctrl+Shift+0"
-
-#: build/OpenSCAD_autogen/include/ui_MainWindow.h:1128
-msgid "&Perspective"
-msgstr "&Perspektiv"
-
-#: build/OpenSCAD_autogen/include/ui_MainWindow.h:1129
-msgid "&Orthogonal"
-msgstr "&Ortogonal"
-
-#: build/OpenSCAD_autogen/include/ui_MainWindow.h:1130
-msgid "Hide Console"
-msgstr "Dölj konsol"
-
-#: build/OpenSCAD_autogen/include/ui_MainWindow.h:1131
-msgid "&About"
-msgstr "&Om"
-
-#: build/OpenSCAD_autogen/include/ui_MainWindow.h:1132
-msgid "&Documentation"
-msgstr "&Dokumentation"
-
-#: build/OpenSCAD_autogen/include/ui_MainWindow.h:1133
-msgid "&Offline Documentation"
-msgstr "&Offline-dokumentation"
-
-#: build/OpenSCAD_autogen/include/ui_MainWindow.h:1134
-msgid "&Offline Cheat Sheet"
-msgstr "&Offline-fusklapp"
-
-#: build/OpenSCAD_autogen/include/ui_MainWindow.h:1135
-msgid "Clear Recent"
-msgstr "Töm tidigare"
-
-#: build/OpenSCAD_autogen/include/ui_MainWindow.h:1136
-msgid "Export as &DXF..."
-msgstr "Exportera som &DXF..."
-
-#: build/OpenSCAD_autogen/include/ui_MainWindow.h:1137
-msgid "Revoke trusted python Files"
-msgstr "Återkalla betrodda python-filer"
-
-#: build/OpenSCAD_autogen/include/ui_MainWindow.h:1138
-msgid "&Close"
-msgstr "S&täng"
-
-#: build/OpenSCAD_autogen/include/ui_MainWindow.h:1140
-msgid "Ctrl+W"
-msgstr "Ctrl+W"
-
-#: build/OpenSCAD_autogen/include/ui_MainWindow.h:1142
-msgid "&Preferences"
-msgstr "&Inställningar"
-
-#: build/OpenSCAD_autogen/include/ui_MainWindow.h:1143
-msgid "&Find..."
-msgstr "&Sök..."
-
-#: build/OpenSCAD_autogen/include/ui_MainWindow.h:1145
-msgid "Ctrl+F"
-msgstr "Ctrl+F"
-
-#: build/OpenSCAD_autogen/include/ui_MainWindow.h:1147
-msgid "Fin&d and Replace..."
-msgstr "Sök och &ersätt..."
-
-#: build/OpenSCAD_autogen/include/ui_MainWindow.h:1149
-msgid "Ctrl+Alt+F"
-msgstr "Ctrl+Alt+F"
-
-#: build/OpenSCAD_autogen/include/ui_MainWindow.h:1151
-msgid "Find Ne&xt"
-msgstr "Hitta &nästa"
-
-#: build/OpenSCAD_autogen/include/ui_MainWindow.h:1153
-msgid "Ctrl+G"
-msgstr "Ctrl+G"
-
-#: build/OpenSCAD_autogen/include/ui_MainWindow.h:1155
-msgid "Find Pre&vious"
-msgstr "Hitta &föregående"
-
-#: build/OpenSCAD_autogen/include/ui_MainWindow.h:1157
-msgid "Ctrl+Shift+G"
-msgstr "Ctrl+Shift+G"
-
-#: build/OpenSCAD_autogen/include/ui_MainWindow.h:1159
-msgid "Use Se&lection for Find"
-msgstr "Använd ma&rkering för att söka"
-
-#: build/OpenSCAD_autogen/include/ui_MainWindow.h:1161
-msgid "Ctrl+E"
-msgstr "Ctrl+E"
-
-#: build/OpenSCAD_autogen/include/ui_MainWindow.h:1163
-msgid "Jump to next error"
-msgstr "Hoppa till nästa fel"
-
-#: build/OpenSCAD_autogen/include/ui_MainWindow.h:1165
-msgid "Ctrl+Alt+E"
-msgstr "Ctrl+Alt+E"
-
-#: build/OpenSCAD_autogen/include/ui_MainWindow.h:1167
-msgid "&Flush Caches"
-msgstr "&Töm cache"
-
-#: build/OpenSCAD_autogen/include/ui_MainWindow.h:1168
-msgid "&OpenSCAD Homepage"
-msgstr "Webbsidan för &OpenSCAD"
-
-#: build/OpenSCAD_autogen/include/ui_MainWindow.h:1169
-msgid "&Automatic Reload and Preview"
-msgstr "&Automatisk uppdatering och förhandsvisning"
-
-#: build/OpenSCAD_autogen/include/ui_MainWindow.h:1170
-msgid "Export as &Image..."
-msgstr "Exportera som &bild..."
-
-#: build/OpenSCAD_autogen/include/ui_MainWindow.h:1171
-msgid "Export as &CSG..."
-msgstr "Exportera som &CSG..."
-
-#: build/OpenSCAD_autogen/include/ui_MainWindow.h:1172
-msgid "&Library info"
-msgstr "&Biblioteksinfo"
-
-#: build/OpenSCAD_autogen/include/ui_MainWindow.h:1173
-msgid "Show &Library Folder..."
-msgstr "Visa &biblioteksmapp..."
-
-#: build/OpenSCAD_autogen/include/ui_MainWindow.h:1174
-msgid "Reset View"
-msgstr "Återställ vy"
-
-#: build/OpenSCAD_autogen/include/ui_MainWindow.h:1175
-msgid "&Font List"
-msgstr "&Typsnittslista"
-
-#: build/OpenSCAD_autogen/include/ui_MainWindow.h:1176
-msgid "Export as S&VG..."
-msgstr "Exportera som S&VG..."
-
-
-#: build/OpenSCAD_autogen/include/ui_MainWindow.h:1178
-msgid "Export as &3MF..."
-msgstr "Exportera som &3MF..."
-
-#: build/OpenSCAD_autogen/include/ui_MainWindow.h:1179
-msgid "Zoom In"
-msgstr "Zooma in"
-
-#: build/OpenSCAD_autogen/include/ui_MainWindow.h:1181
-msgid "Ctrl+]"
-msgstr "Ctrl+]"
-
-#: build/OpenSCAD_autogen/include/ui_MainWindow.h:1183
-msgid "Zoom Out"
-msgstr "Zooma ut"
-
-#: build/OpenSCAD_autogen/include/ui_MainWindow.h:1185
-msgid "Ctrl+["
-msgstr "Ctrl+["
-
-#: build/OpenSCAD_autogen/include/ui_MainWindow.h:1187
-msgid "View All"
-msgstr "Visa alla"
-
-#: build/OpenSCAD_autogen/include/ui_MainWindow.h:1189
-msgid "Ctrl+Shift+V"
-msgstr "Ctrl+Shift+V"
-
-#: build/OpenSCAD_autogen/include/ui_MainWindow.h:1191
-msgid "Conv&ert Tabs to Spaces"
-msgstr "Konvertera &tabbar till blanksteg"
-
-#: build/OpenSCAD_autogen/include/ui_MainWindow.h:1192
-msgid "Toggle Bookmark"
-msgstr "Växla bokmärke"
-
-#: build/OpenSCAD_autogen/include/ui_MainWindow.h:1194
-msgid "Ctrl+F2"
-msgstr "Ctrl+F2"
-
-#: build/OpenSCAD_autogen/include/ui_MainWindow.h:1196
-msgid "Jump to next bookmark"
-msgstr "Hoppa till nästa bokmärke"
-
-#: build/OpenSCAD_autogen/include/ui_MainWindow.h:1198
-msgid "F2"
-msgstr "F2"
-
-#: build/OpenSCAD_autogen/include/ui_MainWindow.h:1200
-msgid "Jump to previous bookmark"
-msgstr "Hoppa till föregående bokmärke"
-
-#: build/OpenSCAD_autogen/include/ui_MainWindow.h:1202
-msgid "Shift+F2"
-msgstr "Skift+F2"
-
-#: build/OpenSCAD_autogen/include/ui_MainWindow.h:1204
-msgid "Hide Editor toolbar"
-msgstr "Dölj redigeringsverktygsfält"
-
-#: build/OpenSCAD_autogen/include/ui_MainWindow.h:1205
-msgid "U&nindent"
-msgstr "Återställ indra&g"
-
-#: build/OpenSCAD_autogen/include/ui_MainWindow.h:1207
-msgid "Ctrl+Shift+I"
-msgstr "Ctrl+Shift+I"
-
-#: build/OpenSCAD_autogen/include/ui_MainWindow.h:1209
-msgid "&Cheat Sheet"
-msgstr "&Fusklapp"
-
-#: build/OpenSCAD_autogen/include/ui_MainWindow.h:1210
-msgid "Hide Customizer"
-msgstr "Dölj anpassare"
-
-#: build/OpenSCAD_autogen/include/ui_MainWindow.h:1211
-msgid "Export as PDF..."
-msgstr "Exportera som PDF..."
-
-#: build/OpenSCAD_autogen/include/ui_MainWindow.h:1212
-msgid "Hide 3D View toolbar"
-msgstr "Dölj verktygsfältets 3D-vy"
-
-#: build/OpenSCAD_autogen/include/ui_MainWindow.h:1213
-msgid "Hide Error Log"
-msgstr "Dölj fellogg"
-
-#: build/OpenSCAD_autogen/include/ui_MainWindow.h:1215
-msgid "Hide ErrorLog"
-msgstr "Dölj fellogg"
-
-#: build/OpenSCAD_autogen/include/ui_MainWindow.h:1217
-#: build/OpenSCAD_autogen/include/ui_MainWindow.h:1219
-msgid "Hide Animation Toolbar/Window"
-msgstr "Dölj verktygsfält/fönster för animation"
-
-#: build/OpenSCAD_autogen/include/ui_MainWindow.h:1221
-#: build/OpenSCAD_autogen/include/ui_MainWindow.h:1223
-msgid "Hide Viewport-Control"
-msgstr "Dölj vyfältskontroll"
-
-#: build/OpenSCAD_autogen/include/ui_MainWindow.h:1225
-msgid "&Editor"
-msgstr "R&edigerare"
-
-#: build/OpenSCAD_autogen/include/ui_MainWindow.h:1226
-msgid "&Console"
-msgstr "&Konsol"
-
-#: build/OpenSCAD_autogen/include/ui_MainWindow.h:1227
-msgid "C&ustomizer"
-msgstr "A&npassare"
-
-#: build/OpenSCAD_autogen/include/ui_MainWindow.h:1228
-msgid "Error &Log"
-msgstr "Fel&logg"
-
-#: build/OpenSCAD_autogen/include/ui_MainWindow.h:1229
-msgid "&Animate"
-msgstr "&Animera"
-
-#: build/OpenSCAD_autogen/include/ui_MainWindow.h:1230
-#: src/gui/MainWindow.cc:3183
-msgid "Viewport-Control"
-msgstr "Vyfältskontroll"
-
-#: build/OpenSCAD_autogen/include/ui_MainWindow.h:1231
-msgid "&Next Window"
-msgstr "&Nästa fönster"
-
-#: build/OpenSCAD_autogen/include/ui_MainWindow.h:1232
-msgid "&Previous Window"
-msgstr "&Föregående fönster"
-
-#: build/OpenSCAD_autogen/include/ui_MainWindow.h:1233
-msgid "Insert Template"
-msgstr "Infoga mall"
-
-#: build/OpenSCAD_autogen/include/ui_MainWindow.h:1235
-msgid "Alt+Ins"
-msgstr "Alt+Inn"
-
-#: build/OpenSCAD_autogen/include/ui_MainWindow.h:1237
-msgid "Fold/Unfoll All"
-msgstr "Vik/vik inte alla"
-
-#: build/OpenSCAD_autogen/include/ui_MainWindow.h:1238
-msgid "Message"
-msgstr "Meddelande"
-
-#: build/OpenSCAD_autogen/include/ui_MainWindow.h:1241
-msgid "&File"
-msgstr "&Arkiv"
-
-#: build/OpenSCAD_autogen/include/ui_MainWindow.h:1242
-msgid "Recen&t Files"
-msgstr "&Tidigare filer"
-
-#: build/OpenSCAD_autogen/include/ui_MainWindow.h:1243
-msgid "&Examples"
-msgstr "&Exempel"
-
-#: build/OpenSCAD_autogen/include/ui_MainWindow.h:1244
-msgid "E&xport"
-msgstr "E&xportera"
-
-#: build/OpenSCAD_autogen/include/ui_MainWindow.h:1245
-msgid "&Edit"
-msgstr "R&edigera"
-
-#: build/OpenSCAD_autogen/include/ui_MainWindow.h:1246
-msgid "&Design"
-msgstr "&Design"
-
-#: build/OpenSCAD_autogen/include/ui_MainWindow.h:1247
-msgid "&View"
-msgstr "&Visa"
-
-#: build/OpenSCAD_autogen/include/ui_MainWindow.h:1248
-msgid "&Help"
-msgstr "&Hjälp"
-
-#: build/OpenSCAD_autogen/include/ui_MainWindow.h:1249
-msgid "&Window"
-msgstr "&Fönster"
-
-#: build/OpenSCAD_autogen/include/ui_MainWindow.h:1250
-#: build/OpenSCAD_autogen/include/ui_Preferences.h:1910 src/gui/Settings.cc:109
-msgid "Tabs"
-msgstr "Flikar"
-
-#: build/OpenSCAD_autogen/include/ui_MainWindow.h:1251
-msgid "Find"
-msgstr "Sök"
-
-#: build/OpenSCAD_autogen/include/ui_MainWindow.h:1252
-#: build/OpenSCAD_autogen/include/ui_MainWindow.h:1259
-msgid "Replace"
-msgstr "Ersätt"
-
-#: build/OpenSCAD_autogen/include/ui_MainWindow.h:1254
-msgid "Search string"
-msgstr "Söksträng"
-
-#: build/OpenSCAD_autogen/include/ui_MainWindow.h:1255
-msgid "Previous"
-msgstr "Föregående"
-
-#: build/OpenSCAD_autogen/include/ui_MainWindow.h:1256
-msgid "Next"
-msgstr "Nästa"
-
-#: build/OpenSCAD_autogen/include/ui_MainWindow.h:1257
-msgid "Done"
-msgstr "Färdig"
-
-#: build/OpenSCAD_autogen/include/ui_MainWindow.h:1258
-msgid "Replacement string"
-msgstr "Ersättningssträng"
-
-#: build/OpenSCAD_autogen/include/ui_MainWindow.h:1261
-msgid "Customizer Widget"
-msgstr "Anpassningswidget"
-
-#: build/OpenSCAD_autogen/include/ui_OpenCSGWarningDialog.h:76
-msgid "OpenGL Warning"
-msgstr "OpenGL-varning"
-
-#: build/OpenSCAD_autogen/include/ui_OpenCSGWarningDialog.h:77
-msgid ""
-"<!DOCTYPE HTML PUBLIC \"-//W3C//DTD HTML 4.0//EN\" \"http://www.w3.org/TR/"
-"REC-html40/strict.dtd\">\n"
-"<html><head><meta name=\"qrichtext\" content=\"1\" /><style type=\"text/"
-"css\">\n"
-"p, li { white-space: pre-wrap; }\n"
-"</style></head><body style=\" font-family:'Lucida Grande'; font-size:13pt; "
-"font-weight:400; font-style:normal;\">\n"
-"<p style=\"-qt-paragraph-type:empty; margin-top:0px; margin-bottom:0px; "
-"margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;\"></"
-"p></body></html>"
+#: build/OpenSCADLibInternal_autogen/include/ui_Export3mfDialog.h:472
+msgid "Use colors from model and color scheme"
 msgstr ""
-"<!DOCTYPE HTML PUBLIC \"-//W3C//DTD HTML 4.0//EN\" \"http://www.w3.org/TR/"
-"REC-html40/strict.dtd\">\n"
-"<html><head><meta name=\"qrichtext\" content=\"1\" /><style type=\"text/"
-"css\">\n"
-"p, li { white-space: pre-wrap; }\n"
-"</style></head><body style=\" font-family:'Lucida Grande'; font-size:13pt; "
-"font-weight:400; font-style:normal;\">\n"
-"<p style=\"-qt-paragraph-type:empty; margin-top:0px; margin-bottom:0px; "
-"margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;\"></"
-"p></body></html>"
 
-#: build/OpenSCAD_autogen/include/ui_OpenCSGWarningDialog.h:82
-msgid "Show this message again"
-msgstr "Visa detta meddelande igen"
+#: build/OpenSCADLibInternal_autogen/include/ui_Export3mfDialog.h:473
+#: src/core/Settings.cc:436
+msgid "No colors"
+msgstr ""
 
-#: build/OpenSCAD_autogen/include/ui_OpenCSGWarningDialog.h:83
-msgid "Close"
-msgstr "Stäng"
+#: build/OpenSCADLibInternal_autogen/include/ui_Export3mfDialog.h:474
+msgid "Use selected color for all objects"
+msgstr ""
 
-#: build/OpenSCAD_autogen/include/ui_ParameterCheckBox.h:60
-#: build/OpenSCAD_autogen/include/ui_ParameterComboBox.h:56
-#: build/OpenSCAD_autogen/include/ui_ParameterDescriptionWidget.h:99
-#: build/OpenSCAD_autogen/include/ui_ParameterSlider.h:86
-#: build/OpenSCAD_autogen/include/ui_ParameterSpinBox.h:69
-#: build/OpenSCAD_autogen/include/ui_ParameterText.h:55
-#: build/OpenSCAD_autogen/include/ui_ParameterVector.h:108
-#: build/OpenSCAD_autogen/include/ui_ParameterWidget.h:141
-msgid "Form"
-msgstr "Formulär"
+#: build/OpenSCADLibInternal_autogen/include/ui_Export3mfDialog.h:478
+#: build/OpenSCADLibInternal_autogen/include/ui_ExportPdfDialog.h:563
+msgid "Meta data"
+msgstr ""
 
-#: build/OpenSCAD_autogen/include/ui_ParameterDescriptionWidget.h:100
-msgid "Parameter"
-msgstr "Parameter"
+#: build/OpenSCADLibInternal_autogen/include/ui_Export3mfDialog.h:479
+msgid ""
+"The fields Title, Application and CreationDate are always filled in the "
+"exported file when meta data is enabled."
+msgstr ""
 
-#: build/OpenSCAD_autogen/include/ui_ParameterDescriptionWidget.h:101
-#: build/OpenSCAD_autogen/include/ui_ParameterDescriptionWidget.h:102
+#: build/OpenSCADLibInternal_autogen/include/ui_Export3mfDialog.h:481
+#: build/OpenSCADLibInternal_autogen/include/ui_ExportPdfDialog.h:572
+msgid "A copyright associated with this document"
+msgstr ""
+
+#: build/OpenSCADLibInternal_autogen/include/ui_Export3mfDialog.h:483
+msgid "Copyright"
+msgstr ""
+
+#: build/OpenSCADLibInternal_autogen/include/ui_Export3mfDialog.h:484
+#: build/OpenSCADLibInternal_autogen/include/ui_ExportPdfDialog.h:569
+msgid "Title, leave empty to use the file name"
+msgstr ""
+
+#: build/OpenSCADLibInternal_autogen/include/ui_Export3mfDialog.h:485
+#: build/OpenSCADLibInternal_autogen/include/ui_ParameterDescriptionWidget.h:100
+#: build/OpenSCADLibInternal_autogen/include/ui_ParameterDescriptionWidget.h:101
 msgid "Description"
 msgstr "Beskrivning"
 
-#: build/OpenSCAD_autogen/include/ui_ParameterWidget.h:142
+#: build/OpenSCADLibInternal_autogen/include/ui_Export3mfDialog.h:486
+#, fuzzy
+msgid "Designer"
+msgstr "&Design"
+
+#: build/OpenSCADLibInternal_autogen/include/ui_Export3mfDialog.h:487
+msgid "License terms"
+msgstr ""
+
+#: build/OpenSCADLibInternal_autogen/include/ui_Export3mfDialog.h:489
+msgid "An industry rating associated with this document"
+msgstr ""
+
+#: build/OpenSCADLibInternal_autogen/include/ui_Export3mfDialog.h:494
+#: build/OpenSCADLibInternal_autogen/include/ui_ExportPdfDialog.h:576
+msgid "A name for a designer of this document"
+msgstr ""
+
+#: build/OpenSCADLibInternal_autogen/include/ui_Export3mfDialog.h:498
+msgid "Rating"
+msgstr ""
+
+#: build/OpenSCADLibInternal_autogen/include/ui_Export3mfDialog.h:500
+msgid "License information associated with this document"
+msgstr ""
+
+#: build/OpenSCADLibInternal_autogen/include/ui_Export3mfDialog.h:504
+#: build/OpenSCADLibInternal_autogen/include/ui_ExportPdfDialog.h:566
+msgid "A description of the document"
+msgstr ""
+
+#: build/OpenSCADLibInternal_autogen/include/ui_Export3mfDialog.h:507
+#, fuzzy
+msgid "Format"
+msgstr "Formulär"
+
+#: build/OpenSCADLibInternal_autogen/include/ui_Export3mfDialog.h:508
+msgid "Decimal precision"
+msgstr ""
+
+#: build/OpenSCADLibInternal_autogen/include/ui_Export3mfDialog.h:509
+msgid "Export colors as"
+msgstr ""
+
+#: build/OpenSCADLibInternal_autogen/include/ui_Export3mfDialog.h:511
+msgid "Reset value to the default decimal precision value."
+msgstr ""
+
+#: build/OpenSCADLibInternal_autogen/include/ui_Export3mfDialog.h:514
+#: build/OpenSCADLibInternal_autogen/include/ui_ExportPdfDialog.h:632
+#: build/OpenSCADLibInternal_autogen/include/ui_PrintInitDialog.h:184
+msgid "Always show dialog"
+msgstr ""
+
+#: build/OpenSCADLibInternal_autogen/include/ui_Export3mfDialog.h:515
+#: build/OpenSCADLibInternal_autogen/include/ui_ExportPdfDialog.h:633
+#: build/OpenSCADLibInternal_autogen/include/ui_ExportSvgDialog.h:221
+#: build/OpenSCADLibInternal_autogen/include/ui_OctoPrintApiKeyDialog.h:109
+#: build/OpenSCADLibInternal_autogen/include/ui_PrintInitDialog.h:185
+msgid "Cancel"
+msgstr "Avbryt"
+
+#: build/OpenSCADLibInternal_autogen/include/ui_ExportPdfDialog.h:550
+msgid "Export PDF Options"
+msgstr "Alternativ för PDF-export"
+
+#: build/OpenSCADLibInternal_autogen/include/ui_ExportPdfDialog.h:552
+msgid "Set the PDF page (paper) size."
+msgstr "Ställ in PDF-sidans (papperets) storlek."
+
+#: build/OpenSCADLibInternal_autogen/include/ui_ExportPdfDialog.h:554
+#, fuzzy
+msgid "Page Size"
+msgstr "Stegstorlek"
+
+#: build/OpenSCADLibInternal_autogen/include/ui_ExportPdfDialog.h:555
+#: src/core/Settings.cc:388
+msgid "A6 (105 x 148 mm)"
+msgstr ""
+
+#: build/OpenSCADLibInternal_autogen/include/ui_ExportPdfDialog.h:556
+#: src/core/Settings.cc:389
+msgid "A5 (148 x 210 mm)"
+msgstr ""
+
+#: build/OpenSCADLibInternal_autogen/include/ui_ExportPdfDialog.h:557
+#: src/core/Settings.cc:390
+msgid "A4 (210x297 mm)"
+msgstr "A4 (210x297 mm)"
+
+#: build/OpenSCADLibInternal_autogen/include/ui_ExportPdfDialog.h:558
+#: src/core/Settings.cc:391
+msgid "A3 (297x420 mm)"
+msgstr "A3 (297x420 mm)"
+
+#: build/OpenSCADLibInternal_autogen/include/ui_ExportPdfDialog.h:559
+#: src/core/Settings.cc:392
+msgid "Letter (8.5x11 in)"
+msgstr "Brev (8,5x11 tum)"
+
+#: build/OpenSCADLibInternal_autogen/include/ui_ExportPdfDialog.h:560
+#: src/core/Settings.cc:393
+msgid "Legal (8.5x14 in)"
+msgstr "Legal (8,5x14 tum)"
+
+#: build/OpenSCADLibInternal_autogen/include/ui_ExportPdfDialog.h:561
+#: src/core/Settings.cc:394
+msgid "Tabloid (11x17 in)"
+msgstr "Tabloidformat (11x17 tum)"
+
+#: build/OpenSCADLibInternal_autogen/include/ui_ExportPdfDialog.h:564
+msgid ""
+"The fields Title, Creator and CreateDate are always filled in the exported "
+"file when meta data is enabled."
+msgstr ""
+
+#: build/OpenSCADLibInternal_autogen/include/ui_ExportPdfDialog.h:570
+msgid "Subject"
+msgstr ""
+
+#: build/OpenSCADLibInternal_autogen/include/ui_ExportPdfDialog.h:574
+msgid "Keywords"
+msgstr ""
+
+#: build/OpenSCADLibInternal_autogen/include/ui_ExportPdfDialog.h:579
+msgid "Author"
+msgstr ""
+
+#: build/OpenSCADLibInternal_autogen/include/ui_ExportPdfDialog.h:582
+#, fuzzy
+msgid "Set the direction of the largest page dimension."
+msgstr "Ställ in riktningen för den största siddimensionen."
+
+#: build/OpenSCADLibInternal_autogen/include/ui_ExportPdfDialog.h:584
+#, fuzzy
+msgid "Page Orientation"
+msgstr "Orientering"
+
+#: build/OpenSCADLibInternal_autogen/include/ui_ExportPdfDialog.h:585
+#: src/core/Settings.cc:398
+msgid "Portrait (Vertical)"
+msgstr "Stående (vertikal)"
+
+#: build/OpenSCADLibInternal_autogen/include/ui_ExportPdfDialog.h:587
+#: src/core/Settings.cc:399
+msgid "Landscape (Horizontal)"
+msgstr "Liggande (horisontell)"
+
+#: build/OpenSCADLibInternal_autogen/include/ui_ExportPdfDialog.h:589
+#, fuzzy
+msgid "Determine best orientation based on maximum geometry dimension."
+msgstr "Bestäm bästa orientering baserat på maximal geometridimension."
+
+#: build/OpenSCADLibInternal_autogen/include/ui_ExportPdfDialog.h:591
+#: src/core/Settings.cc:400
+msgid "Auto"
+msgstr "Automatisk"
+
+#: build/OpenSCADLibInternal_autogen/include/ui_ExportPdfDialog.h:592
+msgid "Annotations"
+msgstr "Anteckningar"
+
+#: build/OpenSCADLibInternal_autogen/include/ui_ExportPdfDialog.h:594
+#, fuzzy
+msgid "Include design filename on page."
+msgstr "Inkludera designens filnamn på sidan."
+
+#: build/OpenSCADLibInternal_autogen/include/ui_ExportPdfDialog.h:596
+msgid "Show Design Filename"
+msgstr "Visa designens filnamn"
+
+#: build/OpenSCADLibInternal_autogen/include/ui_ExportPdfDialog.h:598
+#, fuzzy
+msgid "Include rulers on page to confirm 1:1 printing scale."
+msgstr "Inkludera linjaler på sidan för att bekräfta tryckskalan 1:1."
+
+#: build/OpenSCADLibInternal_autogen/include/ui_ExportPdfDialog.h:600
+msgid "Show Scale"
+msgstr "Visa skala"
+
+#: build/OpenSCADLibInternal_autogen/include/ui_ExportPdfDialog.h:602
+#, fuzzy
+msgid "Include a grid of the selected size on the page."
+msgstr "Inkludera ett rutnät av den valda storleken på sidan."
+
+#: build/OpenSCADLibInternal_autogen/include/ui_ExportPdfDialog.h:604
+msgid "Show Grid"
+msgstr "Visa rutnät"
+
+#: build/OpenSCADLibInternal_autogen/include/ui_ExportPdfDialog.h:605
+msgid "2mm"
+msgstr "2 mm"
+
+#: build/OpenSCADLibInternal_autogen/include/ui_ExportPdfDialog.h:606
+msgid "2.5mm"
+msgstr "2.5 mm"
+
+#: build/OpenSCADLibInternal_autogen/include/ui_ExportPdfDialog.h:607
+msgid "4mm"
+msgstr "4 mm"
+
+#: build/OpenSCADLibInternal_autogen/include/ui_ExportPdfDialog.h:608
+msgid "5mm"
+msgstr "5 mm"
+
+#: build/OpenSCADLibInternal_autogen/include/ui_ExportPdfDialog.h:609
+msgid "10mm"
+msgstr "10 mm"
+
+#: build/OpenSCADLibInternal_autogen/include/ui_ExportPdfDialog.h:611
+#, fuzzy
+msgid "Include text describing usage of scale."
+msgstr "Inkludera text som beskriver användningen av skalan."
+
+#: build/OpenSCADLibInternal_autogen/include/ui_ExportPdfDialog.h:613
+msgid "Show Scale Usage"
+msgstr "Visa skalans användning"
+
+#: build/OpenSCADLibInternal_autogen/include/ui_ExportPdfDialog.h:614
+#: build/OpenSCADLibInternal_autogen/include/ui_ExportSvgDialog.h:203
+msgid "Fill and Stroke"
+msgstr ""
+
+#: build/OpenSCADLibInternal_autogen/include/ui_ExportPdfDialog.h:616
+#: build/OpenSCADLibInternal_autogen/include/ui_ExportSvgDialog.h:205
+msgid "Enable filling of exported geometry with a color."
+msgstr ""
+
+#: build/OpenSCADLibInternal_autogen/include/ui_ExportPdfDialog.h:618
+#: build/OpenSCADLibInternal_autogen/include/ui_ExportSvgDialog.h:207
+msgid "Fill Geometry"
+msgstr ""
+
+#: build/OpenSCADLibInternal_autogen/include/ui_ExportPdfDialog.h:623
+#: build/OpenSCADLibInternal_autogen/include/ui_ExportSvgDialog.h:212
+msgid "Enable outline stroke for exported geometry."
+msgstr ""
+
+#: build/OpenSCADLibInternal_autogen/include/ui_ExportPdfDialog.h:625
+#: build/OpenSCADLibInternal_autogen/include/ui_ExportSvgDialog.h:214
+msgid "Stroke Outline"
+msgstr ""
+
+#: build/OpenSCADLibInternal_autogen/include/ui_ExportPdfDialog.h:629
+#: build/OpenSCADLibInternal_autogen/include/ui_ExportSvgDialog.h:218
+msgid "Stroke Width:"
+msgstr ""
+
+#: build/OpenSCADLibInternal_autogen/include/ui_ExportPdfDialog.h:630
+#: build/OpenSCADLibInternal_autogen/include/ui_ExportSvgDialog.h:219
+#, fuzzy
+msgid " mm"
+msgstr "2 mm"
+
+#: build/OpenSCADLibInternal_autogen/include/ui_ExportSvgDialog.h:202
+#, fuzzy
+msgid "Export SVG Options"
+msgstr "Alternativ för SVG-export"
+
+#: build/OpenSCADLibInternal_autogen/include/ui_FontList.h:291
+#, fuzzy
+msgid "Font List"
+msgstr "&Typsnittslista"
+
+#: build/OpenSCADLibInternal_autogen/include/ui_FontList.h:293
+#, fuzzy
+msgid "Open Font Folder"
+msgstr ""
+
+#: build/OpenSCADLibInternal_autogen/include/ui_FontList.h:294
+msgid "Copy Font Folder"
+msgstr ""
+
+#: build/OpenSCADLibInternal_autogen/include/ui_FontList.h:295
+#, fuzzy
+msgid "Copy Full Path to Font"
+msgstr "Kopiera fullständig sökväg"
+
+#: build/OpenSCADLibInternal_autogen/include/ui_FontList.h:296
+msgid "Copy Font Style"
+msgstr ""
+
+#: build/OpenSCADLibInternal_autogen/include/ui_FontList.h:297
+msgid "Copy Font Name"
+msgstr ""
+
+#: build/OpenSCADLibInternal_autogen/include/ui_FontList.h:298
+msgid "Show Font Name"
+msgstr ""
+
+#: build/OpenSCADLibInternal_autogen/include/ui_FontList.h:299
+msgid "Show Styled Font Name"
+msgstr ""
+
+#: build/OpenSCADLibInternal_autogen/include/ui_FontList.h:300
+msgid "Show Font Style"
+msgstr ""
+
+#: build/OpenSCADLibInternal_autogen/include/ui_FontList.h:301
+#, fuzzy
+msgid "Show Sample Text"
+msgstr "Visa skala"
+
+#: build/OpenSCADLibInternal_autogen/include/ui_FontList.h:302
+#, fuzzy
+msgid "Show File Name"
+msgstr "Visa designens filnamn"
+
+#: build/OpenSCADLibInternal_autogen/include/ui_FontList.h:303
+#, fuzzy
+msgid "Show File Path"
+msgstr "Visa skalans användning"
+
+#: build/OpenSCADLibInternal_autogen/include/ui_FontList.h:304
+#, fuzzy
+msgid "Reset Columns"
+msgstr "Återställ trim"
+
+#: build/OpenSCADLibInternal_autogen/include/ui_FontList.h:307
+msgid "Any"
+msgstr ""
+
+#: build/OpenSCADLibInternal_autogen/include/ui_FontList.h:313
+#: build/OpenSCADLibInternal_autogen/include/ui_FontList.h:317
+#: src/gui/FontList.cc:402
+msgid "Font name"
+msgstr "Typsnittsnamn"
+
+#: build/OpenSCADLibInternal_autogen/include/ui_FontList.h:314
+#: src/gui/FontList.cc:406
+msgid "Sample text"
+msgstr ""
+
+#: build/OpenSCADLibInternal_autogen/include/ui_FontList.h:315
+msgid "Chars"
+msgstr ""
+
+#: build/OpenSCADLibInternal_autogen/include/ui_FontList.h:318
+#, fuzzy
+msgid "Font path"
+msgstr ""
+
+#: build/OpenSCADLibInternal_autogen/include/ui_FontList.h:319
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2521
+msgid "Style"
+msgstr "Stil"
+
+#: build/OpenSCADLibInternal_autogen/include/ui_LaunchingScreen.h:293
+msgid "Welcome to OpenSCAD"
+msgstr "Välkommen till OpenSCAD"
+
+#: build/OpenSCADLibInternal_autogen/include/ui_LaunchingScreen.h:294
+msgid "New"
+msgstr "Ny"
+
+#: build/OpenSCADLibInternal_autogen/include/ui_LaunchingScreen.h:295
+msgid "Open"
+msgstr "Öppna"
+
+#: build/OpenSCADLibInternal_autogen/include/ui_LaunchingScreen.h:296
+msgid "Help"
+msgstr "Hjälp"
+
+#: build/OpenSCADLibInternal_autogen/include/ui_LaunchingScreen.h:297
+msgid "Recents"
+msgstr "Tidigare"
+
+#: build/OpenSCADLibInternal_autogen/include/ui_LaunchingScreen.h:298
+msgid "Open Recent"
+msgstr "Öppna tidigare"
+
+#: build/OpenSCADLibInternal_autogen/include/ui_LaunchingScreen.h:299
+#: build/OpenSCADLibInternal_autogen/include/ui_LaunchingScreen.h:301
+msgid "Examples"
+msgstr "Exempel"
+
+#: build/OpenSCADLibInternal_autogen/include/ui_LaunchingScreen.h:302
+msgid "Open Example"
+msgstr "Öppna exempel"
+
+#: build/OpenSCADLibInternal_autogen/include/ui_LaunchingScreen.h:311
+msgid "Don't show again"
+msgstr "Visa inte igen"
+
+#: build/OpenSCADLibInternal_autogen/include/ui_LaunchingScreen.h:312
+msgid "Version"
+msgstr "Version"
+
+#: build/OpenSCADLibInternal_autogen/include/ui_LibraryInfoDialog.h:75
+msgid "Lib & Build Info"
+msgstr "Lib & Build-information"
+
+#: build/OpenSCADLibInternal_autogen/include/ui_LibraryInfoDialog.h:76
+msgid "OpenSCAD Detailed Library and Build Information"
+msgstr "OpenSCAD Detaljerad biblioteks- och bygginformation"
+
+#: build/OpenSCADLibInternal_autogen/include/ui_LibraryInfoDialog.h:77
+msgid "&OK"
+msgstr "&Ok"
+
+#: build/OpenSCADLibInternal_autogen/include/ui_MainWindow.h:1006
+msgid "&New File"
+msgstr "&Ny fil"
+
+#: build/OpenSCADLibInternal_autogen/include/ui_MainWindow.h:1008
+msgid "Ctrl+N"
+msgstr "Ctrl+N"
+
+#: build/OpenSCADLibInternal_autogen/include/ui_MainWindow.h:1010
+#, fuzzy
+msgid "New &Window"
+msgstr "Nytt fönster"
+
+#: build/OpenSCADLibInternal_autogen/include/ui_MainWindow.h:1011
+#, fuzzy
+msgid "&Open File..."
+msgstr "Ö&ppna fil"
+
+#: build/OpenSCADLibInternal_autogen/include/ui_MainWindow.h:1013
+msgid "Ctrl+O"
+msgstr "Ctrl+O"
+
+#: build/OpenSCADLibInternal_autogen/include/ui_MainWindow.h:1015
+#, fuzzy
+msgid "Open in New Windo&w"
+msgstr "Öppna i nytt fönster"
+
+#: build/OpenSCADLibInternal_autogen/include/ui_MainWindow.h:1016
+msgid "&Save"
+msgstr "&Spara"
+
+#: build/OpenSCADLibInternal_autogen/include/ui_MainWindow.h:1018
+msgid "Ctrl+S"
+msgstr "Ctrl+S"
+
+#: build/OpenSCADLibInternal_autogen/include/ui_MainWindow.h:1020
+msgid "Save &As..."
+msgstr "Spara s&om…"
+
+#: build/OpenSCADLibInternal_autogen/include/ui_MainWindow.h:1022
+msgid "Ctrl+Shift+S"
+msgstr "Ctrl+Shift+S"
+
+#: build/OpenSCADLibInternal_autogen/include/ui_MainWindow.h:1024
+#, fuzzy
+msgid "Save a C&opy..."
+msgstr "Spara en kopia"
+
+#: build/OpenSCADLibInternal_autogen/include/ui_MainWindow.h:1025
+#, fuzzy
+msgid "S&ave All"
+msgstr "Spara alla"
+
+#: build/OpenSCADLibInternal_autogen/include/ui_MainWindow.h:1026
+msgid "&Reload"
+msgstr "Uppdat&era"
+
+#: build/OpenSCADLibInternal_autogen/include/ui_MainWindow.h:1028
+msgid "Ctrl+R"
+msgstr "Ctrl+R"
+
+#: build/OpenSCADLibInternal_autogen/include/ui_MainWindow.h:1030
+msgid "&Quit"
+msgstr "A&vsluta"
+
+#: build/OpenSCADLibInternal_autogen/include/ui_MainWindow.h:1032
+msgid "Ctrl+Q"
+msgstr "Ctrl+Q"
+
+#: build/OpenSCADLibInternal_autogen/include/ui_MainWindow.h:1034
+msgid "&Undo"
+msgstr "Å&ngra"
+
+#: build/OpenSCADLibInternal_autogen/include/ui_MainWindow.h:1036
+msgid "Ctrl+Z"
+msgstr "Ctrl+Z"
+
+#: build/OpenSCADLibInternal_autogen/include/ui_MainWindow.h:1038
+msgid "&Redo"
+msgstr "&Gör om"
+
+#: build/OpenSCADLibInternal_autogen/include/ui_MainWindow.h:1040
+msgid "Ctrl+Shift+Z"
+msgstr "Ctrl+Shift+Z"
+
+#: build/OpenSCADLibInternal_autogen/include/ui_MainWindow.h:1043
+msgid "Ctrl+Y"
+msgstr "Ctrl+Y"
+
+#: build/OpenSCADLibInternal_autogen/include/ui_MainWindow.h:1045
+msgid "Cu&t"
+msgstr "Klipp &ut"
+
+#: build/OpenSCADLibInternal_autogen/include/ui_MainWindow.h:1047
+msgid "Ctrl+X"
+msgstr "Ctrl+X"
+
+#: build/OpenSCADLibInternal_autogen/include/ui_MainWindow.h:1049
+msgid "&Copy"
+msgstr "&Kopiera"
+
+#: build/OpenSCADLibInternal_autogen/include/ui_MainWindow.h:1051
+msgid "Ctrl+C"
+msgstr "Ctrl+C"
+
+#: build/OpenSCADLibInternal_autogen/include/ui_MainWindow.h:1053
+msgid "&Paste"
+msgstr "Klistra &in"
+
+#: build/OpenSCADLibInternal_autogen/include/ui_MainWindow.h:1055
+msgid "Ctrl+V"
+msgstr "Ctrl+V"
+
+#: build/OpenSCADLibInternal_autogen/include/ui_MainWindow.h:1057
+msgid "&Indent"
+msgstr "&Indrag"
+
+#: build/OpenSCADLibInternal_autogen/include/ui_MainWindow.h:1059
+msgid "Ctrl+I"
+msgstr "Ctrl+I"
+
+#: build/OpenSCADLibInternal_autogen/include/ui_MainWindow.h:1061
+msgid "C&omment"
+msgstr "K&ommentar"
+
+#: build/OpenSCADLibInternal_autogen/include/ui_MainWindow.h:1063
+msgid "Ctrl+D"
+msgstr "Ctrl+D"
+
+#: build/OpenSCADLibInternal_autogen/include/ui_MainWindow.h:1065
+msgid "Unco&mment"
+msgstr "Ta bort kommenta&r"
+
+#: build/OpenSCADLibInternal_autogen/include/ui_MainWindow.h:1067
+msgid "Ctrl+Shift+D"
+msgstr "Ctrl+Shift+D"
+
+#: build/OpenSCADLibInternal_autogen/include/ui_MainWindow.h:1069
+msgid "Mo&ve Line Up"
+msgstr ""
+
+#: build/OpenSCADLibInternal_autogen/include/ui_MainWindow.h:1071
+#, fuzzy
+msgid "Ctrl+Alt+Up"
+msgstr "Ctrl+Alt+F"
+
+#: build/OpenSCADLibInternal_autogen/include/ui_MainWindow.h:1073
+msgid "Mo&ve Line Down"
+msgstr ""
+
+#: build/OpenSCADLibInternal_autogen/include/ui_MainWindow.h:1075
+#, fuzzy
+msgid "Ctrl+Alt+Down"
+msgstr "Ctrl+Alt+F"
+
+#: build/OpenSCADLibInternal_autogen/include/ui_MainWindow.h:1077
+#, fuzzy
+msgid "Show &Next Tab"
+msgstr "Visa nästa flik"
+
+#: build/OpenSCADLibInternal_autogen/include/ui_MainWindow.h:1079
+msgid "Ctrl+Tab"
+msgstr "Ctrl+Tab"
+
+#: build/OpenSCADLibInternal_autogen/include/ui_MainWindow.h:1081
+#, fuzzy
+msgid "Show P&revious Tab"
+msgstr "Visa föregående flik"
+
+#: build/OpenSCADLibInternal_autogen/include/ui_MainWindow.h:1083
+msgid "Ctrl+Shift+Tab"
+msgstr "Ctrl+Shift+Tab"
+
+#: build/OpenSCADLibInternal_autogen/include/ui_MainWindow.h:1085
+msgid "Copy viewport ima&ge"
+msgstr "Kopiera vyfältets &bild"
+
+#: build/OpenSCADLibInternal_autogen/include/ui_MainWindow.h:1087
+msgid "Ctrl+Shift+C"
+msgstr "Ctrl+Shift+C"
+
+#: build/OpenSCADLibInternal_autogen/include/ui_MainWindow.h:1089
+msgid "Copy viewport transl&ation"
+msgstr "Kopiera vyfältets översättnin&g"
+
+#: build/OpenSCADLibInternal_autogen/include/ui_MainWindow.h:1091
+msgid "Ctrl+T"
+msgstr "Ctrl+T"
+
+#: build/OpenSCADLibInternal_autogen/include/ui_MainWindow.h:1093
+msgid "Cop&y viewport rotation"
+msgstr "Kopiera vyfältets r&otation"
+
+#: build/OpenSCADLibInternal_autogen/include/ui_MainWindow.h:1094
+msgid "Copy vie&wport distance"
+msgstr "Kopiera vy&fältets avstånd"
+
+#: build/OpenSCADLibInternal_autogen/include/ui_MainWindow.h:1095
+msgid "Copy vie&wport fov"
+msgstr "Kopiera vyfältets s&ynfält"
+
+#: build/OpenSCADLibInternal_autogen/include/ui_MainWindow.h:1096
+msgid "Increase Font &Size"
+msgstr "Öka typsnittets s&torlek"
+
+#: build/OpenSCADLibInternal_autogen/include/ui_MainWindow.h:1098
+msgid "Ctrl++"
+msgstr "Ctrl + +"
+
+#: build/OpenSCADLibInternal_autogen/include/ui_MainWindow.h:1100
+msgid "Decrease Font Si&ze"
+msgstr "Minska typsnittets stor&lek"
+
+#: build/OpenSCADLibInternal_autogen/include/ui_MainWindow.h:1102
+msgid "Ctrl+-"
+msgstr "Ctrl+-"
+
+#: build/OpenSCADLibInternal_autogen/include/ui_MainWindow.h:1104
+msgid "&Reload and Preview"
+msgstr "&Uppdatera och förhandsvisa"
+
+#: build/OpenSCADLibInternal_autogen/include/ui_MainWindow.h:1106
+msgid "F4"
+msgstr "F4"
+
+#: build/OpenSCADLibInternal_autogen/include/ui_MainWindow.h:1108
+msgid "&Preview"
+msgstr "&Förhandsvisning"
+
+#: build/OpenSCADLibInternal_autogen/include/ui_MainWindow.h:1110
+msgid "F5"
+msgstr "F5"
+
+#: build/OpenSCADLibInternal_autogen/include/ui_MainWindow.h:1112
+msgid "R&ender"
+msgstr "R&endera"
+
+#: build/OpenSCADLibInternal_autogen/include/ui_MainWindow.h:1114
+msgid "F6"
+msgstr "F6"
+
+#: build/OpenSCADLibInternal_autogen/include/ui_MainWindow.h:1116
+msgid "&3D Print"
+msgstr "&3D-utskrift"
+
+#: build/OpenSCADLibInternal_autogen/include/ui_MainWindow.h:1118
+msgid "F8"
+msgstr "F8"
+
+#: build/OpenSCADLibInternal_autogen/include/ui_MainWindow.h:1120
+msgid "Measure &Distance"
+msgstr "Mät &avstånd"
+
+#: build/OpenSCADLibInternal_autogen/include/ui_MainWindow.h:1122
+msgid "D"
+msgstr ""
+
+#: build/OpenSCADLibInternal_autogen/include/ui_MainWindow.h:1124
+msgid "Measure &Angle"
+msgstr "Mät &vinkel"
+
+#: build/OpenSCADLibInternal_autogen/include/ui_MainWindow.h:1126
+msgid "A"
+msgstr ""
+
+#: build/OpenSCADLibInternal_autogen/include/ui_MainWindow.h:1128
+msgid "&Check Validity"
+msgstr "&Kontrollera giltighet"
+
+#: build/OpenSCADLibInternal_autogen/include/ui_MainWindow.h:1129
+#, fuzzy
+msgid "Display A&ST"
+msgstr "Visa A&ST..."
+
+#: build/OpenSCADLibInternal_autogen/include/ui_MainWindow.h:1130
+#, fuzzy
+msgid "Display CSG &Tree"
+msgstr "Visa CSG-&träd..."
+
+#: build/OpenSCADLibInternal_autogen/include/ui_MainWindow.h:1131
+#, fuzzy
+msgid "Display CSG Pr&oducts"
+msgstr "Visa CSG-pr&odukter..."
+
+#: build/OpenSCADLibInternal_autogen/include/ui_MainWindow.h:1132
+#, fuzzy
+msgid "Export as &STL (binary)..."
+msgstr "Exportera som &STL..."
+
+#: build/OpenSCADLibInternal_autogen/include/ui_MainWindow.h:1133
+#, fuzzy
+msgid "Export as &STL (ascii)..."
+msgstr "Exportera som &STL..."
+
+#: build/OpenSCADLibInternal_autogen/include/ui_MainWindow.h:1134
+msgid "Export as &OBJ..."
+msgstr "Exportera som &OBJ..."
+
+#: build/OpenSCADLibInternal_autogen/include/ui_MainWindow.h:1135
+#, fuzzy
+msgid "Export as &POV..."
+msgstr "Exportera som &POV..."
+
+#: build/OpenSCADLibInternal_autogen/include/ui_MainWindow.h:1136
+msgid "Export as &OFF..."
+msgstr "Exportera som O&FF..."
+
+#: build/OpenSCADLibInternal_autogen/include/ui_MainWindow.h:1137
+msgid "Export as &WRL..."
+msgstr "Exportera som &WRL..."
+
+#: build/OpenSCADLibInternal_autogen/include/ui_MainWindow.h:1138
+#, fuzzy
+msgid "P&review"
+msgstr "Förhandsvisa"
+
+#: build/OpenSCADLibInternal_autogen/include/ui_MainWindow.h:1140
+msgid "F9"
+msgstr "F9"
+
+#: build/OpenSCADLibInternal_autogen/include/ui_MainWindow.h:1142
+#, fuzzy
+msgid "T&hrown Together"
+msgstr "Kastade tillsammans"
+
+#: build/OpenSCADLibInternal_autogen/include/ui_MainWindow.h:1144
+msgid "F12"
+msgstr "F12"
+
+#: build/OpenSCADLibInternal_autogen/include/ui_MainWindow.h:1146
+#, fuzzy
+msgid "&Show Edges"
+msgstr "Visa kanter"
+
+#: build/OpenSCADLibInternal_autogen/include/ui_MainWindow.h:1148
+msgid "Ctrl+1"
+msgstr "Ctrl+1"
+
+#: build/OpenSCADLibInternal_autogen/include/ui_MainWindow.h:1150
+#, fuzzy
+msgid "Show A&xes"
+msgstr "Visa axlar"
+
+#: build/OpenSCADLibInternal_autogen/include/ui_MainWindow.h:1152
+msgid "Ctrl+2"
+msgstr "Ctrl+2"
+
+#: build/OpenSCADLibInternal_autogen/include/ui_MainWindow.h:1154
+#, fuzzy
+msgid "Show &Crosshairs"
+msgstr "Visa hårkors"
+
+#: build/OpenSCADLibInternal_autogen/include/ui_MainWindow.h:1156
+msgid "Ctrl+3"
+msgstr "Ctrl+3"
+
+#: build/OpenSCADLibInternal_autogen/include/ui_MainWindow.h:1158
+#, fuzzy
+msgid "Show Scale &Markers"
+msgstr "Visa skalmarkeringar"
+
+#: build/OpenSCADLibInternal_autogen/include/ui_MainWindow.h:1159
+msgid "&Top"
+msgstr "&Topp"
+
+#: build/OpenSCADLibInternal_autogen/include/ui_MainWindow.h:1161
+msgid "Ctrl+4"
+msgstr "Ctrl+4"
+
+#: build/OpenSCADLibInternal_autogen/include/ui_MainWindow.h:1163
+msgid "&Bottom"
+msgstr "&Botten"
+
+#: build/OpenSCADLibInternal_autogen/include/ui_MainWindow.h:1165
+msgid "Ctrl+5"
+msgstr "Ctrl+5"
+
+#: build/OpenSCADLibInternal_autogen/include/ui_MainWindow.h:1167
+msgid "&Left"
+msgstr "&Vänster"
+
+#: build/OpenSCADLibInternal_autogen/include/ui_MainWindow.h:1169
+msgid "Ctrl+6"
+msgstr "Ctrl+6"
+
+#: build/OpenSCADLibInternal_autogen/include/ui_MainWindow.h:1171
+msgid "&Right"
+msgstr "&Höger"
+
+#: build/OpenSCADLibInternal_autogen/include/ui_MainWindow.h:1173
+msgid "Ctrl+7"
+msgstr "Ctrl+7"
+
+#: build/OpenSCADLibInternal_autogen/include/ui_MainWindow.h:1175
+msgid "&Front"
+msgstr "&Fram"
+
+#: build/OpenSCADLibInternal_autogen/include/ui_MainWindow.h:1177
+msgid "Ctrl+8"
+msgstr "Ctrl+8"
+
+#: build/OpenSCADLibInternal_autogen/include/ui_MainWindow.h:1179
+msgid "Bac&k"
+msgstr "&Bak"
+
+#: build/OpenSCADLibInternal_autogen/include/ui_MainWindow.h:1181
+msgid "Ctrl+9"
+msgstr "Ctrl+9"
+
+#: build/OpenSCADLibInternal_autogen/include/ui_MainWindow.h:1183
+msgid "&Diagonal"
+msgstr "&Diagonal"
+
+#: build/OpenSCADLibInternal_autogen/include/ui_MainWindow.h:1185
+msgid "Ctrl+0"
+msgstr "Ctrl+0"
+
+#: build/OpenSCADLibInternal_autogen/include/ui_MainWindow.h:1187
+msgid "Ce&nter"
+msgstr "Ce&nter"
+
+#: build/OpenSCADLibInternal_autogen/include/ui_MainWindow.h:1189
+msgid "Ctrl+Shift+0"
+msgstr "Ctrl+Shift+0"
+
+#: build/OpenSCADLibInternal_autogen/include/ui_MainWindow.h:1191
+msgid "&Perspective"
+msgstr "&Perspektiv"
+
+#: build/OpenSCADLibInternal_autogen/include/ui_MainWindow.h:1192
+msgid "&Orthogonal"
+msgstr "&Ortogonal"
+
+#: build/OpenSCADLibInternal_autogen/include/ui_MainWindow.h:1193
+msgid "&About"
+msgstr "&Om"
+
+#: build/OpenSCADLibInternal_autogen/include/ui_MainWindow.h:1194
+msgid "&Documentation"
+msgstr "&Dokumentation"
+
+#: build/OpenSCADLibInternal_autogen/include/ui_MainWindow.h:1195
+msgid "&Offline Documentation"
+msgstr "&Offline-dokumentation"
+
+#: build/OpenSCADLibInternal_autogen/include/ui_MainWindow.h:1196
+msgid "&Offline Cheat Sheet"
+msgstr "&Offline-fusklapp"
+
+#: build/OpenSCADLibInternal_autogen/include/ui_MainWindow.h:1197
+msgid "Clear Recent"
+msgstr "Töm tidigare"
+
+#: build/OpenSCADLibInternal_autogen/include/ui_MainWindow.h:1198
+msgid "Export as &DXF..."
+msgstr "Exportera som &DXF..."
+
+#: build/OpenSCADLibInternal_autogen/include/ui_MainWindow.h:1199
+#: build/OpenSCADLibInternal_autogen/include/ui_MainWindow.h:1201
+#, fuzzy
+msgid "Revoke Trusted Python Files"
+msgstr "Återkalla betrodda python-filer"
+
+#: build/OpenSCADLibInternal_autogen/include/ui_MainWindow.h:1203
+msgid "&Close"
+msgstr "S&täng"
+
+#: build/OpenSCADLibInternal_autogen/include/ui_MainWindow.h:1205
+msgid "Ctrl+W"
+msgstr "Ctrl+W"
+
+#: build/OpenSCADLibInternal_autogen/include/ui_MainWindow.h:1207
+msgid "&Preferences"
+msgstr "&Inställningar"
+
+#: build/OpenSCADLibInternal_autogen/include/ui_MainWindow.h:1208
+msgid "&Find..."
+msgstr "&Sök..."
+
+#: build/OpenSCADLibInternal_autogen/include/ui_MainWindow.h:1210
+msgid "Ctrl+F"
+msgstr "Ctrl+F"
+
+#: build/OpenSCADLibInternal_autogen/include/ui_MainWindow.h:1212
+msgid "Fin&d and Replace..."
+msgstr "Sök och &ersätt..."
+
+#: build/OpenSCADLibInternal_autogen/include/ui_MainWindow.h:1214
+msgid "Ctrl+Alt+F"
+msgstr "Ctrl+Alt+F"
+
+#: build/OpenSCADLibInternal_autogen/include/ui_MainWindow.h:1216
+msgid "Find Ne&xt"
+msgstr "Hitta &nästa"
+
+#: build/OpenSCADLibInternal_autogen/include/ui_MainWindow.h:1218
+msgid "Ctrl+G"
+msgstr "Ctrl+G"
+
+#: build/OpenSCADLibInternal_autogen/include/ui_MainWindow.h:1220
+msgid "Find Pre&vious"
+msgstr "Hitta &föregående"
+
+#: build/OpenSCADLibInternal_autogen/include/ui_MainWindow.h:1222
+msgid "Ctrl+Shift+G"
+msgstr "Ctrl+Shift+G"
+
+#: build/OpenSCADLibInternal_autogen/include/ui_MainWindow.h:1224
+msgid "Use Se&lection for Find"
+msgstr "Använd ma&rkering för att söka"
+
+#: build/OpenSCADLibInternal_autogen/include/ui_MainWindow.h:1226
+msgid "Ctrl+E"
+msgstr "Ctrl+E"
+
+#: build/OpenSCADLibInternal_autogen/include/ui_MainWindow.h:1228
+#, fuzzy
+msgid "J&ump to next error"
+msgstr "Hoppa till nästa fel"
+
+#: build/OpenSCADLibInternal_autogen/include/ui_MainWindow.h:1230
+msgid "Ctrl+Alt+E"
+msgstr "Ctrl+Alt+E"
+
+#: build/OpenSCADLibInternal_autogen/include/ui_MainWindow.h:1232
+msgid "&Flush Caches"
+msgstr "&Töm cache"
+
+#: build/OpenSCADLibInternal_autogen/include/ui_MainWindow.h:1233
+msgid "&OpenSCAD Homepage"
+msgstr "Webbsidan för &OpenSCAD"
+
+#: build/OpenSCADLibInternal_autogen/include/ui_MainWindow.h:1234
+msgid "&Automatic Reload and Preview"
+msgstr "&Automatisk uppdatering och förhandsvisning"
+
+#: build/OpenSCADLibInternal_autogen/include/ui_MainWindow.h:1235
+msgid "Export as &Image..."
+msgstr "Exportera som &bild..."
+
+#: build/OpenSCADLibInternal_autogen/include/ui_MainWindow.h:1236
+msgid "Export as &CSG..."
+msgstr "Exportera som &CSG..."
+
+#: build/OpenSCADLibInternal_autogen/include/ui_MainWindow.h:1237
+msgid "&Library info"
+msgstr "&Biblioteksinfo"
+
+#: build/OpenSCADLibInternal_autogen/include/ui_MainWindow.h:1238
+#, fuzzy
+msgid "Show &Library Folder"
+msgstr "Visa &biblioteksmapp..."
+
+#: build/OpenSCADLibInternal_autogen/include/ui_MainWindow.h:1239
+#, fuzzy
+msgid "Reset &View"
+msgstr "Återställ vy"
+
+#: build/OpenSCADLibInternal_autogen/include/ui_MainWindow.h:1240
+msgid "Export as S&VG..."
+msgstr "Exportera som S&VG..."
+
+#: build/OpenSCADLibInternal_autogen/include/ui_MainWindow.h:1241
+msgid "Export as &3MF..."
+msgstr "Exportera som &3MF..."
+
+#: build/OpenSCADLibInternal_autogen/include/ui_MainWindow.h:1242
+#, fuzzy
+msgid "Zoom &In"
+msgstr "Zooma in"
+
+#: build/OpenSCADLibInternal_autogen/include/ui_MainWindow.h:1244
+msgid "Ctrl+]"
+msgstr "Ctrl+]"
+
+#: build/OpenSCADLibInternal_autogen/include/ui_MainWindow.h:1246
+#, fuzzy
+msgid "&Zoom Out"
+msgstr "Zooma ut"
+
+#: build/OpenSCADLibInternal_autogen/include/ui_MainWindow.h:1248
+msgid "Ctrl+["
+msgstr "Ctrl+["
+
+#: build/OpenSCADLibInternal_autogen/include/ui_MainWindow.h:1250
+#, fuzzy
+msgid "View &All"
+msgstr "Visa alla"
+
+#: build/OpenSCADLibInternal_autogen/include/ui_MainWindow.h:1252
+msgid "Ctrl+Shift+V"
+msgstr "Ctrl+Shift+V"
+
+#: build/OpenSCADLibInternal_autogen/include/ui_MainWindow.h:1254
+msgid "Conv&ert Tabs to Spaces"
+msgstr "Konvertera &tabbar till blanksteg"
+
+#: build/OpenSCADLibInternal_autogen/include/ui_MainWindow.h:1255
+#, fuzzy
+msgid "&Toggle Bookmark"
+msgstr "Växla bokmärke"
+
+#: build/OpenSCADLibInternal_autogen/include/ui_MainWindow.h:1257
+msgid "Ctrl+F2"
+msgstr "Ctrl+F2"
+
+#: build/OpenSCADLibInternal_autogen/include/ui_MainWindow.h:1259
+#, fuzzy
+msgid "Jump to next &bookmark"
+msgstr "Hoppa till nästa bokmärke"
+
+#: build/OpenSCADLibInternal_autogen/include/ui_MainWindow.h:1261
+msgid "F2"
+msgstr "F2"
+
+#: build/OpenSCADLibInternal_autogen/include/ui_MainWindow.h:1263
+#, fuzzy
+msgid "Jump to &previous bookmark"
+msgstr "Hoppa till föregående bokmärke"
+
+#: build/OpenSCADLibInternal_autogen/include/ui_MainWindow.h:1265
+msgid "Shift+F2"
+msgstr "Skift+F2"
+
+#: build/OpenSCADLibInternal_autogen/include/ui_MainWindow.h:1267
+#, fuzzy
+msgid "&Hide Editor toolbar"
+msgstr "Dölj redigeringsverktygsfält"
+
+#: build/OpenSCADLibInternal_autogen/include/ui_MainWindow.h:1268
+msgid "U&nindent"
+msgstr "Återställ indra&g"
+
+#: build/OpenSCADLibInternal_autogen/include/ui_MainWindow.h:1270
+msgid "Ctrl+Shift+I"
+msgstr "Ctrl+Shift+I"
+
+#: build/OpenSCADLibInternal_autogen/include/ui_MainWindow.h:1272
+msgid "&Cheat Sheet"
+msgstr "&Fusklapp"
+
+#: build/OpenSCADLibInternal_autogen/include/ui_MainWindow.h:1273
+msgid "Export as PDF..."
+msgstr "Exportera som PDF..."
+
+#: build/OpenSCADLibInternal_autogen/include/ui_MainWindow.h:1274
+#, fuzzy
+msgid "Hide &3D View toolbar"
+msgstr "Dölj verktygsfältets 3D-vy"
+
+#: build/OpenSCADLibInternal_autogen/include/ui_MainWindow.h:1275
+#, fuzzy
+msgid "&Next Window\tCtrl+K"
+msgstr "&Nästa fönster"
+
+#: build/OpenSCADLibInternal_autogen/include/ui_MainWindow.h:1276
+#, fuzzy
+msgid "&Previous Window\tCtrl+H"
+msgstr "&Föregående fönster"
+
+#: build/OpenSCADLibInternal_autogen/include/ui_MainWindow.h:1277
+msgid "Insert Template"
+msgstr "Infoga mall"
+
+#: build/OpenSCADLibInternal_autogen/include/ui_MainWindow.h:1279
+msgid "Alt+Ins"
+msgstr "Alt+Inn"
+
+#: build/OpenSCADLibInternal_autogen/include/ui_MainWindow.h:1281
+#, fuzzy
+msgid "Fold/Unfold All"
+msgstr "Vik/vik inte alla"
+
+#: build/OpenSCADLibInternal_autogen/include/ui_MainWindow.h:1282
+msgid "&Jump To"
+msgstr ""
+
+#: build/OpenSCADLibInternal_autogen/include/ui_MainWindow.h:1284
+#, fuzzy
+msgid "Ctrl+J"
+msgstr "Ctrl+N"
+
+#: build/OpenSCADLibInternal_autogen/include/ui_MainWindow.h:1286
+#: src/gui/MainWindow.cc:1346 src/gui/MainWindow.cc:1353
+#: src/gui/MainWindow.cc:1366 src/gui/MainWindow.cc:1371
+msgid "Create Virtual Environment"
+msgstr ""
+
+#: build/OpenSCADLibInternal_autogen/include/ui_MainWindow.h:1287
+#: src/gui/MainWindow.cc:1388
+msgid "Select Virtual Environment"
+msgstr ""
+
+#: build/OpenSCADLibInternal_autogen/include/ui_MainWindow.h:1288
+#: build/OpenSCADLibInternal_autogen/include/ui_OctoPrintApiKeyDialog.h:107
+msgid "Message"
+msgstr "Meddelande"
+
+#: build/OpenSCADLibInternal_autogen/include/ui_MainWindow.h:1291
+msgid "&File"
+msgstr "&Arkiv"
+
+#: build/OpenSCADLibInternal_autogen/include/ui_MainWindow.h:1292
+msgid "Recen&t Files"
+msgstr "&Tidigare filer"
+
+#: build/OpenSCADLibInternal_autogen/include/ui_MainWindow.h:1293
+msgid "&Examples"
+msgstr "&Exempel"
+
+#: build/OpenSCADLibInternal_autogen/include/ui_MainWindow.h:1294
+msgid "E&xport"
+msgstr "E&xportera"
+
+#: build/OpenSCADLibInternal_autogen/include/ui_MainWindow.h:1295
+msgid "Python"
+msgstr ""
+
+#: build/OpenSCADLibInternal_autogen/include/ui_MainWindow.h:1296
+msgid "&Edit"
+msgstr "R&edigera"
+
+#: build/OpenSCADLibInternal_autogen/include/ui_MainWindow.h:1297
+msgid "&Design"
+msgstr "&Design"
+
+#: build/OpenSCADLibInternal_autogen/include/ui_MainWindow.h:1298
+msgid "&View"
+msgstr "&Visa"
+
+#: build/OpenSCADLibInternal_autogen/include/ui_MainWindow.h:1299
+msgid "&Help"
+msgstr "&Hjälp"
+
+#: build/OpenSCADLibInternal_autogen/include/ui_MainWindow.h:1300
+msgid "&Window"
+msgstr "&Fönster"
+
+#: build/OpenSCADLibInternal_autogen/include/ui_MainWindow.h:1301
+msgid "Find"
+msgstr "Sök"
+
+#: build/OpenSCADLibInternal_autogen/include/ui_MainWindow.h:1302
+#: build/OpenSCADLibInternal_autogen/include/ui_MainWindow.h:1306
+msgid "Replace"
+msgstr "Ersätt"
+
+#: build/OpenSCADLibInternal_autogen/include/ui_MainWindow.h:1304
+msgid "Search string"
+msgstr "Söksträng"
+
+#: build/OpenSCADLibInternal_autogen/include/ui_MainWindow.h:1305
+msgid "Replacement string"
+msgstr "Ersättningssträng"
+
+#: build/OpenSCADLibInternal_autogen/include/ui_MainWindow.h:1308
+msgid "Previous"
+msgstr "Föregående"
+
+#: build/OpenSCADLibInternal_autogen/include/ui_MainWindow.h:1309
+msgid "Next"
+msgstr "Nästa"
+
+#: build/OpenSCADLibInternal_autogen/include/ui_MainWindow.h:1310
+msgid "Done"
+msgstr "Färdig"
+
+#: build/OpenSCADLibInternal_autogen/include/ui_MainWindow.h:1311
+msgid "Customizer Widget"
+msgstr "Anpassningswidget"
+
+#: build/OpenSCADLibInternal_autogen/include/ui_MouseConfigWidget.h:214
+msgid "Ctrl + Shift + Middle-click"
+msgstr ""
+
+#: build/OpenSCADLibInternal_autogen/include/ui_MouseConfigWidget.h:215
+msgid "Left-click"
+msgstr ""
+
+#: build/OpenSCADLibInternal_autogen/include/ui_MouseConfigWidget.h:216
+msgid "Ctrl + Left-click"
+msgstr ""
+
+#: build/OpenSCADLibInternal_autogen/include/ui_MouseConfigWidget.h:217
+msgid "Shift + Left-click"
+msgstr ""
+
+#: build/OpenSCADLibInternal_autogen/include/ui_MouseConfigWidget.h:218
+msgid "Ctrl + Shift + Right-click"
+msgstr ""
+
+#: build/OpenSCADLibInternal_autogen/include/ui_MouseConfigWidget.h:219
+msgid "Preset"
+msgstr ""
+
+#: build/OpenSCADLibInternal_autogen/include/ui_MouseConfigWidget.h:220
+msgid "Right-click"
+msgstr ""
+
+#: build/OpenSCADLibInternal_autogen/include/ui_MouseConfigWidget.h:221
+msgid "Ctrl + Middle-click"
+msgstr ""
+
+#: build/OpenSCADLibInternal_autogen/include/ui_MouseConfigWidget.h:222
+msgid "Shift + Middle-click"
+msgstr ""
+
+#: build/OpenSCADLibInternal_autogen/include/ui_MouseConfigWidget.h:223
+msgid "Ctrl + Right-click"
+msgstr ""
+
+#: build/OpenSCADLibInternal_autogen/include/ui_MouseConfigWidget.h:224
+msgid "Ctrl + Shift + Left-click"
+msgstr ""
+
+#: build/OpenSCADLibInternal_autogen/include/ui_MouseConfigWidget.h:225
+msgid "Shift + Right-click"
+msgstr ""
+
+#: build/OpenSCADLibInternal_autogen/include/ui_MouseConfigWidget.h:226
+msgid "Middle-click"
+msgstr ""
+
+#: build/OpenSCADLibInternal_autogen/include/ui_OctoPrintApiKeyDialog.h:106
+msgid "OctoPrint API Key Request"
+msgstr ""
+
+#: build/OpenSCADLibInternal_autogen/include/ui_OctoPrintApiKeyDialog.h:108
+msgid "Retry"
+msgstr ""
+
+#: build/OpenSCADLibInternal_autogen/include/ui_OpenCSGWarningDialog.h:76
+msgid "OpenGL Warning"
+msgstr "OpenGL-varning"
+
+#: build/OpenSCADLibInternal_autogen/include/ui_OpenCSGWarningDialog.h:77
+msgid "Show this message again"
+msgstr "Visa detta meddelande igen"
+
+#: build/OpenSCADLibInternal_autogen/include/ui_OpenCSGWarningDialog.h:78
+msgid "Close"
+msgstr "Stäng"
+
+#: build/OpenSCADLibInternal_autogen/include/ui_ParameterCheckBox.h:60
+#: build/OpenSCADLibInternal_autogen/include/ui_ParameterComboBox.h:56
+#: build/OpenSCADLibInternal_autogen/include/ui_ParameterDescriptionWidget.h:98
+#: build/OpenSCADLibInternal_autogen/include/ui_ParameterSlider.h:86
+#: build/OpenSCADLibInternal_autogen/include/ui_ParameterSpinBox.h:69
+#: build/OpenSCADLibInternal_autogen/include/ui_ParameterText.h:55
+#: build/OpenSCADLibInternal_autogen/include/ui_ParameterVector.h:108
+#: build/OpenSCADLibInternal_autogen/include/ui_ParameterWidget.h:154
+msgid "Form"
+msgstr "Formulär"
+
+#: build/OpenSCADLibInternal_autogen/include/ui_ParameterDescriptionWidget.h:99
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2598
+msgid "Parameter"
+msgstr "Parameter"
+
+#: build/OpenSCADLibInternal_autogen/include/ui_ParameterWidget.h:155
 msgid "Automatic Preview"
 msgstr "Automatisk förhandsvisning"
 
-#: build/OpenSCAD_autogen/include/ui_ParameterWidget.h:143
+#: build/OpenSCADLibInternal_autogen/include/ui_ParameterWidget.h:156
 msgid "Show Details"
 msgstr "Visa detaljer"
 
-#: build/OpenSCAD_autogen/include/ui_ParameterWidget.h:144
+#: build/OpenSCADLibInternal_autogen/include/ui_ParameterWidget.h:157
 msgid "Inline Details"
 msgstr "Inline-detaljer"
 
-#: build/OpenSCAD_autogen/include/ui_ParameterWidget.h:145
+#: build/OpenSCADLibInternal_autogen/include/ui_ParameterWidget.h:158
 msgid "Hide Details"
 msgstr "Dölj detaljer"
 
-#: build/OpenSCAD_autogen/include/ui_ParameterWidget.h:146
+#: build/OpenSCADLibInternal_autogen/include/ui_ParameterWidget.h:159
 msgid "Description Only"
 msgstr "Endast beskrivning"
 
-#: build/OpenSCAD_autogen/include/ui_ParameterWidget.h:148
+#: build/OpenSCADLibInternal_autogen/include/ui_ParameterWidget.h:161
 msgid "<design default>"
 msgstr "<designstandard>"
 
-#: build/OpenSCAD_autogen/include/ui_ParameterWidget.h:151
+#: build/OpenSCADLibInternal_autogen/include/ui_ParameterWidget.h:164
 msgid "preset selection"
 msgstr "val av förinställning"
 
-#: build/OpenSCAD_autogen/include/ui_ParameterWidget.h:154
+#: build/OpenSCADLibInternal_autogen/include/ui_ParameterWidget.h:167
 msgid "Add new preset"
 msgstr "Lägg till ny förinställning"
 
-#: build/OpenSCAD_autogen/include/ui_ParameterWidget.h:156
+#: build/OpenSCADLibInternal_autogen/include/ui_ParameterWidget.h:169
 msgid "+"
 msgstr "+"
 
-#: build/OpenSCAD_autogen/include/ui_ParameterWidget.h:158
+#: build/OpenSCADLibInternal_autogen/include/ui_ParameterWidget.h:171
 msgid "Remove current preset"
 msgstr "Ta bort aktuell förinställning"
 
-#: build/OpenSCAD_autogen/include/ui_ParameterWidget.h:160
+#: build/OpenSCADLibInternal_autogen/include/ui_ParameterWidget.h:173
 msgid "-"
 msgstr "-"
 
-#: build/OpenSCAD_autogen/include/ui_Preferences.h:1840
+#: build/OpenSCADLibInternal_autogen/include/ui_ParameterWidget.h:175
+#, fuzzy
+msgid "More actions"
+msgstr "Anteckningar"
+
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2464
+msgid "Preferences"
+msgstr "Inställningar"
+
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2465
 msgid "3D View"
 msgstr "3D-vy"
 
-#: build/OpenSCAD_autogen/include/ui_Preferences.h:1841
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2466
 msgctxt "preferences"
 msgid "Advanced"
 msgstr "Avancerat"
 
-#: build/OpenSCAD_autogen/include/ui_Preferences.h:1842
-#: src/gui/MainWindow.cc:3111 src/gui/MainWindow.cc:3116
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2467
 msgid "Editor"
 msgstr "Redigerare"
 
-#: build/OpenSCAD_autogen/include/ui_Preferences.h:1844
-#: build/OpenSCAD_autogen/include/ui_Preferences.h:1928
-msgid "Features"
-msgstr "Funktioner"
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2469
+msgid "Experimental"
+msgstr ""
 
-#: build/OpenSCAD_autogen/include/ui_Preferences.h:1846
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2471
 msgid "Enable/Disable experimental features"
 msgstr "Aktivera/inaktivera experimentella funktioner"
 
-#: build/OpenSCAD_autogen/include/ui_Preferences.h:1848
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2473
 msgid "Axes"
 msgstr "Axlar"
 
-#: build/OpenSCAD_autogen/include/ui_Preferences.h:1850
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2475
 msgid "Input driver configuration and Axis mapping"
 msgstr "Konfiguration av ingångsdrivrutiner och axelmappning"
 
-#: build/OpenSCAD_autogen/include/ui_Preferences.h:1852
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2477
 msgid "Buttons"
 msgstr "Knappar"
 
-#: build/OpenSCAD_autogen/include/ui_Preferences.h:1853
-#: build/OpenSCAD_autogen/include/ui_PrintInitDialog.h:109
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2478
+msgid "Mouse"
+msgstr ""
+
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2479
+#: build/OpenSCADLibInternal_autogen/include/ui_PrintInitDialog.h:178
 msgid "3D Print"
 msgstr "3D-utskrift"
 
-#: build/OpenSCAD_autogen/include/ui_Preferences.h:1855
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2481
 msgid "3D Printing Services"
 msgstr "3D-utskriftstjänster"
 
-#: build/OpenSCAD_autogen/include/ui_Preferences.h:1857
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2483
+msgid "Dialogs"
+msgstr ""
+
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2484
+msgid "AI"
+msgstr ""
+
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2486
+msgid "AI and LLM configurations"
+msgstr ""
+
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2488
+msgid "Directory of the output file"
+msgstr ""
+
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2489
+msgid "Extension of the output file without leading dot"
+msgstr ""
+
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2490
+msgid "Full path to the main source file"
+msgstr ""
+
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2491
+msgid "Directory of the main source file"
+msgstr ""
+
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2492
+msgid "Full path to the output file"
+msgstr ""
+
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2493
 msgid "Color scheme:"
 msgstr "Färgschema:"
 
-#: build/OpenSCAD_autogen/include/ui_Preferences.h:1858
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2494
 msgid "Show Warnings and Errors in 3D View"
 msgstr "Visa varningar och fel i 3D-vyn"
 
-#: build/OpenSCAD_autogen/include/ui_Preferences.h:1859
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2495
 msgid "mouse centric zoom"
 msgstr "muscentrerad zoom"
 
-#: build/OpenSCAD_autogen/include/ui_Preferences.h:1860
-msgid "Swap Mouse Buttons"
-msgstr "Byt ut musknappar"
-
-#: build/OpenSCAD_autogen/include/ui_Preferences.h:1861
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2496
 msgid "Number Scroll"
 msgstr "Nummerrullning"
 
-#: build/OpenSCAD_autogen/include/ui_Preferences.h:1862 src/gui/Settings.cc:115
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2497
+#: src/core/Settings.cc:198
 msgid "Alt"
 msgstr "Alt"
 
-#: build/OpenSCAD_autogen/include/ui_Preferences.h:1863 src/gui/Settings.cc:115
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2498
+#: src/core/Settings.cc:199
 msgid "Left Mouse Button"
 msgstr "Vänster musknapp"
 
-#: build/OpenSCAD_autogen/include/ui_Preferences.h:1864 src/gui/Settings.cc:115
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2499
+#: src/core/Settings.cc:200
 msgid "Either"
 msgstr "Båda"
 
-#: build/OpenSCAD_autogen/include/ui_Preferences.h:1866
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2501
 msgid "Step Size"
 msgstr "Stegstorlek"
 
-#: build/OpenSCAD_autogen/include/ui_Preferences.h:1867
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2502
 msgid "Number Scroll Via Mouse Wheel"
 msgstr "Nummerrullning via mushjulet"
 
-#: build/OpenSCAD_autogen/include/ui_Preferences.h:1868
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2503
 msgid "Modifier For Wheel Scroll "
 msgstr "Modifierare för hjulrullning "
 
-#: build/OpenSCAD_autogen/include/ui_Preferences.h:1869
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2504
 msgid "Autocomplete"
 msgstr "Automatisk komplettering"
 
-#: build/OpenSCAD_autogen/include/ui_Preferences.h:1870
-msgid "Enable Autocompletion"
-msgstr "Aktivera automatisk komplettering"
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2505
+msgid " Include defined modules"
+msgstr ""
 
-#: build/OpenSCAD_autogen/include/ui_Preferences.h:1871
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2506
 msgid "Character Threshold"
 msgstr "Tröskelvärde för tecken"
 
-#: build/OpenSCAD_autogen/include/ui_Preferences.h:1872
-#: build/OpenSCAD_autogen/include/ui_Preferences.h:1897
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2507
+msgid " Include defined functions"
+msgstr ""
+
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2508
+msgid "Enable Autocompletion"
+msgstr "Aktivera automatisk komplettering"
+
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2509
+msgid " Include defined variables"
+msgstr ""
+
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2510
+msgid "Mode"
+msgstr ""
+
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2511
+#: src/core/Settings.cc:519
+#, fuzzy
+msgid "Parsed File Mode"
+msgstr "Betrodda filer"
+
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2512
+#: src/core/Settings.cc:520
+msgid "Regex Input Text Mode"
+msgstr ""
+
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2514
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2539
 msgid "Line wrap"
 msgstr "Radbrytning"
 
-#: build/OpenSCAD_autogen/include/ui_Preferences.h:1873
-#: build/OpenSCAD_autogen/include/ui_Preferences.h:1886
-#: build/OpenSCAD_autogen/include/ui_Preferences.h:1892 src/gui/Settings.cc:82
-#: src/gui/Settings.cc:100 src/gui/Settings.cc:103 src/gui/Settings.cc:104
-#: src/gui/input/ButtonConfigWidget.cc:236
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2515
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2528
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2534
+#: src/core/Settings.cc:45 src/core/Settings.cc:155 src/core/Settings.cc:166
+#: src/core/Settings.cc:172 src/gui/input/ButtonConfigWidget.cc:248
 msgid "None"
 msgstr "Ingen"
 
-#: build/OpenSCAD_autogen/include/ui_Preferences.h:1874 src/gui/Settings.cc:100
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2516
+#: src/core/Settings.cc:156
 msgid "Wrap at character boundaries"
 msgstr "Börja om vid teckengränser"
 
-#: build/OpenSCAD_autogen/include/ui_Preferences.h:1875 src/gui/Settings.cc:100
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2517
+#: src/core/Settings.cc:157
 msgid "Wrap at word boundaries"
 msgstr "Börja om vid ordgränser"
 
-#: build/OpenSCAD_autogen/include/ui_Preferences.h:1877
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2519
 msgid "Line wrap indentation"
 msgstr "Indragning med radbrytning"
 
-#: build/OpenSCAD_autogen/include/ui_Preferences.h:1878
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2520
 msgid "Line wrap visualization"
 msgstr "Visualisering av radbrytning"
 
-#: build/OpenSCAD_autogen/include/ui_Preferences.h:1879
-msgid "Style"
-msgstr "Stil"
-
-#: build/OpenSCAD_autogen/include/ui_Preferences.h:1880 src/gui/Settings.cc:101
-msgid "Fixed"
-msgstr "Fast"
-
-#: build/OpenSCAD_autogen/include/ui_Preferences.h:1881 src/gui/Settings.cc:101
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2523
+#: src/core/Settings.cc:161
 msgid "Same"
 msgstr "Samma"
 
-#: build/OpenSCAD_autogen/include/ui_Preferences.h:1882 src/gui/Settings.cc:101
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2524
+#: src/core/Settings.cc:161
 msgid "Indented"
 msgstr "Indragen"
 
-#: build/OpenSCAD_autogen/include/ui_Preferences.h:1884
-#: build/OpenSCAD_autogen/include/ui_Preferences.h:1915 src/gui/Settings.cc:110
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2526
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2557
+#: src/core/Settings.cc:189
 msgid "Indent"
 msgstr "Dra in"
 
-#: build/OpenSCAD_autogen/include/ui_Preferences.h:1885
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2527
 msgid "Start"
 msgstr "Början"
 
-#: build/OpenSCAD_autogen/include/ui_Preferences.h:1887
-#: build/OpenSCAD_autogen/include/ui_Preferences.h:1893 src/gui/Settings.cc:103
-#: src/gui/Settings.cc:104
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2529
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2535
+#: src/core/Settings.cc:167 src/core/Settings.cc:173
 msgid "Text"
 msgstr "Text"
 
-#: build/OpenSCAD_autogen/include/ui_Preferences.h:1888
-#: build/OpenSCAD_autogen/include/ui_Preferences.h:1894 src/gui/Settings.cc:103
-#: src/gui/Settings.cc:104
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2530
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2536
+#: src/core/Settings.cc:168 src/core/Settings.cc:174
 msgid "Border"
 msgstr "Ram"
 
-#: build/OpenSCAD_autogen/include/ui_Preferences.h:1889
-#: build/OpenSCAD_autogen/include/ui_Preferences.h:1895 src/gui/Settings.cc:103
-#: src/gui/Settings.cc:104
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2531
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2537
+#: src/core/Settings.cc:169 src/core/Settings.cc:175
 msgid "Margin"
 msgstr "Marginal"
 
-#: build/OpenSCAD_autogen/include/ui_Preferences.h:1891
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2533
 msgid "End"
 msgstr "Slut"
 
-#: build/OpenSCAD_autogen/include/ui_Preferences.h:1898
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2540
 msgid "Display"
 msgstr "Visning"
 
-#: build/OpenSCAD_autogen/include/ui_Preferences.h:1899
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2541
 msgid "Highlight current line"
 msgstr "Markera aktuell rad"
 
-#: build/OpenSCAD_autogen/include/ui_Preferences.h:1900
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2542
 msgid "Display Line Numbers"
 msgstr "Visa radnummer"
 
-#: build/OpenSCAD_autogen/include/ui_Preferences.h:1901
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2543
 msgid "Enable brace matching"
 msgstr "Aktivera klammermatchning"
 
-#: build/OpenSCAD_autogen/include/ui_Preferences.h:1902
-#: build/OpenSCAD_autogen/include/ui_Preferences.h:1967
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2544
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2617
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2629
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2631
 msgid "Font"
 msgstr "Typsnitt"
 
-#: build/OpenSCAD_autogen/include/ui_Preferences.h:1903
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2545
 msgid "Color syntax highlighting"
 msgstr "Färgmarkering för syntax"
 
-#: build/OpenSCAD_autogen/include/ui_Preferences.h:1904
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2546
 msgid "Ctrl/Cmd-Mouse-wheel zooms text"
 msgstr "Ctrl/Cmd-Mushjulet zoomar texten"
 
-#: build/OpenSCAD_autogen/include/ui_Preferences.h:1905
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2547
 msgid "Indentation"
 msgstr "Indragning"
 
-#: build/OpenSCAD_autogen/include/ui_Preferences.h:1906
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2548
 msgid "Auto Indent"
 msgstr "Automatisk indragning"
 
-#: build/OpenSCAD_autogen/include/ui_Preferences.h:1907
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2549
 msgid "Backspace unindents"
 msgstr "Backsteg avindenterar"
 
-#: build/OpenSCAD_autogen/include/ui_Preferences.h:1908
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2550
 msgid "Indent using"
 msgstr "Dra in med"
 
-#: build/OpenSCAD_autogen/include/ui_Preferences.h:1909 src/gui/Settings.cc:109
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2551
+#: src/core/Settings.cc:187
 msgid "Spaces"
 msgstr "Blanksteg"
 
-#: build/OpenSCAD_autogen/include/ui_Preferences.h:1912
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2552
+#: src/core/Settings.cc:187
+msgid "Tabs"
+msgstr "Flikar"
+
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2554
 msgid "Indentation width"
 msgstr "Indragningsbredd"
 
-#: build/OpenSCAD_autogen/include/ui_Preferences.h:1913
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2555
 msgid "Tab width"
 msgstr "Tabulatorbredd"
 
-#: build/OpenSCAD_autogen/include/ui_Preferences.h:1914
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2556
 msgid "Tab key function"
 msgstr "Tabbtangentens funktion"
 
-#: build/OpenSCAD_autogen/include/ui_Preferences.h:1916 src/gui/Settings.cc:110
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2558
+#: src/core/Settings.cc:190
 msgid "Insert Tab"
 msgstr "Infoga tabulator"
 
-#: build/OpenSCAD_autogen/include/ui_Preferences.h:1918
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2560
 msgid "Show whitespace"
 msgstr "Visa blanksteg"
 
-#: build/OpenSCAD_autogen/include/ui_Preferences.h:1919 src/gui/Settings.cc:105
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2561
+#: src/core/Settings.cc:178
 msgid "Never"
 msgstr "Aldrig"
 
-#: build/OpenSCAD_autogen/include/ui_Preferences.h:1920 src/gui/Settings.cc:105
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2562
+#: src/core/Settings.cc:179
 msgid "Always"
 msgstr "Alltid"
 
-#: build/OpenSCAD_autogen/include/ui_Preferences.h:1921
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2563
 msgid "Only after indentation"
 msgstr "Endast efter indragning"
 
-#: build/OpenSCAD_autogen/include/ui_Preferences.h:1924
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2565
+msgid "Size"
+msgstr "Storlek"
+
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2566
 msgid "Automatically check for updates"
 msgstr "Leta automatiskt efter uppdateringar"
 
-#: build/OpenSCAD_autogen/include/ui_Preferences.h:1925
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2567
 msgid "Include development snapshots"
 msgstr "Inkludera ögonblicksbilder av utvecklingsversioner"
 
-#: build/OpenSCAD_autogen/include/ui_Preferences.h:1926
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2568
 msgid "Check Now"
 msgstr "Kontrollera nu"
 
-#: build/OpenSCAD_autogen/include/ui_Preferences.h:1927
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2569
 msgid "Last checked: "
 msgstr "Senast kontrollerad: "
 
-#: build/OpenSCAD_autogen/include/ui_Preferences.h:1929
-#: build/OpenSCAD_autogen/include/ui_PrintInitDialog.h:114
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2570
+#, fuzzy
+msgid "Experimental Features"
+msgstr "Exportfunktioner"
+
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2571
+msgid ""
+"These features are experimental.  They may change or be removed entirely "
+"without notice. You may enable them and use them and comment on them, but "
+"you must assume that they may not be in their final form and may never "
+"appear in an OpenSCAD release in any form."
+msgstr ""
+
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2572
+msgid "General"
+msgstr ""
+
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2573
+#, fuzzy
+msgid "Default Print Service"
+msgstr "3D-utskriftstjänster"
+
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2574
+msgid "Enable remote print services"
+msgstr ""
+
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2575
+#: build/OpenSCADLibInternal_autogen/include/ui_PrintInitDialog.h:181
+#: src/gui/Preferences.cc:606
 msgid "OctoPrint"
 msgstr "OctoPrint"
 
-#: build/OpenSCAD_autogen/include/ui_Preferences.h:1930
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2576
 msgid "URL"
 msgstr "URL"
 
-#: build/OpenSCAD_autogen/include/ui_Preferences.h:1931
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2577
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2667
 msgid "API Key"
 msgstr "API-nyckel"
 
-#: build/OpenSCAD_autogen/include/ui_Preferences.h:1932
-#: build/OpenSCAD_autogen/include/ui_Preferences.h:1933
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2578
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2579
 msgid "Load"
 msgstr "Läs in"
 
-#: build/OpenSCAD_autogen/include/ui_Preferences.h:1935
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2581
 msgid "Check"
 msgstr "Kontrollera"
 
-#: build/OpenSCAD_autogen/include/ui_Preferences.h:1936
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2582
 msgid "Slicing Profile"
 msgstr "Skärningsprofil"
 
-#: build/OpenSCAD_autogen/include/ui_Preferences.h:1937
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2583
 msgid "Slicing Engine"
 msgstr "Skärningsmotor"
 
-#: build/OpenSCAD_autogen/include/ui_Preferences.h:1938
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2584
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2590
 msgid "File Format"
 msgstr "Filformat"
 
-#: build/OpenSCAD_autogen/include/ui_Preferences.h:1939
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2585
 msgid "Action"
 msgstr "Åtgärd"
 
-#: build/OpenSCAD_autogen/include/ui_Preferences.h:1940
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2586
+msgid "Request"
+msgstr ""
+
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2587
 msgid "Show"
 msgstr "Visa"
 
-#: build/OpenSCAD_autogen/include/ui_Preferences.h:1941
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2588
 msgid "Note: The API key is stored unencrypted in the application settings."
 msgstr "Observera: API-nyckeln lagras okrypterad i programmets inställningar."
 
-#: build/OpenSCAD_autogen/include/ui_Preferences.h:1942
-msgid "OpenCSG"
-msgstr "OpenCSG"
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2589
+#: src/gui/Preferences.cc:607
+msgid "Local Application"
+msgstr ""
 
-#: build/OpenSCAD_autogen/include/ui_Preferences.h:1943
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2591
+#, fuzzy
+msgid "File"
+msgstr "&Arkiv"
+
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2596
+msgid "Executable"
+msgstr ""
+
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2600
+msgid ""
+"Directory for storing the exported file, leave empty to use the default "
+"system location."
+msgstr ""
+
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2603
+msgid "Temp Dir"
+msgstr ""
+
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2605
+msgid "3D Preview (OpenCSG)"
+msgstr ""
+
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2606
 msgid "Show capability warning"
 msgstr "Visa kapacitetsvarning"
 
-#: build/OpenSCAD_autogen/include/ui_Preferences.h:1944
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2607
 msgid "Turn off rendering at "
 msgstr "Stäng av rendering vid "
 
-#: build/OpenSCAD_autogen/include/ui_Preferences.h:1945
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2608
 msgid "elements"
 msgstr "element"
 
-#: build/OpenSCAD_autogen/include/ui_Preferences.h:1946
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2609
 msgid "Force Goldfeather"
 msgstr "Tvinga Goldfeather"
 
-#: build/OpenSCAD_autogen/include/ui_Preferences.h:1947
-msgid "CGAL"
-msgstr "CGAL"
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2610
+#, fuzzy
+msgid "3D Rendering"
+msgstr "R&endera"
 
-#: build/OpenSCAD_autogen/include/ui_Preferences.h:1948
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2611
+msgid "Backend"
+msgstr ""
+
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2612
 msgid "CGAL Cache size"
 msgstr "Storlek för CGAL-cache"
 
-#: build/OpenSCAD_autogen/include/ui_Preferences.h:1949
-#: build/OpenSCAD_autogen/include/ui_Preferences.h:1951
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2613
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2615
 msgid "MB"
 msgstr "MB"
 
-#: build/OpenSCAD_autogen/include/ui_Preferences.h:1950
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2614
 msgid "PolySet Cache size"
 msgstr "Storlek för PolySet-cache"
 
-#: build/OpenSCAD_autogen/include/ui_Preferences.h:1952
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2616
 msgid "User Interface"
 msgstr "Användargränssnitt"
 
-#: build/OpenSCAD_autogen/include/ui_Preferences.h:1953
-msgid "Enable docking of Editor and Console in different places"
-msgstr "Aktivera dockning av Redigera och Konsol på olika platser"
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2618
+msgid "Enable docking helper widgets in different places"
+msgstr "Aktivera dockningshjälpwidgetar på olika platser"
 
-#: build/OpenSCAD_autogen/include/ui_Preferences.h:1954
-msgid "Enable undocking of Editor and Console to separate windows"
-msgstr "Aktivera avdockning av Redigerare och Konsol till separata fönster"
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2619
+msgid "Enable undocking of helper widgets to separate windows"
+msgstr "Aktivera avdockning av hjälpwidgetar till separata fönster"
 
-#: build/OpenSCAD_autogen/include/ui_Preferences.h:1955
-msgid "Show Welcome Screen"
-msgstr "Visa välkomstskärm"
-
-#: build/OpenSCAD_autogen/include/ui_Preferences.h:1956
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2620
 msgid "Enable user interface localization (requires restart of OpenSCAD)"
 msgstr ""
 "Aktivera lokalisering av användargränssnitt (kräver omstart av OpenSCAD)"
 
-#: build/OpenSCAD_autogen/include/ui_Preferences.h:1957
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2621
 msgid "Bring window to front after automatic reload"
 msgstr "Ta fram fönstret efter automatisk omläsning"
 
-#: build/OpenSCAD_autogen/include/ui_Preferences.h:1958
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2622
 msgid "Play sound notification on render complete"
 msgstr "Spela upp ett ljudmeddelande när renderingen är klar"
 
-#: build/OpenSCAD_autogen/include/ui_Preferences.h:1959
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2623
 msgid "Play sound when render completion time is at least"
 msgstr "Spela ljud när renderingstiden är minst"
 
-#: build/OpenSCAD_autogen/include/ui_Preferences.h:1960
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2624
 msgid "sec"
 msgstr "s"
 
-#: build/OpenSCAD_autogen/include/ui_Preferences.h:1961
-msgid "Toolbar Export 3D"
-msgstr "Verktygsfält Exportera 3D"
-
-#: build/OpenSCAD_autogen/include/ui_Preferences.h:1962
-msgid "Toolbar Export 2D"
-msgstr "Verktygsfältet Exportera 2D"
-
-#: build/OpenSCAD_autogen/include/ui_Preferences.h:1963
-#: src/gui/MainWindow.cc:3129 src/gui/MainWindow.cc:3134
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2625
 msgid "Console"
 msgstr "Konsol"
 
-#: build/OpenSCAD_autogen/include/ui_Preferences.h:1964
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2626
 msgid "Clear console before Preview/Render"
 msgstr "Töm konsolen före Förhandsvisa/Rendera"
 
-#: build/OpenSCAD_autogen/include/ui_Preferences.h:1965
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2627
 msgid "Maximum lines for Console to keep:"
 msgstr "Maximalt antal rader för konsolen att behålla:"
 
-#: build/OpenSCAD_autogen/include/ui_Preferences.h:1966
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2628
 msgid "(0 for unlimited)"
 msgstr "(0 för obegränsad)"
 
-#: build/OpenSCAD_autogen/include/ui_Preferences.h:1968
-msgid "Toolbar Export Format 3D"
-msgstr "Verktygsfältet Exportformat 3D"
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2630
+msgid "Customizer"
+msgstr "Anpassare"
 
-#: build/OpenSCAD_autogen/include/ui_Preferences.h:1969
-msgid "STL"
-msgstr "STL"
-
-#: build/OpenSCAD_autogen/include/ui_Preferences.h:1970
-msgid "OBJ"
-msgstr "OBJ"
-
-#: build/OpenSCAD_autogen/include/ui_Preferences.h:1971
-msgid "OFF"
-msgstr "AV"
-
-#: build/OpenSCAD_autogen/include/ui_Preferences.h:1972
-msgid "WRL"
-msgstr "WRL"
-
-
-#: build/OpenSCAD_autogen/include/ui_Preferences.h:1974
-msgid "3MF"
-msgstr "3MF"
-
-#: build/OpenSCAD_autogen/include/ui_Preferences.h:1976
-msgid "Toolbar Export Format 2D"
-msgstr "Verktygsfältet Exportformat 2D"
-
-#: build/OpenSCAD_autogen/include/ui_Preferences.h:1977
-msgid "none"
-msgstr "ingen"
-
-#: build/OpenSCAD_autogen/include/ui_Preferences.h:1978
-msgid "DXF"
-msgstr "DXF"
-
-#: build/OpenSCAD_autogen/include/ui_Preferences.h:1979
-msgid "SVG"
-msgstr "SVG"
-
-#: build/OpenSCAD_autogen/include/ui_Preferences.h:1980
-msgid "PDF"
-msgstr "PDF"
-
-#: build/OpenSCAD_autogen/include/ui_Preferences.h:1982
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2632
 msgid "OpenSCAD Language Features"
 msgstr "Språkfunktioner i OpenSCAD"
 
-#: build/OpenSCAD_autogen/include/ui_Preferences.h:1983
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2633
 msgid "Warnings"
 msgstr "Varningar"
 
-#: build/OpenSCAD_autogen/include/ui_Preferences.h:1984
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2634
 msgid "Stop on the first warning"
 msgstr "Stoppa vid första varningen"
 
-#: build/OpenSCAD_autogen/include/ui_Preferences.h:1985
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2635
 msgid "Check the parameter range for builtin modules"
 msgstr "Kontrollera parameterintervallet för inbyggda moduler"
 
-#: build/OpenSCAD_autogen/include/ui_Preferences.h:1986
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2636
 msgid "Warn when there is a parameter mismatch in user module calls"
 msgstr ""
 "Varning när en parameter inte stämmer överens i anrop till användarmodul"
 
-#: build/OpenSCAD_autogen/include/ui_Preferences.h:1987
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2637
 msgid "Trace"
 msgstr "Spåra"
 
-#: build/OpenSCAD_autogen/include/ui_Preferences.h:1988
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2638
 msgid "Trace depth:"
 msgstr "Spårningsdjup:"
 
-#: build/OpenSCAD_autogen/include/ui_Preferences.h:1989
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2639
 msgid "(max. number or trace messages)"
 msgstr "(max. antal eller spårningsmeddelanden)"
 
-#: build/OpenSCAD_autogen/include/ui_Preferences.h:1990
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2640
 msgid "Show parameters of usermodule calls in trace"
 msgstr "Visa parametrar för usermodule-anrop i spårning"
 
-#: build/OpenSCAD_autogen/include/ui_Preferences.h:1991
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2641
 msgid "Render Summary"
 msgstr "Sammanfattning av rendering"
 
-#: build/OpenSCAD_autogen/include/ui_Preferences.h:1992
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2642
 msgid "Camera"
 msgstr "Kamera"
 
-#: build/OpenSCAD_autogen/include/ui_Preferences.h:1993
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2643
 msgid "Bounding Box"
 msgstr "Begränsningsruta"
 
-#: build/OpenSCAD_autogen/include/ui_Preferences.h:1994
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2644
 msgid "Measurements: Area"
 msgstr "Mätningar: Yta"
 
-#: build/OpenSCAD_autogen/include/ui_Preferences.h:1995
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2645
 msgid "Export Features"
 msgstr "Exportfunktioner"
 
-#: build/OpenSCAD_autogen/include/ui_Preferences.h:1996
-msgid "Default to ASCII STL export"
-msgstr "Standard till ASCII STL-export"
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2646
+msgid "Toolbar Export 3D"
+msgstr "Verktygsfält Exportera 3D"
 
-#: build/OpenSCAD_autogen/include/ui_Preferences.h:1997
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2647
+msgid "Toolbar Export 2D"
+msgstr "Verktygsfältet Exportera 2D"
+
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2648
 msgid "Debugging"
 msgstr "Felsökning"
 
-#: build/OpenSCAD_autogen/include/ui_Preferences.h:1998
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2649
 msgid "Enable tracing of HIDAPI events (requires restart of OpenSCAD)"
 msgstr "Aktivera spårning av HIDAPI-händelser (kräver omstart av OpenSCAD)"
 
-#: build/OpenSCAD_autogen/include/ui_PrintInitDialog.h:111
-msgid "Cancel"
-msgstr "Avbryt"
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2650
+msgid "Network"
+msgstr ""
 
-#: build/OpenSCAD_autogen/include/ui_PrintInitDialog.h:113
-msgid "%1"
-msgstr "%1"
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2651
+msgid "Custom CA certificates (PEM)"
+msgstr ""
 
-#: build/OpenSCAD_autogen/include/ui_ProgressWidget.h:70
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2653
+msgid "Skip TLS certificate verification (insecure)"
+msgstr ""
+
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2654
+msgid "Dialog visibility"
+msgstr ""
+
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2655
+#, fuzzy
+msgid "Always show Welcome screen"
+msgstr "Visa välkomstskärm"
+
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2656
+msgid "Always show PDF export dialog"
+msgstr ""
+
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2657
+msgid "Always show 3MF export dialog"
+msgstr ""
+
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2658
+msgid "Always show Print Service dialog"
+msgstr ""
+
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2659
+#, fuzzy
+msgid "AI Preferences"
+msgstr "Inställningar"
+
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2660
+msgid ""
+"AI assistant integration is active. Configure your connection profiles and "
+"parameters below."
+msgstr ""
+
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2661
+#, fuzzy
+msgid "Profiles"
+msgstr ""
+
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2662
+#, fuzzy
+msgid "Active Profile"
+msgstr ""
+
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2663
+#, fuzzy
+msgid "New Profile"
+msgstr "&Ny fil"
+
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2664
+msgid "Delete"
+msgstr ""
+
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2665
+msgid "API Configuration"
+msgstr ""
+
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2666
+msgid "API Endpoint"
+msgstr ""
+
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2668
+msgid "System Prompt / Instructions"
+msgstr ""
+
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2669
+msgid "Default User Prompt"
+msgstr ""
+
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2670
+#, fuzzy
+msgid "API Parameters"
+msgstr ""
+
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2671
+#, fuzzy
+msgid "Add Parameter"
+msgstr "Parameter"
+
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2672
+#, fuzzy
+msgid "Remove Parameter"
+msgstr "Parameter"
+
+#: build/OpenSCADLibInternal_autogen/include/ui_PrintInitDialog.h:180
+#, fuzzy
+msgid "Run local Application"
+msgstr ""
+
+#: build/OpenSCADLibInternal_autogen/include/ui_PrintInitDialog.h:182
+#, fuzzy
+msgid "File format"
+msgstr "Filformat"
+
+#: build/OpenSCADLibInternal_autogen/include/ui_PrintInitDialog.h:183
+msgid "Enable remote services that need network access"
+msgstr ""
+
+#: build/OpenSCADLibInternal_autogen/include/ui_ProgressWidget.h:70
 msgid "%v / %m"
 msgstr "%v / %m"
 
-#: build/OpenSCAD_autogen/include/ui_ViewportControl.h:198
-msgid "ViewportControlWidget"
-msgstr "ViewportControlWidget"
-
-#: build/OpenSCAD_autogen/include/ui_ViewportControl.h:203
-msgid "absolute"
-msgstr "absolute"
-
-#: build/OpenSCAD_autogen/include/ui_ViewportControl.h:204
-msgid "distance"
-msgstr "avstånd"
-
-#: build/OpenSCAD_autogen/include/ui_ViewportControl.h:205
-msgid "translate"
-msgstr "översätt"
-
-#: build/OpenSCAD_autogen/include/ui_ViewportControl.h:206
-msgid "rotate"
-msgstr "rotera"
-
-#: build/OpenSCAD_autogen/include/ui_ViewportControl.h:207
-msgid "fov"
-msgstr "synfält"
-
-#: build/OpenSCAD_autogen/include/ui_ViewportControl.h:208
+#: build/OpenSCADLibInternal_autogen/include/ui_ViewportControl.h:271
 msgid "Aspect Ratio"
 msgstr "Bildförhållande"
 
-#: build/OpenSCAD_autogen/include/ui_ViewportControl.h:209
-msgid ":"
-msgstr ":"
+#: build/OpenSCADLibInternal_autogen/include/ui_ViewportControl.h:272
+msgid "Width"
+msgstr ""
 
-#: build/OpenSCAD_autogen/include/ui_ViewportControl.h:210
+#: build/OpenSCADLibInternal_autogen/include/ui_ViewportControl.h:273
+#, fuzzy
+msgid "Height"
+msgstr "&Höger"
+
+#: build/OpenSCADLibInternal_autogen/include/ui_ViewportControl.h:275
 msgid "Lock"
 msgstr "Lås"
 
-#: src/gui/Network.h:121
-msgid "Timeout error"
-msgstr "Timeout-fel"
+#: build/OpenSCADLibInternal_autogen/include/ui_ViewportControl.h:276
+#, fuzzy
+msgid "Details"
+msgstr "Visa detaljer"
 
-#: src/gui/Animate.cc:39
-msgid "toggle pause/unpause"
-msgstr "växla mellan paus/avpaus"
+#: build/OpenSCADLibInternal_autogen/include/ui_ViewportControl.h:277
+#, fuzzy
+msgid "Distance"
+msgstr "avstånd"
 
-#: src/gui/Animate.cc:72
-msgid "Move to beginning (first frame)"
-msgstr "Flytta till början (första bildrutan)"
+#: build/OpenSCADLibInternal_autogen/include/ui_ViewportControl.h:278
+msgid "FOV"
+msgstr ""
 
-#: src/gui/Animate.cc:76
-msgid "step one frame back"
-msgstr "stega en bildruta bakåt"
+#: src/core/Settings.cc:49
+#, c-format
+msgid "Axis %d"
+msgstr "Axel %d"
 
-#: src/gui/Animate.cc:80
-msgid "play animation"
-msgstr "spela upp animation"
+#: src/core/Settings.cc:53
+#, c-format
+msgid "Axis %d (inverted)"
+msgstr "Axel %d (inverterad)"
 
-#: src/gui/Animate.cc:84
-msgid "pause animation"
-msgstr "pausa animering"
+#: src/core/Settings.cc:181
+msgid "After indentation"
+msgstr "Efter indragning"
 
-#: src/gui/Animate.cc:88
-msgid "step one frame forward"
-msgstr "stega en bildruta framåt"
+#: src/core/Settings.cc:215
+msgid "Upload only"
+msgstr "Endast uppladdning"
 
-#: src/gui/Animate.cc:92
-msgid "Move to end (last frame)"
-msgstr "Hoppa till slutet (sista bildrutan)"
+#: src/core/Settings.cc:216
+msgid "Upload & Slice"
+msgstr "Ladda upp och skär"
 
-#: src/gui/Animate.cc:242
+#: src/core/Settings.cc:217
+msgid "Upload, Slice & Select for printing"
+msgstr "Ladda upp, skär och välj för utskrift"
+
+#: src/core/Settings.cc:218
+msgid "Upload, Slice & Start printing"
+msgstr "Ladda upp, skär och börja skriva ut"
+
+#: src/core/Settings.cc:435
+msgid "Use colors from model"
+msgstr ""
+
+#: src/core/Settings.cc:437
+#, fuzzy
+msgid "Use selected color only"
+msgstr "Använd ma&rkering för att söka"
+
+#: src/core/Settings.cc:444
+msgid "Millimeter"
+msgstr ""
+
+#: src/core/Settings.cc:448
+msgid "Feet"
+msgstr ""
+
+#: src/core/Settings.cc:456
+msgid "Color"
+msgstr ""
+
+#: src/core/Settings.cc:457
+msgid "Base Material"
+msgstr ""
+
+#: src/core/Settings.cc:509
+msgid "Alphabetical"
+msgstr ""
+
+#: src/glview/Camera.cc:208
+#, c-format
+msgid ""
+"Viewport: translate = [ %.2f %.2f %.2f ], rotate = [ %.2f %.2f %.2f ], "
+"distance = %.2f, fov = %.2f"
+msgstr ""
+
+#: src/gui/ai/ChatWidget.cc:101 src/gui/ai/ChatWidget.cc:454
+msgid "Thinking..."
+msgstr ""
+
+#: src/gui/ai/ChatWidget.cc:110
+msgid "Thinking"
+msgstr ""
+
+#: src/gui/ai/ChatWidget.cc:153
+#, fuzzy
+msgid "Export Chat..."
+msgstr ""
+
+#: src/gui/ai/ChatWidget.cc:154
+#, fuzzy
+msgid "Import Chat..."
+msgstr ""
+
+#: src/gui/ai/ChatWidget.cc:156
+msgid "Copy as Markdown"
+msgstr ""
+
+#: src/gui/ai/ChatWidget.cc:200 src/gui/ai/ChatWidget.cc:613
+msgid ""
+"Hello! I am your OpenSCAD AI assistant. Ask me to write some code, e.g. "
+"\"draw a sphere\" or \"create a box with a hole\"."
+msgstr ""
+
+#: src/gui/ai/ChatWidget.cc:215
+msgid "AI proposed code changes:"
+msgstr ""
+
+#: src/gui/ai/ChatWidget.cc:218
+msgid "Review & Apply"
+msgstr ""
+
+#: src/gui/ai/ChatWidget.cc:223
+msgid "Discard"
+msgstr ""
+
+#: src/gui/ai/ChatWidget.cc:291 src/gui/ai/ChatWidget.cc:634
+msgid "Stop"
+msgstr ""
+
+#: src/gui/ai/ChatWidget.cc:481 src/gui/ai/ChatWidget.cc:488
+#, fuzzy
+msgid "Viewport Error"
+msgstr ""
+
+#: src/gui/ai/ChatWidget.cc:482
+msgid "Could not find active 3D Viewport to grab screen."
+msgstr ""
+
+#: src/gui/ai/ChatWidget.cc:488
+msgid "Failed to capture 3D viewport frame."
+msgstr ""
+
+#: src/gui/ai/ChatWidget.cc:509
+msgid "Image Files (*.png *.jpg *.jpeg *.webp)"
+msgstr ""
+
+#: src/gui/ai/ChatWidget.cc:517
+#, fuzzy
+msgid "File Error"
+msgstr ""
+
+#: src/gui/ai/ChatWidget.cc:517
+msgid "Could not open the selected image file."
+msgstr ""
+
+#: src/gui/ai/ChatWidget.cc:577
+msgid "[Img]"
+msgstr ""
+
+#: src/gui/ai/ChatWidget.cc:582
+msgid "Remove attachment"
+msgstr ""
+
+#: src/gui/ai/ChatWidget.cc:902
+msgid "Export Chat History"
+msgstr ""
+
+#: src/gui/ai/ChatWidget.cc:902 src/gui/ai/ChatWidget.cc:949
+#, fuzzy
+msgid "JSON Files (*.json)"
+msgstr "JSON-filer (*.json)"
+
+#: src/gui/ai/ChatWidget.cc:938
+#, fuzzy
+msgid "Export Warning"
+msgstr ""
+
+#: src/gui/ai/ChatWidget.cc:938
+msgid "Could not write to the chosen file."
+msgstr ""
+
+#: src/gui/ai/ChatWidget.cc:943
+#, fuzzy
+msgid "Export Successful"
+msgstr ""
+
+#: src/gui/ai/ChatWidget.cc:943
+msgid "Chat history exported successfully."
+msgstr ""
+
+#: src/gui/ai/ChatWidget.cc:949
+msgid "Import Chat History"
+msgstr ""
+
+#: src/gui/ai/ChatWidget.cc:957 src/gui/ai/ChatWidget.cc:965
+#: src/gui/ai/ChatWidget.cc:970 src/gui/ai/ChatWidget.cc:1013
+#, fuzzy
+msgid "Import Warning"
+msgstr ""
+
+#: src/gui/ai/ChatWidget.cc:957
+msgid "Could not open the selected file."
+msgstr ""
+
+#: src/gui/ai/ChatWidget.cc:971
+msgid "Selected file does not contain a valid chat history array."
+msgstr ""
+
+#: src/gui/ai/ChatWidget.cc:1016
+msgid "Import Successful"
+msgstr ""
+
+#: src/gui/ai/ChatWidget.cc:1016
+msgid "Chat history imported successfully."
+msgstr ""
+
+#: src/gui/ai/ChatWidget.cc:1051
+msgid "Chat Copied"
+msgstr ""
+
+#: src/gui/ai/ChatWidget.cc:1052
+msgid "Chat conversation copied to clipboard as Markdown."
+msgstr ""
+
+#: src/gui/Animate.cc:207
 msgid "press to pause animation"
 msgstr "tryck för att pausa animeringen"
 
-#: src/gui/Animate.cc:246
+#: src/gui/Animate.cc:211
 msgid "press to start animation"
 msgstr "tryck för att starta animering"
 
-#: src/gui/Animate.cc:249
+#: src/gui/Animate.cc:214
 msgid "incorrect values"
 msgstr "felaktiga värden"
 
-#: src/gui/Console.cc:133
+#: src/gui/ColorList.cc:207
+msgid "Filter (%1 colors found)"
+msgstr ""
+
+#: src/gui/Console.cc:188
 msgid "Save console content"
 msgstr "Spara konsolens innehåll"
 
-#: src/gui/FontListDialog.cc:85
-msgid "Font name"
+#: src/gui/Export3mfDialog.cc:78
+msgid ""
+"This OpenSCAD build uses lib3mf version 1. Setting the decimal precision for "
+"export needs version 2 or later."
+msgstr ""
+
+#: src/gui/ExternalToolInterface.cc:188
+msgid "Exported design exceeds the service upload limit of (%1 MB)."
+msgstr ""
+"Den exporterade designen överskrider tjänstens uppladdningsgräns på (%1 MB)."
+
+#: src/gui/FontList.cc:403
+#, fuzzy
+msgid "Styled font name"
 msgstr "Typsnittsnamn"
 
-#: src/gui/FontListDialog.cc:86
+#: src/gui/FontList.cc:404
 msgid "Font style"
 msgstr "Typsnittstil"
 
-#: src/gui/FontListDialog.cc:87
-msgid "Filename"
+#: src/gui/FontList.cc:407
+#, fuzzy
+msgid "File name"
 msgstr "Filnamn"
 
-#: src/gui/MainWindow.cc:1171
+#: src/gui/FontList.cc:408
+#, fuzzy
+msgid "File path"
+msgstr "Filformat"
+
+#: src/gui/FontList.cc:409
+msgid "Hash"
+msgstr ""
+
+#: src/gui/input/AxisConfigWidget.h:89
+msgid ""
+"This driver was not enabled during build time and is thus not available."
+msgstr ""
+"Den här drivrutinen aktiverades inte under byggtiden och är därför inte "
+"tillgänglig."
+
+#: src/gui/input/AxisConfigWidget.h:92
+msgid ""
+"The DBUS driver is not for actual devices but for remote control, Linux only."
+msgstr ""
+"DBUS-drivrutinen är inte avsedd för faktiska enheter utan för fjärrstyrning, "
+"endast Linux."
+
+#: src/gui/input/AxisConfigWidget.h:94
+msgid ""
+"The HIDAPI driver communicates directly with the 3D mice, Windows and macOS."
+msgstr "HIDAPI-drivrutinen kommunicerar direkt med 3D-möss, Windows och macOS."
+
+#: src/gui/input/AxisConfigWidget.h:96
+msgid ""
+"The SpaceNav driver enables 3D-input-devices using the spacenavd daemon, "
+"Linux only."
+msgstr ""
+"SpaceNav-drivrutinen möjliggör 3D-inmatningsenheter med hjälp av daemon "
+"spacenavd, endast Linux."
+
+#: src/gui/input/AxisConfigWidget.h:98
+msgid ""
+"The Joystick driver uses the Linux joystick device (fixed to /dev/input/"
+"js0), Linux only."
+msgstr ""
+"Joystick-drivrutinen använder Linux joystick-enhet (fast till /dev/input/"
+"js0), endast Linux."
+
+#: src/gui/input/AxisConfigWidget.h:100
+msgid "The QGAMEPAD driver is for multiplattform Gamepad Support."
+msgstr ""
+"QGAMEPAD-drivrutinen är avsedd för stöd för Gamepad med flera plattformar."
+
+#: src/gui/input/ButtonConfigWidget.cc:249
+msgid "Toggle Perspective"
+msgstr "Växla perspektiv"
+
+#: src/gui/MainWindow.cc:872
 msgid "Compile error."
 msgstr "Kompileringsfel."
 
-#: src/gui/MainWindow.cc:1174
+#: src/gui/MainWindow.cc:875
 msgid "Error while compiling '%1'."
 msgstr "Fel vid kompilering av '%1'."
 
-#: src/gui/MainWindow.cc:1178
+#: src/gui/MainWindow.cc:880
 msgid "Compilation generated %1 warning."
 msgid_plural "Compilation generated %1 warnings."
 msgstr[0] "Kompileringen genererade %1 varning."
 msgstr[1] "Kompileringen genererade %1 varningar."
 
-#: src/gui/MainWindow.cc:1188
+#: src/gui/MainWindow.cc:893
 msgid ""
 " For details see the <a href=\"#errorlog\">error log</a> and <a "
 "href=\"#console\">console window</a>."
@@ -2172,23 +3089,24 @@ msgstr ""
 " För mer information, se <a href=\"#errorlog\">felloggen</a> och <a "
 "href=\"#console\">konsolfönstret</a>."
 
-#: src/gui/MainWindow.cc:1572
+#: src/gui/MainWindow.cc:1331
 msgid "Trusted Files"
 msgstr "Betrodda filer"
 
-#: src/gui/MainWindow.cc:1877
+#: src/gui/MainWindow.cc:1715
+#, fuzzy
 msgid ""
-"Python files can potentially contain harumful stuff.\n"
+"Python files can potentially contain harmful stuff.\n"
 "Do you trust this file ?\n"
 msgstr ""
 "Python-filer kan eventuellt innehålla skadliga saker.\n"
 "Litar du på den här filen?\n"
 
-#: src/gui/MainWindow.cc:1974
+#: src/gui/MainWindow.cc:1821
 msgid "Application"
 msgstr "Applikation"
 
-#: src/gui/MainWindow.cc:1975
+#: src/gui/MainWindow.cc:1822
 msgid ""
 "The document has been modified.\n"
 "Do you really want to reload the file?"
@@ -2196,66 +3114,98 @@ msgstr ""
 "Dokumentet har ändrats.\n"
 "Vill du verkligen läsa om filen?"
 
-#: src/gui/MainWindow.cc:2233
-msgid "Exported design exceeds the service upload limit of (%1 MB)."
-msgstr ""
-"Den exporterade designen överskrider tjänstens uppladdningsgräns på (%1 MB)."
-
-#: src/gui/MainWindow.cc:2234
-msgid "Upload Error"
-msgstr "Uppladdningsfel"
-
-#: src/gui/MainWindow.cc:2692
+#: src/gui/MainWindow.cc:2575
 msgid "Export %1 File"
 msgstr "Exportera %1-fil"
 
-#: src/gui/MainWindow.cc:2693
+#: src/gui/MainWindow.cc:2576
 msgid "%1 Files (*%2)"
 msgstr "%1-filer (*%2)"
 
-#: src/gui/MainWindow.cc:2812
+#: src/gui/MainWindow.cc:2624
 msgid "Export CSG File"
 msgstr "Exportera CSG-fil"
 
-#: src/gui/MainWindow.cc:2812
+#: src/gui/MainWindow.cc:2625
 msgid "CSG Files (*.csg)"
 msgstr "CSG-filer (*.csg)"
 
-#: src/gui/MainWindow.cc:2838
+#: src/gui/MainWindow.cc:2648
 msgid "Export Image"
 msgstr "Exportera bild"
 
-#: src/gui/MainWindow.cc:2838
+#: src/gui/MainWindow.cc:2648
 msgid "PNG Files (*.png)"
 msgstr "PNG-filer (*.png)"
 
-#: src/gui/MainWindow.cc:3145
-msgid "Customizer"
-msgstr "Anpassare"
+#: src/gui/MainWindow.cc:3038 src/gui/MainWindow.cc:3798
+msgid "&AI Chat"
+msgstr ""
 
-#: src/gui/MainWindow.cc:3150 src/gui/MainWindow.cc:3155
-msgid "Error-Log"
-msgstr "Fellogg"
-
-#: src/gui/MainWindow.cc:3197 src/gui/TabManager.cc:213
-#: src/gui/TabManager.cc:458 src/gui/TabManager.cc:522
-#: src/gui/TabManager.cc:697 src/gui/TabManager.cc:728
+#: src/gui/MainWindow.cc:3140 src/gui/TabManager.cc:735
+#: src/gui/TabManager.cc:786
 msgid "Untitled.scad"
 msgstr "Namnlös.scad"
 
-#: src/gui/MainWindow.cc:3652 src/gui/MainWindow.cc:3655
-msgid "Untitled"
-msgstr "Namnlös"
+#: src/gui/MainWindow.cc:3790
+msgid "&Editor"
+msgstr "R&edigerare"
 
-#: src/gui/OpenSCADApp.cc:61
+#: src/gui/MainWindow.cc:3791
+msgid "&Console"
+msgstr "&Konsol"
+
+#: src/gui/MainWindow.cc:3792
+msgid "C&ustomizer"
+msgstr "A&npassare"
+
+#: src/gui/MainWindow.cc:3793
+msgid "Error &Log"
+msgstr "Fel&logg"
+
+#: src/gui/MainWindow.cc:3794
+msgid "&Animate"
+msgstr "&Animera"
+
+#: src/gui/MainWindow.cc:3795
+msgid "&Font List"
+msgstr "&Typsnittslista"
+
+#: src/gui/MainWindow.cc:3796
+#, fuzzy
+msgid "C&olor List"
+msgstr ""
+
+#: src/gui/MainWindow.cc:3797
+#, fuzzy
+msgid "&Viewport Control"
+msgstr "Vyfältskontroll"
+
+#: src/gui/Network.h:168
+msgid "Timeout error"
+msgstr "Timeout-fel"
+
+#: src/gui/OctoPrintApiKeyDialog.cc:58
+msgid "API key created, waiting for approval in OctoPrint..."
+msgstr ""
+
+#: src/gui/OctoPrintApiKeyDialog.cc:89
+msgid "API key approved."
+msgstr ""
+
+#: src/gui/OctoPrintApiKeyDialog.cc:99
+msgid "API key approval failed."
+msgstr ""
+
+#: src/gui/OpenSCADApp.cc:66
 msgid "Unknown error"
 msgstr "Okänt fel"
 
-#: src/gui/OpenSCADApp.cc:64
+#: src/gui/OpenSCADApp.cc:70
 msgid "Critical Error"
 msgstr "Kritiskt fel"
 
-#: src/gui/OpenSCADApp.cc:64
+#: src/gui/OpenSCADApp.cc:71
 msgid ""
 "A critical error was caught. The application may have become unstable:\n"
 "%1"
@@ -2263,7 +3213,7 @@ msgstr ""
 "Ett kritiskt fel har uppstått. Programmet kan ha blivit instabilt:\n"
 "%1"
 
-#: src/gui/OpenSCADApp.cc:88
+#: src/gui/OpenSCADApp.cc:97
 msgid ""
 "Fontconfig needs to update its font cache.\n"
 "This can take up to a couple of minutes."
@@ -2271,25 +3221,103 @@ msgstr ""
 "Fontconfig måste uppdatera sin typsnittscache.\n"
 "Detta kan ta upp till ett par minuter."
 
-#: src/gui/Preferences.cc:218 src/gui/Preferences.cc:223
-#: src/gui/Preferences.cc:808 src/gui/Preferences.cc:844
+#: src/gui/parameter/ParameterWidget.cc:72
+#, fuzzy
+msgid "Collapse All"
+msgstr ""
+
+#: src/gui/parameter/ParameterWidget.cc:75
+msgid "Expand All"
+msgstr ""
+
+#: src/gui/parameter/ParameterWidget.cc:116
+msgid "Saving presets"
+msgstr "Sparar förinställningar"
+
+#: src/gui/parameter/ParameterWidget.cc:117
+msgid "%1 was found, but was unreadable. Do you want to overwrite %1?"
+msgstr "%1 hittades, men var oläslig. Vill du skriva över %1?"
+
+#: src/gui/parameter/ParameterWidget.cc:228
+msgid "Create new set of parameter"
+msgstr "Skapa en ny uppsättning parametrar"
+
+#: src/gui/parameter/ParameterWidget.cc:228
+msgid "Enter name of the parameter set"
+msgstr "Ange namn på parameteruppsättningen"
+
+#: src/gui/parameter/ParameterWidget.cc:284
+msgid "New set "
+msgstr "Ny uppsättning "
+
+#: src/gui/Preferences.cc:273
+#, fuzzy
+msgid "Parameter Key"
+msgstr ""
+
+#: src/gui/Preferences.cc:273
+#, fuzzy
+msgid "Parameter Value"
+msgstr ""
+
+#: src/gui/Preferences.cc:289 src/gui/Preferences.cc:294
+msgid "Ollama Local"
+msgstr ""
+
+#: src/gui/Preferences.cc:446 src/gui/Preferences.cc:451
+#: src/gui/Preferences.cc:1384 src/gui/Preferences.cc:1423
 msgid "<Default>"
 msgstr "<Standard>"
 
-#: src/gui/Preferences.cc:792
+#: src/gui/Preferences.cc:605
+msgid "NONE"
+msgstr ""
+
+#: src/gui/Preferences.cc:1113
+msgid "Select CA certificate"
+msgstr ""
+
+#: src/gui/Preferences.cc:1114
+msgid "Certificate files (*.pem *.crt *.cer);;All files (*)"
+msgstr ""
+
+#: src/gui/Preferences.cc:1367
 msgid "Success: Server Version = %2, API Version = %1"
 msgstr "Lyckades: Serverversion = %2, API-version = %1"
 
-#: src/gui/Preferences.cc:794 src/gui/Preferences.cc:818
-#: src/gui/Preferences.cc:854
+#: src/gui/Preferences.cc:1369 src/gui/Preferences.cc:1394
+#: src/gui/Preferences.cc:1433
 msgid "Error"
 msgstr "Fel"
 
-#: src/gui/PrintInitDialog.cc:44
-msgid "Print Service not available"
-msgstr "Utskriftstjänsten är inte tillgänglig"
+#: src/gui/Preferences.cc:1484
+#, fuzzy
+msgid "New AI Profile"
+msgstr "&Ny fil"
 
-#: src/gui/QGLView.cc:143
+#: src/gui/Preferences.cc:1484
+#, fuzzy
+msgid "Profile name:"
+msgstr ""
+
+#: src/gui/Preferences.cc:1489
+#, fuzzy
+msgid "Duplicate Profile"
+msgstr ""
+
+#: src/gui/Preferences.cc:1489
+msgid "A profile with that name already exists."
+msgstr ""
+
+#: src/gui/Preferences.cc:1551
+msgid "Delete AI Profile"
+msgstr ""
+
+#: src/gui/Preferences.cc:1552
+msgid "Delete profile \"%1\"?"
+msgstr ""
+
+#: src/gui/QGLView.cc:188
 msgid ""
 "Warning: Missing OpenGL capabilities for OpenCSG - OpenCSG has been "
 "disabled.\n"
@@ -2298,7 +3326,7 @@ msgstr ""
 "Varning: Saknar OpenGL-funktioner för OpenCSG - OpenCSG har inaktiverats.\n"
 "\n"
 
-#: src/gui/QGLView.cc:144
+#: src/gui/QGLView.cc:190
 msgid ""
 "It is highly recommended to use OpenSCAD on a system with OpenGL 2.0 or "
 "later.\n"
@@ -2308,7 +3336,7 @@ msgstr ""
 "2.0 eller senare.\n"
 "Din renderingsinformation är som följer:\n"
 
-#: src/gui/QGLView.cc:148
+#: src/gui/QGLView.cc:194
 msgid ""
 "GLEW version %1\n"
 "%2 (%3)\n"
@@ -2318,7 +3346,7 @@ msgstr ""
 "%2 (%3)\n"
 "OpenGL-version %4\n"
 
-#: src/gui/QGLView.cc:155
+#: src/gui/QGLView.cc:200
 msgid ""
 "GLAD version %1\n"
 "%2 (%3)\n"
@@ -2328,85 +3356,60 @@ msgstr ""
 "%2 (%3)\n"
 "OpenGL version %4\n"
 
-#: src/gui/Settings.cc:85
-#, c-format
-msgid "Axis %d"
-msgstr "Axel %d"
-
-#: src/gui/Settings.cc:89
-#, c-format
-msgid "Axis %d (inverted)"
-msgstr "Axel %d (inverterad)"
-
-#: src/gui/Settings.cc:105
-msgid "After indentation"
-msgstr "Efter indragning"
-
-#: src/gui/Settings.cc:121
-msgid "Upload only"
-msgstr "Endast uppladdning"
-
-#: src/gui/Settings.cc:121
-msgid "Upload & Slice"
-msgstr "Ladda upp och skär"
-
-#: src/gui/Settings.cc:121
-msgid "Upload, Slice & Select for printing"
-msgstr "Ladda upp, skär och välj för utskrift"
-
-#: src/gui/Settings.cc:121
-msgid "Upload, Slice & Start printing"
-msgstr "Ladda upp, skär och börja skriva ut"
-
-#: src/gui/TabManager.cc:404
+#: src/gui/TabManager.cc:436
 msgid "Copy file name"
 msgstr "Kopiera filnamn"
 
-#: src/gui/TabManager.cc:410
+#: src/gui/TabManager.cc:442
 msgid "Copy full path"
 msgstr "Kopiera fullständig sökväg"
 
-#: src/gui/TabManager.cc:416
-msgid "Open folder"
+#: src/gui/TabManager.cc:448
+#, fuzzy
+msgid "Open Folder"
 msgstr "Öppna mapp"
 
-#: src/gui/TabManager.cc:421
+#: src/gui/TabManager.cc:453
 msgid "Close Tab"
 msgstr "Stäng fliken"
 
-#: src/gui/TabManager.cc:571
+#: src/gui/TabManager.cc:458
+msgid "Close All But This Tab"
+msgstr ""
+
+#: src/gui/TabManager.cc:607
 msgid "The document has been modified."
 msgstr "Dokumentet har ändrats."
 
-#: src/gui/TabManager.cc:572
+#: src/gui/TabManager.cc:608
 msgid "Do you want to save your changes?"
 msgstr "Vill du spara dina ändringar?"
 
-#: src/gui/TabManager.cc:603
+#: src/gui/TabManager.cc:639
 msgid "Some tabs have unsaved changes."
 msgstr "Vissa flikar har osparade ändringar."
 
-#: src/gui/TabManager.cc:604
+#: src/gui/TabManager.cc:640
 msgid "Do you want to save all your changes?"
 msgstr "Vill du spara alla dina ändringar?"
 
-#: src/gui/TabManager.cc:665
+#: src/gui/TabManager.cc:702 src/gui/TabManager.cc:815
 msgid "Failed to open file for writing"
 msgstr "Misslyckades med att öppna filen för skrivning"
 
-#: src/gui/TabManager.cc:688
+#: src/gui/TabManager.cc:726 src/gui/TabManager.cc:829
 msgid "Error saving design"
 msgstr "Fel vid sparning av ritning"
 
-#: src/gui/TabManager.cc:698
+#: src/gui/TabManager.cc:737
 msgid "Save File"
 msgstr "Spara fil"
 
-#: src/gui/TabManager.cc:698 src/gui/TabManager.cc:729
+#: src/gui/TabManager.cc:737
 msgid "OpenSCAD Designs (*.scad)"
 msgstr "OpenSCAD-ritningar (*.scad)"
 
-#: src/gui/TabManager.cc:710
+#: src/gui/TabManager.cc:752
 msgid ""
 "%1 already exists.\n"
 "Do you want to replace it?"
@@ -2414,98 +3417,44 @@ msgstr ""
 "%1 finns redan.\n"
 "Vill du ersätta den?"
 
-#: src/gui/ViewportControl.cc:118 src/gui/ViewportControl.cc:121
-#: src/gui/ViewportControl.cc:134
+#: src/gui/ViewportControl.cc:204 src/gui/ViewportControl.cc:207
+#: src/gui/ViewportControl.cc:220
 msgid "extreme values might may lead to strange behavior"
 msgstr "extrema värden kan leda till konstigt beteende"
 
-#: src/gui/ViewportControl.cc:131
+#: src/gui/ViewportControl.cc:217
 msgid "negative distances are not supported"
 msgstr "negativa avstånd stöds inte"
 
-#: src/gui/input/AxisConfigWidget.h:83
-msgid ""
-"This driver was not enabled during build time and is thus not available."
+#: src/io/export.cc:249
+#, c-format
+msgid "Can't open file \"%1$s\" for export"
 msgstr ""
-"Den här drivrutinen aktiverades inte under byggtiden och är därför inte "
-"tillgänglig."
 
-#: src/gui/input/AxisConfigWidget.h:85
-msgid ""
-"The DBUS driver is not for actual devices but for remote control, Linux only."
+#: src/io/export.cc:265
+#, c-format
+msgid "\"%1$s\" write error. (Disk full?)"
 msgstr ""
-"DBUS-drivrutinen är inte avsedd för faktiska enheter utan för fjärrstyrning, "
-"endast Linux."
 
-#: src/gui/input/AxisConfigWidget.h:86
-msgid ""
-"The HIDAPI driver communicates directly with the 3D mice, Windows and macOS."
-msgstr "HIDAPI-drivrutinen kommunicerar direkt med 3D-möss, Windows och macOS."
-
-#: src/gui/input/AxisConfigWidget.h:87
-msgid ""
-"The SpaceNav driver enables 3D-input-devices using the spacenavd daemon, "
-"Linux only."
-msgstr ""
-"SpaceNav-drivrutinen möjliggör 3D-inmatningsenheter med hjälp av daemon "
-"spacenavd, endast Linux."
-
-#: src/gui/input/AxisConfigWidget.h:88
-msgid ""
-"The Joystick driver uses the Linux joystick device (fixed to /dev/input/"
-"js0), Linux only."
-msgstr ""
-"Joystick-drivrutinen använder Linux joystick-enhet (fast till /dev/input/"
-"js0), endast Linux."
-
-#: src/gui/input/AxisConfigWidget.h:89
-msgid "The QGAMEPAD driver is for multiplattform Gamepad Support."
-msgstr ""
-"QGAMEPAD-drivrutinen är avsedd för stöd för Gamepad med flera plattformar."
-
-#: src/gui/input/ButtonConfigWidget.cc:237
-msgid "Toggle Perspective"
-msgstr "Växla perspektiv"
-
-#: src/gui/parameter/ParameterWidget.cc:93
-msgid "Saving presets"
-msgstr "Sparar förinställningar"
-
-#: src/gui/parameter/ParameterWidget.cc:94
-msgid "%1 was found, but was unreadable. Do you want to overwrite %1?"
-msgstr "%1 hittades, men var oläslig. Vill du skriva över %1?"
-
-#: src/gui/parameter/ParameterWidget.cc:194
-msgid "Create new set of parameter"
-msgstr "Skapa en ny uppsättning parametrar"
-
-#: src/gui/parameter/ParameterWidget.cc:195
-msgid "Enter name of the parameter set"
-msgstr "Ange namn på parameteruppsättningen"
-
-#: src/gui/parameter/ParameterWidget.cc:240
-msgid "New set "
-msgstr "Ny uppsättning "
-
-#: examples/examples.json:2
-msgid "Basics"
-msgstr "Grundläggande"
-
-#: examples/examples.json:15
-msgid "Functions"
-msgstr "Funktioner"
-
-#: examples/examples.json:22
+#: examples
 msgid "Advanced"
 msgstr "Avancerat"
 
-#: examples/examples.json:32
-msgid "Parametric"
-msgstr "Parametrisk"
+#: examples
+msgid "Basics"
+msgstr "Grundläggande"
 
-#: examples/examples.json:36
+#: examples
+msgid "Functions"
+msgstr "Funktioner"
+
+#: examples
 msgid "Old"
 msgstr "Gammal"
+
+#: examples
+msgid "Parametric"
+msgstr "Parametrisk"
 
 #. (itstool) path: component/summary
 #: openscad.appdata.xml.in2:6
@@ -2513,7 +3462,7 @@ msgid "The Programmers Solid 3D CAD Modeller"
 msgstr "Programmerarens solida 3D CAD-modellerare"
 
 #. (itstool) path: description/p
-#: openscad.appdata.xml.in2:20
+#: openscad.appdata.xml.in2:27
 msgid ""
 "OpenSCAD is a software for creating solid 3D CAD models. Unlike most free "
 "software for creating 3D models (such as Blender) it does not focus on the "
@@ -2531,7 +3480,7 @@ msgstr ""
 "datoranimerade filmer."
 
 #. (itstool) path: description/p
-#: openscad.appdata.xml.in2:21
+#: openscad.appdata.xml.in2:28
 msgid ""
 "OpenSCAD is not an interactive modeller. Instead it is something like a 3D-"
 "compiler that reads in a script file that describes the object and renders "
@@ -2548,7 +3497,7 @@ msgstr ""
 "definieras av konfigurerbara parametrar."
 
 #. (itstool) path: description/p
-#: openscad.appdata.xml.in2:22
+#: openscad.appdata.xml.in2:29
 msgid ""
 "OpenSCAD provides two main modelling techniques: First there is constructive "
 "solid geometry (aka CSG) and second there is extrusion of 2D outlines. As "
@@ -2563,3 +3512,30 @@ msgstr ""
 "DXF-filer. Förutom 2D-banor för extrudering är det också möjligt att läsa "
 "designparametrar från DXF-filer. Förutom DXF-filer kan OpenSCAD läsa och "
 "skapa 3D-modeller i filformaten STL och OFF."
+
+#~ msgid "absolute"
+#~ msgstr "absolute"
+
+#~ msgid "translate"
+#~ msgstr "översätt"
+
+#~ msgid "rotate"
+#~ msgstr "rotera"
+
+#~ msgid "fov"
+#~ msgstr "synfält"
+
+#~ msgid "play animation"
+#~ msgstr "spela upp animation"
+
+#~ msgid "pause animation"
+#~ msgstr "pausa animering"
+
+#~ msgid "Upload Error"
+#~ msgstr "Uppladdningsfel"
+
+#~ msgid "Untitled"
+#~ msgstr "Namnlös"
+
+#~ msgid "Print Service not available"
+#~ msgstr "Utskriftstjänsten är inte tillgänglig"

--- a/locale/tr.po
+++ b/locale/tr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: OpenSCAD 2021.12.04\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-09-06 23:38+0200\n"
+"POT-Creation-Date: 2026-09-06 17:48-0700\n"
 "PO-Revision-Date: 2021-12-04 17:55+0300\n"
 "Last-Translator: Serkan ÖNDER <serkanonder@outlook.com>\n"
 "Language-Team: Turkish\n"
@@ -102,148 +102,113 @@ msgstr "Adımlar:"
 msgid "Dump Pictures"
 msgstr "Döküm Resimleri"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:852
-#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:362
-#: build/OpenSCADLibInternal_autogen/include/ui_MouseConfigWidget.h:214
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2464
-msgid "Preferences"
-msgstr "Tercihler"
-
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:853
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:854
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:858
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:862
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:864
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:866
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:868
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:870
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:881
+#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:860
+#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:861
+#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:865
+#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:869
+#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:871
+#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:873
+#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:875
+#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:877
+#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:888
 msgid "Trim"
 msgstr "Trim"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:855
+#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:862
 msgid "Reset Trim"
 msgstr "Trim'i Sıfırla"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:856
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:859
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:860
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:861
 #: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:863
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:865
+#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:866
 #: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:867
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:869
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:880
+#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:868
+#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:870
+#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:872
+#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:874
+#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:876
+#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:887
 msgid "DeadZone"
 msgstr "ÖlüBölge"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:857
+#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:864
 msgid "Auto Trim Axes"
 msgstr "Otomatik Trim Eksenleri"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:871
+#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:878
 msgid "Axis 2"
 msgstr "Eksen 2"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:872
+#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:879
 msgid "Axis 0"
 msgstr "Eksen 0"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:873
+#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:880
 msgid "Axis 3"
 msgstr "Eksen 3"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:874
+#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:881
 msgid "Axis 6"
 msgstr "Eksen 6"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:875
+#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:882
 msgid "Axis 8"
 msgstr "Eksen 8"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:876
+#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:883
 msgid "Axis 7"
 msgstr "Eksen 7"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:877
+#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:884
 msgid "Axis 5"
 msgstr "Eksen 5"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:878
+#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:885
 msgid "Axis 1"
 msgstr "Eksen 1"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:879
+#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:886
 msgid "Axis 4"
 msgstr "Eksen 4"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:882
+#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:889
 #: build/OpenSCADLibInternal_autogen/include/ui_ViewportControl.h:279
 msgid "Rotation"
 msgstr "Döndürme"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:883
+#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:890
 msgid "Zoom"
 msgstr "Yakınlaştır"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:884
-msgid "X"
-msgstr "X"
-
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:885
+#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:891
 msgid "Gain"
 msgstr "Kazanç"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:886
-msgid "Y"
-msgstr "Y"
-
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:887
-msgid "Z"
-msgstr "Z"
-
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:888
+#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:892
 #: build/OpenSCADLibInternal_autogen/include/ui_ViewportControl.h:280
 msgid "Translation"
 msgstr "Çeviri"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:889
+#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:893
 msgid "ViewPort rel.<br/>Translation"
 msgstr "BağlantıNoktasını Görüntüle<br/>Çeviri"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:890
-msgid "ViewPort rel.<br />Rotation"
-msgstr "BağlantıNoktasını Görüntüle.<br />Döndürme"
+#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:894
+msgid "ViewPort rel.<br/>Rotation"
+msgstr "BağlantıNoktasını Görüntüle.<br/>Döndürme"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:891
+#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:895
 msgid "Axis Setup:"
 msgstr "Eksen Kurulumu:"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:892
+#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:896
 msgid "<b>Driver selection:</b> <i>(changes requires restarting OpenSCAD)</i>"
 msgstr ""
 "<b>Sürücü seçimi:</b> <i>(değişiklikler OpenSCAD'in yeniden başlatılmasını "
 "gerektirir)</i>"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:893
-msgid "SpaceNav"
-msgstr "BoşlukGezin"
-
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:894
-msgid "HIDAPI"
-msgstr "HIDAPI"
-
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:895
-msgid "QGamepad"
-msgstr "QOyun Kumandası"
-
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:896
+#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:897
 msgid "Joystick"
 msgstr "Oyun kolu"
-
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:897
-msgid "DBus"
-msgstr "VYolu"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:898
 msgid "Axes Mapping:"
@@ -254,133 +219,125 @@ msgid "Status:"
 msgstr "Durum:"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:900
-msgid "TextLabel"
-msgstr "MetinEtiketi"
-
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:901
 #: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2468
 msgid "Update"
 msgstr "Güncelle"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:363
+#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:362
 #, fuzzy
 msgid "Button 19"
 msgstr "Düğme 1"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:364
+#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:363
 msgid "Button 5"
 msgstr "Düğme 5"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:365
+#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:364
 msgid "Button 14"
 msgstr "Düğme 14"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:366
+#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:365
 msgid "Button 7"
 msgstr "Düğme 7"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:367
+#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:366
 #, fuzzy
 msgid "Button 16"
 msgstr "Düğme 1"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:368
+#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:367
 #, fuzzy
 msgid "Button 20"
 msgstr "Düğme 2"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:369
+#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:368
 msgid "Button 1"
 msgstr "Düğme 1"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:370
+#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:369
 #, fuzzy
 msgid "Button 21"
 msgstr "Düğme 2"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:371
+#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:370
 #, fuzzy
 msgid "Button 18"
 msgstr "Düğme 1"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:372
+#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:371
 msgid "Button 0"
 msgstr "Düğme 0"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:373
+#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:372
 msgid "Button 4"
 msgstr "Düğme 4"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:374
+#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:373
 msgid "Button 10"
 msgstr "Düğme 10"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:375
+#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:374
 msgid "Button 6"
 msgstr "Düğme 6"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:376
+#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:375
 msgid "Button 8"
 msgstr "Düğme 8"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:377
+#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:376
 msgid "Button 15"
 msgstr "Düğme 15"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:378
+#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:377
 msgid "Button 11"
 msgstr "Düğme 11"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:379
+#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:378
 msgid "Button 3"
 msgstr "Düğme 3"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:380
+#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:379
 #, fuzzy
 msgid "Button 23"
 msgstr "Düğme 2"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:381
+#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:380
 msgid "Button 9"
 msgstr "Düğme 9"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:382
+#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:381
 msgid "Button 2"
 msgstr "Düğme 2"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:383
+#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:382
 msgid "Button 13"
 msgstr "Düğme 13"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:384
+#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:383
 msgid "Button 12"
 msgstr "Düğme 12"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:385
+#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:384
 #, fuzzy
 msgid "Button 17"
 msgstr "Düğme 1"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:386
+#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:385
 #, fuzzy
 msgid "Button 22"
 msgstr "Düğme 2"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_ChatWidget.h:194
+#: build/OpenSCADLibInternal_autogen/include/ui_ChatWidget.h:195
 msgid "AI Chat"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_ChatWidget.h:195
+#: build/OpenSCADLibInternal_autogen/include/ui_ChatWidget.h:196
 #: src/gui/ai/ChatWidget.cc:138
 msgid "AI Assistant"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_ChatWidget.h:197
+#: build/OpenSCADLibInternal_autogen/include/ui_ChatWidget.h:198
 msgid "Chat options"
-msgstr ""
-
-#: build/OpenSCADLibInternal_autogen/include/ui_ChatWidget.h:199
-msgid "☰"
 msgstr ""
 
 #: build/OpenSCADLibInternal_autogen/include/ui_ChatWidget.h:201
@@ -604,7 +561,8 @@ msgstr "Hata Günlüğü"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_ErrorLog.h:93
 #: build/OpenSCADLibInternal_autogen/include/ui_ViewportControl.h:267
-msgid "RowSelected"
+#, fuzzy
+msgid "Row Selected"
 msgstr "SatırSeçili"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_ErrorLog.h:95
@@ -660,9 +618,7 @@ msgid "Export 3MF Options"
 msgstr "Dışa Aktarma Özellikleri"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_Export3mfDialog.h:459
-#: build/OpenSCADLibInternal_autogen/include/ui_ExportPdfDialog.h:552
-msgid ""
-"<html><head/><body><p>Set the PDF page (paper) size.  </p></body></html>"
+msgid "Set the unit used in the exported file"
 msgstr ""
 
 #: build/OpenSCADLibInternal_autogen/include/ui_Export3mfDialog.h:461
@@ -813,6 +769,10 @@ msgstr "Vazgeç"
 msgid "Export PDF Options"
 msgstr "Dışa Aktarma Özellikleri"
 
+#: build/OpenSCADLibInternal_autogen/include/ui_ExportPdfDialog.h:552
+msgid "Set the PDF page (paper) size."
+msgstr ""
+
 #: build/OpenSCADLibInternal_autogen/include/ui_ExportPdfDialog.h:554
 #, fuzzy
 msgid "Page Size"
@@ -872,9 +832,7 @@ msgid "Author"
 msgstr ""
 
 #: build/OpenSCADLibInternal_autogen/include/ui_ExportPdfDialog.h:582
-msgid ""
-"<html><head/><body><p>Set the direction of the largest page dimension.</p></"
-"body></html>"
+msgid "Set the direction of the largest page dimension."
 msgstr ""
 
 #: build/OpenSCADLibInternal_autogen/include/ui_ExportPdfDialog.h:584
@@ -893,9 +851,7 @@ msgid "Landscape (Horizontal)"
 msgstr ""
 
 #: build/OpenSCADLibInternal_autogen/include/ui_ExportPdfDialog.h:589
-msgid ""
-"<html><head/><body><p>Determine best orientation based on maximum geometry "
-"dimension.</p></body></html>"
+msgid "Determine best orientation based on maximum geometry dimension."
 msgstr ""
 
 #: build/OpenSCADLibInternal_autogen/include/ui_ExportPdfDialog.h:591
@@ -909,8 +865,7 @@ msgid "Annotations"
 msgstr "Döndürme"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_ExportPdfDialog.h:594
-msgid ""
-"<html><head/><body><p>Include design filename on page.</p></body></html>"
+msgid "Include design filename on page."
 msgstr ""
 
 #: build/OpenSCADLibInternal_autogen/include/ui_ExportPdfDialog.h:596
@@ -918,9 +873,7 @@ msgid "Show Design Filename"
 msgstr ""
 
 #: build/OpenSCADLibInternal_autogen/include/ui_ExportPdfDialog.h:598
-msgid ""
-"<html><head/><body><p>Include rulers on page to confirm 1:1 printing scale.</"
-"p></body></html>"
+msgid "Include rulers on page to confirm 1:1 printing scale."
 msgstr ""
 
 #: build/OpenSCADLibInternal_autogen/include/ui_ExportPdfDialog.h:600
@@ -929,9 +882,7 @@ msgid "Show Scale"
 msgstr "Ölçek İşaretlerini Göster"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_ExportPdfDialog.h:602
-msgid ""
-"<html><head/><body><p>Include a grid of the selected size on the page.</p></"
-"body></html>"
+msgid "Include a grid of the selected size on the page."
 msgstr ""
 
 #: build/OpenSCADLibInternal_autogen/include/ui_ExportPdfDialog.h:604
@@ -960,9 +911,7 @@ msgid "10mm"
 msgstr ""
 
 #: build/OpenSCADLibInternal_autogen/include/ui_ExportPdfDialog.h:611
-msgid ""
-"<html><head/><body><p>Include text describing usage of scale.</p></body></"
-"html>"
+msgid "Include text describing usage of scale."
 msgstr ""
 
 #: build/OpenSCADLibInternal_autogen/include/ui_ExportPdfDialog.h:613
@@ -976,9 +925,8 @@ msgid "Fill and Stroke"
 msgstr ""
 
 #: build/OpenSCADLibInternal_autogen/include/ui_ExportPdfDialog.h:616
-msgid ""
-"<html><head/><body><p>Enable filling of exported geometry with a color.</p></"
-"body></html>"
+#: build/OpenSCADLibInternal_autogen/include/ui_ExportSvgDialog.h:205
+msgid "Enable filling of exported geometry with a color."
 msgstr ""
 
 #: build/OpenSCADLibInternal_autogen/include/ui_ExportPdfDialog.h:618
@@ -987,9 +935,8 @@ msgid "Fill Geometry"
 msgstr ""
 
 #: build/OpenSCADLibInternal_autogen/include/ui_ExportPdfDialog.h:623
-msgid ""
-"<html><head/><body><p>Enable outline stroke for exported geometry.</p></"
-"body></html>"
+#: build/OpenSCADLibInternal_autogen/include/ui_ExportSvgDialog.h:212
+msgid "Enable outline stroke for exported geometry."
 msgstr ""
 
 #: build/OpenSCADLibInternal_autogen/include/ui_ExportPdfDialog.h:625
@@ -1011,14 +958,6 @@ msgstr ""
 #, fuzzy
 msgid "Export SVG Options"
 msgstr "Dışa Aktarma Özellikleri"
-
-#: build/OpenSCADLibInternal_autogen/include/ui_ExportSvgDialog.h:205
-msgid "Enable filling of exported geometry with a color."
-msgstr ""
-
-#: build/OpenSCADLibInternal_autogen/include/ui_ExportSvgDialog.h:212
-msgid "Enable outline stroke for exported geometry."
-msgstr ""
 
 #: build/OpenSCADLibInternal_autogen/include/ui_FontList.h:291
 #, fuzzy
@@ -1070,7 +1009,7 @@ msgstr "Ölçek İşaretlerini Göster"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_FontList.h:302
 #, fuzzy
-msgid "ShowFileName"
+msgid "Show File Name"
 msgstr "Dosya adını kopyala"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_FontList.h:303
@@ -1851,13 +1790,13 @@ msgid "Ctrl+J"
 msgstr "Ctrl+N"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_MainWindow.h:1286
-#: src/gui/MainWindow.cc:1335 src/gui/MainWindow.cc:1342
-#: src/gui/MainWindow.cc:1355 src/gui/MainWindow.cc:1360
+#: src/gui/MainWindow.cc:1346 src/gui/MainWindow.cc:1353
+#: src/gui/MainWindow.cc:1366 src/gui/MainWindow.cc:1371
 msgid "Create Virtual Environment"
 msgstr ""
 
 #: build/OpenSCADLibInternal_autogen/include/ui_MainWindow.h:1287
-#: src/gui/MainWindow.cc:1377
+#: src/gui/MainWindow.cc:1388
 msgid "Select Virtual Environment"
 msgstr ""
 
@@ -1939,55 +1878,55 @@ msgstr "Bitti"
 msgid "Customizer Widget"
 msgstr "Özelleştirici Aracı"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_MouseConfigWidget.h:215
+#: build/OpenSCADLibInternal_autogen/include/ui_MouseConfigWidget.h:214
 msgid "Ctrl + Shift + Middle-click"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_MouseConfigWidget.h:216
+#: build/OpenSCADLibInternal_autogen/include/ui_MouseConfigWidget.h:215
 msgid "Left-click"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_MouseConfigWidget.h:217
+#: build/OpenSCADLibInternal_autogen/include/ui_MouseConfigWidget.h:216
 msgid "Ctrl + Left-click"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_MouseConfigWidget.h:218
+#: build/OpenSCADLibInternal_autogen/include/ui_MouseConfigWidget.h:217
 msgid "Shift + Left-click"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_MouseConfigWidget.h:219
+#: build/OpenSCADLibInternal_autogen/include/ui_MouseConfigWidget.h:218
 msgid "Ctrl + Shift + Right-click"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_MouseConfigWidget.h:220
+#: build/OpenSCADLibInternal_autogen/include/ui_MouseConfigWidget.h:219
 msgid "Preset"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_MouseConfigWidget.h:221
+#: build/OpenSCADLibInternal_autogen/include/ui_MouseConfigWidget.h:220
 msgid "Right-click"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_MouseConfigWidget.h:222
+#: build/OpenSCADLibInternal_autogen/include/ui_MouseConfigWidget.h:221
 msgid "Ctrl + Middle-click"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_MouseConfigWidget.h:223
+#: build/OpenSCADLibInternal_autogen/include/ui_MouseConfigWidget.h:222
 msgid "Shift + Middle-click"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_MouseConfigWidget.h:224
+#: build/OpenSCADLibInternal_autogen/include/ui_MouseConfigWidget.h:223
 msgid "Ctrl + Right-click"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_MouseConfigWidget.h:225
+#: build/OpenSCADLibInternal_autogen/include/ui_MouseConfigWidget.h:224
 msgid "Ctrl + Shift + Left-click"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_MouseConfigWidget.h:226
+#: build/OpenSCADLibInternal_autogen/include/ui_MouseConfigWidget.h:225
 msgid "Shift + Right-click"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_MouseConfigWidget.h:227
+#: build/OpenSCADLibInternal_autogen/include/ui_MouseConfigWidget.h:226
 msgid "Middle-click"
 msgstr ""
 
@@ -2004,34 +1943,10 @@ msgid "OpenGL Warning"
 msgstr "OpenGL Uyarısı"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_OpenCSGWarningDialog.h:77
-msgid ""
-"<!DOCTYPE HTML PUBLIC \"-//W3C//DTD HTML 4.0//EN\" \"http://www.w3.org/TR/"
-"REC-html40/strict.dtd\">\n"
-"<html><head><meta name=\"qrichtext\" content=\"1\" /><style type=\"text/"
-"css\">\n"
-"p, li { white-space: pre-wrap; }\n"
-"</style></head><body style=\" font-family:'Lucida Grande'; font-size:13pt; "
-"font-weight:400; font-style:normal;\">\n"
-"<p style=\"-qt-paragraph-type:empty; margin-top:0px; margin-bottom:0px; "
-"margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;\"></"
-"p></body></html>"
-msgstr ""
-"<!DOCTYPE HTML PUBLIC \"-//W3C//DTD HTML 4.0//EN\" \"http://www.w3.org/TR/"
-"REC-html40/strict.dtd\">\n"
-"<html><head><meta name=\"qrichtext\" content=\"1\" /><style type=\"text/"
-"css\">\n"
-"p, li { white-space: pre-wrap; }\n"
-"</style></head><body style=\" font-family:'Lucida Grande'; font-size:13pt; "
-"font-weight:400; font-style:normal;\">\n"
-"<p style=\"-qt-paragraph-type:empty; margin-top:0px; margin-bottom:0px; "
-"margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;\"></"
-"p></body></html>"
-
-#: build/OpenSCADLibInternal_autogen/include/ui_OpenCSGWarningDialog.h:82
 msgid "Show this message again"
 msgstr "Bu mesajı tekrar göster"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_OpenCSGWarningDialog.h:83
+#: build/OpenSCADLibInternal_autogen/include/ui_OpenCSGWarningDialog.h:78
 msgid "Close"
 msgstr "Kapat"
 
@@ -2099,6 +2014,10 @@ msgstr "-"
 #, fuzzy
 msgid "More actions"
 msgstr "Döndürme"
+
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2464
+msgid "Preferences"
+msgstr "Tercihler"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2465
 msgid "3D View"
@@ -3176,21 +3095,21 @@ msgstr ""
 msgid "Toggle Perspective"
 msgstr "Perspektifi Değiştir"
 
-#: src/gui/MainWindow.cc:861
+#: src/gui/MainWindow.cc:872
 msgid "Compile error."
 msgstr "Derleme hatası."
 
-#: src/gui/MainWindow.cc:864
+#: src/gui/MainWindow.cc:875
 msgid "Error while compiling '%1'."
 msgstr "'%1' derlenirken hata oluştu."
 
-#: src/gui/MainWindow.cc:869
+#: src/gui/MainWindow.cc:880
 msgid "Compilation generated %1 warning."
 msgid_plural "Compilation generated %1 warnings."
 msgstr[0] "Derleme %1 uyarısı oluşturdu."
 msgstr[1] "Derleme %1 uyarıları oluşturdu."
 
-#: src/gui/MainWindow.cc:882
+#: src/gui/MainWindow.cc:893
 msgid ""
 " For details see the <a href=\"#errorlog\">error log</a> and <a "
 "href=\"#console\">console window</a>."
@@ -3198,21 +3117,21 @@ msgstr ""
 " Ayrıntılar için <a href=\"#errorlog\">hata günlüğüne</a> ve <a "
 "href=\"#console\">konsol penceresine</a> bakın."
 
-#: src/gui/MainWindow.cc:1320
+#: src/gui/MainWindow.cc:1331
 msgid "Trusted Files"
 msgstr ""
 
-#: src/gui/MainWindow.cc:1704
+#: src/gui/MainWindow.cc:1715
 msgid ""
 "Python files can potentially contain harmful stuff.\n"
 "Do you trust this file ?\n"
 msgstr ""
 
-#: src/gui/MainWindow.cc:1810
+#: src/gui/MainWindow.cc:1821
 msgid "Application"
 msgstr "Uygulama"
 
-#: src/gui/MainWindow.cc:1811
+#: src/gui/MainWindow.cc:1822
 msgid ""
 "The document has been modified.\n"
 "Do you really want to reload the file?"
@@ -3220,70 +3139,70 @@ msgstr ""
 "Belge değiştirildi.\n"
 "Dosyayı gerçekten yeniden yüklemek istiyor musunuz?"
 
-#: src/gui/MainWindow.cc:2564
+#: src/gui/MainWindow.cc:2575
 msgid "Export %1 File"
 msgstr "%1 Dosyasını Dışa Aktar"
 
-#: src/gui/MainWindow.cc:2565
+#: src/gui/MainWindow.cc:2576
 msgid "%1 Files (*%2)"
 msgstr "%1 Dosya (*%2)"
 
-#: src/gui/MainWindow.cc:2613
+#: src/gui/MainWindow.cc:2624
 msgid "Export CSG File"
 msgstr "CSG Dosyasını Dışa Aktar"
 
-#: src/gui/MainWindow.cc:2614
+#: src/gui/MainWindow.cc:2625
 msgid "CSG Files (*.csg)"
 msgstr "CSG Dosyaları (*.csg)"
 
-#: src/gui/MainWindow.cc:2637
+#: src/gui/MainWindow.cc:2648
 msgid "Export Image"
 msgstr "Görüntüyü Dışa Aktar"
 
-#: src/gui/MainWindow.cc:2637
+#: src/gui/MainWindow.cc:2648
 msgid "PNG Files (*.png)"
 msgstr "PNG Dosyaları (*.png)"
 
-#: src/gui/MainWindow.cc:3027 src/gui/MainWindow.cc:3787
+#: src/gui/MainWindow.cc:3038 src/gui/MainWindow.cc:3798
 msgid "&AI Chat"
 msgstr ""
 
-#: src/gui/MainWindow.cc:3129 src/gui/TabManager.cc:735
+#: src/gui/MainWindow.cc:3140 src/gui/TabManager.cc:735
 #: src/gui/TabManager.cc:786
 msgid "Untitled.scad"
 msgstr "Başlıksız.scad"
 
-#: src/gui/MainWindow.cc:3779
+#: src/gui/MainWindow.cc:3790
 msgid "&Editor"
 msgstr "&Düzenleyici"
 
-#: src/gui/MainWindow.cc:3780
+#: src/gui/MainWindow.cc:3791
 msgid "&Console"
 msgstr "&Konsol"
 
-#: src/gui/MainWindow.cc:3781
+#: src/gui/MainWindow.cc:3792
 msgid "C&ustomizer"
 msgstr "Ö&zelleştirici"
 
-#: src/gui/MainWindow.cc:3782
+#: src/gui/MainWindow.cc:3793
 msgid "Error &Log"
 msgstr "Hata &Günlüğü"
 
-#: src/gui/MainWindow.cc:3783
+#: src/gui/MainWindow.cc:3794
 #, fuzzy
 msgid "&Animate"
 msgstr "Canlandır"
 
-#: src/gui/MainWindow.cc:3784
+#: src/gui/MainWindow.cc:3795
 msgid "&Font List"
 msgstr "&Yazı Tipi Listesi"
 
-#: src/gui/MainWindow.cc:3785
+#: src/gui/MainWindow.cc:3796
 #, fuzzy
 msgid "C&olor List"
 msgstr "Renk şeması:"
 
-#: src/gui/MainWindow.cc:3786
+#: src/gui/MainWindow.cc:3797
 #, fuzzy
 msgid "&Viewport Control"
 msgstr "3B Görünüm araç çubuğunu gizle"
@@ -3546,8 +3465,12 @@ msgid "\"%1$s\" write error. (Disk full?)"
 msgstr "\"%1$s\" yazma hatası. (Disk dolu?)"
 
 #: examples
-msgid "Parametric"
-msgstr "Parametrik"
+msgid "Advanced"
+msgstr "Gelişmiş"
+
+#: examples
+msgid "Basics"
+msgstr "Temel bilgiler"
 
 #: examples
 msgid "Functions"
@@ -3558,12 +3481,8 @@ msgid "Old"
 msgstr "Eski"
 
 #: examples
-msgid "Advanced"
-msgstr "Gelişmiş"
-
-#: examples
-msgid "Basics"
-msgstr "Temel bilgiler"
+msgid "Parametric"
+msgstr "Parametrik"
 
 #. (itstool) path: component/summary
 #: openscad.appdata.xml.in2:6
@@ -3620,123 +3539,6 @@ msgstr ""
 "Ekstrüzyon için 2B yollara ek olarak, DXF dosyalarından tasarım "
 "parametrelerini okumak da mümkündür. DXF dosyalarının yanı sıra OpenSCAD, "
 "STL ve OFF dosya formatlarında 3B modelleri okuyabilir ve oluşturabilir."
-
-#, fuzzy
-#~ msgid "meter"
-#~ msgstr "Parametre"
-
-#~ msgid "Features"
-#~ msgstr "Özellikler"
-
-#, fuzzy
-#~ msgid "Reset"
-#~ msgstr "Trim'i Sıfırla"
-
-#, fuzzy
-#~ msgid "Search action..."
-#~ msgstr "Arama dizisi"
-
-#, fuzzy
-#~ msgid "ViewportControlWidget"
-#~ msgstr "3B Görünüm araç çubuğunu gizle"
-
-#~ msgid "OpenSCAD Font List"
-#~ msgstr "OpenSCAD Yazı Tipi Listesi"
-
-#~ msgid "Copy to Clipboard"
-#~ msgstr "Panoya Kopyala"
-
-#~ msgid "Filter:"
-#~ msgstr "Filtre:"
-
-#~ msgid ""
-#~ "<html><head/><body><p>This list shows the fonts currently registered with "
-#~ "OpenSCAD.</p><p>Example:</p><pre style=\" margin-top:12px; margin-"
-#~ "bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-"
-#~ "indent:0px;\"><span style=\" font-family:'Courier New,courier';\">  "
-#~ "text(&quot;OpenSCAD&quot;, font = &quot;DejaVu Sans&quot;);</span></"
-#~ "pre><pre style=\" margin-top:0px; margin-bottom:12px; margin-left:0px; "
-#~ "margin-right:0px; -qt-block-indent:0; text-indent:0px;\"><span style=\" "
-#~ "font-family:'Courier New,courier';\">  text(&quot;OpenSCAD&quot;, font = "
-#~ "&quot;Liberation Sans:style=Italic&quot;);</span></pre></body></html>"
-#~ msgstr ""
-#~ "<html><head/><body><p>Bu liste, şu anda OpenSCAD'de kayıtlı olan yazı "
-#~ "tiplerini gösterir.</p><p>Örnek:</p><pre style=\" margin-top:12px; margin-"
-#~ "bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-"
-#~ "indent:0px;\"><span style=\" font-family:'Courier New,courier';\">  "
-#~ "metin(&quot;OpenSCAD&quot;, yazı tipi = &quot;DejaVu Sans&quot;);</span></"
-#~ "pre><pre style=\" margin-top:0px; margin-bottom:12px; margin-left:0px; "
-#~ "margin-right:0px; -qt-block-indent:0; text-indent:0px;\"><span style=\" "
-#~ "font-family:'Courier New,courier';\">  metin(&quot;OpenSCAD&quot;, yazı "
-#~ "tipi = &quot;Liberation Sans:biçim=Italic&quot;);</span></pre></body></"
-#~ "html>"
-
-#~ msgid "Error-Log"
-#~ msgstr "Hata-Günlüğü"
-
-#~ msgid "F7"
-#~ msgstr "F7"
-
-#, fuzzy
-#~ msgid "Swap Mouse Buttons"
-#~ msgstr "Sol fare tuşu"
-
-#, fuzzy
-#~ msgid "Line"
-#~ msgstr "Satır kaydırma"
-
-#, fuzzy
-#~ msgid "Filename"
-#~ msgstr "Dosya adını kopyala"
-
-#, fuzzy
-#~ msgid "Font Lists"
-#~ msgstr "&Yazı Tipi Listesi"
-
-#, fuzzy
-#~ msgid "PushButton"
-#~ msgstr "Düğmeler"
-
-#~ msgid "Hide Editor"
-#~ msgstr "Düzenleyiciyi Gizle"
-
-#~ msgid "Surfaces"
-#~ msgstr "Yüzeyler"
-
-#~ msgid "F10"
-#~ msgstr "F10"
-
-#~ msgid "F11"
-#~ msgstr "F11"
-
-#~ msgid "Hide Console"
-#~ msgstr "Konsolu Gizle"
-
-#~ msgid "Hide Customizer"
-#~ msgstr "Özelleştiriciyi Gizle"
-
-#~ msgid "Hide Error Log"
-#~ msgstr "Hata Günlüğünü Gizle"
-
-#, fuzzy
-#~ msgid "Hide Animation Toolbar/Window"
-#~ msgstr "Düzenleyici araç çubuğunu gizle"
-
-#~ msgid "OpenCSG"
-#~ msgstr "OpenCSG"
-
-#~ msgid "CGAL"
-#~ msgstr "CGAL"
-
-#, fuzzy
-#~ msgid "WRL"
-#~ msgstr "URL"
-
-#~ msgid "Default to ASCII STL export"
-#~ msgstr "Varsayılan olarak ASCII STL dışa aktarma"
-
-#~ msgid "%1"
-#~ msgstr "%1"
 
 #, fuzzy
 #~ msgid "translate"

--- a/locale/uk.po
+++ b/locale/uk.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: OpenSCAD 2018.08.15\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-09-06 23:38+0200\n"
+"POT-Creation-Date: 2026-09-06 17:48-0700\n"
 "PO-Revision-Date: 2018-11-11 13:00+0200\n"
 "Last-Translator: Kyrylo Romanenko <romanenko-kv@hotmail.com>\n"
 "Language-Team: Ukrainian\n"
@@ -102,151 +102,115 @@ msgstr "Кроки:"
 msgid "Dump Pictures"
 msgstr "Зберігати картинки"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:852
-#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:362
-#: build/OpenSCADLibInternal_autogen/include/ui_MouseConfigWidget.h:214
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2464
-msgid "Preferences"
-msgstr "Налаштування"
-
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:853
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:854
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:858
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:862
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:864
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:866
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:868
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:870
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:881
+#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:860
+#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:861
+#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:865
+#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:869
+#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:871
+#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:873
+#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:875
+#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:877
+#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:888
 msgid "Trim"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:855
+#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:862
 #, fuzzy
 msgid "Reset Trim"
 msgstr "Скинути вид"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:856
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:859
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:860
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:861
 #: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:863
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:865
+#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:866
 #: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:867
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:869
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:880
+#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:868
+#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:870
+#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:872
+#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:874
+#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:876
+#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:887
 msgid "DeadZone"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:857
+#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:864
 msgid "Auto Trim Axes"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:871
+#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:878
 msgid "Axis 2"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:872
+#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:879
 msgid "Axis 0"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:873
+#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:880
 msgid "Axis 3"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:874
+#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:881
 msgid "Axis 6"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:875
+#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:882
 msgid "Axis 8"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:876
+#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:883
 msgid "Axis 7"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:877
+#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:884
 msgid "Axis 5"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:878
+#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:885
 msgid "Axis 1"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:879
+#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:886
 msgid "Axis 4"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:882
+#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:889
 #: build/OpenSCADLibInternal_autogen/include/ui_ViewportControl.h:279
 #, fuzzy
 msgid "Rotation"
 msgstr "&Документація"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:883
+#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:890
 #, fuzzy
 msgid "Zoom"
 msgstr "Приблизити"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:884
-msgid "X"
-msgstr ""
-
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:885
+#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:891
 msgid "Gain"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:886
-msgid "Y"
-msgstr ""
-
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:887
-msgid "Z"
-msgstr ""
-
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:888
+#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:892
 #: build/OpenSCADLibInternal_autogen/include/ui_ViewportControl.h:280
 msgid "Translation"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:889
+#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:893
 #, fuzzy
 msgid "ViewPort rel.<br/>Translation"
 msgstr "Вставити &зміщення видового екрану"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:890
+#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:894
 #, fuzzy
-msgid "ViewPort rel.<br />Rotation"
+msgid "ViewPort rel.<br/>Rotation"
 msgstr "Вставити &зміщення видового екрану"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:891
+#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:895
 msgid "Axis Setup:"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:892
+#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:896
 msgid "<b>Driver selection:</b> <i>(changes requires restarting OpenSCAD)</i>"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:893
-#, fuzzy
-msgid "SpaceNav"
-msgstr "Пробілами"
-
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:894
-msgid "HIDAPI"
-msgstr ""
-
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:895
-msgid "QGamepad"
-msgstr ""
-
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:896
-msgid "Joystick"
-msgstr ""
-
 #: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:897
-msgid "DBus"
+msgid "Joystick"
 msgstr ""
 
 #: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:898
@@ -258,126 +222,117 @@ msgid "Status:"
 msgstr ""
 
 #: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:900
-#, fuzzy
-msgid "TextLabel"
-msgstr "Текст"
-
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:901
 #: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2468
 msgid "Update"
 msgstr "Оновлення"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:363
+#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:362
 msgid "Button 19"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:364
+#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:363
 msgid "Button 5"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:365
+#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:364
 msgid "Button 14"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:366
+#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:365
 msgid "Button 7"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:367
+#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:366
 msgid "Button 16"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:368
+#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:367
 msgid "Button 20"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:369
+#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:368
 msgid "Button 1"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:370
+#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:369
 msgid "Button 21"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:371
+#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:370
 msgid "Button 18"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:372
+#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:371
 msgid "Button 0"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:373
+#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:372
 msgid "Button 4"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:374
+#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:373
 msgid "Button 10"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:375
+#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:374
 msgid "Button 6"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:376
+#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:375
 msgid "Button 8"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:377
+#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:376
 msgid "Button 15"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:378
+#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:377
 msgid "Button 11"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:379
+#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:378
 msgid "Button 3"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:380
+#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:379
 msgid "Button 23"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:381
+#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:380
 msgid "Button 9"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:382
+#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:381
 msgid "Button 2"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:383
+#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:382
 msgid "Button 13"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:384
+#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:383
 msgid "Button 12"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:385
+#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:384
 msgid "Button 17"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:386
+#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:385
 msgid "Button 22"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_ChatWidget.h:194
+#: build/OpenSCADLibInternal_autogen/include/ui_ChatWidget.h:195
 msgid "AI Chat"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_ChatWidget.h:195
+#: build/OpenSCADLibInternal_autogen/include/ui_ChatWidget.h:196
 #: src/gui/ai/ChatWidget.cc:138
 msgid "AI Assistant"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_ChatWidget.h:197
+#: build/OpenSCADLibInternal_autogen/include/ui_ChatWidget.h:198
 msgid "Chat options"
-msgstr ""
-
-#: build/OpenSCADLibInternal_autogen/include/ui_ChatWidget.h:199
-msgid "☰"
 msgstr ""
 
 #: build/OpenSCADLibInternal_autogen/include/ui_ChatWidget.h:201
@@ -604,8 +559,9 @@ msgstr "Сховати панелі інструментів"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_ErrorLog.h:93
 #: build/OpenSCADLibInternal_autogen/include/ui_ViewportControl.h:267
-msgid "RowSelected"
-msgstr ""
+#, fuzzy
+msgid "Row Selected"
+msgstr "пресет не обрано"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_ErrorLog.h:95
 #: build/OpenSCADLibInternal_autogen/include/ui_ViewportControl.h:269
@@ -661,9 +617,7 @@ msgid "Export 3MF Options"
 msgstr "Можливості"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_Export3mfDialog.h:459
-#: build/OpenSCADLibInternal_autogen/include/ui_ExportPdfDialog.h:552
-msgid ""
-"<html><head/><body><p>Set the PDF page (paper) size.  </p></body></html>"
+msgid "Set the unit used in the exported file"
 msgstr ""
 
 #: build/OpenSCADLibInternal_autogen/include/ui_Export3mfDialog.h:461
@@ -814,6 +768,10 @@ msgstr ""
 msgid "Export PDF Options"
 msgstr "Можливості"
 
+#: build/OpenSCADLibInternal_autogen/include/ui_ExportPdfDialog.h:552
+msgid "Set the PDF page (paper) size."
+msgstr ""
+
 #: build/OpenSCADLibInternal_autogen/include/ui_ExportPdfDialog.h:554
 #, fuzzy
 msgid "Page Size"
@@ -873,9 +831,7 @@ msgid "Author"
 msgstr ""
 
 #: build/OpenSCADLibInternal_autogen/include/ui_ExportPdfDialog.h:582
-msgid ""
-"<html><head/><body><p>Set the direction of the largest page dimension.</p></"
-"body></html>"
+msgid "Set the direction of the largest page dimension."
 msgstr ""
 
 #: build/OpenSCADLibInternal_autogen/include/ui_ExportPdfDialog.h:584
@@ -894,9 +850,7 @@ msgid "Landscape (Horizontal)"
 msgstr ""
 
 #: build/OpenSCADLibInternal_autogen/include/ui_ExportPdfDialog.h:589
-msgid ""
-"<html><head/><body><p>Determine best orientation based on maximum geometry "
-"dimension.</p></body></html>"
+msgid "Determine best orientation based on maximum geometry dimension."
 msgstr ""
 
 #: build/OpenSCADLibInternal_autogen/include/ui_ExportPdfDialog.h:591
@@ -910,8 +864,7 @@ msgid "Annotations"
 msgstr "&Документація"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_ExportPdfDialog.h:594
-msgid ""
-"<html><head/><body><p>Include design filename on page.</p></body></html>"
+msgid "Include design filename on page."
 msgstr ""
 
 #: build/OpenSCADLibInternal_autogen/include/ui_ExportPdfDialog.h:596
@@ -919,9 +872,7 @@ msgid "Show Design Filename"
 msgstr ""
 
 #: build/OpenSCADLibInternal_autogen/include/ui_ExportPdfDialog.h:598
-msgid ""
-"<html><head/><body><p>Include rulers on page to confirm 1:1 printing scale.</"
-"p></body></html>"
+msgid "Include rulers on page to confirm 1:1 printing scale."
 msgstr ""
 
 #: build/OpenSCADLibInternal_autogen/include/ui_ExportPdfDialog.h:600
@@ -930,9 +881,7 @@ msgid "Show Scale"
 msgstr "Показувати масштабні маркери"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_ExportPdfDialog.h:602
-msgid ""
-"<html><head/><body><p>Include a grid of the selected size on the page.</p></"
-"body></html>"
+msgid "Include a grid of the selected size on the page."
 msgstr ""
 
 #: build/OpenSCADLibInternal_autogen/include/ui_ExportPdfDialog.h:604
@@ -961,9 +910,7 @@ msgid "10mm"
 msgstr ""
 
 #: build/OpenSCADLibInternal_autogen/include/ui_ExportPdfDialog.h:611
-msgid ""
-"<html><head/><body><p>Include text describing usage of scale.</p></body></"
-"html>"
+msgid "Include text describing usage of scale."
 msgstr ""
 
 #: build/OpenSCADLibInternal_autogen/include/ui_ExportPdfDialog.h:613
@@ -977,9 +924,8 @@ msgid "Fill and Stroke"
 msgstr ""
 
 #: build/OpenSCADLibInternal_autogen/include/ui_ExportPdfDialog.h:616
-msgid ""
-"<html><head/><body><p>Enable filling of exported geometry with a color.</p></"
-"body></html>"
+#: build/OpenSCADLibInternal_autogen/include/ui_ExportSvgDialog.h:205
+msgid "Enable filling of exported geometry with a color."
 msgstr ""
 
 #: build/OpenSCADLibInternal_autogen/include/ui_ExportPdfDialog.h:618
@@ -988,9 +934,8 @@ msgid "Fill Geometry"
 msgstr ""
 
 #: build/OpenSCADLibInternal_autogen/include/ui_ExportPdfDialog.h:623
-msgid ""
-"<html><head/><body><p>Enable outline stroke for exported geometry.</p></"
-"body></html>"
+#: build/OpenSCADLibInternal_autogen/include/ui_ExportSvgDialog.h:212
+msgid "Enable outline stroke for exported geometry."
 msgstr ""
 
 #: build/OpenSCADLibInternal_autogen/include/ui_ExportPdfDialog.h:625
@@ -1012,14 +957,6 @@ msgstr ""
 #, fuzzy
 msgid "Export SVG Options"
 msgstr "Можливості"
-
-#: build/OpenSCADLibInternal_autogen/include/ui_ExportSvgDialog.h:205
-msgid "Enable filling of exported geometry with a color."
-msgstr ""
-
-#: build/OpenSCADLibInternal_autogen/include/ui_ExportSvgDialog.h:212
-msgid "Enable outline stroke for exported geometry."
-msgstr ""
 
 #: build/OpenSCADLibInternal_autogen/include/ui_FontList.h:291
 #, fuzzy
@@ -1070,7 +1007,7 @@ msgstr "Показувати масштабні маркери"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_FontList.h:302
 #, fuzzy
-msgid "ShowFileName"
+msgid "Show File Name"
 msgstr "&Файл"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_FontList.h:303
@@ -1863,13 +1800,13 @@ msgid "Ctrl+J"
 msgstr "Ctrl+N"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_MainWindow.h:1286
-#: src/gui/MainWindow.cc:1335 src/gui/MainWindow.cc:1342
-#: src/gui/MainWindow.cc:1355 src/gui/MainWindow.cc:1360
+#: src/gui/MainWindow.cc:1346 src/gui/MainWindow.cc:1353
+#: src/gui/MainWindow.cc:1366 src/gui/MainWindow.cc:1371
 msgid "Create Virtual Environment"
 msgstr ""
 
 #: build/OpenSCADLibInternal_autogen/include/ui_MainWindow.h:1287
-#: src/gui/MainWindow.cc:1377
+#: src/gui/MainWindow.cc:1388
 msgid "Select Virtual Environment"
 msgstr ""
 
@@ -1953,56 +1890,56 @@ msgstr "Готово"
 msgid "Customizer Widget"
 msgstr "Віджет параметрів"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_MouseConfigWidget.h:215
+#: build/OpenSCADLibInternal_autogen/include/ui_MouseConfigWidget.h:214
 msgid "Ctrl + Shift + Middle-click"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_MouseConfigWidget.h:216
+#: build/OpenSCADLibInternal_autogen/include/ui_MouseConfigWidget.h:215
 msgid "Left-click"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_MouseConfigWidget.h:217
+#: build/OpenSCADLibInternal_autogen/include/ui_MouseConfigWidget.h:216
 msgid "Ctrl + Left-click"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_MouseConfigWidget.h:218
+#: build/OpenSCADLibInternal_autogen/include/ui_MouseConfigWidget.h:217
 msgid "Shift + Left-click"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_MouseConfigWidget.h:219
+#: build/OpenSCADLibInternal_autogen/include/ui_MouseConfigWidget.h:218
 msgid "Ctrl + Shift + Right-click"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_MouseConfigWidget.h:220
+#: build/OpenSCADLibInternal_autogen/include/ui_MouseConfigWidget.h:219
 #, fuzzy
 msgid "Preset"
 msgstr "Скидання"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_MouseConfigWidget.h:221
+#: build/OpenSCADLibInternal_autogen/include/ui_MouseConfigWidget.h:220
 msgid "Right-click"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_MouseConfigWidget.h:222
+#: build/OpenSCADLibInternal_autogen/include/ui_MouseConfigWidget.h:221
 msgid "Ctrl + Middle-click"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_MouseConfigWidget.h:223
+#: build/OpenSCADLibInternal_autogen/include/ui_MouseConfigWidget.h:222
 msgid "Shift + Middle-click"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_MouseConfigWidget.h:224
+#: build/OpenSCADLibInternal_autogen/include/ui_MouseConfigWidget.h:223
 msgid "Ctrl + Right-click"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_MouseConfigWidget.h:225
+#: build/OpenSCADLibInternal_autogen/include/ui_MouseConfigWidget.h:224
 msgid "Ctrl + Shift + Left-click"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_MouseConfigWidget.h:226
+#: build/OpenSCADLibInternal_autogen/include/ui_MouseConfigWidget.h:225
 msgid "Shift + Right-click"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_MouseConfigWidget.h:227
+#: build/OpenSCADLibInternal_autogen/include/ui_MouseConfigWidget.h:226
 msgid "Middle-click"
 msgstr ""
 
@@ -2019,24 +1956,10 @@ msgid "OpenGL Warning"
 msgstr "Попередження OpenGL"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_OpenCSGWarningDialog.h:77
-msgid ""
-"<!DOCTYPE HTML PUBLIC \"-//W3C//DTD HTML 4.0//EN\" \"http://www.w3.org/TR/"
-"REC-html40/strict.dtd\">\n"
-"<html><head><meta name=\"qrichtext\" content=\"1\" /><style type=\"text/"
-"css\">\n"
-"p, li { white-space: pre-wrap; }\n"
-"</style></head><body style=\" font-family:'Lucida Grande'; font-size:13pt; "
-"font-weight:400; font-style:normal;\">\n"
-"<p style=\"-qt-paragraph-type:empty; margin-top:0px; margin-bottom:0px; "
-"margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;\"></"
-"p></body></html>"
-msgstr ""
-
-#: build/OpenSCADLibInternal_autogen/include/ui_OpenCSGWarningDialog.h:82
 msgid "Show this message again"
 msgstr "Показати це повідомлення знову"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_OpenCSGWarningDialog.h:83
+#: build/OpenSCADLibInternal_autogen/include/ui_OpenCSGWarningDialog.h:78
 msgid "Close"
 msgstr "Закрити"
 
@@ -2106,6 +2029,10 @@ msgstr "-"
 #, fuzzy
 msgid "More actions"
 msgstr "&Документація"
+
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2464
+msgid "Preferences"
+msgstr "Налаштування"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2465
 msgid "3D View"
@@ -3172,43 +3099,43 @@ msgstr ""
 msgid "Toggle Perspective"
 msgstr "Перспе&ктивний вид"
 
-#: src/gui/MainWindow.cc:861
+#: src/gui/MainWindow.cc:872
 msgid "Compile error."
 msgstr "Помилка компіляції."
 
-#: src/gui/MainWindow.cc:864
+#: src/gui/MainWindow.cc:875
 msgid "Error while compiling '%1'."
 msgstr "Помилка під час компіляції '%1'."
 
-#: src/gui/MainWindow.cc:869
+#: src/gui/MainWindow.cc:880
 msgid "Compilation generated %1 warning."
 msgid_plural "Compilation generated %1 warnings."
 msgstr[0] "Компіляція видала %1 попередження."
 msgstr[1] "Компіляція видала %1 попереджень."
 msgstr[2] "Компіляція видала %1 попереджень."
 
-#: src/gui/MainWindow.cc:882
+#: src/gui/MainWindow.cc:893
 #, fuzzy
 msgid ""
 " For details see the <a href=\"#errorlog\">error log</a> and <a "
 "href=\"#console\">console window</a>."
 msgstr " Для деталей дивіться <a href=\"#console\">вікно консолі</a>."
 
-#: src/gui/MainWindow.cc:1320
+#: src/gui/MainWindow.cc:1331
 msgid "Trusted Files"
 msgstr ""
 
-#: src/gui/MainWindow.cc:1704
+#: src/gui/MainWindow.cc:1715
 msgid ""
 "Python files can potentially contain harmful stuff.\n"
 "Do you trust this file ?\n"
 msgstr ""
 
-#: src/gui/MainWindow.cc:1810
+#: src/gui/MainWindow.cc:1821
 msgid "Application"
 msgstr "Програма"
 
-#: src/gui/MainWindow.cc:1811
+#: src/gui/MainWindow.cc:1822
 msgid ""
 "The document has been modified.\n"
 "Do you really want to reload the file?"
@@ -3216,74 +3143,74 @@ msgstr ""
 "Документ було змінено.\n"
 "Ви дійсно бажаєте перезавантажити файл?"
 
-#: src/gui/MainWindow.cc:2564
+#: src/gui/MainWindow.cc:2575
 msgid "Export %1 File"
 msgstr "Експорт файлу %1"
 
-#: src/gui/MainWindow.cc:2565
+#: src/gui/MainWindow.cc:2576
 msgid "%1 Files (*%2)"
 msgstr "%1 файли (*%2)"
 
-#: src/gui/MainWindow.cc:2613
+#: src/gui/MainWindow.cc:2624
 msgid "Export CSG File"
 msgstr "Експорт CSG файлу"
 
-#: src/gui/MainWindow.cc:2614
+#: src/gui/MainWindow.cc:2625
 msgid "CSG Files (*.csg)"
 msgstr "CSG файли (*.csg)"
 
-#: src/gui/MainWindow.cc:2637
+#: src/gui/MainWindow.cc:2648
 msgid "Export Image"
 msgstr "Експорт зображення"
 
-#: src/gui/MainWindow.cc:2637
+#: src/gui/MainWindow.cc:2648
 msgid "PNG Files (*.png)"
 msgstr "PNG файли (*.png)"
 
-#: src/gui/MainWindow.cc:3027 src/gui/MainWindow.cc:3787
+#: src/gui/MainWindow.cc:3038 src/gui/MainWindow.cc:3798
 msgid "&AI Chat"
 msgstr ""
 
-#: src/gui/MainWindow.cc:3129 src/gui/TabManager.cc:735
+#: src/gui/MainWindow.cc:3140 src/gui/TabManager.cc:735
 #: src/gui/TabManager.cc:786
 msgid "Untitled.scad"
 msgstr "Безіменний.scad"
 
-#: src/gui/MainWindow.cc:3779
+#: src/gui/MainWindow.cc:3790
 #, fuzzy
 msgid "&Editor"
 msgstr "Редактор"
 
-#: src/gui/MainWindow.cc:3780
+#: src/gui/MainWindow.cc:3791
 #, fuzzy
 msgid "&Console"
 msgstr "Консоль"
 
-#: src/gui/MainWindow.cc:3781
+#: src/gui/MainWindow.cc:3792
 #, fuzzy
 msgid "C&ustomizer"
 msgstr "Кастомайзер"
 
-#: src/gui/MainWindow.cc:3782
+#: src/gui/MainWindow.cc:3793
 #, fuzzy
 msgid "Error &Log"
 msgstr "Сховати панелі інструментів"
 
-#: src/gui/MainWindow.cc:3783
+#: src/gui/MainWindow.cc:3794
 #, fuzzy
 msgid "&Animate"
 msgstr "Анімувати"
 
-#: src/gui/MainWindow.cc:3784
+#: src/gui/MainWindow.cc:3795
 msgid "&Font List"
 msgstr "Список &шрифтів"
 
-#: src/gui/MainWindow.cc:3785
+#: src/gui/MainWindow.cc:3796
 #, fuzzy
 msgid "C&olor List"
 msgstr "Схема кольорів:"
 
-#: src/gui/MainWindow.cc:3786
+#: src/gui/MainWindow.cc:3797
 #, fuzzy
 msgid "&Viewport Control"
 msgstr "Сховати панелі інструментів"
@@ -3548,8 +3475,12 @@ msgid "\"%1$s\" write error. (Disk full?)"
 msgstr "ПОМИЛКА: \"%1$s\" помилка запису. (Диск переповнено?)"
 
 #: examples
-msgid "Parametric"
-msgstr "Пераметричне"
+msgid "Advanced"
+msgstr "Поглиблене"
+
+#: examples
+msgid "Basics"
+msgstr "Основи"
 
 #: examples
 msgid "Functions"
@@ -3560,12 +3491,8 @@ msgid "Old"
 msgstr "Старі"
 
 #: examples
-msgid "Advanced"
-msgstr "Поглиблене"
-
-#: examples
-msgid "Basics"
-msgstr "Основи"
+msgid "Parametric"
+msgstr "Пераметричне"
 
 #. (itstool) path: component/summary
 #: openscad.appdata.xml.in2:6
@@ -3621,102 +3548,6 @@ msgstr ""
 "обміну даних для цих 2D контурів використовуються файли AutoCAD DXF. Окрім "
 "файлів DXF OpenSCAD може читати та створювати 3D моделі у форматах файлів "
 "STL та OFF."
-
-#, fuzzy
-#~ msgid "meter"
-#~ msgstr "Параметр"
-
-#~ msgid "Features"
-#~ msgstr "Можливості"
-
-#, fuzzy
-#~ msgid "Reset"
-#~ msgstr "Скидання"
-
-#, fuzzy
-#~ msgid "Search action..."
-#~ msgstr "Шукати рядок"
-
-#, fuzzy
-#~ msgid "ViewportControlWidget"
-#~ msgstr "Сховати панелі інструментів"
-
-#~ msgid "OpenSCAD Font List"
-#~ msgstr "Список шрифтів OpenSCAD"
-
-#~ msgid "Copy to Clipboard"
-#~ msgstr "Скопіювати до буферу"
-
-#~ msgid "Filter:"
-#~ msgstr "Фільтр:"
-
-#~ msgid ""
-#~ "<html><head/><body><p>This list shows the fonts currently registered with "
-#~ "OpenSCAD.</p><p>Example:</p><pre style=\" margin-top:12px; margin-"
-#~ "bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-"
-#~ "indent:0px;\"><span style=\" font-family:'Courier New,courier';\">  "
-#~ "text(&quot;OpenSCAD&quot;, font = &quot;DejaVu Sans&quot;);</span></"
-#~ "pre><pre style=\" margin-top:0px; margin-bottom:12px; margin-left:0px; "
-#~ "margin-right:0px; -qt-block-indent:0; text-indent:0px;\"><span style=\" "
-#~ "font-family:'Courier New,courier';\">  text(&quot;OpenSCAD&quot;, font = "
-#~ "&quot;Liberation Sans:style=Italic&quot;);</span></pre></body></html>"
-#~ msgstr ""
-#~ "<html><head/><body><p>Цей перелік показує шрифти зареєстровані у OpenSCAD."
-#~ "</p><p>Приклад:</p><pre style=\" margin-top:12px; margin-bottom:0px; "
-#~ "margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;"
-#~ "\"><span style=\" font-family:'Courier New,courier';\">  "
-#~ "text(&quot;OpenSCAD&quot;, font = &quot;DejaVu Sans&quot;);</span></"
-#~ "pre><pre style=\" margin-top:0px; margin-bottom:12px; margin-left:0px; "
-#~ "margin-right:0px; -qt-block-indent:0; text-indent:0px;\"><span style=\" "
-#~ "font-family:'Courier New,courier';\">  text(&quot;OpenSCAD&quot;, font = "
-#~ "&quot;Liberation Sans:style=Italic&quot;);</span></pre></body></html>"
-
-#, fuzzy
-#~ msgid "Error-Log"
-#~ msgstr "Сховати панелі інструментів"
-
-#, fuzzy
-#~ msgid "Line"
-#~ msgstr "Згортання рядків"
-
-#, fuzzy
-#~ msgid "Filename"
-#~ msgstr "&Файл"
-
-#, fuzzy
-#~ msgid "Font Lists"
-#~ msgstr "Список &шрифтів"
-
-#, fuzzy
-#~ msgid "Hide Editor"
-#~ msgstr "C&ховати редактор"
-
-#~ msgid "Surfaces"
-#~ msgstr "Поверхні"
-
-#~ msgid "F10"
-#~ msgstr "F10"
-
-#~ msgid "F11"
-#~ msgstr "F11"
-
-#, fuzzy
-#~ msgid "Hide Console"
-#~ msgstr "За&ховати консоль"
-
-#~ msgid "Hide Customizer"
-#~ msgstr "Приховати кастомайзер"
-
-#, fuzzy
-#~ msgid "Hide Error Log"
-#~ msgstr "Сховати панелі інструментів"
-
-#, fuzzy
-#~ msgid "Hide Animation Toolbar/Window"
-#~ msgstr "Сховати панелі інструментів"
-
-#~ msgid "OpenCSG"
-#~ msgstr "OpenCSG"
 
 #, fuzzy
 #~ msgid "play animation"
@@ -3839,6 +3670,3 @@ msgstr ""
 
 #~ msgid "Untitled.png"
 #~ msgstr "Безіменний.png"
-
-#~ msgid "no preset selected"
-#~ msgstr "пресет не обрано"

--- a/locale/zh_CN.po
+++ b/locale/zh_CN.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: OpenSCAD 2015.03.05\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-09-06 23:38+0200\n"
+"POT-Creation-Date: 2026-09-06 17:48-0700\n"
 "PO-Revision-Date: 2021-02-26 14:17+0800\n"
 "Last-Translator: 玉堂白鹤 <yjwork@qq.com>\n"
 "Language-Team: \n"
@@ -103,149 +103,114 @@ msgstr "步数:"
 msgid "Dump Pictures"
 msgstr "生成图片"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:852
-#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:362
-#: build/OpenSCADLibInternal_autogen/include/ui_MouseConfigWidget.h:214
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2464
-msgid "Preferences"
-msgstr "首选项"
-
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:853
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:854
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:858
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:862
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:864
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:866
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:868
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:870
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:881
+#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:860
+#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:861
+#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:865
+#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:869
+#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:871
+#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:873
+#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:875
+#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:877
+#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:888
 msgid "Trim"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:855
+#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:862
 #, fuzzy
 msgid "Reset Trim"
 msgstr "重置视图"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:856
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:859
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:860
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:861
 #: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:863
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:865
+#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:866
 #: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:867
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:869
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:880
+#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:868
+#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:870
+#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:872
+#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:874
+#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:876
+#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:887
 msgid "DeadZone"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:857
+#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:864
 msgid "Auto Trim Axes"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:871
+#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:878
 msgid "Axis 2"
 msgstr "轴 2"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:872
+#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:879
 msgid "Axis 0"
 msgstr "轴 0"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:873
+#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:880
 msgid "Axis 3"
 msgstr "轴 3"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:874
+#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:881
 msgid "Axis 6"
 msgstr "轴 6"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:875
+#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:882
 msgid "Axis 8"
 msgstr "轴 8"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:876
+#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:883
 msgid "Axis 7"
 msgstr "轴 7"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:877
+#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:884
 msgid "Axis 5"
 msgstr "轴 5"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:878
+#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:885
 msgid "Axis 1"
 msgstr "轴 1"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:879
+#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:886
 msgid "Axis 4"
 msgstr "轴 4"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:882
+#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:889
 #: build/OpenSCADLibInternal_autogen/include/ui_ViewportControl.h:279
 msgid "Rotation"
 msgstr "旋转"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:883
+#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:890
 msgid "Zoom"
 msgstr "缩放"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:884
-msgid "X"
-msgstr "X"
-
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:885
+#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:891
 msgid "Gain"
 msgstr "增益"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:886
-msgid "Y"
-msgstr "Y"
-
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:887
-msgid "Z"
-msgstr "Z"
-
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:888
+#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:892
 #: build/OpenSCADLibInternal_autogen/include/ui_ViewportControl.h:280
 msgid "Translation"
 msgstr "平移"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:889
+#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:893
 #, fuzzy
 msgid "ViewPort rel.<br/>Translation"
 msgstr "复制三维视图平移状态(&A)"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:890
+#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:894
 #, fuzzy
-msgid "ViewPort rel.<br />Rotation"
+msgid "ViewPort rel.<br/>Rotation"
 msgstr "复制三维视图旋转状态(&Y)"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:891
+#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:895
 msgid "Axis Setup:"
 msgstr "坐标轴设置:"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:892
+#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:896
 msgid "<b>Driver selection:</b> <i>(changes requires restarting OpenSCAD)</i>"
 msgstr "<b>驱动选择:</b> <i>(更改需重启 OpenSCAD 生效)</i>"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:893
-msgid "SpaceNav"
-msgstr "SpaceNav"
-
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:894
-msgid "HIDAPI"
-msgstr "HIDAPI"
-
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:895
-msgid "QGamepad"
-msgstr "QGamepad"
-
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:896
+#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:897
 msgid "Joystick"
 msgstr "Joystick"
-
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:897
-msgid "DBus"
-msgstr "DBus"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:898
 msgid "Axes Mapping:"
@@ -256,133 +221,125 @@ msgid "Status:"
 msgstr "状态:"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:900
-msgid "TextLabel"
-msgstr "文本标签"
-
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:901
 #: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2468
 msgid "Update"
 msgstr "更新"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:363
+#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:362
 #, fuzzy
 msgid "Button 19"
 msgstr "按钮 1"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:364
+#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:363
 msgid "Button 5"
 msgstr "按钮 5"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:365
+#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:364
 msgid "Button 14"
 msgstr "按钮 14"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:366
+#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:365
 msgid "Button 7"
 msgstr "按钮 7"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:367
+#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:366
 #, fuzzy
 msgid "Button 16"
 msgstr "按钮 1"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:368
+#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:367
 #, fuzzy
 msgid "Button 20"
 msgstr "按钮 2"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:369
+#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:368
 msgid "Button 1"
 msgstr "按钮 1"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:370
+#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:369
 #, fuzzy
 msgid "Button 21"
 msgstr "按钮 2"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:371
+#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:370
 #, fuzzy
 msgid "Button 18"
 msgstr "按钮 1"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:372
+#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:371
 msgid "Button 0"
 msgstr "按钮 0"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:373
+#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:372
 msgid "Button 4"
 msgstr "按钮 4"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:374
+#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:373
 msgid "Button 10"
 msgstr "按钮 10"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:375
+#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:374
 msgid "Button 6"
 msgstr "按钮 6"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:376
+#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:375
 msgid "Button 8"
 msgstr "按钮 8"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:377
+#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:376
 msgid "Button 15"
 msgstr "按钮 15"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:378
+#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:377
 msgid "Button 11"
 msgstr "按钮 11"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:379
+#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:378
 msgid "Button 3"
 msgstr "按钮 3"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:380
+#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:379
 #, fuzzy
 msgid "Button 23"
 msgstr "按钮 2"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:381
+#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:380
 msgid "Button 9"
 msgstr "按钮 9"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:382
+#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:381
 msgid "Button 2"
 msgstr "按钮 2"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:383
+#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:382
 msgid "Button 13"
 msgstr "按钮 13"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:384
+#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:383
 msgid "Button 12"
 msgstr "按钮 12"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:385
+#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:384
 #, fuzzy
 msgid "Button 17"
 msgstr "按钮 1"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:386
+#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:385
 #, fuzzy
 msgid "Button 22"
 msgstr "按钮 2"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_ChatWidget.h:194
+#: build/OpenSCADLibInternal_autogen/include/ui_ChatWidget.h:195
 msgid "AI Chat"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_ChatWidget.h:195
+#: build/OpenSCADLibInternal_autogen/include/ui_ChatWidget.h:196
 #: src/gui/ai/ChatWidget.cc:138
 msgid "AI Assistant"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_ChatWidget.h:197
+#: build/OpenSCADLibInternal_autogen/include/ui_ChatWidget.h:198
 msgid "Chat options"
-msgstr ""
-
-#: build/OpenSCADLibInternal_autogen/include/ui_ChatWidget.h:199
-msgid "☰"
 msgstr ""
 
 #: build/OpenSCADLibInternal_autogen/include/ui_ChatWidget.h:201
@@ -606,7 +563,8 @@ msgstr "错误日志"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_ErrorLog.h:93
 #: build/OpenSCADLibInternal_autogen/include/ui_ViewportControl.h:267
-msgid "RowSelected"
+#, fuzzy
+msgid "Row Selected"
 msgstr "选定行"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_ErrorLog.h:95
@@ -662,9 +620,7 @@ msgid "Export 3MF Options"
 msgstr "导出功能"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_Export3mfDialog.h:459
-#: build/OpenSCADLibInternal_autogen/include/ui_ExportPdfDialog.h:552
-msgid ""
-"<html><head/><body><p>Set the PDF page (paper) size.  </p></body></html>"
+msgid "Set the unit used in the exported file"
 msgstr ""
 
 #: build/OpenSCADLibInternal_autogen/include/ui_Export3mfDialog.h:461
@@ -815,6 +771,10 @@ msgstr "取消"
 msgid "Export PDF Options"
 msgstr "导出功能"
 
+#: build/OpenSCADLibInternal_autogen/include/ui_ExportPdfDialog.h:552
+msgid "Set the PDF page (paper) size."
+msgstr ""
+
 #: build/OpenSCADLibInternal_autogen/include/ui_ExportPdfDialog.h:554
 #, fuzzy
 msgid "Page Size"
@@ -874,9 +834,7 @@ msgid "Author"
 msgstr ""
 
 #: build/OpenSCADLibInternal_autogen/include/ui_ExportPdfDialog.h:582
-msgid ""
-"<html><head/><body><p>Set the direction of the largest page dimension.</p></"
-"body></html>"
+msgid "Set the direction of the largest page dimension."
 msgstr ""
 
 #: build/OpenSCADLibInternal_autogen/include/ui_ExportPdfDialog.h:584
@@ -895,9 +853,7 @@ msgid "Landscape (Horizontal)"
 msgstr ""
 
 #: build/OpenSCADLibInternal_autogen/include/ui_ExportPdfDialog.h:589
-msgid ""
-"<html><head/><body><p>Determine best orientation based on maximum geometry "
-"dimension.</p></body></html>"
+msgid "Determine best orientation based on maximum geometry dimension."
 msgstr ""
 
 #: build/OpenSCADLibInternal_autogen/include/ui_ExportPdfDialog.h:591
@@ -911,8 +867,7 @@ msgid "Annotations"
 msgstr "旋转"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_ExportPdfDialog.h:594
-msgid ""
-"<html><head/><body><p>Include design filename on page.</p></body></html>"
+msgid "Include design filename on page."
 msgstr ""
 
 #: build/OpenSCADLibInternal_autogen/include/ui_ExportPdfDialog.h:596
@@ -920,9 +875,7 @@ msgid "Show Design Filename"
 msgstr ""
 
 #: build/OpenSCADLibInternal_autogen/include/ui_ExportPdfDialog.h:598
-msgid ""
-"<html><head/><body><p>Include rulers on page to confirm 1:1 printing scale.</"
-"p></body></html>"
+msgid "Include rulers on page to confirm 1:1 printing scale."
 msgstr ""
 
 #: build/OpenSCADLibInternal_autogen/include/ui_ExportPdfDialog.h:600
@@ -931,9 +884,7 @@ msgid "Show Scale"
 msgstr "显示坐标轴刻度"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_ExportPdfDialog.h:602
-msgid ""
-"<html><head/><body><p>Include a grid of the selected size on the page.</p></"
-"body></html>"
+msgid "Include a grid of the selected size on the page."
 msgstr ""
 
 #: build/OpenSCADLibInternal_autogen/include/ui_ExportPdfDialog.h:604
@@ -962,9 +913,7 @@ msgid "10mm"
 msgstr ""
 
 #: build/OpenSCADLibInternal_autogen/include/ui_ExportPdfDialog.h:611
-msgid ""
-"<html><head/><body><p>Include text describing usage of scale.</p></body></"
-"html>"
+msgid "Include text describing usage of scale."
 msgstr ""
 
 #: build/OpenSCADLibInternal_autogen/include/ui_ExportPdfDialog.h:613
@@ -978,9 +927,8 @@ msgid "Fill and Stroke"
 msgstr ""
 
 #: build/OpenSCADLibInternal_autogen/include/ui_ExportPdfDialog.h:616
-msgid ""
-"<html><head/><body><p>Enable filling of exported geometry with a color.</p></"
-"body></html>"
+#: build/OpenSCADLibInternal_autogen/include/ui_ExportSvgDialog.h:205
+msgid "Enable filling of exported geometry with a color."
 msgstr ""
 
 #: build/OpenSCADLibInternal_autogen/include/ui_ExportPdfDialog.h:618
@@ -989,9 +937,8 @@ msgid "Fill Geometry"
 msgstr ""
 
 #: build/OpenSCADLibInternal_autogen/include/ui_ExportPdfDialog.h:623
-msgid ""
-"<html><head/><body><p>Enable outline stroke for exported geometry.</p></"
-"body></html>"
+#: build/OpenSCADLibInternal_autogen/include/ui_ExportSvgDialog.h:212
+msgid "Enable outline stroke for exported geometry."
 msgstr ""
 
 #: build/OpenSCADLibInternal_autogen/include/ui_ExportPdfDialog.h:625
@@ -1013,14 +960,6 @@ msgstr ""
 #, fuzzy
 msgid "Export SVG Options"
 msgstr "导出功能"
-
-#: build/OpenSCADLibInternal_autogen/include/ui_ExportSvgDialog.h:205
-msgid "Enable filling of exported geometry with a color."
-msgstr ""
-
-#: build/OpenSCADLibInternal_autogen/include/ui_ExportSvgDialog.h:212
-msgid "Enable outline stroke for exported geometry."
-msgstr ""
 
 #: build/OpenSCADLibInternal_autogen/include/ui_FontList.h:291
 #, fuzzy
@@ -1072,7 +1011,7 @@ msgstr "显示坐标轴刻度"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_FontList.h:302
 #, fuzzy
-msgid "ShowFileName"
+msgid "Show File Name"
 msgstr "复制文件名"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_FontList.h:303
@@ -1853,13 +1792,13 @@ msgid "Ctrl+J"
 msgstr "Ctrl+N"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_MainWindow.h:1286
-#: src/gui/MainWindow.cc:1335 src/gui/MainWindow.cc:1342
-#: src/gui/MainWindow.cc:1355 src/gui/MainWindow.cc:1360
+#: src/gui/MainWindow.cc:1346 src/gui/MainWindow.cc:1353
+#: src/gui/MainWindow.cc:1366 src/gui/MainWindow.cc:1371
 msgid "Create Virtual Environment"
 msgstr ""
 
 #: build/OpenSCADLibInternal_autogen/include/ui_MainWindow.h:1287
-#: src/gui/MainWindow.cc:1377
+#: src/gui/MainWindow.cc:1388
 msgid "Select Virtual Environment"
 msgstr ""
 
@@ -1941,56 +1880,56 @@ msgstr "完成"
 msgid "Customizer Widget"
 msgstr "定制工具"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_MouseConfigWidget.h:215
+#: build/OpenSCADLibInternal_autogen/include/ui_MouseConfigWidget.h:214
 msgid "Ctrl + Shift + Middle-click"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_MouseConfigWidget.h:216
+#: build/OpenSCADLibInternal_autogen/include/ui_MouseConfigWidget.h:215
 msgid "Left-click"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_MouseConfigWidget.h:217
+#: build/OpenSCADLibInternal_autogen/include/ui_MouseConfigWidget.h:216
 msgid "Ctrl + Left-click"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_MouseConfigWidget.h:218
+#: build/OpenSCADLibInternal_autogen/include/ui_MouseConfigWidget.h:217
 msgid "Shift + Left-click"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_MouseConfigWidget.h:219
+#: build/OpenSCADLibInternal_autogen/include/ui_MouseConfigWidget.h:218
 msgid "Ctrl + Shift + Right-click"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_MouseConfigWidget.h:220
+#: build/OpenSCADLibInternal_autogen/include/ui_MouseConfigWidget.h:219
 #, fuzzy
 msgid "Preset"
 msgstr "重置"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_MouseConfigWidget.h:221
+#: build/OpenSCADLibInternal_autogen/include/ui_MouseConfigWidget.h:220
 msgid "Right-click"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_MouseConfigWidget.h:222
+#: build/OpenSCADLibInternal_autogen/include/ui_MouseConfigWidget.h:221
 msgid "Ctrl + Middle-click"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_MouseConfigWidget.h:223
+#: build/OpenSCADLibInternal_autogen/include/ui_MouseConfigWidget.h:222
 msgid "Shift + Middle-click"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_MouseConfigWidget.h:224
+#: build/OpenSCADLibInternal_autogen/include/ui_MouseConfigWidget.h:223
 msgid "Ctrl + Right-click"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_MouseConfigWidget.h:225
+#: build/OpenSCADLibInternal_autogen/include/ui_MouseConfigWidget.h:224
 msgid "Ctrl + Shift + Left-click"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_MouseConfigWidget.h:226
+#: build/OpenSCADLibInternal_autogen/include/ui_MouseConfigWidget.h:225
 msgid "Shift + Right-click"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_MouseConfigWidget.h:227
+#: build/OpenSCADLibInternal_autogen/include/ui_MouseConfigWidget.h:226
 msgid "Middle-click"
 msgstr ""
 
@@ -2007,34 +1946,10 @@ msgid "OpenGL Warning"
 msgstr "OpenGL 警告"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_OpenCSGWarningDialog.h:77
-msgid ""
-"<!DOCTYPE HTML PUBLIC \"-//W3C//DTD HTML 4.0//EN\" \"http://www.w3.org/TR/"
-"REC-html40/strict.dtd\">\n"
-"<html><head><meta name=\"qrichtext\" content=\"1\" /><style type=\"text/"
-"css\">\n"
-"p, li { white-space: pre-wrap; }\n"
-"</style></head><body style=\" font-family:'Lucida Grande'; font-size:13pt; "
-"font-weight:400; font-style:normal;\">\n"
-"<p style=\"-qt-paragraph-type:empty; margin-top:0px; margin-bottom:0px; "
-"margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;\"></"
-"p></body></html>"
-msgstr ""
-"<!DOCTYPE HTML PUBLIC \"-//W3C//DTD HTML 4.0//EN\" \"http://www.w3.org/TR/"
-"REC-html40/strict.dtd\">\n"
-"<html><head><meta name=\"qrichtext\" content=\"1\" /><style type=\"text/"
-"css\">\n"
-"p, li { white-space: pre-wrap; }\n"
-"</style></head><body style=\" font-family:'Lucida Grande'; font-size:13pt; "
-"font-weight:400; font-style:normal;\">\n"
-"<p style=\"-qt-paragraph-type:empty; margin-top:0px; margin-bottom:0px; "
-"margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;\"></"
-"p></body></html>"
-
-#: build/OpenSCADLibInternal_autogen/include/ui_OpenCSGWarningDialog.h:82
 msgid "Show this message again"
 msgstr "再次显示此消息"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_OpenCSGWarningDialog.h:83
+#: build/OpenSCADLibInternal_autogen/include/ui_OpenCSGWarningDialog.h:78
 msgid "Close"
 msgstr "关闭"
 
@@ -2104,6 +2019,10 @@ msgstr "-"
 #, fuzzy
 msgid "More actions"
 msgstr "旋转"
+
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2464
+msgid "Preferences"
+msgstr "首选项"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2465
 msgid "3D View"
@@ -3167,20 +3086,20 @@ msgstr ""
 msgid "Toggle Perspective"
 msgstr "切换透视"
 
-#: src/gui/MainWindow.cc:861
+#: src/gui/MainWindow.cc:872
 msgid "Compile error."
 msgstr "编译错误。"
 
-#: src/gui/MainWindow.cc:864
+#: src/gui/MainWindow.cc:875
 msgid "Error while compiling '%1'."
 msgstr "编译 '%1' 时出错。"
 
-#: src/gui/MainWindow.cc:869
+#: src/gui/MainWindow.cc:880
 msgid "Compilation generated %1 warning."
 msgid_plural "Compilation generated %1 warnings."
 msgstr[0] "编译生成 %1 个告警。"
 
-#: src/gui/MainWindow.cc:882
+#: src/gui/MainWindow.cc:893
 msgid ""
 " For details see the <a href=\"#errorlog\">error log</a> and <a "
 "href=\"#console\">console window</a>."
@@ -3188,21 +3107,21 @@ msgstr ""
 " 详见 <a href=\"#errorlog\">错误日志</a>和<a href=\"#console\">控制台窗口</"
 "a>。"
 
-#: src/gui/MainWindow.cc:1320
+#: src/gui/MainWindow.cc:1331
 msgid "Trusted Files"
 msgstr ""
 
-#: src/gui/MainWindow.cc:1704
+#: src/gui/MainWindow.cc:1715
 msgid ""
 "Python files can potentially contain harmful stuff.\n"
 "Do you trust this file ?\n"
 msgstr ""
 
-#: src/gui/MainWindow.cc:1810
+#: src/gui/MainWindow.cc:1821
 msgid "Application"
 msgstr "应用程序"
 
-#: src/gui/MainWindow.cc:1811
+#: src/gui/MainWindow.cc:1822
 msgid ""
 "The document has been modified.\n"
 "Do you really want to reload the file?"
@@ -3210,70 +3129,70 @@ msgstr ""
 "该文档已被修改。\n"
 "您真的要重新加载文件吗？"
 
-#: src/gui/MainWindow.cc:2564
+#: src/gui/MainWindow.cc:2575
 msgid "Export %1 File"
 msgstr "导出 %1 文件"
 
-#: src/gui/MainWindow.cc:2565
+#: src/gui/MainWindow.cc:2576
 msgid "%1 Files (*%2)"
 msgstr "%1 文件 (*%2)"
 
-#: src/gui/MainWindow.cc:2613
+#: src/gui/MainWindow.cc:2624
 msgid "Export CSG File"
 msgstr "导出 CSG 文件"
 
-#: src/gui/MainWindow.cc:2614
+#: src/gui/MainWindow.cc:2625
 msgid "CSG Files (*.csg)"
 msgstr "CSG 文件 (*.csg)"
 
-#: src/gui/MainWindow.cc:2637
+#: src/gui/MainWindow.cc:2648
 msgid "Export Image"
 msgstr "导出图像"
 
-#: src/gui/MainWindow.cc:2637
+#: src/gui/MainWindow.cc:2648
 msgid "PNG Files (*.png)"
 msgstr "PNG 文件 (*.png)"
 
-#: src/gui/MainWindow.cc:3027 src/gui/MainWindow.cc:3787
+#: src/gui/MainWindow.cc:3038 src/gui/MainWindow.cc:3798
 msgid "&AI Chat"
 msgstr ""
 
-#: src/gui/MainWindow.cc:3129 src/gui/TabManager.cc:735
+#: src/gui/MainWindow.cc:3140 src/gui/TabManager.cc:735
 #: src/gui/TabManager.cc:786
 msgid "Untitled.scad"
 msgstr "未命名.scad"
 
-#: src/gui/MainWindow.cc:3779
+#: src/gui/MainWindow.cc:3790
 msgid "&Editor"
 msgstr "编辑器(&E)"
 
-#: src/gui/MainWindow.cc:3780
+#: src/gui/MainWindow.cc:3791
 msgid "&Console"
 msgstr "控制台(&C)"
 
-#: src/gui/MainWindow.cc:3781
+#: src/gui/MainWindow.cc:3792
 msgid "C&ustomizer"
 msgstr "定制器(&U)"
 
-#: src/gui/MainWindow.cc:3782
+#: src/gui/MainWindow.cc:3793
 msgid "Error &Log"
 msgstr "错误日志(&L)"
 
-#: src/gui/MainWindow.cc:3783
+#: src/gui/MainWindow.cc:3794
 #, fuzzy
 msgid "&Animate"
 msgstr "动画"
 
-#: src/gui/MainWindow.cc:3784
+#: src/gui/MainWindow.cc:3795
 msgid "&Font List"
 msgstr "字体列表(&F)"
 
-#: src/gui/MainWindow.cc:3785
+#: src/gui/MainWindow.cc:3796
 #, fuzzy
 msgid "C&olor List"
 msgstr "配色方案:"
 
-#: src/gui/MainWindow.cc:3786
+#: src/gui/MainWindow.cc:3797
 #, fuzzy
 msgid "&Viewport Control"
 msgstr "隐藏 3D 视图工具栏"
@@ -3536,8 +3455,12 @@ msgid "\"%1$s\" write error. (Disk full?)"
 msgstr "\"%1$s\" 写入错误。(磁盘已满?)"
 
 #: examples
-msgid "Parametric"
-msgstr "参数"
+msgid "Advanced"
+msgstr "高级"
+
+#: examples
+msgid "Basics"
+msgstr "基础"
 
 #: examples
 msgid "Functions"
@@ -3548,12 +3471,8 @@ msgid "Old"
 msgstr "旧版"
 
 #: examples
-msgid "Advanced"
-msgstr "高级"
-
-#: examples
-msgid "Basics"
-msgstr "基础"
+msgid "Parametric"
+msgstr "参数"
 
 #. (itstool) path: component/summary
 #: openscad.appdata.xml.in2:6
@@ -3592,125 +3511,6 @@ msgid ""
 "parameters from DXF files. Besides DXF files OpenSCAD can read and create 3D "
 "models in the STL and OFF file formats."
 msgstr ""
-
-#, fuzzy
-#~ msgid "meter"
-#~ msgstr "参数"
-
-#~ msgid "Features"
-#~ msgstr "特性"
-
-#~ msgid "Shortcut"
-#~ msgstr "快捷方式"
-
-#, fuzzy
-#~ msgid "Reset"
-#~ msgstr "重置"
-
-#, fuzzy
-#~ msgid "Search action..."
-#~ msgstr "搜索字符串"
-
-#, fuzzy
-#~ msgid "ViewportControlWidget"
-#~ msgstr "隐藏 3D 视图工具栏"
-
-#~ msgid "OpenSCAD Font List"
-#~ msgstr "OpenSCAD 字体列表"
-
-#~ msgid "Copy to Clipboard"
-#~ msgstr "复制到剪贴板"
-
-#~ msgid "Filter:"
-#~ msgstr "筛选:"
-
-#~ msgid ""
-#~ "<html><head/><body><p>This list shows the fonts currently registered with "
-#~ "OpenSCAD.</p><p>Example:</p><pre style=\" margin-top:12px; margin-"
-#~ "bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-"
-#~ "indent:0px;\"><span style=\" font-family:'Courier New,courier';\">  "
-#~ "text(&quot;OpenSCAD&quot;, font = &quot;DejaVu Sans&quot;);</span></"
-#~ "pre><pre style=\" margin-top:0px; margin-bottom:12px; margin-left:0px; "
-#~ "margin-right:0px; -qt-block-indent:0; text-indent:0px;\"><span style=\" "
-#~ "font-family:'Courier New,courier';\">  text(&quot;OpenSCAD&quot;, font = "
-#~ "&quot;Liberation Sans:style=Italic&quot;);</span></pre></body></html>"
-#~ msgstr ""
-#~ "<html><head/><body><p>这个列表显示了当前在 OpenSCAD 中注册的字体。</p><p>"
-#~ "例如:</p><pre style=\" margin-top:12px; margin-bottom:0px; margin-"
-#~ "left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;\"><span "
-#~ "style=\" font-family:'Courier New,courier';\">  "
-#~ "text(&quot;OpenSCAD&quot;, font = &quot;DejaVu Sans&quot;);</span></"
-#~ "pre><pre style=\" margin-top:0px; margin-bottom:12px; margin-left:0px; "
-#~ "margin-right:0px; -qt-block-indent:0; text-indent:0px;\"><span style=\" "
-#~ "font-family:'Courier New,courier';\">  text(&quot;OpenSCAD&quot;, font = "
-#~ "&quot;Liberation Sans:style=Italic&quot;);</span></pre></body></html>"
-
-#~ msgid "Error-Log"
-#~ msgstr "错误日志"
-
-#~ msgid "F7"
-#~ msgstr "F7"
-
-#, fuzzy
-#~ msgid "Swap Mouse Buttons"
-#~ msgstr "鼠标左键"
-
-#, fuzzy
-#~ msgid "Line"
-#~ msgstr "自动换行"
-
-#, fuzzy
-#~ msgid "Filename"
-#~ msgstr "复制文件名"
-
-#, fuzzy
-#~ msgid "Font Lists"
-#~ msgstr "字体列表(&F)"
-
-#, fuzzy
-#~ msgid "PushButton"
-#~ msgstr "按钮"
-
-#~ msgid "Hide Editor"
-#~ msgstr "隐藏编辑器"
-
-#~ msgid "Surfaces"
-#~ msgstr "面"
-
-#~ msgid "F10"
-#~ msgstr "F10"
-
-#~ msgid "F11"
-#~ msgstr "F11"
-
-#~ msgid "Hide Console"
-#~ msgstr "隐藏控制台"
-
-#~ msgid "Hide Customizer"
-#~ msgstr "隐藏定制器"
-
-#~ msgid "Hide Error Log"
-#~ msgstr "隐藏错误日志"
-
-#, fuzzy
-#~ msgid "Hide Animation Toolbar/Window"
-#~ msgstr "隐藏编辑工具栏"
-
-#~ msgid "OpenCSG"
-#~ msgstr "OpenCSG"
-
-#~ msgid "CGAL"
-#~ msgstr "CGAL"
-
-#, fuzzy
-#~ msgid "WRL"
-#~ msgstr "URL"
-
-#~ msgid "Default to ASCII STL export"
-#~ msgstr "默认为 ASCII STL 导出"
-
-#~ msgid "%1"
-#~ msgstr "%1"
 
 #, fuzzy
 #~ msgid "translate"

--- a/locale/zh_TW.po
+++ b/locale/zh_TW.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: OpenSCAD 2020.02.17\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-09-06 23:38+0200\n"
+"POT-Creation-Date: 2026-09-06 17:48-0700\n"
 "PO-Revision-Date: 2020-05-28 14:42+0200\n"
 "Last-Translator: Michael Tsao <cwtsao@sce.pccu.edu.tw>\n"
 "Language-Team: Distance Learning Center at the Chinese Culture University "
@@ -103,147 +103,112 @@ msgstr "步驟："
 msgid "Dump Pictures"
 msgstr "轉存圖片"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:852
-#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:362
-#: build/OpenSCADLibInternal_autogen/include/ui_MouseConfigWidget.h:214
-#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2464
-msgid "Preferences"
-msgstr "偏好設定"
-
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:853
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:854
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:858
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:862
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:864
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:866
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:868
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:870
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:881
+#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:860
+#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:861
+#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:865
+#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:869
+#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:871
+#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:873
+#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:875
+#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:877
+#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:888
 msgid "Trim"
 msgstr "歸零點"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:855
+#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:862
 msgid "Reset Trim"
 msgstr "重置歸零點"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:856
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:859
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:860
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:861
 #: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:863
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:865
+#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:866
 #: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:867
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:869
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:880
+#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:868
+#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:870
+#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:872
+#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:874
+#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:876
+#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:887
 msgid "DeadZone"
 msgstr "盲區"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:857
+#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:864
 msgid "Auto Trim Axes"
 msgstr "自動歸零軸"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:871
+#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:878
 msgid "Axis 2"
 msgstr "軸 2"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:872
+#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:879
 msgid "Axis 0"
 msgstr "軸 0"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:873
+#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:880
 msgid "Axis 3"
 msgstr "軸 3"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:874
+#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:881
 msgid "Axis 6"
 msgstr "軸 6"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:875
+#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:882
 msgid "Axis 8"
 msgstr "軸 8"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:876
+#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:883
 msgid "Axis 7"
 msgstr "軸 7"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:877
+#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:884
 msgid "Axis 5"
 msgstr "軸 5"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:878
+#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:885
 msgid "Axis 1"
 msgstr "軸 1"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:879
+#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:886
 msgid "Axis 4"
 msgstr "軸 4"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:882
+#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:889
 #: build/OpenSCADLibInternal_autogen/include/ui_ViewportControl.h:279
 msgid "Rotation"
 msgstr "旋轉"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:883
+#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:890
 msgid "Zoom"
 msgstr "縮放"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:884
-msgid "X"
-msgstr "X"
-
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:885
+#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:891
 msgid "Gain"
 msgstr "倍率"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:886
-msgid "Y"
-msgstr "Y"
-
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:887
-msgid "Z"
-msgstr "Z"
-
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:888
+#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:892
 #: build/OpenSCADLibInternal_autogen/include/ui_ViewportControl.h:280
 msgid "Translation"
 msgstr "平移"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:889
+#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:893
 msgid "ViewPort rel.<br/>Translation"
 msgstr "視圖相關<br/>平移"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:890
-msgid "ViewPort rel.<br />Rotation"
+#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:894
+msgid "ViewPort rel.<br/>Rotation"
 msgstr "視圖相關<br/>旋轉"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:891
+#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:895
 #, fuzzy
 msgid "Axis Setup:"
 msgstr "座標軸設置: "
 
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:892
+#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:896
 msgid "<b>Driver selection:</b> <i>(changes requires restarting OpenSCAD)</i>"
 msgstr "<b>驅動程式選擇:</b> <i>(套用後需重新啟動OpenSCAD)</i>"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:893
-msgid "SpaceNav"
-msgstr "SpaceNav"
-
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:894
-msgid "HIDAPI"
-msgstr "HIDAPI"
-
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:895
-msgid "QGamepad"
-msgstr "QGamepad"
-
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:896
+#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:897
 msgid "Joystick"
 msgstr "操縱桿"
-
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:897
-msgid "DBus"
-msgstr "DBus"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:898
 msgid "Axes Mapping:"
@@ -254,134 +219,125 @@ msgid "Status:"
 msgstr "狀態："
 
 #: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:900
-#, fuzzy
-msgid "TextLabel"
-msgstr "文字標籤"
-
-#: build/OpenSCADLibInternal_autogen/include/ui_AxisConfigWidget.h:901
 #: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2468
 msgid "Update"
 msgstr "更新"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:363
+#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:362
 #, fuzzy
 msgid "Button 19"
 msgstr "按鈕 1"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:364
+#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:363
 msgid "Button 5"
 msgstr "按鈕 5"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:365
+#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:364
 msgid "Button 14"
 msgstr "按鈕 14"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:366
+#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:365
 msgid "Button 7"
 msgstr "按鈕 7"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:367
+#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:366
 #, fuzzy
 msgid "Button 16"
 msgstr "按鈕 1"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:368
+#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:367
 #, fuzzy
 msgid "Button 20"
 msgstr "按鈕 2"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:369
+#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:368
 msgid "Button 1"
 msgstr "按鈕 1"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:370
+#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:369
 #, fuzzy
 msgid "Button 21"
 msgstr "按鈕 2"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:371
+#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:370
 #, fuzzy
 msgid "Button 18"
 msgstr "按鈕 1"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:372
+#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:371
 msgid "Button 0"
 msgstr "按鈕 0"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:373
+#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:372
 msgid "Button 4"
 msgstr "按鈕 4"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:374
+#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:373
 msgid "Button 10"
 msgstr "按鈕 10"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:375
+#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:374
 msgid "Button 6"
 msgstr "按鈕 6"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:376
+#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:375
 msgid "Button 8"
 msgstr "按鈕 8"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:377
+#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:376
 msgid "Button 15"
 msgstr "按鈕 15"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:378
+#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:377
 msgid "Button 11"
 msgstr "按鈕 11"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:379
+#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:378
 msgid "Button 3"
 msgstr "按鈕 3"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:380
+#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:379
 #, fuzzy
 msgid "Button 23"
 msgstr "按鈕 2"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:381
+#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:380
 msgid "Button 9"
 msgstr "按鈕 9"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:382
+#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:381
 msgid "Button 2"
 msgstr "按鈕 2"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:383
+#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:382
 msgid "Button 13"
 msgstr "按鈕 13"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:384
+#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:383
 msgid "Button 12"
 msgstr "按鈕 12"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:385
+#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:384
 #, fuzzy
 msgid "Button 17"
 msgstr "按鈕 1"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:386
+#: build/OpenSCADLibInternal_autogen/include/ui_ButtonConfigWidget.h:385
 #, fuzzy
 msgid "Button 22"
 msgstr "按鈕 2"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_ChatWidget.h:194
+#: build/OpenSCADLibInternal_autogen/include/ui_ChatWidget.h:195
 msgid "AI Chat"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_ChatWidget.h:195
+#: build/OpenSCADLibInternal_autogen/include/ui_ChatWidget.h:196
 #: src/gui/ai/ChatWidget.cc:138
 msgid "AI Assistant"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_ChatWidget.h:197
+#: build/OpenSCADLibInternal_autogen/include/ui_ChatWidget.h:198
 msgid "Chat options"
-msgstr ""
-
-#: build/OpenSCADLibInternal_autogen/include/ui_ChatWidget.h:199
-msgid "☰"
 msgstr ""
 
 #: build/OpenSCADLibInternal_autogen/include/ui_ChatWidget.h:201
@@ -607,7 +563,7 @@ msgstr "錯誤日誌"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_ErrorLog.h:93
 #: build/OpenSCADLibInternal_autogen/include/ui_ViewportControl.h:267
-msgid "RowSelected"
+msgid "Row Selected"
 msgstr ""
 
 #: build/OpenSCADLibInternal_autogen/include/ui_ErrorLog.h:95
@@ -664,9 +620,7 @@ msgid "Export 3MF Options"
 msgstr "特徵"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_Export3mfDialog.h:459
-#: build/OpenSCADLibInternal_autogen/include/ui_ExportPdfDialog.h:552
-msgid ""
-"<html><head/><body><p>Set the PDF page (paper) size.  </p></body></html>"
+msgid "Set the unit used in the exported file"
 msgstr ""
 
 #: build/OpenSCADLibInternal_autogen/include/ui_Export3mfDialog.h:461
@@ -817,6 +771,10 @@ msgstr "取消"
 msgid "Export PDF Options"
 msgstr "特徵"
 
+#: build/OpenSCADLibInternal_autogen/include/ui_ExportPdfDialog.h:552
+msgid "Set the PDF page (paper) size."
+msgstr ""
+
 #: build/OpenSCADLibInternal_autogen/include/ui_ExportPdfDialog.h:554
 #, fuzzy
 msgid "Page Size"
@@ -876,9 +834,7 @@ msgid "Author"
 msgstr ""
 
 #: build/OpenSCADLibInternal_autogen/include/ui_ExportPdfDialog.h:582
-msgid ""
-"<html><head/><body><p>Set the direction of the largest page dimension.</p></"
-"body></html>"
+msgid "Set the direction of the largest page dimension."
 msgstr ""
 
 #: build/OpenSCADLibInternal_autogen/include/ui_ExportPdfDialog.h:584
@@ -897,9 +853,7 @@ msgid "Landscape (Horizontal)"
 msgstr ""
 
 #: build/OpenSCADLibInternal_autogen/include/ui_ExportPdfDialog.h:589
-msgid ""
-"<html><head/><body><p>Determine best orientation based on maximum geometry "
-"dimension.</p></body></html>"
+msgid "Determine best orientation based on maximum geometry dimension."
 msgstr ""
 
 #: build/OpenSCADLibInternal_autogen/include/ui_ExportPdfDialog.h:591
@@ -913,8 +867,7 @@ msgid "Annotations"
 msgstr "旋轉"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_ExportPdfDialog.h:594
-msgid ""
-"<html><head/><body><p>Include design filename on page.</p></body></html>"
+msgid "Include design filename on page."
 msgstr ""
 
 #: build/OpenSCADLibInternal_autogen/include/ui_ExportPdfDialog.h:596
@@ -922,9 +875,7 @@ msgid "Show Design Filename"
 msgstr ""
 
 #: build/OpenSCADLibInternal_autogen/include/ui_ExportPdfDialog.h:598
-msgid ""
-"<html><head/><body><p>Include rulers on page to confirm 1:1 printing scale.</"
-"p></body></html>"
+msgid "Include rulers on page to confirm 1:1 printing scale."
 msgstr ""
 
 #: build/OpenSCADLibInternal_autogen/include/ui_ExportPdfDialog.h:600
@@ -933,9 +884,7 @@ msgid "Show Scale"
 msgstr "顯示刻度標記"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_ExportPdfDialog.h:602
-msgid ""
-"<html><head/><body><p>Include a grid of the selected size on the page.</p></"
-"body></html>"
+msgid "Include a grid of the selected size on the page."
 msgstr ""
 
 #: build/OpenSCADLibInternal_autogen/include/ui_ExportPdfDialog.h:604
@@ -964,9 +913,7 @@ msgid "10mm"
 msgstr ""
 
 #: build/OpenSCADLibInternal_autogen/include/ui_ExportPdfDialog.h:611
-msgid ""
-"<html><head/><body><p>Include text describing usage of scale.</p></body></"
-"html>"
+msgid "Include text describing usage of scale."
 msgstr ""
 
 #: build/OpenSCADLibInternal_autogen/include/ui_ExportPdfDialog.h:613
@@ -980,9 +927,8 @@ msgid "Fill and Stroke"
 msgstr ""
 
 #: build/OpenSCADLibInternal_autogen/include/ui_ExportPdfDialog.h:616
-msgid ""
-"<html><head/><body><p>Enable filling of exported geometry with a color.</p></"
-"body></html>"
+#: build/OpenSCADLibInternal_autogen/include/ui_ExportSvgDialog.h:205
+msgid "Enable filling of exported geometry with a color."
 msgstr ""
 
 #: build/OpenSCADLibInternal_autogen/include/ui_ExportPdfDialog.h:618
@@ -991,9 +937,8 @@ msgid "Fill Geometry"
 msgstr ""
 
 #: build/OpenSCADLibInternal_autogen/include/ui_ExportPdfDialog.h:623
-msgid ""
-"<html><head/><body><p>Enable outline stroke for exported geometry.</p></"
-"body></html>"
+#: build/OpenSCADLibInternal_autogen/include/ui_ExportSvgDialog.h:212
+msgid "Enable outline stroke for exported geometry."
 msgstr ""
 
 #: build/OpenSCADLibInternal_autogen/include/ui_ExportPdfDialog.h:625
@@ -1015,14 +960,6 @@ msgstr ""
 #, fuzzy
 msgid "Export SVG Options"
 msgstr "特徵"
-
-#: build/OpenSCADLibInternal_autogen/include/ui_ExportSvgDialog.h:205
-msgid "Enable filling of exported geometry with a color."
-msgstr ""
-
-#: build/OpenSCADLibInternal_autogen/include/ui_ExportSvgDialog.h:212
-msgid "Enable outline stroke for exported geometry."
-msgstr ""
 
 #: build/OpenSCADLibInternal_autogen/include/ui_FontList.h:291
 #, fuzzy
@@ -1074,7 +1011,7 @@ msgstr "顯示刻度標記"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_FontList.h:302
 #, fuzzy
-msgid "ShowFileName"
+msgid "Show File Name"
 msgstr "複製檔案名稱"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_FontList.h:303
@@ -1866,13 +1803,13 @@ msgid "Ctrl+J"
 msgstr "Ctrl+N"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_MainWindow.h:1286
-#: src/gui/MainWindow.cc:1335 src/gui/MainWindow.cc:1342
-#: src/gui/MainWindow.cc:1355 src/gui/MainWindow.cc:1360
+#: src/gui/MainWindow.cc:1346 src/gui/MainWindow.cc:1353
+#: src/gui/MainWindow.cc:1366 src/gui/MainWindow.cc:1371
 msgid "Create Virtual Environment"
 msgstr ""
 
 #: build/OpenSCADLibInternal_autogen/include/ui_MainWindow.h:1287
-#: src/gui/MainWindow.cc:1377
+#: src/gui/MainWindow.cc:1388
 msgid "Select Virtual Environment"
 msgstr ""
 
@@ -1956,56 +1893,56 @@ msgstr "完成"
 msgid "Customizer Widget"
 msgstr "自訂小工具"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_MouseConfigWidget.h:215
+#: build/OpenSCADLibInternal_autogen/include/ui_MouseConfigWidget.h:214
 msgid "Ctrl + Shift + Middle-click"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_MouseConfigWidget.h:216
+#: build/OpenSCADLibInternal_autogen/include/ui_MouseConfigWidget.h:215
 msgid "Left-click"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_MouseConfigWidget.h:217
+#: build/OpenSCADLibInternal_autogen/include/ui_MouseConfigWidget.h:216
 msgid "Ctrl + Left-click"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_MouseConfigWidget.h:218
+#: build/OpenSCADLibInternal_autogen/include/ui_MouseConfigWidget.h:217
 msgid "Shift + Left-click"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_MouseConfigWidget.h:219
+#: build/OpenSCADLibInternal_autogen/include/ui_MouseConfigWidget.h:218
 msgid "Ctrl + Shift + Right-click"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_MouseConfigWidget.h:220
+#: build/OpenSCADLibInternal_autogen/include/ui_MouseConfigWidget.h:219
 #, fuzzy
 msgid "Preset"
 msgstr "重設"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_MouseConfigWidget.h:221
+#: build/OpenSCADLibInternal_autogen/include/ui_MouseConfigWidget.h:220
 msgid "Right-click"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_MouseConfigWidget.h:222
+#: build/OpenSCADLibInternal_autogen/include/ui_MouseConfigWidget.h:221
 msgid "Ctrl + Middle-click"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_MouseConfigWidget.h:223
+#: build/OpenSCADLibInternal_autogen/include/ui_MouseConfigWidget.h:222
 msgid "Shift + Middle-click"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_MouseConfigWidget.h:224
+#: build/OpenSCADLibInternal_autogen/include/ui_MouseConfigWidget.h:223
 msgid "Ctrl + Right-click"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_MouseConfigWidget.h:225
+#: build/OpenSCADLibInternal_autogen/include/ui_MouseConfigWidget.h:224
 msgid "Ctrl + Shift + Left-click"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_MouseConfigWidget.h:226
+#: build/OpenSCADLibInternal_autogen/include/ui_MouseConfigWidget.h:225
 msgid "Shift + Right-click"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_MouseConfigWidget.h:227
+#: build/OpenSCADLibInternal_autogen/include/ui_MouseConfigWidget.h:226
 msgid "Middle-click"
 msgstr ""
 
@@ -2022,34 +1959,10 @@ msgid "OpenGL Warning"
 msgstr "OpenGL警告"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_OpenCSGWarningDialog.h:77
-msgid ""
-"<!DOCTYPE HTML PUBLIC \"-//W3C//DTD HTML 4.0//EN\" \"http://www.w3.org/TR/"
-"REC-html40/strict.dtd\">\n"
-"<html><head><meta name=\"qrichtext\" content=\"1\" /><style type=\"text/"
-"css\">\n"
-"p, li { white-space: pre-wrap; }\n"
-"</style></head><body style=\" font-family:'Lucida Grande'; font-size:13pt; "
-"font-weight:400; font-style:normal;\">\n"
-"<p style=\"-qt-paragraph-type:empty; margin-top:0px; margin-bottom:0px; "
-"margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;\"></"
-"p></body></html>"
-msgstr ""
-"<!DOCTYPE HTML PUBLIC \"-//W3C//DTD HTML 4.0//EN\" \"http://www.w3.org/TR/"
-"REC-html40/strict.dtd\">\n"
-"<html><head><meta name=\"qrichtext\" content=\"1\" /><style type=\"text/"
-"css\">\n"
-"p, li { white-space: pre-wrap; }\n"
-"</style></head><body style=\" font-family:'Lucida Grande'; font-size:13pt; "
-"font-weight:400; font-style:normal;\">\n"
-"<p style=\"-qt-paragraph-type:empty; margin-top:0px; margin-bottom:0px; "
-"margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;\"></"
-"p></body></html>"
-
-#: build/OpenSCADLibInternal_autogen/include/ui_OpenCSGWarningDialog.h:82
 msgid "Show this message again"
 msgstr "再次顯示訊息"
 
-#: build/OpenSCADLibInternal_autogen/include/ui_OpenCSGWarningDialog.h:83
+#: build/OpenSCADLibInternal_autogen/include/ui_OpenCSGWarningDialog.h:78
 msgid "Close"
 msgstr "關閉"
 
@@ -2120,6 +2033,10 @@ msgstr "-"
 #, fuzzy
 msgid "More actions"
 msgstr "旋轉"
+
+#: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2464
+msgid "Preferences"
+msgstr "偏好設定"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2465
 msgid "3D View"
@@ -3189,41 +3106,41 @@ msgstr "QGAMEPAD驅動程式用於多平台手把支援。"
 msgid "Toggle Perspective"
 msgstr "切換視角"
 
-#: src/gui/MainWindow.cc:861
+#: src/gui/MainWindow.cc:872
 msgid "Compile error."
 msgstr "編譯錯誤."
 
-#: src/gui/MainWindow.cc:864
+#: src/gui/MainWindow.cc:875
 msgid "Error while compiling '%1'."
 msgstr "編譯 '%1' 時錯誤."
 
-#: src/gui/MainWindow.cc:869
+#: src/gui/MainWindow.cc:880
 msgid "Compilation generated %1 warning."
 msgid_plural "Compilation generated %1 warnings."
 msgstr[0] "編譯產生 %1 警告."
 
-#: src/gui/MainWindow.cc:882
+#: src/gui/MainWindow.cc:893
 #, fuzzy
 msgid ""
 " For details see the <a href=\"#errorlog\">error log</a> and <a "
 "href=\"#console\">console window</a>."
 msgstr "詳見<a href=\"#console\">控制台視窗</a>."
 
-#: src/gui/MainWindow.cc:1320
+#: src/gui/MainWindow.cc:1331
 msgid "Trusted Files"
 msgstr ""
 
-#: src/gui/MainWindow.cc:1704
+#: src/gui/MainWindow.cc:1715
 msgid ""
 "Python files can potentially contain harmful stuff.\n"
 "Do you trust this file ?\n"
 msgstr ""
 
-#: src/gui/MainWindow.cc:1810
+#: src/gui/MainWindow.cc:1821
 msgid "Application"
 msgstr "套用"
 
-#: src/gui/MainWindow.cc:1811
+#: src/gui/MainWindow.cc:1822
 msgid ""
 "The document has been modified.\n"
 "Do you really want to reload the file?"
@@ -3231,74 +3148,74 @@ msgstr ""
 "此文件已被變更.\n"
 "是否要重新載入檔案?"
 
-#: src/gui/MainWindow.cc:2564
+#: src/gui/MainWindow.cc:2575
 msgid "Export %1 File"
 msgstr "匯出 %1 檔案"
 
-#: src/gui/MainWindow.cc:2565
+#: src/gui/MainWindow.cc:2576
 msgid "%1 Files (*%2)"
 msgstr "%1 個檔案 (*%2)"
 
-#: src/gui/MainWindow.cc:2613
+#: src/gui/MainWindow.cc:2624
 msgid "Export CSG File"
 msgstr "匯出CSG檔案"
 
-#: src/gui/MainWindow.cc:2614
+#: src/gui/MainWindow.cc:2625
 msgid "CSG Files (*.csg)"
 msgstr "CSG檔案 (*.csg)"
 
-#: src/gui/MainWindow.cc:2637
+#: src/gui/MainWindow.cc:2648
 msgid "Export Image"
 msgstr "匯出圖片"
 
-#: src/gui/MainWindow.cc:2637
+#: src/gui/MainWindow.cc:2648
 msgid "PNG Files (*.png)"
 msgstr "PNG檔 (*.png)"
 
-#: src/gui/MainWindow.cc:3027 src/gui/MainWindow.cc:3787
+#: src/gui/MainWindow.cc:3038 src/gui/MainWindow.cc:3798
 msgid "&AI Chat"
 msgstr ""
 
-#: src/gui/MainWindow.cc:3129 src/gui/TabManager.cc:735
+#: src/gui/MainWindow.cc:3140 src/gui/TabManager.cc:735
 #: src/gui/TabManager.cc:786
 msgid "Untitled.scad"
 msgstr "無標題.SCAD"
 
-#: src/gui/MainWindow.cc:3779
+#: src/gui/MainWindow.cc:3790
 #, fuzzy
 msgid "&Editor"
 msgstr "編輯器"
 
-#: src/gui/MainWindow.cc:3780
+#: src/gui/MainWindow.cc:3791
 #, fuzzy
 msgid "&Console"
 msgstr "控制台"
 
-#: src/gui/MainWindow.cc:3781
+#: src/gui/MainWindow.cc:3792
 #, fuzzy
 msgid "C&ustomizer"
 msgstr "自訂"
 
-#: src/gui/MainWindow.cc:3782
+#: src/gui/MainWindow.cc:3793
 #, fuzzy
 msgid "Error &Log"
 msgstr "錯誤日誌"
 
-#: src/gui/MainWindow.cc:3783
+#: src/gui/MainWindow.cc:3794
 #, fuzzy
 msgid "&Animate"
 msgstr "動畫"
 
-#: src/gui/MainWindow.cc:3784
+#: src/gui/MainWindow.cc:3795
 msgid "&Font List"
 msgstr "字型清單(&F)"
 
-#: src/gui/MainWindow.cc:3785
+#: src/gui/MainWindow.cc:3796
 #, fuzzy
 msgid "C&olor List"
 msgstr "色彩方案:"
 
-#: src/gui/MainWindow.cc:3786
+#: src/gui/MainWindow.cc:3797
 #, fuzzy
 msgid "&Viewport Control"
 msgstr "隱藏3D檢視工具列"
@@ -3558,8 +3475,12 @@ msgid "\"%1$s\" write error. (Disk full?)"
 msgstr "錯誤: \"%1$s\" 寫入錯誤. (磁碟滿載?)"
 
 #: examples
-msgid "Parametric"
-msgstr "參數"
+msgid "Advanced"
+msgstr "進階"
+
+#: examples
+msgid "Basics"
+msgstr "基礎"
 
 #: examples
 msgid "Functions"
@@ -3570,12 +3491,8 @@ msgid "Old"
 msgstr "舊範例"
 
 #: examples
-msgid "Advanced"
-msgstr "進階"
-
-#: examples
-msgid "Basics"
-msgstr "基礎"
+msgid "Parametric"
+msgstr "參數"
 
 #. (itstool) path: component/summary
 #: openscad.appdata.xml.in2:6
@@ -3624,119 +3541,6 @@ msgstr ""
 "出。以Autocad DXF檔案作為2D輪廓的資料交換格式。除了用於擠出的2D路徑外，還可以"
 "從DXF文件中讀取設計參數。除了DXF文件外OpenSCAD還可以讀取和創建STL和OFF文件格"
 "式的3D模型。"
-
-#, fuzzy
-#~ msgid "meter"
-#~ msgstr "參數"
-
-#~ msgid "Features"
-#~ msgstr "特徵"
-
-#, fuzzy
-#~ msgid "Reset"
-#~ msgstr "重設"
-
-#, fuzzy
-#~ msgid "Search action..."
-#~ msgstr "搜尋字串"
-
-#, fuzzy
-#~ msgid "ViewportControlWidget"
-#~ msgstr "隱藏3D檢視工具列"
-
-#~ msgid "OpenSCAD Font List"
-#~ msgstr "OpenSCAD 字型清單"
-
-#~ msgid "Copy to Clipboard"
-#~ msgstr "複製到剪貼簿"
-
-#~ msgid "Filter:"
-#~ msgstr "過濾器："
-
-#~ msgid ""
-#~ "<html><head/><body><p>This list shows the fonts currently registered with "
-#~ "OpenSCAD.</p><p>Example:</p><pre style=\" margin-top:12px; margin-"
-#~ "bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-"
-#~ "indent:0px;\"><span style=\" font-family:'Courier New,courier';\">  "
-#~ "text(&quot;OpenSCAD&quot;, font = &quot;DejaVu Sans&quot;);</span></"
-#~ "pre><pre style=\" margin-top:0px; margin-bottom:12px; margin-left:0px; "
-#~ "margin-right:0px; -qt-block-indent:0; text-indent:0px;\"><span style=\" "
-#~ "font-family:'Courier New,courier';\">  text(&quot;OpenSCAD&quot;, font = "
-#~ "&quot;Liberation Sans:style=Italic&quot;);</span></pre></body></html>"
-#~ msgstr ""
-#~ "<html><head/><body><p>此清單顯示目前已註冊的字體 OpenSCAD.</p><p>例:</"
-#~ "p><pre style=\" margin-top:12px; margin-bottom:0px; margin-left:0px; "
-#~ "margin-right:0px; -qt-block-indent:0; text-indent:0px;\"><span style=\" "
-#~ "font-family:'Courier New,courier';\">  text(&quot;OpenSCAD&quot;, font = "
-#~ "&quot;DejaVu Sans&quot;);</span></pre><pre style=\" margin-top:0px; "
-#~ "margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-"
-#~ "indent:0; text-indent:0px;\"><span style=\" font-family:'Courier "
-#~ "New,courier';\">  text(&quot;OpenSCAD&quot;, font = &quot;Liberation "
-#~ "Sans:style=Italic&quot;);</span></pre></body></html>"
-
-#, fuzzy
-#~ msgid "Error-Log"
-#~ msgstr "錯誤日誌"
-
-#~ msgid "F7"
-#~ msgstr "F7"
-
-#, fuzzy
-#~ msgid "Line"
-#~ msgstr "自動換行"
-
-#, fuzzy
-#~ msgid "Filename"
-#~ msgstr "複製檔案名稱"
-
-#, fuzzy
-#~ msgid "Font Lists"
-#~ msgstr "字型清單(&F)"
-
-#, fuzzy
-#~ msgid "PushButton"
-#~ msgstr "按鈕"
-
-#, fuzzy
-#~ msgid "Hide Editor"
-#~ msgstr "隱藏編輯器(&I)"
-
-#~ msgid "Surfaces"
-#~ msgstr "表面"
-
-#~ msgid "F10"
-#~ msgstr "F10"
-
-#~ msgid "F11"
-#~ msgstr "F11"
-
-#, fuzzy
-#~ msgid "Hide Console"
-#~ msgstr "隱藏控制台(&H)"
-
-#~ msgid "Hide Customizer"
-#~ msgstr "隱藏自訂"
-
-#, fuzzy
-#~ msgid "Hide Error Log"
-#~ msgstr "隱藏錯誤日誌"
-
-#, fuzzy
-#~ msgid "Hide Animation Toolbar/Window"
-#~ msgstr "隱藏編輯器工具列"
-
-#~ msgid "OpenCSG"
-#~ msgstr "OpenCSG"
-
-#~ msgid "CGAL"
-#~ msgstr "CGAL"
-
-#, fuzzy
-#~ msgid "WRL"
-#~ msgstr "網址"
-
-#~ msgid "%1"
-#~ msgstr "%1"
 
 #, fuzzy
 #~ msgid "translate"

--- a/src/gui/ErrorLog.ui
+++ b/src/gui/ErrorLog.ui
@@ -114,7 +114,7 @@
   </layout>
   <action name="actionRowSelected">
    <property name="text">
-    <string>RowSelected</string>
+    <string>Row Selected</string>
    </property>
    <property name="shortcut">
     <string>Return</string>

--- a/src/gui/Export3mfDialog.ui
+++ b/src/gui/Export3mfDialog.ui
@@ -65,7 +65,7 @@
        <item row="0" column="1">
         <widget class="QGroupBox" name="groupUnit">
          <property name="toolTip">
-          <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Set the PDF page (paper) size.  &lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+          <string>Set the unit used in the exported file</string>
          </property>
          <property name="title">
           <string>Unit</string>

--- a/src/gui/ExportPdfDialog.ui
+++ b/src/gui/ExportPdfDialog.ui
@@ -38,7 +38,7 @@
        <item row="0" column="0" rowspan="2">
         <widget class="QGroupBox" name="groupSize">
          <property name="toolTip">
-          <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Set the PDF page (paper) size.  &lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+          <string>Set the PDF page (paper) size.</string>
          </property>
          <property name="title">
           <string>Page Size</string>
@@ -286,7 +286,7 @@
        <item row="0" column="1">
         <widget class="QGroupBox" name="groupOrientation">
          <property name="toolTip">
-          <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Set the direction of the largest page dimension.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+          <string>Set the direction of the largest page dimension.</string>
          </property>
          <property name="title">
           <string>Page Orientation</string>
@@ -324,7 +324,7 @@
           <item>
            <widget class="QRadioButton" name="radioButtonOrientationAuto">
             <property name="toolTip">
-             <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Determine best orientation based on maximum geometry dimension.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+             <string>Determine best orientation based on maximum geometry dimension.</string>
             </property>
             <property name="text">
              <string>Auto</string>
@@ -349,7 +349,7 @@
           <item>
            <widget class="QCheckBox" name="checkBoxShowFilename">
             <property name="toolTip">
-             <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Include design filename on page.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+             <string>Include design filename on page.</string>
             </property>
             <property name="text">
              <string>Show Design Filename</string>
@@ -362,7 +362,7 @@
           <item>
            <widget class="QGroupBox" name="groupScale">
             <property name="toolTip">
-             <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Include rulers on page to confirm 1:1 printing scale.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+             <string>Include rulers on page to confirm 1:1 printing scale.</string>
             </property>
             <property name="title">
              <string>Show Scale</string>
@@ -380,7 +380,7 @@
              <item>
               <widget class="QGroupBox" name="groupGrid">
                <property name="toolTip">
-                <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Include a grid of the selected size on the page.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+                <string>Include a grid of the selected size on the page.</string>
                </property>
                <property name="title">
                 <string>Show Grid</string>
@@ -475,7 +475,7 @@
                 <bool>true</bool>
                </property>
                <property name="toolTip">
-                <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Include text describing usage of scale.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+                <string>Include text describing usage of scale.</string>
                </property>
                <property name="text">
                 <string>Show Scale Usage</string>
@@ -500,7 +500,7 @@
           <item>
            <widget class="QCheckBox" name="checkBoxEnableFill">
             <property name="toolTip">
-             <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Enable filling of exported geometry with a color.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+             <string>Enable filling of exported geometry with a color.</string>
             </property>
             <property name="text">
              <string>Fill Geometry</string>
@@ -557,7 +557,7 @@
           <item>
            <widget class="QCheckBox" name="checkBoxEnableStroke">
             <property name="toolTip">
-             <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Enable outline stroke for exported geometry.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+             <string>Enable outline stroke for exported geometry.</string>
             </property>
             <property name="text">
              <string>Stroke Outline</string>

--- a/src/gui/FontList.ui
+++ b/src/gui/FontList.ui
@@ -370,7 +370,7 @@
     <bool>true</bool>
    </property>
    <property name="text">
-    <string>ShowFileName</string>
+    <string>Show File Name</string>
    </property>
   </action>
   <action name="actionShowFilePathColumn">

--- a/src/gui/OpenCSGWarningDialog.ui
+++ b/src/gui/OpenCSGWarningDialog.ui
@@ -19,13 +19,6 @@
      <property name="readOnly">
       <bool>true</bool>
      </property>
-     <property name="html">
-      <string>&lt;!DOCTYPE HTML PUBLIC &quot;-//W3C//DTD HTML 4.0//EN&quot; &quot;http://www.w3.org/TR/REC-html40/strict.dtd&quot;&gt;
-&lt;html&gt;&lt;head&gt;&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; /&gt;&lt;style type=&quot;text/css&quot;&gt;
-p, li { white-space: pre-wrap; }
-&lt;/style&gt;&lt;/head&gt;&lt;body style=&quot; font-family:'Lucida Grande'; font-size:13pt; font-weight:400; font-style:normal;&quot;&gt;
-&lt;p style=&quot;-qt-paragraph-type:empty; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-     </property>
     </widget>
    </item>
    <item>

--- a/src/gui/ViewportControl.ui
+++ b/src/gui/ViewportControl.ui
@@ -324,7 +324,7 @@
   </layout>
   <action name="actionRowSelected">
    <property name="text">
-    <string>RowSelected</string>
+    <string>Row Selected</string>
    </property>
    <property name="shortcut">
     <string>Return</string>

--- a/src/gui/ai/ChatWidget.ui
+++ b/src/gui/ai/ChatWidget.ui
@@ -81,7 +81,7 @@
          <string>Chat options</string>
         </property>
         <property name="text">
-         <string>&#x2630;</string>
+         <string notr="true">&#x2630;</string>
         </property>
         <property name="popupMode">
          <enum>QToolButton::InstantPopup</enum>

--- a/src/gui/input/AxisConfigWidget.ui
+++ b/src/gui/input/AxisConfigWidget.ui
@@ -16,9 +16,6 @@
     <verstretch>0</verstretch>
    </sizepolicy>
   </property>
-  <property name="windowTitle">
-   <string>Preferences</string>
-  </property>
   <property name="unifiedTitleAndToolBarOnMac" stdset="0">
    <bool>true</bool>
   </property>
@@ -801,7 +798,7 @@
          <item row="0" column="1">
           <widget class="QLabel" name="label_11">
            <property name="text">
-            <string>X</string>
+            <string notr="true">X</string>
            </property>
            <property name="alignment">
             <set>Qt::AlignCenter</set>
@@ -850,7 +847,7 @@
          <item row="0" column="2">
           <widget class="QLabel" name="label_14">
            <property name="text">
-            <string>Y</string>
+            <string notr="true">Y</string>
            </property>
            <property name="alignment">
             <set>Qt::AlignCenter</set>
@@ -895,7 +892,7 @@
          <item row="0" column="3">
           <widget class="QLabel" name="label_15">
            <property name="text">
-            <string>Z</string>
+            <string notr="true">Z</string>
            </property>
            <property name="alignment">
             <set>Qt::AlignCenter</set>
@@ -986,7 +983,7 @@
          <item row="4" column="0">
           <widget class="QLabel" name="labelInputRotationViewPortRelative">
            <property name="text">
-            <string>ViewPort rel.&lt;br /&gt;Rotation</string>
+            <string>ViewPort rel.&lt;br/&gt;Rotation</string>
            </property>
           </widget>
          </item>
@@ -1059,7 +1056,7 @@
             <bool>false</bool>
            </property>
            <property name="text">
-            <string>SpaceNav</string>
+            <string notr="true">SpaceNav</string>
            </property>
           </widget>
          </item>
@@ -1069,7 +1066,7 @@
             <bool>false</bool>
            </property>
            <property name="text">
-            <string>HIDAPI</string>
+            <string notr="true">HIDAPI</string>
            </property>
           </widget>
          </item>
@@ -1079,7 +1076,7 @@
             <bool>false</bool>
            </property>
            <property name="text">
-            <string>QGamepad</string>
+            <string notr="true">QGamepad</string>
            </property>
           </widget>
          </item>
@@ -1099,7 +1096,7 @@
             <bool>false</bool>
            </property>
            <property name="text">
-            <string>DBus</string>
+            <string notr="true">DBus</string>
            </property>
           </widget>
          </item>
@@ -1134,7 +1131,7 @@
        <item row="35" column="0" colspan="2">
         <widget class="QLabel" name="label_driverInfo">
          <property name="text">
-          <string>TextLabel</string>
+          <string notr="true">(driver status placeholder)</string>
          </property>
         </widget>
        </item>

--- a/src/gui/input/ButtonConfigWidget.ui
+++ b/src/gui/input/ButtonConfigWidget.ui
@@ -16,9 +16,6 @@
     <verstretch>0</verstretch>
    </sizepolicy>
   </property>
-  <property name="windowTitle">
-   <string>Preferences</string>
-  </property>
   <property name="unifiedTitleAndToolBarOnMac" stdset="0">
    <bool>true</bool>
   </property>

--- a/src/gui/input/MouseConfigWidget.ui
+++ b/src/gui/input/MouseConfigWidget.ui
@@ -16,9 +16,6 @@
     <verstretch>0</verstretch>
    </sizepolicy>
   </property>
-  <property name="windowTitle">
-   <string>Preferences</string>
-  </property>
   <property name="unifiedTitleAndToolBarOnMac" stdset="0">
    <bool>true</bool>
   </property>


### PR DESCRIPTION
Marked a number of things as not-translatable.
Turned a number of things from HTML to plain text.
Deleted a number of stale messages.
Added a few translations.

Most of the changes, by line count, are just changes in the line numbers in generated files.  I haven't investigated why those line numbers changed.  Perhaps I made changes that affected them, or perhaps I'm running a slightly different version of the Qt tools and they generate slightly different files.