### PR TITLE
Update German translation 

### DIFF
--- a/locale/de.po
+++ b/locale/de.po
@@ -9,7 +9,7 @@ msgstr ""
 "Project-Id-Version: OpenSCAD 2014.01.05\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2026-09-06 23:38+0200\n"
-"PO-Revision-Date: 2026-09-02 14:00+0200\n"
+"PO-Revision-Date: 2026-09-07 12:00+0200\n"
 "Last-Translator: Torsten Paul <Torsten.Paul@gmx.de>\n"
 "Language-Team: German\n"
 "Language: de\n"
@@ -29,23 +29,15 @@ msgstr "Über OpenSCAD"
 #: build/OpenSCADLibInternal_autogen/include/ui_LaunchingScreen.h:304
 msgid ""
 "<html><head/><body>\n"
-"<p style=\"font-family: 'Open Sans', 'Droid Sans', 'sans-serif'; font-"
-"weight: bold; padding-bottom: 0; margin-bottom: 0; font-size: 22pt;\"><span "
-"style=\"color: green;\">Open</span>SCAD</p>\n"
-"<p style=\"font-family: 'Open Sans', 'Droid Sans', 'sans-serif'; font-"
-"weight: normal; font-size: 14pt; padding-top: 0; margin-top: 0; margin-left: "
-"2em;\">The Programmers Solid 3D CAD Modeller</p>\n"
+"<p style=\"font-family: 'Open Sans', 'Droid Sans', 'sans-serif'; font-weight: bold; padding-bottom: 0; margin-bottom: 0; font-size: 22pt;\"><span style=\"color: green;\">Open</span>SCAD</p>\n"
+"<p style=\"font-family: 'Open Sans', 'Droid Sans', 'sans-serif'; font-weight: normal; font-size: 14pt; padding-top: 0; margin-top: 0; margin-left: 2em;\">The Programmers Solid 3D CAD Modeller</p>\n"
 "</body></html>\n"
 "\n"
 "\n"
 msgstr ""
 "<html><head/><body>\n"
-"<p style=\"font-family: 'Open Sans', 'Droid Sans', 'sans-serif'; font-"
-"weight: bold; padding-bottom: 0; margin-bottom: 0; font-size: 22pt;\"><span "
-"style=\"color: green;\">Open</span>SCAD</p>\n"
-"<p style=\"font-family: 'Open Sans', 'Droid Sans', 'sans-serif'; font-"
-"weight: normal; font-size: 14pt; padding-top: 0; margin-top: 0; margin-left: "
-"2em;\">The Programmers Solid 3D CAD Modeller</p>\n"
+"<p style=\"font-family: 'Open Sans', 'Droid Sans', 'sans-serif'; font-weight: bold; padding-bottom: 0; margin-bottom: 0; font-size: 22pt;\"><span style=\"color: green;\">Open</span>SCAD</p>\n"
+"<p style=\"font-family: 'Open Sans', 'Droid Sans', 'sans-serif'; font-weight: normal; font-size: 14pt; padding-top: 0; margin-top: 0; margin-left: 2em;\">The Programmers Solid 3D CAD Modeller</p>\n"
 "</body></html>\n"
 "\n"
 "\n"
@@ -368,17 +360,19 @@ msgstr "Knopf 22"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_ChatWidget.h:194
 msgid "AI Chat"
-msgstr ""
+msgstr "KI-Chat"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_ChatWidget.h:195
 #: src/gui/ai/ChatWidget.cc:138
 msgid "AI Assistant"
-msgstr ""
+msgstr "KI-Assistent"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_ChatWidget.h:197
 msgid "Chat options"
-msgstr ""
+msgstr "Chat-Einstellungen"
 
+#. Tastenfolge, Objektname oder fester Wert - nicht uebersetzen. Ein leerer
+#. msgstr laesst gettext den Originaltext zurueckgeben.
 #: build/OpenSCADLibInternal_autogen/include/ui_ChatWidget.h:199
 msgid "☰"
 msgstr ""
@@ -386,7 +380,7 @@ msgstr ""
 #: build/OpenSCADLibInternal_autogen/include/ui_ChatWidget.h:201
 #: src/gui/ai/ChatWidget.cc:140
 msgid "Clear chat history"
-msgstr ""
+msgstr "Chatverlauf leeren"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_ChatWidget.h:203
 #: build/OpenSCADLibInternal_autogen/include/ui_Console.h:42
@@ -397,34 +391,36 @@ msgstr "Löschen"
 #: build/OpenSCADLibInternal_autogen/include/ui_ChatWidget.h:204
 #: src/gui/ai/ChatWidget.cc:141 src/gui/ai/ChatWidget.cc:630
 msgid "Send"
-msgstr ""
+msgstr "Senden"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_ChatWidget.h:206
 msgid "Grab active 3D viewport frame and camera metadata"
-msgstr ""
+msgstr "Aktuelles Bild der 3D-Ansicht samt Kameradaten übernehmen"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_ChatWidget.h:208
 msgid "Analyze Screen"
-msgstr ""
+msgstr "Ansicht auswerten"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_ChatWidget.h:210
 msgid "Attach local image file"
-msgstr ""
+msgstr "Lokale Bilddatei anhängen"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_ChatWidget.h:212
 #: src/gui/ai/ChatWidget.cc:508
 msgid "Attach Image"
-msgstr ""
+msgstr "Bild anhängen"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_ChatWidget.h:214
 msgid ""
 "Agentic mode: allow the AI to call tools in multiple automatic turns per "
 "request"
 msgstr ""
+"Handelnder Modus: Die KI darf pro Anfrage mehrere Werkzeugaufrufe "
+"selbsttätig ausführen"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_ChatWidget.h:216
 msgid "Agentic"
-msgstr ""
+msgstr "Handelnd"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_ColorList.h:399
 msgid "Color List"
@@ -517,6 +513,8 @@ msgstr "Auswahl"
 msgid "Reset background color"
 msgstr "Hintergrundfarbe zurücksetzen"
 
+#. Tastenfolge, Objektname oder fester Wert - nicht uebersetzen. Ein leerer
+#. msgstr laesst gettext den Originaltext zurueckgeben.
 #: build/OpenSCADLibInternal_autogen/include/ui_ColorList.h:435
 #: build/OpenSCADLibInternal_autogen/include/ui_ColorList.h:439
 #: build/OpenSCADLibInternal_autogen/include/ui_ColorList.h:451
@@ -557,14 +555,20 @@ msgstr "Als Vordergrund"
 msgid "As Background"
 msgstr "Als Hintergrund"
 
+#. Tastenfolge, Objektname oder fester Wert - nicht uebersetzen. Ein leerer
+#. msgstr laesst gettext den Originaltext zurueckgeben.
 #: build/OpenSCADLibInternal_autogen/include/ui_ColorList.h:443
 msgid "R:"
 msgstr ""
 
+#. Tastenfolge, Objektname oder fester Wert - nicht uebersetzen. Ein leerer
+#. msgstr laesst gettext den Originaltext zurueckgeben.
 #: build/OpenSCADLibInternal_autogen/include/ui_ColorList.h:444
 msgid "G:"
 msgstr ""
 
+#. Tastenfolge, Objektname oder fester Wert - nicht uebersetzen. Ein leerer
+#. msgstr laesst gettext den Originaltext zurueckgeben.
 #: build/OpenSCADLibInternal_autogen/include/ui_ColorList.h:445
 msgid "B:"
 msgstr ""
@@ -654,6 +658,7 @@ msgstr "3MF-Exporteinstellungen"
 msgid ""
 "<html><head/><body><p>Set the PDF page (paper) size.  </p></body></html>"
 msgstr ""
+"<html><head/><body><p>Legt die Seitengröße des PDFs fest.</p></body></html>"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_Export3mfDialog.h:461
 msgid "Unit"
@@ -862,9 +867,11 @@ msgstr "Verfasser"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_ExportPdfDialog.h:582
 msgid ""
-"<html><head/><body><p>Set the direction of the largest page dimension.</p></"
-"body></html>"
+"<html><head/><body><p>Set the direction of the largest page "
+"dimension.</p></body></html>"
 msgstr ""
+"<html><head/><body><p>Legt fest, in welche Richtung die längere Seitenkante "
+"zeigt.</p></body></html>"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_ExportPdfDialog.h:584
 msgid "Page Orientation"
@@ -885,6 +892,8 @@ msgid ""
 "<html><head/><body><p>Determine best orientation based on maximum geometry "
 "dimension.</p></body></html>"
 msgstr ""
+"<html><head/><body><p>Wählt die Ausrichtung anhand der größten Abmessung der"
+" Geometrie.</p></body></html>"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_ExportPdfDialog.h:591
 #: src/core/Settings.cc:400
@@ -899,6 +908,8 @@ msgstr "Beschriftungen"
 msgid ""
 "<html><head/><body><p>Include design filename on page.</p></body></html>"
 msgstr ""
+"<html><head/><body><p>Nimmt den Dateinamen des Entwurfs mit auf die "
+"Seite.</p></body></html>"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_ExportPdfDialog.h:596
 msgid "Show Design Filename"
@@ -906,9 +917,11 @@ msgstr "Dateinamen des Entwurfs anzeigen"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_ExportPdfDialog.h:598
 msgid ""
-"<html><head/><body><p>Include rulers on page to confirm 1:1 printing scale.</"
-"p></body></html>"
+"<html><head/><body><p>Include rulers on page to confirm 1:1 printing "
+"scale.</p></body></html>"
 msgstr ""
+"<html><head/><body><p>Nimmt Maßstäbe auf die Seite, um den Druck im Maßstab "
+"1:1 zu prüfen.</p></body></html>"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_ExportPdfDialog.h:600
 msgid "Show Scale"
@@ -916,39 +929,53 @@ msgstr "Maßstab anzeigen"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_ExportPdfDialog.h:602
 msgid ""
-"<html><head/><body><p>Include a grid of the selected size on the page.</p></"
-"body></html>"
+"<html><head/><body><p>Include a grid of the selected size on the "
+"page.</p></body></html>"
 msgstr ""
+"<html><head/><body><p>Legt ein Raster der gewählten Größe über die "
+"Seite.</p></body></html>"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_ExportPdfDialog.h:604
 msgid "Show Grid"
 msgstr "Raster anzeigen"
 
+#. Tastenfolge, Objektname oder fester Wert - nicht uebersetzen. Ein leerer
+#. msgstr laesst gettext den Originaltext zurueckgeben.
 #: build/OpenSCADLibInternal_autogen/include/ui_ExportPdfDialog.h:605
 msgid "2mm"
 msgstr ""
 
+#. Tastenfolge, Objektname oder fester Wert - nicht uebersetzen. Ein leerer
+#. msgstr laesst gettext den Originaltext zurueckgeben.
 #: build/OpenSCADLibInternal_autogen/include/ui_ExportPdfDialog.h:606
 msgid "2.5mm"
 msgstr ""
 
+#. Tastenfolge, Objektname oder fester Wert - nicht uebersetzen. Ein leerer
+#. msgstr laesst gettext den Originaltext zurueckgeben.
 #: build/OpenSCADLibInternal_autogen/include/ui_ExportPdfDialog.h:607
 msgid "4mm"
 msgstr ""
 
+#. Tastenfolge, Objektname oder fester Wert - nicht uebersetzen. Ein leerer
+#. msgstr laesst gettext den Originaltext zurueckgeben.
 #: build/OpenSCADLibInternal_autogen/include/ui_ExportPdfDialog.h:608
 msgid "5mm"
 msgstr ""
 
+#. Tastenfolge, Objektname oder fester Wert - nicht uebersetzen. Ein leerer
+#. msgstr laesst gettext den Originaltext zurueckgeben.
 #: build/OpenSCADLibInternal_autogen/include/ui_ExportPdfDialog.h:609
 msgid "10mm"
 msgstr ""
 
 #: build/OpenSCADLibInternal_autogen/include/ui_ExportPdfDialog.h:611
 msgid ""
-"<html><head/><body><p>Include text describing usage of scale.</p></body></"
-"html>"
+"<html><head/><body><p>Include text describing usage of "
+"scale.</p></body></html>"
 msgstr ""
+"<html><head/><body><p>Nimmt einen erläuternden Hinweis zum Maßstab mit "
+"auf.</p></body></html>"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_ExportPdfDialog.h:613
 msgid "Show Scale Usage"
@@ -961,9 +988,11 @@ msgstr "Füllung und Kontur"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_ExportPdfDialog.h:616
 msgid ""
-"<html><head/><body><p>Enable filling of exported geometry with a color.</p></"
-"body></html>"
+"<html><head/><body><p>Enable filling of exported geometry with a "
+"color.</p></body></html>"
 msgstr ""
+"<html><head/><body><p>Füllt die exportierte Geometrie mit einer "
+"Farbe.</p></body></html>"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_ExportPdfDialog.h:618
 #: build/OpenSCADLibInternal_autogen/include/ui_ExportSvgDialog.h:207
@@ -972,9 +1001,11 @@ msgstr "Geometrie füllen"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_ExportPdfDialog.h:623
 msgid ""
-"<html><head/><body><p>Enable outline stroke for exported geometry.</p></"
-"body></html>"
+"<html><head/><body><p>Enable outline stroke for exported "
+"geometry.</p></body></html>"
 msgstr ""
+"<html><head/><body><p>Zeichnet die Kontur der exportierten "
+"Geometrie.</p></body></html>"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_ExportPdfDialog.h:625
 #: build/OpenSCADLibInternal_autogen/include/ui_ExportSvgDialog.h:214
@@ -989,7 +1020,7 @@ msgstr "Konturbreite:"
 #: build/OpenSCADLibInternal_autogen/include/ui_ExportPdfDialog.h:630
 #: build/OpenSCADLibInternal_autogen/include/ui_ExportSvgDialog.h:219
 msgid " mm"
-msgstr ""
+msgstr " mm"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_ExportSvgDialog.h:202
 msgid "Export SVG Options"
@@ -1043,6 +1074,8 @@ msgstr "Schriftschnitt anzeigen"
 msgid "Show Sample Text"
 msgstr "Beispieltext anzeigen"
 
+#. Tastenfolge, Objektname oder fester Wert - nicht uebersetzen. Ein leerer
+#. msgstr laesst gettext den Originaltext zurueckgeben.
 #: build/OpenSCADLibInternal_autogen/include/ui_FontList.h:302
 msgid "ShowFileName"
 msgstr ""
@@ -1145,23 +1178,20 @@ msgid "Ctrl+N"
 msgstr "Ctrl+N"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_MainWindow.h:1010
-#, fuzzy
 msgid "New &Window"
-msgstr "Neues Fenster"
+msgstr "Neues &Fenster"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_MainWindow.h:1011
-#, fuzzy
 msgid "&Open File..."
-msgstr "&Datei öffen"
+msgstr "&Datei öffnen..."
 
 #: build/OpenSCADLibInternal_autogen/include/ui_MainWindow.h:1013
 msgid "Ctrl+O"
 msgstr "Ctrl+O"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_MainWindow.h:1015
-#, fuzzy
 msgid "Open in New Windo&w"
-msgstr "In neuem Fenster öffenen"
+msgstr "&In neuem Fenster öffnen"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_MainWindow.h:1016
 msgid "&Save"
@@ -1173,21 +1203,19 @@ msgstr "Ctrl+S"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_MainWindow.h:1020
 msgid "Save &As..."
-msgstr "Speichern &Unter..."
+msgstr "Speichern &unter..."
 
 #: build/OpenSCADLibInternal_autogen/include/ui_MainWindow.h:1022
 msgid "Ctrl+Shift+S"
 msgstr "Ctrl+Shift+S"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_MainWindow.h:1024
-#, fuzzy
 msgid "Save a C&opy..."
-msgstr "Kopie speichern"
+msgstr "&Kopie speichern..."
 
 #: build/OpenSCADLibInternal_autogen/include/ui_MainWindow.h:1025
-#, fuzzy
 msgid "S&ave All"
-msgstr "Alles Speichern"
+msgstr "&Alle speichern"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_MainWindow.h:1026
 msgid "&Reload"
@@ -1199,7 +1227,7 @@ msgstr "Ctrl+R"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_MainWindow.h:1030
 msgid "&Quit"
-msgstr "Beenden"
+msgstr "B&eenden"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_MainWindow.h:1032
 msgid "Ctrl+Q"
@@ -1243,7 +1271,7 @@ msgstr "Ctrl+C"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_MainWindow.h:1053
 msgid "&Paste"
-msgstr "Einfügen"
+msgstr "&Einfügen"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_MainWindow.h:1055
 msgid "Ctrl+V"
@@ -1251,7 +1279,7 @@ msgstr "Ctrl+V"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_MainWindow.h:1057
 msgid "&Indent"
-msgstr "Einzug er&höhen"
+msgstr "Einzu&g erhöhen"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_MainWindow.h:1059
 msgid "Ctrl+I"
@@ -1259,7 +1287,7 @@ msgstr "Ctrl+I"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_MainWindow.h:1061
 msgid "C&omment"
-msgstr "K&ommentieren"
+msgstr "Ko&mmentieren"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_MainWindow.h:1063
 msgid "Ctrl+D"
@@ -1267,7 +1295,7 @@ msgstr "Ctrl+D"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_MainWindow.h:1065
 msgid "Unco&mment"
-msgstr "Kommentar ent&fernen"
+msgstr "K&ommentar entfernen"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_MainWindow.h:1067
 msgid "Ctrl+Shift+D"
@@ -1275,35 +1303,35 @@ msgstr "Ctrl+Shift+D"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_MainWindow.h:1069
 msgid "Mo&ve Line Up"
-msgstr ""
+msgstr "Zeile nach o&ben"
 
+#. Tastenfolge, Objektname oder fester Wert - nicht uebersetzen. Ein leerer
+#. msgstr laesst gettext den Originaltext zurueckgeben.
 #: build/OpenSCADLibInternal_autogen/include/ui_MainWindow.h:1071
-#, fuzzy
 msgid "Ctrl+Alt+Up"
-msgstr "Ctrl+Alt+F"
+msgstr ""
 
 #: build/OpenSCADLibInternal_autogen/include/ui_MainWindow.h:1073
 msgid "Mo&ve Line Down"
+msgstr "Zei&le nach unten"
+
+#. Tastenfolge, Objektname oder fester Wert - nicht uebersetzen. Ein leerer
+#. msgstr laesst gettext den Originaltext zurueckgeben.
+#: build/OpenSCADLibInternal_autogen/include/ui_MainWindow.h:1075
+msgid "Ctrl+Alt+Down"
 msgstr ""
 
-#: build/OpenSCADLibInternal_autogen/include/ui_MainWindow.h:1075
-#, fuzzy
-msgid "Ctrl+Alt+Down"
-msgstr "Ctrl+Alt+F"
-
 #: build/OpenSCADLibInternal_autogen/include/ui_MainWindow.h:1077
-#, fuzzy
 msgid "Show &Next Tab"
-msgstr "Nächsten Reitern anzeigen"
+msgstr "Näc&hsten Reiter anzeigen"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_MainWindow.h:1079
 msgid "Ctrl+Tab"
 msgstr "Ctrl+Tab"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_MainWindow.h:1081
-#, fuzzy
 msgid "Show P&revious Tab"
-msgstr "Vorheriger Reiter"
+msgstr "&Vorherigen Reiter anzeigen"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_MainWindow.h:1083
 msgid "Ctrl+Shift+Tab"
@@ -1311,7 +1339,7 @@ msgstr "Ctrl+Shift+Tab"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_MainWindow.h:1085
 msgid "Copy viewport ima&ge"
-msgstr "Viewport Bild kopieren"
+msgstr "Ansichtsbild kopieren"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_MainWindow.h:1087
 msgid "Ctrl+Shift+C"
@@ -1319,7 +1347,7 @@ msgstr "Ctrl+Shift+C"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_MainWindow.h:1089
 msgid "Copy viewport transl&ation"
-msgstr "Aktuelle Versch&iebung kopieren"
+msgstr "Aktuelle Verschiebung kopieren"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_MainWindow.h:1091
 msgid "Ctrl+T"
@@ -1327,19 +1355,19 @@ msgstr "Ctrl+T"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_MainWindow.h:1093
 msgid "Cop&y viewport rotation"
-msgstr "Aktuelle Ro&tation kopieren"
+msgstr "Aktuelle Rotation kopieren"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_MainWindow.h:1094
 msgid "Copy vie&wport distance"
-msgstr "Aktuellen Abstand kopieren"
+msgstr "Aktuellen Abstand ko&pieren"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_MainWindow.h:1095
 msgid "Copy vie&wport fov"
-msgstr "Viewport Sichtfeld kopieren"
+msgstr "Aktuelles Sichtfeld kopieren"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_MainWindow.h:1096
 msgid "Increase Font &Size"
-msgstr "Font&größe erhöhen"
+msgstr "Schri&ftgröße erhöhen"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_MainWindow.h:1098
 msgid "Ctrl++"
@@ -1347,7 +1375,7 @@ msgstr "Ctrl++"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_MainWindow.h:1100
 msgid "Decrease Font Si&ze"
-msgstr "Fontgröße &verringern"
+msgstr "S&chriftgröße verringern"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_MainWindow.h:1102
 msgid "Ctrl+-"
@@ -1355,7 +1383,7 @@ msgstr "Ctrl+-"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_MainWindow.h:1104
 msgid "&Reload and Preview"
-msgstr "Neu &laden und Vorschau"
+msgstr "&Neu laden und Vorschau"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_MainWindow.h:1106
 msgid "F4"
@@ -1389,6 +1417,8 @@ msgstr "F8"
 msgid "Measure &Distance"
 msgstr "Abstand &messen"
 
+#. Tastenfolge, Objektname oder fester Wert - nicht uebersetzen. Ein leerer
+#. msgstr laesst gettext den Originaltext zurueckgeben.
 #: build/OpenSCADLibInternal_autogen/include/ui_MainWindow.h:1122
 msgid "D"
 msgstr ""
@@ -1397,28 +1427,27 @@ msgstr ""
 msgid "Measure &Angle"
 msgstr "&Winkel messen"
 
+#. Tastenfolge, Objektname oder fester Wert - nicht uebersetzen. Ein leerer
+#. msgstr laesst gettext den Originaltext zurueckgeben.
 #: build/OpenSCADLibInternal_autogen/include/ui_MainWindow.h:1126
 msgid "A"
 msgstr ""
 
 #: build/OpenSCADLibInternal_autogen/include/ui_MainWindow.h:1128
 msgid "&Check Validity"
-msgstr "&Design überprüfen"
+msgstr "&Gültigkeit prüfen"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_MainWindow.h:1129
-#, fuzzy
 msgid "Display A&ST"
-msgstr "A&ST Baum anzeigen..."
+msgstr "A&ST anzeigen"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_MainWindow.h:1130
-#, fuzzy
 msgid "Display CSG &Tree"
-msgstr "CSG &Baum anzeigen..."
+msgstr "CSG-&Baum anzeigen"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_MainWindow.h:1131
-#, fuzzy
 msgid "Display CSG Pr&oducts"
-msgstr "CSG &Gleichungen anzeigen..."
+msgstr "&CSG-Produkte anzeigen"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_MainWindow.h:1132
 msgid "Export as &STL (binary)..."
@@ -1434,7 +1463,7 @@ msgstr "OB&J exportieren..."
 
 #: build/OpenSCADLibInternal_autogen/include/ui_MainWindow.h:1135
 msgid "Export as &POV..."
-msgstr "POV e&xportieren..."
+msgstr "&POV exportieren..."
 
 #: build/OpenSCADLibInternal_autogen/include/ui_MainWindow.h:1136
 msgid "Export as &OFF..."
@@ -1445,7 +1474,6 @@ msgid "Export as &WRL..."
 msgstr "&WRL exportieren..."
 
 #: build/OpenSCADLibInternal_autogen/include/ui_MainWindow.h:1138
-#, fuzzy
 msgid "P&review"
 msgstr "&Vorschau"
 
@@ -1454,7 +1482,6 @@ msgid "F9"
 msgstr "F9"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_MainWindow.h:1142
-#, fuzzy
 msgid "T&hrown Together"
 msgstr "Kom&binierte Anzeige"
 
@@ -1463,25 +1490,22 @@ msgid "F12"
 msgstr "F12"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_MainWindow.h:1146
-#, fuzzy
 msgid "&Show Edges"
-msgstr "&Kanten anzeigen"
+msgstr "Kanten anze&igen"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_MainWindow.h:1148
 msgid "Ctrl+1"
 msgstr "Ctrl+1"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_MainWindow.h:1150
-#, fuzzy
 msgid "Show A&xes"
-msgstr "Koordinaten&achsen anzeigen"
+msgstr "&Koordinatenachsen anzeigen"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_MainWindow.h:1152
 msgid "Ctrl+2"
 msgstr "Ctrl+2"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_MainWindow.h:1154
-#, fuzzy
 msgid "Show &Crosshairs"
 msgstr "Rotations&mittelpunkt anzeigen"
 
@@ -1490,9 +1514,8 @@ msgid "Ctrl+3"
 msgstr "Ctrl+3"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_MainWindow.h:1158
-#, fuzzy
 msgid "Show Scale &Markers"
-msgstr "Achsen&einteilung anzeigen"
+msgstr "&Achseneinteilung anzeigen"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_MainWindow.h:1159
 msgid "&Top"
@@ -1568,7 +1591,7 @@ msgstr "Or&thogonal"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_MainWindow.h:1193
 msgid "&About"
-msgstr "Über &OpenSCAD"
+msgstr "Üb&er OpenSCAD"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_MainWindow.h:1194
 msgid "&Documentation"
@@ -1576,11 +1599,11 @@ msgstr "&Dokumentation"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_MainWindow.h:1195
 msgid "&Offline Documentation"
-msgstr "Offline Dokumentation"
+msgstr "O&ffline-Dokumentation"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_MainWindow.h:1196
 msgid "&Offline Cheat Sheet"
-msgstr "&Offline Befehlsübersicht"
+msgstr "&Offline-Befehlsübersicht"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_MainWindow.h:1197
 msgid "Clear Recent"
@@ -1593,11 +1616,11 @@ msgstr "&DXF exportieren..."
 #: build/OpenSCADLibInternal_autogen/include/ui_MainWindow.h:1199
 #: build/OpenSCADLibInternal_autogen/include/ui_MainWindow.h:1201
 msgid "Revoke Trusted Python Files"
-msgstr "Vertrauen für Python-Dateien widerrufen"
+msgstr "&Vertrauen für Python-Dateien widerrufen"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_MainWindow.h:1203
 msgid "&Close"
-msgstr "Schließen"
+msgstr "S&chließen"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_MainWindow.h:1205
 msgid "Ctrl+W"
@@ -1617,7 +1640,7 @@ msgstr "Ctrl+F"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_MainWindow.h:1212
 msgid "Fin&d and Replace..."
-msgstr "Suchen und &Ersetzen..."
+msgstr "Suchen un&d Ersetzen..."
 
 #: build/OpenSCADLibInternal_autogen/include/ui_MainWindow.h:1214
 msgid "Ctrl+Alt+F"
@@ -1625,7 +1648,7 @@ msgstr "Ctrl+Alt+F"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_MainWindow.h:1216
 msgid "Find Ne&xt"
-msgstr "&Weiter suchen"
+msgstr "We&iter suchen"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_MainWindow.h:1218
 msgid "Ctrl+G"
@@ -1633,7 +1656,7 @@ msgstr "Ctrl+G"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_MainWindow.h:1220
 msgid "Find Pre&vious"
-msgstr "Rüc&kwärts suchen"
+msgstr "Rückwär&ts suchen"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_MainWindow.h:1222
 msgid "Ctrl+Shift+G"
@@ -1641,14 +1664,13 @@ msgstr "Ctrl+Shift+G"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_MainWindow.h:1224
 msgid "Use Se&lection for Find"
-msgstr "&Auswahl suchen"
+msgstr "A&uswahl suchen"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_MainWindow.h:1226
 msgid "Ctrl+E"
 msgstr "Ctrl+E"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_MainWindow.h:1228
-#, fuzzy
 msgid "J&ump to next error"
 msgstr "Zum nächsten Fehler springen"
 
@@ -1658,15 +1680,15 @@ msgstr "Ctrl+Alt+E"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_MainWindow.h:1232
 msgid "&Flush Caches"
-msgstr "&Cache leeren"
+msgstr "&Zwischenspeicher leeren"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_MainWindow.h:1233
 msgid "&OpenSCAD Homepage"
-msgstr "OpenSCAD &Homepage"
+msgstr "OpenSCAD-&Homepage"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_MainWindow.h:1234
 msgid "&Automatic Reload and Preview"
-msgstr "&Automatisch neu Laden und Vorschau"
+msgstr "&Automatisch neu laden und Vorschau"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_MainWindow.h:1235
 msgid "Export as &Image..."
@@ -1681,14 +1703,12 @@ msgid "&Library info"
 msgstr "&Versionsinformationen"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_MainWindow.h:1238
-#, fuzzy
 msgid "Show &Library Folder"
-msgstr "Bibli&otheken anzeigen..."
+msgstr "Bibli&otheken anzeigen"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_MainWindow.h:1239
-#, fuzzy
 msgid "Reset &View"
-msgstr "Ans&icht zurücksetzen"
+msgstr "Ansi&cht zurücksetzen"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_MainWindow.h:1240
 msgid "Export as S&VG..."
@@ -1699,25 +1719,22 @@ msgid "Export as &3MF..."
 msgstr "&3MF exportieren..."
 
 #: build/OpenSCADLibInternal_autogen/include/ui_MainWindow.h:1242
-#, fuzzy
 msgid "Zoom &In"
-msgstr "Vergrößern"
+msgstr "Ver&größern"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_MainWindow.h:1244
 msgid "Ctrl+]"
 msgstr "Ctrl+]"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_MainWindow.h:1246
-#, fuzzy
 msgid "&Zoom Out"
-msgstr "Verkleinern"
+msgstr "V&erkleinern"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_MainWindow.h:1248
 msgid "Ctrl+["
 msgstr "Ctrl+["
 
 #: build/OpenSCADLibInternal_autogen/include/ui_MainWindow.h:1250
-#, fuzzy
 msgid "View &All"
 msgstr "Alle&s anzeigen"
 
@@ -1727,43 +1744,39 @@ msgstr "Ctrl+Shift+V"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_MainWindow.h:1254
 msgid "Conv&ert Tabs to Spaces"
-msgstr "Tabs in Leerzeichen &umwandeln"
+msgstr "Tabs in Leerzeichen umwandeln"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_MainWindow.h:1255
-#, fuzzy
 msgid "&Toggle Bookmark"
-msgstr "Marker umschalten"
+msgstr "Lesezeichen umschalten"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_MainWindow.h:1257
 msgid "Ctrl+F2"
 msgstr "Ctrl+F2"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_MainWindow.h:1259
-#, fuzzy
 msgid "Jump to next &bookmark"
-msgstr "Zum nächsten Marker springen"
+msgstr "Zum nächsten Lesezeichen springen"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_MainWindow.h:1261
 msgid "F2"
 msgstr "F2"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_MainWindow.h:1263
-#, fuzzy
 msgid "Jump to &previous bookmark"
-msgstr "Zum vorherigen Marker springen"
+msgstr "Zum vorherigen Lesezeichen springen"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_MainWindow.h:1265
 msgid "Shift+F2"
 msgstr "Shift+F2"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_MainWindow.h:1267
-#, fuzzy
 msgid "&Hide Editor toolbar"
-msgstr "Editor Symbolleiste ausblenden"
+msgstr "Editor-&Werkzeugleiste ausblenden"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_MainWindow.h:1268
 msgid "U&nindent"
-msgstr "Einzug ver&mindern"
+msgstr "Ein&zug vermindern"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_MainWindow.h:1270
 msgid "Ctrl+Shift+I"
@@ -1775,12 +1788,11 @@ msgstr "&Befehlsübersicht"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_MainWindow.h:1273
 msgid "Export as PDF..."
-msgstr "&PDF exportieren..."
+msgstr "PD&F exportieren..."
 
 #: build/OpenSCADLibInternal_autogen/include/ui_MainWindow.h:1274
-#, fuzzy
 msgid "Hide &3D View toolbar"
-msgstr "3D Symbolleiste ausblenden"
+msgstr "&3D-Werkzeugleiste ausblenden"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_MainWindow.h:1275
 msgid "&Next Window\tCtrl+K"
@@ -1799,15 +1811,15 @@ msgid "Alt+Ins"
 msgstr "Alt+Ins"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_MainWindow.h:1281
-#, fuzzy
 msgid "Fold/Unfold All"
 msgstr "Alle ein-/ausklappen"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_MainWindow.h:1282
-#, fuzzy
 msgid "&Jump To"
-msgstr "Springe zu …"
+msgstr "&Springe zu"
 
+#. Tastenfolge, Objektname oder fester Wert - nicht uebersetzen. Ein leerer
+#. msgstr laesst gettext den Originaltext zurueckgeben.
 #: build/OpenSCADLibInternal_autogen/include/ui_MainWindow.h:1284
 msgid "Ctrl+J"
 msgstr ""
@@ -1816,12 +1828,12 @@ msgstr ""
 #: src/gui/MainWindow.cc:1335 src/gui/MainWindow.cc:1342
 #: src/gui/MainWindow.cc:1355 src/gui/MainWindow.cc:1360
 msgid "Create Virtual Environment"
-msgstr "Virtuelle Umgebung anlegen"
+msgstr "Virtuelle Umgebung &anlegen"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_MainWindow.h:1287
 #: src/gui/MainWindow.cc:1377
 msgid "Select Virtual Environment"
-msgstr "Virtuelle Umgebung auswählen"
+msgstr "Virtuelle &Umgebung auswählen"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_MainWindow.h:1288
 #: build/OpenSCADLibInternal_autogen/include/ui_OctoPrintApiKeyDialog.h:107
@@ -1834,7 +1846,7 @@ msgstr "&Datei"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_MainWindow.h:1292
 msgid "Recen&t Files"
-msgstr "Zuletzt benutze &Dateien"
+msgstr "&Zuletzt benutzte Dateien"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_MainWindow.h:1293
 msgid "&Examples"
@@ -1842,8 +1854,10 @@ msgstr "&Beispiele"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_MainWindow.h:1294
 msgid "E&xport"
-msgstr "&Exportieren"
+msgstr "E&xportieren"
 
+#. Tastenfolge, Objektname oder fester Wert - nicht uebersetzen. Ein leerer
+#. msgstr laesst gettext den Originaltext zurueckgeben.
 #: build/OpenSCADLibInternal_autogen/include/ui_MainWindow.h:1295
 msgid "Python"
 msgstr ""
@@ -1854,7 +1868,7 @@ msgstr "&Bearbeiten"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_MainWindow.h:1297
 msgid "&Design"
-msgstr "D&esign"
+msgstr "&Entwurf"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_MainWindow.h:1298
 msgid "&View"
@@ -1967,27 +1981,17 @@ msgstr "OpenGL Warnung"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_OpenCSGWarningDialog.h:77
 msgid ""
-"<!DOCTYPE HTML PUBLIC \"-//W3C//DTD HTML 4.0//EN\" \"http://www.w3.org/TR/"
-"REC-html40/strict.dtd\">\n"
-"<html><head><meta name=\"qrichtext\" content=\"1\" /><style type=\"text/"
-"css\">\n"
+"<!DOCTYPE HTML PUBLIC \"-//W3C//DTD HTML 4.0//EN\" \"http://www.w3.org/TR/REC-html40/strict.dtd\">\n"
+"<html><head><meta name=\"qrichtext\" content=\"1\" /><style type=\"text/css\">\n"
 "p, li { white-space: pre-wrap; }\n"
-"</style></head><body style=\" font-family:'Lucida Grande'; font-size:13pt; "
-"font-weight:400; font-style:normal;\">\n"
-"<p style=\"-qt-paragraph-type:empty; margin-top:0px; margin-bottom:0px; "
-"margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;\"></"
-"p></body></html>"
+"</style></head><body style=\" font-family:'Lucida Grande'; font-size:13pt; font-weight:400; font-style:normal;\">\n"
+"<p style=\"-qt-paragraph-type:empty; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;\"></p></body></html>"
 msgstr ""
-"<!DOCTYPE HTML PUBLIC \"-//W3C//DTD HTML 4.0//EN\" \"http://www.w3.org/TR/"
-"REC-html40/strict.dtd\">\n"
-"<html><head><meta name=\"qrichtext\" content=\"1\" /><style type=\"text/"
-"css\">\n"
+"<!DOCTYPE HTML PUBLIC \"-//W3C//DTD HTML 4.0//EN\" \"http://www.w3.org/TR/REC-html40/strict.dtd\">\n"
+"<html><head><meta name=\"qrichtext\" content=\"1\" /><style type=\"text/css\">\n"
 "p, li { white-space: pre-wrap; }\n"
-"</style></head><body style=\" font-family:'Lucida Grande'; font-size:13pt; "
-"font-weight:400; font-style:normal;\">\n"
-"<p style=\"-qt-paragraph-type:empty; margin-top:0px; margin-bottom:0px; "
-"margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;\"></"
-"p></body></html>"
+"</style></head><body style=\" font-family:'Lucida Grande'; font-size:13pt; font-weight:400; font-style:normal;\">\n"
+"<p style=\"-qt-paragraph-type:empty; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;\"></p></body></html>"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_OpenCSGWarningDialog.h:82
 msgid "Show this message again"
@@ -2058,9 +2062,8 @@ msgid "-"
 msgstr "-"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_ParameterWidget.h:175
-#, fuzzy
 msgid "More actions"
-msgstr "Beschriftungen"
+msgstr "Weitere Aktionen"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2465
 msgid "3D View"
@@ -2076,9 +2079,8 @@ msgid "Editor"
 msgstr "Editor"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2469
-#, fuzzy
 msgid "Experimental"
-msgstr "Export Features"
+msgstr "Experimentell"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2471
 msgid "Enable/Disable experimental features"
@@ -2115,11 +2117,11 @@ msgstr "Dialoge"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2484
 msgid "AI"
-msgstr ""
+msgstr "KI"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2486
 msgid "AI and LLM configurations"
-msgstr ""
+msgstr "KI- und LLM-Konfigurationen"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2488
 msgid "Directory of the output file"
@@ -2190,7 +2192,7 @@ msgstr "Automatisch vervollständigen"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2505
 msgid " Include defined modules"
-msgstr ""
+msgstr " Definierte Module einbeziehen"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2506
 msgid "Character Threshold"
@@ -2198,7 +2200,7 @@ msgstr "Zeichengrenze"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2507
 msgid " Include defined functions"
-msgstr ""
+msgstr " Definierte Funktionen einbeziehen"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2508
 msgid "Enable Autocompletion"
@@ -2206,22 +2208,21 @@ msgstr "Automatisches Vervollständigen einschalten"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2509
 msgid " Include defined variables"
-msgstr ""
+msgstr " Definierte Variablen einbeziehen"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2510
 msgid "Mode"
-msgstr ""
+msgstr "Modus"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2511
 #: src/core/Settings.cc:519
-#, fuzzy
 msgid "Parsed File Mode"
-msgstr "Vertrauenswürdige Dateien"
+msgstr "Modus für eingelesene Dateien"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2512
 #: src/core/Settings.cc:520
 msgid "Regex Input Text Mode"
-msgstr ""
+msgstr "Modus für reguläre Ausdrücke"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2514
 #: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2539
@@ -2409,9 +2410,8 @@ msgid "Last checked: "
 msgstr "Zuletzt gesucht: "
 
 #: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2570
-#, fuzzy
 msgid "Experimental Features"
-msgstr "Export Features"
+msgstr "Experimentelle Funktionen"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2571
 msgid ""
@@ -2420,6 +2420,10 @@ msgid ""
 "you must assume that they may not be in their final form and may never "
 "appear in an OpenSCAD release in any form."
 msgstr ""
+"Diese Funktionen sind experimentell. Sie können sich ändern oder ohne "
+"Ankündigung ganz entfallen. Sie dürfen sie einschalten, benutzen und "
+"kommentieren, müssen aber davon ausgehen, dass sie noch nicht endgültig sind"
+" und möglicherweise nie in einer OpenSCAD-Veröffentlichung erscheinen."
 
 #: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2572
 msgid "General"
@@ -2558,14 +2562,12 @@ msgid "User Interface"
 msgstr "Benutzerinterface"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2618
-#, fuzzy
 msgid "Enable docking helper widgets in different places"
-msgstr "Verschieben des Editor und Konsolen-Fensters erlauben"
+msgstr "Andocken der Hilfsfenster an verschiedenen Stellen erlauben"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2619
-#, fuzzy
 msgid "Enable undocking of helper widgets to separate windows"
-msgstr "Separate Editor und Konsolen-Fenster erlauben"
+msgstr "Abdocken der Hilfsfenster in eigene Fenster erlauben"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2620
 msgid "Enable user interface localization (requires restart of OpenSCAD)"
@@ -2681,24 +2683,23 @@ msgstr "Protokoll für HIDAPI einschalten (benötigt Neustart von OpenSCAD)"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2650
 msgid "Network"
-msgstr ""
+msgstr "Netzwerk"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2651
 msgid "Custom CA certificates (PEM)"
-msgstr ""
+msgstr "Eigene CA-Zertifikate (PEM)"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2653
 msgid "Skip TLS certificate verification (insecure)"
-msgstr ""
+msgstr "TLS-Zertifikatsprüfung überspringen (unsicher)"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2654
 msgid "Dialog visibility"
 msgstr "Sichtbarkeit der Dialoge"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2655
-#, fuzzy
 msgid "Always show Welcome screen"
-msgstr "Startbildschirm anzeigen"
+msgstr "Startbildschirm immer anzeigen"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2656
 msgid "Always show PDF export dialog"
@@ -2713,65 +2714,60 @@ msgid "Always show Print Service dialog"
 msgstr "Druckdienst-Dialog immer anzeigen"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2659
-#, fuzzy
 msgid "AI Preferences"
-msgstr "Einstellungen"
+msgstr "KI-Einstellungen"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2660
 msgid ""
 "AI assistant integration is active. Configure your connection profiles and "
 "parameters below."
 msgstr ""
+"Die KI-Anbindung ist aktiv. Verbindungsprofile und Parameter lassen sich "
+"unten einstellen."
 
 #: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2661
-#, fuzzy
 msgid "Profiles"
-msgstr "Slicing Profil"
+msgstr "Profile"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2662
-#, fuzzy
 msgid "Active Profile"
-msgstr "Slicing Profil"
+msgstr "Aktives Profil"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2663
-#, fuzzy
 msgid "New Profile"
-msgstr "&Neue Datei"
+msgstr "Neues Profil"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2664
 msgid "Delete"
-msgstr ""
+msgstr "Löschen"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2665
 msgid "API Configuration"
-msgstr ""
+msgstr "API-Konfiguration"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2666
 msgid "API Endpoint"
-msgstr ""
+msgstr "API-Endpunkt"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2668
 msgid "System Prompt / Instructions"
-msgstr ""
+msgstr "Systemanweisung"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2669
 msgid "Default User Prompt"
-msgstr ""
+msgstr "Vorgegebene Benutzeranfrage"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2670
-#, fuzzy
 msgid "API Parameters"
-msgstr "Parameter"
+msgstr "API-Parameter"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2671
-#, fuzzy
 msgid "Add Parameter"
-msgstr "Parameter"
+msgstr "Parameter hinzufügen"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_Preferences.h:2672
-#, fuzzy
 msgid "Remove Parameter"
-msgstr "Parameter"
+msgstr "Parameter entfernen"
 
 #: build/OpenSCADLibInternal_autogen/include/ui_PrintInitDialog.h:180
 msgid "Run local Application"
@@ -2813,6 +2809,8 @@ msgstr "Einzelheiten"
 msgid "Distance"
 msgstr "Abstand"
 
+#. Tastenfolge, Objektname oder fester Wert - nicht uebersetzen. Ein leerer
+#. msgstr laesst gettext den Originaltext zurueckgeben.
 #: build/OpenSCADLibInternal_autogen/include/ui_ViewportControl.h:278
 msgid "FOV"
 msgstr ""
@@ -2872,7 +2870,6 @@ msgid "Base Material"
 msgstr "Grundmaterial"
 
 #: src/core/Settings.cc:509
-#, fuzzy
 msgid "Alphabetical"
 msgstr "Alphabetisch"
 
@@ -2887,143 +2884,140 @@ msgstr ""
 
 #: src/gui/ai/ChatWidget.cc:101 src/gui/ai/ChatWidget.cc:454
 msgid "Thinking..."
-msgstr ""
+msgstr "Denkt nach..."
 
 #: src/gui/ai/ChatWidget.cc:110
 msgid "Thinking"
-msgstr ""
+msgstr "Denkt nach"
 
 #: src/gui/ai/ChatWidget.cc:153
-#, fuzzy
 msgid "Export Chat..."
-msgstr "&PDF exportieren..."
+msgstr "Chat exportieren..."
 
 #: src/gui/ai/ChatWidget.cc:154
-#, fuzzy
 msgid "Import Chat..."
-msgstr "&PDF exportieren..."
+msgstr "Chat einlesen..."
 
 #: src/gui/ai/ChatWidget.cc:156
 msgid "Copy as Markdown"
-msgstr ""
+msgstr "Als Markdown kopieren"
 
 #: src/gui/ai/ChatWidget.cc:200 src/gui/ai/ChatWidget.cc:613
 msgid ""
 "Hello! I am your OpenSCAD AI assistant. Ask me to write some code, e.g. "
 "\"draw a sphere\" or \"create a box with a hole\"."
 msgstr ""
+"Hallo! Ich bin Ihr OpenSCAD-KI-Assistent. Bitten Sie mich um Quelltext, etwa"
+" „zeichne eine Kugel“ oder „erzeuge einen Quader mit einer Bohrung“."
 
 #: src/gui/ai/ChatWidget.cc:215
 msgid "AI proposed code changes:"
-msgstr ""
+msgstr "Von der KI vorgeschlagene Änderungen:"
 
 #: src/gui/ai/ChatWidget.cc:218
 msgid "Review & Apply"
-msgstr ""
+msgstr "Prüfen und übernehmen"
 
 #: src/gui/ai/ChatWidget.cc:223
-#, fuzzy
 msgid "Discard"
-msgstr "Platzhalter"
+msgstr "Verwerfen"
 
 #: src/gui/ai/ChatWidget.cc:291 src/gui/ai/ChatWidget.cc:634
 msgid "Stop"
-msgstr ""
+msgstr "Anhalten"
 
 #: src/gui/ai/ChatWidget.cc:481 src/gui/ai/ChatWidget.cc:488
-#, fuzzy
 msgid "Viewport Error"
-msgstr "Ansichtssteuerung"
+msgstr "Fehler in der Ansicht"
 
 #: src/gui/ai/ChatWidget.cc:482
 msgid "Could not find active 3D Viewport to grab screen."
 msgstr ""
+"Es wurde keine aktive 3D-Ansicht gefunden, deren Bild übernommen werden "
+"könnte."
 
 #: src/gui/ai/ChatWidget.cc:488
 msgid "Failed to capture 3D viewport frame."
-msgstr ""
+msgstr "Das Bild der 3D-Ansicht konnte nicht übernommen werden."
 
 #: src/gui/ai/ChatWidget.cc:509
 msgid "Image Files (*.png *.jpg *.jpeg *.webp)"
-msgstr ""
+msgstr "Bilddateien (*.png *.jpg *.jpeg *.webp)"
 
 #: src/gui/ai/ChatWidget.cc:517
-#, fuzzy
 msgid "File Error"
-msgstr "Fehlerliste ausblenden"
+msgstr "Dateifehler"
 
 #: src/gui/ai/ChatWidget.cc:517
 msgid "Could not open the selected image file."
-msgstr ""
+msgstr "Die gewählte Bilddatei konnte nicht geöffnet werden."
 
+#. Tastenfolge, Objektname oder fester Wert - nicht uebersetzen. Ein leerer
+#. msgstr laesst gettext den Originaltext zurueckgeben.
 #: src/gui/ai/ChatWidget.cc:577
 msgid "[Img]"
 msgstr ""
 
 #: src/gui/ai/ChatWidget.cc:582
 msgid "Remove attachment"
-msgstr ""
+msgstr "Anhang entfernen"
 
 #: src/gui/ai/ChatWidget.cc:902
 msgid "Export Chat History"
-msgstr ""
+msgstr "Chatverlauf exportieren"
 
 #: src/gui/ai/ChatWidget.cc:902 src/gui/ai/ChatWidget.cc:949
-#, fuzzy
 msgid "JSON Files (*.json)"
-msgstr "CSG Dateien (*.csg)"
+msgstr "JSON-Dateien (*.json)"
 
 #: src/gui/ai/ChatWidget.cc:938
-#, fuzzy
 msgid "Export Warning"
-msgstr "Image exportieren"
+msgstr "Warnung beim Exportieren"
 
 #: src/gui/ai/ChatWidget.cc:938
 msgid "Could not write to the chosen file."
-msgstr ""
+msgstr "In die gewählte Datei konnte nicht geschrieben werden."
 
 #: src/gui/ai/ChatWidget.cc:943
-#, fuzzy
 msgid "Export Successful"
-msgstr "Export Features"
+msgstr "Export erfolgreich"
 
 #: src/gui/ai/ChatWidget.cc:943
 msgid "Chat history exported successfully."
-msgstr ""
+msgstr "Der Chatverlauf wurde exportiert."
 
 #: src/gui/ai/ChatWidget.cc:949
 msgid "Import Chat History"
-msgstr ""
+msgstr "Chatverlauf einlesen"
 
 #: src/gui/ai/ChatWidget.cc:957 src/gui/ai/ChatWidget.cc:965
 #: src/gui/ai/ChatWidget.cc:970 src/gui/ai/ChatWidget.cc:1013
-#, fuzzy
 msgid "Import Warning"
-msgstr "OpenGL Warnung"
+msgstr "Warnung beim Einlesen"
 
 #: src/gui/ai/ChatWidget.cc:957
 msgid "Could not open the selected file."
-msgstr ""
+msgstr "Die gewählte Datei konnte nicht geöffnet werden."
 
 #: src/gui/ai/ChatWidget.cc:971
 msgid "Selected file does not contain a valid chat history array."
-msgstr ""
+msgstr "Die gewählte Datei enthält keinen gültigen Chatverlauf."
 
 #: src/gui/ai/ChatWidget.cc:1016
 msgid "Import Successful"
-msgstr ""
+msgstr "Einlesen erfolgreich"
 
 #: src/gui/ai/ChatWidget.cc:1016
 msgid "Chat history imported successfully."
-msgstr ""
+msgstr "Der Chatverlauf wurde eingelesen."
 
 #: src/gui/ai/ChatWidget.cc:1051
 msgid "Chat Copied"
-msgstr ""
+msgstr "Chat kopiert"
 
 #: src/gui/ai/ChatWidget.cc:1052
 msgid "Chat conversation copied to clipboard as Markdown."
-msgstr ""
+msgstr "Der Chatverlauf wurde als Markdown in die Zwischenablage kopiert."
 
 #: src/gui/Animate.cc:207
 msgid "press to pause animation"
@@ -3039,7 +3033,7 @@ msgstr "ungültige Werte"
 
 #: src/gui/ColorList.cc:207
 msgid "Filter (%1 colors found)"
-msgstr ""
+msgstr "Filter (%1 Farben gefunden)"
 
 #: src/gui/Console.cc:188
 msgid "Save console content"
@@ -3047,8 +3041,8 @@ msgstr "Log speichern"
 
 #: src/gui/Export3mfDialog.cc:78
 msgid ""
-"This OpenSCAD build uses lib3mf version 1. Setting the decimal precision for "
-"export needs version 2 or later."
+"This OpenSCAD build uses lib3mf version 1. Setting the decimal precision for"
+" export needs version 2 or later."
 msgstr ""
 "Diese OpenSCAD-Fassung verwendet lib3mf Version 1. Das Einstellen der "
 "Nachkommastellen für den Export erfordert Version 2 oder neuer."
@@ -3086,7 +3080,8 @@ msgstr ""
 
 #: src/gui/input/AxisConfigWidget.h:92
 msgid ""
-"The DBUS driver is not for actual devices but for remote control, Linux only."
+"The DBUS driver is not for actual devices but for remote control, Linux "
+"only."
 msgstr "Der DBUS Treiber dient der Fernsteuerung, nur für Linux."
 
 #: src/gui/input/AxisConfigWidget.h:94
@@ -3105,11 +3100,11 @@ msgstr ""
 
 #: src/gui/input/AxisConfigWidget.h:98
 msgid ""
-"The Joystick driver uses the Linux joystick device (fixed to /dev/input/"
-"js0), Linux only."
+"The Joystick driver uses the Linux joystick device (fixed to "
+"/dev/input/js0), Linux only."
 msgstr ""
-"Der Joystick Treiber bedient die Linux Joystick Schnittstelle (/dev/input/"
-"js0), nur Linux."
+"Der Joystick Treiber bedient die Linux Joystick Schnittstelle "
+"(/dev/input/js0), nur Linux."
 
 #: src/gui/input/AxisConfigWidget.h:100
 msgid "The QGAMEPAD driver is for multiplattform Gamepad Support."
@@ -3191,7 +3186,7 @@ msgstr "PNG Dateien (*.png)"
 
 #: src/gui/MainWindow.cc:3027 src/gui/MainWindow.cc:3787
 msgid "&AI Chat"
-msgstr ""
+msgstr "KI-&Chat"
 
 #: src/gui/MainWindow.cc:3129 src/gui/TabManager.cc:735
 #: src/gui/TabManager.cc:786
@@ -3208,30 +3203,27 @@ msgstr "&Konsole"
 
 #: src/gui/MainWindow.cc:3781
 msgid "C&ustomizer"
-msgstr "C&ustomizer"
+msgstr "&Anpassung"
 
 #: src/gui/MainWindow.cc:3782
 msgid "Error &Log"
-msgstr "Fehler&liste"
+msgstr "&Fehlerliste"
 
 #: src/gui/MainWindow.cc:3783
-#, fuzzy
 msgid "&Animate"
-msgstr "Animation"
+msgstr "A&nimation"
 
 #: src/gui/MainWindow.cc:3784
 msgid "&Font List"
-msgstr "&Fontliste"
+msgstr "&Schriftenliste"
 
 #: src/gui/MainWindow.cc:3785
-#, fuzzy
 msgid "C&olor List"
-msgstr "Farbliste"
+msgstr "Farb&liste"
 
 #: src/gui/MainWindow.cc:3786
-#, fuzzy
 msgid "&Viewport Control"
-msgstr "Ansichtssteuerung"
+msgstr "Ans&ichtssteuerung"
 
 #: src/gui/Network.h:168
 msgid "Timeout error"
@@ -3262,8 +3254,7 @@ msgid ""
 "A critical error was caught. The application may have become unstable:\n"
 "%1"
 msgstr ""
-"Ein kritischer Fehler wurde abgefangen. Die Anwendung könnte jetzt instabil "
-"laufen:\n"
+"Ein kritischer Fehler wurde abgefangen. Die Anwendung könnte jetzt instabil laufen:\n"
 "%1"
 
 #: src/gui/OpenSCADApp.cc:97
@@ -3275,13 +3266,12 @@ msgstr ""
 "Dies kann einige Minuten dauern."
 
 #: src/gui/parameter/ParameterWidget.cc:72
-#, fuzzy
 msgid "Collapse All"
-msgstr "Alles Speichern"
+msgstr "Alle einklappen"
 
 #: src/gui/parameter/ParameterWidget.cc:75
 msgid "Expand All"
-msgstr ""
+msgstr "Alle ausklappen"
 
 #: src/gui/parameter/ParameterWidget.cc:116
 msgid "Saving presets"
@@ -3306,18 +3296,16 @@ msgid "New set "
 msgstr "Neue Parameter Liste"
 
 #: src/gui/Preferences.cc:273
-#, fuzzy
 msgid "Parameter Key"
-msgstr "Parameter"
+msgstr "Parameterschlüssel"
 
 #: src/gui/Preferences.cc:273
-#, fuzzy
 msgid "Parameter Value"
-msgstr "Parameter"
+msgstr "Parameterwert"
 
 #: src/gui/Preferences.cc:289 src/gui/Preferences.cc:294
 msgid "Ollama Local"
-msgstr ""
+msgstr "Ollama lokal"
 
 #: src/gui/Preferences.cc:446 src/gui/Preferences.cc:451
 #: src/gui/Preferences.cc:1384 src/gui/Preferences.cc:1423
@@ -3330,11 +3318,11 @@ msgstr "KEINE"
 
 #: src/gui/Preferences.cc:1113
 msgid "Select CA certificate"
-msgstr ""
+msgstr "CA-Zertifikat auswählen"
 
 #: src/gui/Preferences.cc:1114
 msgid "Certificate files (*.pem *.crt *.cer);;All files (*)"
-msgstr ""
+msgstr "Zertifikatsdateien (*.pem *.crt *.cer);;Alle Dateien (*)"
 
 #: src/gui/Preferences.cc:1367
 msgid "Success: Server Version = %2, API Version = %1"
@@ -3346,51 +3334,43 @@ msgid "Error"
 msgstr "Fehler"
 
 #: src/gui/Preferences.cc:1484
-#, fuzzy
 msgid "New AI Profile"
-msgstr "&Neue Datei"
+msgstr "Neues KI-Profil"
 
 #: src/gui/Preferences.cc:1484
-#, fuzzy
 msgid "Profile name:"
-msgstr "Dateiname kopieren"
+msgstr "Profilname:"
 
 #: src/gui/Preferences.cc:1489
-#, fuzzy
 msgid "Duplicate Profile"
-msgstr "Slicing Profil"
+msgstr "Profil verdoppeln"
 
 #: src/gui/Preferences.cc:1489
-#, fuzzy
 msgid "A profile with that name already exists."
-msgstr "Set %1 existiert bereits"
+msgstr "Ein Profil dieses Namens gibt es bereits."
 
 #: src/gui/Preferences.cc:1551
 msgid "Delete AI Profile"
-msgstr ""
+msgstr "KI-Profil löschen"
 
 #: src/gui/Preferences.cc:1552
 msgid "Delete profile \"%1\"?"
-msgstr ""
+msgstr "Profil „%1“ löschen?"
 
 #: src/gui/QGLView.cc:188
 msgid ""
-"Warning: Missing OpenGL capabilities for OpenCSG - OpenCSG has been "
-"disabled.\n"
+"Warning: Missing OpenGL capabilities for OpenCSG - OpenCSG has been disabled.\n"
 "\n"
 msgstr ""
-"Achtung: Der Funktionsumfang des OpenGL Treibers reicht für die Vorschau "
-"nicht aus - OpenCSG wurde deaktiviert.\n"
+"Achtung: Der Funktionsumfang des OpenGL Treibers reicht für die Vorschau nicht aus - OpenCSG wurde deaktiviert.\n"
 "\n"
 
 #: src/gui/QGLView.cc:190
 msgid ""
-"It is highly recommended to use OpenSCAD on a system with OpenGL 2.0 or "
-"later.\n"
+"It is highly recommended to use OpenSCAD on a system with OpenGL 2.0 or later.\n"
 "Your renderer information is as follows:\n"
 msgstr ""
-"Für die korrekte Anzeige der Vorschau benötigt OpenSCAD mindestens OpenGL "
-"2.0.\n"
+"Für die korrekte Anzeige der Vorschau benötigt OpenSCAD mindestens OpenGL 2.0.\n"
 "Informationen zum OpenGL Treiber:\n"
 
 #: src/gui/QGLView.cc:194
@@ -3431,7 +3411,7 @@ msgstr "Reiter schließen"
 
 #: src/gui/TabManager.cc:458
 msgid "Close All But This Tab"
-msgstr ""
+msgstr "Alle Reiter außer diesem schließen"
 
 #: src/gui/TabManager.cc:607
 msgid "The document has been modified."
@@ -3523,50 +3503,50 @@ msgid ""
 "OpenSCAD is a software for creating solid 3D CAD models. Unlike most free "
 "software for creating 3D models (such as Blender) it does not focus on the "
 "artistic aspects of 3D modelling but instead on the CAD aspects. Thus it "
-"might be the application you are looking for when you are planning to create "
-"3D models of machine parts but pretty sure is not what you are looking for "
+"might be the application you are looking for when you are planning to create"
+" 3D models of machine parts but pretty sure is not what you are looking for "
 "when you are more interested in creating computer-animated movies."
 msgstr ""
 "OpenSCAD is a software for creating solid 3D CAD models. Unlike most free "
 "software for creating 3D models (such as Blender) it does not focus on the "
 "artistic aspects of 3D modelling but instead on the CAD aspects. Thus it "
-"might be the application you are looking for when you are planning to create "
-"3D models of machine parts but pretty sure is not what you are looking for "
+"might be the application you are looking for when you are planning to create"
+" 3D models of machine parts but pretty sure is not what you are looking for "
 "when you are more interested in creating computer-animated movies."
 
 #. (itstool) path: description/p
 #: openscad.appdata.xml.in2:28
 msgid ""
-"OpenSCAD is not an interactive modeller. Instead it is something like a 3D-"
-"compiler that reads in a script file that describes the object and renders "
-"the 3D model from this script file. This gives you (the designer) full "
-"control over the modelling process and enables you to easily change any step "
-"in the modelling process or make designs that are defined by configurable "
-"parameters."
+"OpenSCAD is not an interactive modeller. Instead it is something like a "
+"3D-compiler that reads in a script file that describes the object and "
+"renders the 3D model from this script file. This gives you (the designer) "
+"full control over the modelling process and enables you to easily change any"
+" step in the modelling process or make designs that are defined by "
+"configurable parameters."
 msgstr ""
-"OpenSCAD is not an interactive modeller. Instead it is something like a 3D-"
-"compiler that reads in a script file that describes the object and renders "
-"the 3D model from this script file. This gives you (the designer) full "
-"control over the modelling process and enables you to easily change any step "
-"in the modelling process or make designs that are defined by configurable "
-"parameters."
+"OpenSCAD is not an interactive modeller. Instead it is something like a "
+"3D-compiler that reads in a script file that describes the object and "
+"renders the 3D model from this script file. This gives you (the designer) "
+"full control over the modelling process and enables you to easily change any"
+" step in the modelling process or make designs that are defined by "
+"configurable parameters."
 
 #. (itstool) path: description/p
 #: openscad.appdata.xml.in2:29
 msgid ""
-"OpenSCAD provides two main modelling techniques: First there is constructive "
-"solid geometry (aka CSG) and second there is extrusion of 2D outlines. As "
+"OpenSCAD provides two main modelling techniques: First there is constructive"
+" solid geometry (aka CSG) and second there is extrusion of 2D outlines. As "
 "data exchange format for this 2D outlines Autocad DXF files are used. In "
 "addition to 2D paths for extrusion it is also possible to read design "
-"parameters from DXF files. Besides DXF files OpenSCAD can read and create 3D "
-"models in the STL and OFF file formats."
+"parameters from DXF files. Besides DXF files OpenSCAD can read and create 3D"
+" models in the STL and OFF file formats."
 msgstr ""
-"OpenSCAD provides two main modelling techniques: First there is constructive "
-"solid geometry (aka CSG) and second there is extrusion of 2D outlines. As "
+"OpenSCAD provides two main modelling techniques: First there is constructive"
+" solid geometry (aka CSG) and second there is extrusion of 2D outlines. As "
 "data exchange format for this 2D outlines Autocad DXF files are used. In "
 "addition to 2D paths for extrusion it is also possible to read design "
-"parameters from DXF files. Besides DXF files OpenSCAD can read and create 3D "
-"models in the STL and OFF file formats."
+"parameters from DXF files. Besides DXF files OpenSCAD can read and create 3D"
+" models in the STL and OFF file formats."
 
 #~ msgid "Features"
 #~ msgstr "Funktionen"
@@ -3596,22 +3576,21 @@ msgstr ""
 #~ "OpenSCAD.</p><p>Example:</p><pre style=\" margin-top:12px; margin-"
 #~ "bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-"
 #~ "indent:0px;\"><span style=\" font-family:'Courier New,courier';\">  "
-#~ "text(&quot;OpenSCAD&quot;, font = &quot;DejaVu Sans&quot;);</span></"
-#~ "pre><pre style=\" margin-top:0px; margin-bottom:12px; margin-left:0px; "
-#~ "margin-right:0px; -qt-block-indent:0; text-indent:0px;\"><span style=\" "
-#~ "font-family:'Courier New,courier';\">  text(&quot;OpenSCAD&quot;, font = "
+#~ "text(&quot;OpenSCAD&quot;, font = &quot;DejaVu Sans&quot;);</span></pre><pre"
+#~ " style=\" margin-top:0px; margin-bottom:12px; margin-left:0px; margin-"
+#~ "right:0px; -qt-block-indent:0; text-indent:0px;\"><span style=\" font-"
+#~ "family:'Courier New,courier';\">  text(&quot;OpenSCAD&quot;, font = "
 #~ "&quot;Liberation Sans:style=Italic&quot;);</span></pre></body></html>"
 #~ msgstr ""
-#~ "<html><head/><body><p>Diese Liste zeigt die Fonts, die momentan mit "
-#~ "OpenSCAD registriert sind.</p><p>Beispiele:</p><pre style=\" margin-"
-#~ "top:12px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-"
-#~ "indent:0; text-indent:0px;\"><span style=\" font-family:'Courier "
-#~ "New,courier';\">  text(&quot;OpenSCAD&quot;, font = &quot;DejaVu "
-#~ "Sans&quot;);</span></pre><pre style=\" margin-top:0px; margin-"
-#~ "bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-"
-#~ "indent:0px;\"><span style=\" font-family:'Courier New,courier';\">  "
-#~ "text(&quot;OpenSCAD&quot;, font = &quot;Liberation "
-#~ "Sans:style=Italic&quot;);</span></pre></body></html>"
+#~ "<html><head/><body><p>Diese Liste zeigt die Fonts, die momentan mit OpenSCAD"
+#~ " registriert sind.</p><p>Beispiele:</p><pre style=\" margin-top:12px; "
+#~ "margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; "
+#~ "text-indent:0px;\"><span style=\" font-family:'Courier New,courier';\">  "
+#~ "text(&quot;OpenSCAD&quot;, font = &quot;DejaVu Sans&quot;);</span></pre><pre"
+#~ " style=\" margin-top:0px; margin-bottom:12px; margin-left:0px; margin-"
+#~ "right:0px; -qt-block-indent:0; text-indent:0px;\"><span style=\" font-"
+#~ "family:'Courier New,courier';\">  text(&quot;OpenSCAD&quot;, font = "
+#~ "&quot;Liberation Sans:style=Italic&quot;);</span></pre></body></html>"
 
 #~ msgid "Error-Log"
 #~ msgstr "Fehlerliste"
@@ -3710,8 +3689,7 @@ msgstr ""
 #~ "Warning: You may experience OpenCSG rendering errors.\n"
 #~ "\n"
 #~ msgstr ""
-#~ "Achtung: Es können Darstellungsfehler beim Anzeigen der Vorschau "
-#~ "auftreten.\n"
+#~ "Achtung: Es können Darstellungsfehler beim Anzeigen der Vorschau auftreten.\n"
 #~ "\n"
 
 #~ msgid "save preset"
@@ -3733,8 +3711,8 @@ msgstr ""
 #~ msgstr "Änderungen an den aktuelle Voreinstellung nicht gespeichert"
 
 #~ msgid ""
-#~ "The changes on the current preset %1 are not saved yet. Do you really "
-#~ "want to reset this preset and lose your changes?"
+#~ "The changes on the current preset %1 are not saved yet. Do you really want "
+#~ "to reset this preset and lose your changes?"
 #~ msgstr ""
 #~ "Die Änderungen an der akutellen Voreinstellung %1 sind noch nicht "
 #~ "gespeichert.Möchten Sie die Änderungen wirklich zurücksetzen?"
@@ -3746,12 +3724,12 @@ msgstr ""
 #~ msgstr "JSON file ist nicht schreibbar"
 
 #~ msgid ""
-#~ "The current preset %1 contains changes, but is not saved yet. Do you "
-#~ "really want to change the preset and lose your changes?"
+#~ "The current preset %1 contains changes, but is not saved yet. Do you really "
+#~ "want to change the preset and lose your changes?"
 #~ msgstr ""
 #~ "Die Änderungen an der akutellen Voreinstellung %1 sind noch nicht "
-#~ "gespeichert.Möchten Sie wirklich die Voreinstellung wechseln und somit "
-#~ "Ihre Änderungen verlieren?"
+#~ "gespeichert.Möchten Sie wirklich die Voreinstellung wechseln und somit Ihre "
+#~ "Änderungen verlieren?"
 
 #~ msgid "Do you want to delete the current preset?"
 #~ msgstr "Möchten Sie die aktuelle Voreinstellung löschen?"


### PR DESCRIPTION
The template regeneration in #7018 exposed the strings that had been missing from the catalogue, and msgmerge matched the old translations to the new msgids by similarity. That left 65 fuzzy and 88 untranslated entries, 153 of 774 reaching the interface in English.

Confirm or replace all 65 fuzzy entries. Most were correct translations whose msgid had only gained an accelerator marker. Two were actively wrong and would have broken a shortcut had anyone accepted them: Ctrl+Alt+Up and Ctrl+Alt+Down had both been matched to "Ctrl+Alt+F". Both are now left untranslated, together with the other key sequences and object names, each carrying a translator comment.

Fix errors inherited from the old catalogue that were invisible until now because the msgids did not match: "Datei öffen" and "In neuem Fenster öffenen" for "open", "Nächsten Reitern anzeigen" for "Show Next Tab", "Alles Speichern" for "Save All", and several compounds written as two words.

Translate the 88 remaining strings: the AI chat widget, the AI preferences page, the network settings, and the tooltips of the PDF export dialog.

Assign accelerators per menu rather than per string. Every menu is now free of duplicates, which the previous catalogue was not: Redo and Find Next both used W, Cut and Use Selection for Find both used A, Copy and Find Previous both used K, About and Offline Cheat Sheet both used O. The Edit menu has 31 entries and German offers fewer distinct initial letters than that, so nine of them carry no accelerator; none of them collide.

Result: 755 translated, 19 untranslated, the latter all key sequences, object names and fixed values that must stay as they are. msgfmt -c reports no problems.